### PR TITLE
fix : Billing, Plans & Credits page blank issue

### DIFF
--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -85,6 +85,7 @@ import { useDomainActions } from "@/generated/domain-actions"
 import { useSession } from "@/contexts/SessionProvider"
 import { InviteMemberModal, PendingInvitationsView, MyInvitationsView } from "@/components/app/workspace/members"
 import { PlanSelector } from "@/components/app/billing/PlanSelector"
+import { useBillingData } from "@/hooks/useBillingData"
 
 // Tab types
 type TabId =
@@ -1059,34 +1060,23 @@ function PeopleTab() {
 // ============================================================================
 function BillingTab() {
   const { currentWorkspace } = useWorkspaceData()
-  const store = useSDKDomain() as IDomainStore
+  
+  // Use billing data hook to get subscription and credit ledger
+  const {
+    subscription,
+    effectiveBalance,
+    hasActiveSubscription,
+    isLoading: isBillingLoading,
+  } = useBillingData(currentWorkspace?.id)
 
-  // Get subscription for current workspace from SDK store
-  const getActiveSubscription = (workspaceId: string) => {
-    if (!store?.subscriptionCollection) return null
-    try {
-      const subscriptions = store.subscriptionCollection.all.filter((s: any) => s.workspaceId === workspaceId)
-      return subscriptions.find((s: any) => s.status === 'active' || s.status === 'trialing') || null
-    } catch {
-      return null
-    }
-  }
-
-  const subscription = currentWorkspace ? getActiveSubscription(currentWorkspace.id) : null
   const currentPlanId = subscription?.planId || undefined
-
-  // Get credit info
-  const creditLedger = currentWorkspace
-    ? billing?.creditLedgerCollection?.findByWorkspace?.(currentWorkspace.id)
-    : null
-  const effectiveBalance = creditLedger?.effectiveBalance
 
   const planType = subscription
     ? subscription.planId.charAt(0).toUpperCase() + subscription.planId.slice(1)
     : "Free"
 
-  const creditsRemaining = effectiveBalance?.total ?? (subscription ? 105 : 5)
-  const creditsTotal = subscription ? 105 : 5
+  const creditsRemaining = effectiveBalance?.total ?? (hasActiveSubscription ? 105 : 5)
+  const creditsTotal = hasActiveSubscription ? 105 : 5
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
**AFTER :**
<img width="1919" height="727" alt="image" src="https://github.com/user-attachments/assets/ff7b064a-bfb4-413a-81b4-d8c6e1779742" />

**BEFORE :**
<img width="1919" height="559" alt="image" src="https://github.com/user-attachments/assets/ff4a0ce7-8f38-4a82-bc6a-16f033b4d02f" />

## Fix: Billing page blank due to undefined `billing` variable

### Problem
The billing tab on the settings page was blank due to a runtime error. The `BillingTab` component referenced an undefined `billing` variable, causing a `ReferenceError: billing is not defined` and crashing the component.

### Root Cause
At line 1080 in `SettingsPage.tsx`, the code attempted to access:
```typescript
billing?.creditLedgerCollection?.findByWorkspace?.(currentWorkspace.id)
```
However, `billing` was never defined, imported, or created anywhere in the component.

### Solution
- Replaced the undefined `billing` reference with the existing `useBillingData` hook
- Added import for `useBillingData` from `@/hooks/useBillingData`
- Refactored `BillingTab` to use the hook's returned values (`subscription`, `effectiveBalance`, `hasActiveSubscription`) instead of manually accessing the store
- Aligned the implementation with the pattern used in `AppBillingPage`

### Changes
- Added `useBillingData` import to `SettingsPage.tsx`
- Updated `BillingTab` to use `useBillingData(currentWorkspace?.id)` instead of manual store access and undefined `billing` variable
- Removed redundant subscription fetching logic (now handled by the hook)

### Testing
- Billing tab now renders without errors
- Subscription and credit information displays correctly
- No console errors when navigating to `/settings?tab=billing`