### PR TITLE
Fix: Theme-aware sidebar scrollbar

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -665,6 +665,36 @@ body {
  * Scrollbar Utilities
  * ============================================================================ */
 
+/* Theme-aware scrollbar styling */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 4px;
+  transition: background 0.2s ease;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--muted-foreground);
+}
+
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+/* Firefox scrollbar styling */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
 /* Hide scrollbar while maintaining scroll functionality */
 .scrollbar-hide {
   -ms-overflow-style: none;  /* IE and Edge */


### PR DESCRIPTION
After :
<img width="552" height="833" alt="image" src="https://github.com/user-attachments/assets/6e62efa6-8f8f-4cb2-8021-ba408d44438b" />

Before :
<img width="703" height="898" alt="image" src="https://github.com/user-attachments/assets/9b2a6d41-2df5-4fb1-8890-e712967cced2" />


**Fix: Theme-aware sidebar scrollbar**

Makes the sidebar scrollbar theme-aware so it uses the correct colors in light and dark modes.

**Changes:**
- Added theme-aware scrollbar styling using CSS variables (`var(--border)`, `var(--muted-foreground)`)
- Scrollbar thumb now adapts to light/dark theme instead of showing black background in light mode
- Works for both WebKit browsers (Chrome, Safari, Edge) and Firefox

**Before:** Scrollbar showed black background in light theme  
**After:** Scrollbar uses theme-appropriate colors (`#e4e4e7` in light, `#333333` in dark)

---
