### PR TITLE
Fix: Close modal when clicking View all plans button and Redirect plans and billing

### DIFF
--- a/apps/web/src/components/app/shared/SettingsModal.tsx
+++ b/apps/web/src/components/app/shared/SettingsModal.tsx
@@ -726,13 +726,18 @@ function PeopleTab() {
 }
 
 // Billing Tab
-function BillingTab() {
+function BillingTab({ onClose }: { onClose?: () => void }) {
   const navigate = useNavigate()
 
   // Mock data - would come from billing domain
   const planType = "Free"
   const creditsUsed = 0
   const creditsTotal = 5
+
+  const handleNavigateToBilling = () => {
+    onClose?.()
+    navigate("/billing")
+  }
 
   return (
     <div className="space-y-6">
@@ -753,7 +758,7 @@ function BillingTab() {
             <div className="font-medium">You're on {planType} Plan</div>
             <div className="text-sm text-muted-foreground">Upgrade anytime</div>
           </div>
-          <Button className="ml-auto" onClick={() => navigate("/billing")}>
+          <Button className="ml-auto" onClick={handleNavigateToBilling}>
             Manage
           </Button>
         </div>
@@ -774,7 +779,7 @@ function BillingTab() {
       </div>
 
       {/* View plans button */}
-      <Button variant="outline" className="w-full" onClick={() => navigate("/billing")}>
+      <Button variant="outline" className="w-full" onClick={handleNavigateToBilling}>
         View all plans
         <ExternalLink className="h-4 w-4 ml-2" />
       </Button>
@@ -1022,7 +1027,7 @@ export const SettingsModal = observer(function SettingsModal({
           <div className="flex-1 overflow-y-auto p-6">
             {activeTab === "workspace" && <WorkspaceTab onClose={() => onOpenChange(false)} />}
             {activeTab === "people" && <PeopleTab />}
-            {activeTab === "billing" && <BillingTab />}
+            {activeTab === "billing" && <BillingTab onClose={() => onOpenChange(false)} />}
             {activeTab === "account" && <AccountTab />}
             {activeTab === "integrations" && <IntegrationsTab />}
           </div>


### PR DESCRIPTION

<img width="1657" height="590" alt="image" src="https://github.com/user-attachments/assets/8e5950d8-6856-488d-9ca3-087f2ca9debb" />
<img width="1434" height="492" alt="image" src="https://github.com/user-attachments/assets/ab1628cb-1dba-4f3b-b7be-fc72bdbe0c68" />
 view all plan and manage on profile manage modal ,now redirets to billings page

# Fix: Close modal when clicking "View all plans" button

## Problem
When clicking the "View all plans" button in the Plans & credits modal, the page would navigate to `/billing` in the background, but the modal would remain open, making it appear as if the button wasn't working.

## Solution
- Added `onClose` prop to the `BillingTab` component to handle modal closure
- Created `handleNavigateToBilling` function that closes the modal before navigating
- Updated both "Manage" and "View all plans" buttons to use the new handler
- Passed the `onClose` handler from the parent `SettingsModal` component to `BillingTab`

## Changes
- Modified `apps/web/src/components/app/shared/SettingsModal.tsx`
  - Updated `BillingTab` component to accept and use `onClose` prop
  - Both navigation buttons now properly close the modal before navigating

## Testing
- Click "View all plans" button → Modal closes and navigates to billing page ✅
- Click "Manage" button → Modal closes and navigates to billing page ✅

## Screenshots
The modal now properly closes when navigating to the billing page, providing a better user experience.

