### PR TITLE
Implement functional Project Breakdown in Usage Tab

### DIFF
--- a/apps/web/src/components/admin/hooks/useAdminApi.ts
+++ b/apps/web/src/components/admin/hooks/useAdminApi.ts
@@ -194,12 +194,13 @@ export function useUsageSummary(period: AnalyticsPeriod = '30d', basePath: strin
 export function useUsageLog(
   period: AnalyticsPeriod = '30d',
   page: number = 1,
-  basePath: string = API_BASE
+  basePath: string = API_BASE,
+  limit: number = 50
 ) {
   return useScopedFetch<UsageLogData>(`${basePath}/analytics/usage-log`, {
     period,
     page: String(page),
-    limit: '50',
+    limit: String(limit),
   })
 }
 

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -8,7 +8,7 @@
  * - Connectors: Connectors, GitHub
  */
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useMemo } from "react"
 import { observer } from "mobx-react-lite"
 import { useNavigate, useSearchParams, useParams } from "react-router-dom"
 import { format } from "date-fns"
@@ -81,6 +81,8 @@ import {
 } from "@/components/ui/select"
 import { cn } from "@/lib/utils"
 import { UsageTable, type UsageSummaryData, type UsageLogData } from "@/components/admin/analytics/UsageTable"
+import { useUsageLog } from "@/components/admin/hooks/useAdminApi"
+import type { AnalyticsPeriod } from "@/components/admin/analytics/PeriodSelector"
 import { useWorkspaceData } from "@/components/app/workspace"
 import { useDomains, useSDKDomain } from "@/contexts/DomainProvider"
 import type { IDomainStore } from "@/generated/domain"
@@ -137,56 +139,52 @@ interface ProjectUsageData {
 }
 
 function useProjectUsageBreakdown(workspaceId: string | undefined, period: string) {
-  const [data, setData] = useState<ProjectUsageData[]>([])
-  const [loading, setLoading] = useState(true)
+  // Get projects from SDK domain store (already loaded by useWorkspaceData)
+  const store = useSDKDomain() as IDomainStore
 
-  useEffect(() => {
-    if (!workspaceId) { setLoading(false); return }
-    
-    setLoading(true)
-    
-    // Fetch projects and their usage
-    Promise.all([
-      // Fetch projects
-      fetch(`/api/projects?workspaceId=${workspaceId}`, { credentials: 'include' })
-        .then((r) => r.json())
-        .then((res: { ok: boolean; items?: Array<{ id: string; name: string }> }) => res.items || []),
-      // Fetch usage events for the period
-      fetch(`/api/workspaces/${workspaceId}/analytics/usage-log?period=${period}&limit=1000`, { credentials: 'include' })
-        .then((r) => r.json())
-        .then((res: ApiResponse<UsageLogData>) => res.data?.entries || [])
-    ])
-      .then(([projects, usageEvents]) => {
-        // Aggregate AI credits by project
-        const projectCreditsMap = new Map<string, number>()
-        
-        // Initialize all projects with 0 credits
-        projects.forEach((project: { id: string; name: string }) => {
-          projectCreditsMap.set(project.id, 0)
-        })
-        
-        // Sum creditCost from usage events per project
-        usageEvents.forEach((event: any) => {
-          if (event.projectId) {
-            const existing = projectCreditsMap.get(event.projectId) || 0
-            projectCreditsMap.set(event.projectId, existing + (event.creditCost || 0))
-          }
-        })
-        
-        // Convert to array format
-        const result: ProjectUsageData[] = projects.map((project: { id: string; name: string }) => ({
-          projectId: project.id,
-          projectName: project.name,
-          aiCredits: projectCreditsMap.get(project.id) || 0,
-        }))
-        
-        setData(result)
-        setLoading(false)
-      })
-      .catch(() => {
-        setLoading(false)
-      })
-  }, [workspaceId, period])
+  // Fetch usage events via the centralized useUsageLog hook
+  const basePath = workspaceId ? `/api/workspaces/${workspaceId}` : ''
+  const { data: usageLogData, loading: usageLoading } = useUsageLog(
+    period as AnalyticsPeriod,
+    1,
+    basePath,
+    1000
+  )
+
+  // Derive project usage breakdown from SDK store + usage log data
+  const projects = workspaceId && store?.projectCollection
+    ? store.projectCollection.all.filter((p: any) => p.workspaceId === workspaceId)
+    : []
+
+  const data: ProjectUsageData[] = useMemo(() => {
+    if (!projects.length) return []
+
+    // Aggregate AI credits by project
+    const projectCreditsMap = new Map<string, number>()
+
+    // Initialize all projects with 0 credits
+    projects.forEach((project: any) => {
+      projectCreditsMap.set(project.id, 0)
+    })
+
+    // Sum creditCost from usage events per project
+    const entries = usageLogData?.entries || []
+    entries.forEach((event: any) => {
+      if (event.projectId) {
+        const existing = projectCreditsMap.get(event.projectId) || 0
+        projectCreditsMap.set(event.projectId, existing + (event.creditCost || 0))
+      }
+    })
+
+    // Convert to array format
+    return projects.map((project: any) => ({
+      projectId: project.id,
+      projectName: project.name,
+      aiCredits: projectCreditsMap.get(project.id) || 0,
+    }))
+  }, [projects, usageLogData])
+
+  const loading = usageLoading
 
   return { data, loading }
 }


### PR DESCRIPTION
<img width="1360" height="558" alt="image" src="https://github.com/user-attachments/assets/7a8d5979-131a-48e7-a498-5023966d4977" />


### Summary
Replaces the static, non-functional "Project breakdown" section in the Cloud & AI Balance settings tab with a fully functional expandable component that shows per-project AI credit usage.

### What changed
**File:** `apps/web/src/pages/SettingsPage.tsx`

#### New hook: `useProjectUsageBreakdown`
- Fetches all workspace projects from `/api/projects`
- Fetches usage events from `/api/workspaces/{id}/analytics/usage-log`
- Aggregates `creditCost` from `usage_events` table grouped by `projectId`
- Returns per-project AI credit totals for the selected time period

#### New component: `ProjectBreakdown`
- **Expand/collapse** — click header to toggle table visibility with chevron indicator
- **Table** — displays project name and AI usage in credits (sourced from `usage_events.creditCost`)
- **Pagination** — 10 projects per page with previous/next navigation
- **Loading state** — spinner while data is fetching
- **Empty state** — message when no projects exist

### Data source
| Column | Table | Field |
|--------|-------|-------|
| Project | `projects` | `name` |
| AI usage (credits) | `usage_events` | `SUM(creditCost)` per `projectId` |

### Notes
- `usage_events` is populated when users interact with AI features (`chat_message`, `ai_proxy_completion`)
- Projects with no AI usage correctly show `0` credits
- Added `ChevronRight` and `ChevronLeft` lucide icon imports for expand/collapse and pagination