### PR TITLE
Fix: Theme selector display, chat copy button, and preview refresh

### DIFF
--- a/apps/web/src/components/app/chat/turns/MessageContent.tsx
+++ b/apps/web/src/components/app/chat/turns/MessageContent.tsx
@@ -33,7 +33,7 @@ interface ImagePart {
  * Extract text content from a message.
  * Handles AI SDK v3 parts array format.
  */
-function extractTextContent(message: Message): string {
+export function extractTextContent(message: Message): string {
   // If message has content string, use it
   if (typeof message.content === "string" && message.content) {
     return message.content

--- a/apps/web/src/components/app/chat/turns/TurnGroup.tsx
+++ b/apps/web/src/components/app/chat/turns/TurnGroup.tsx
@@ -8,11 +8,13 @@
  * Now renders tool calls interleaved within assistant content.
  */
 
+import { useState, useCallback } from "react"
+import { Copy, Check } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { usePhaseColor } from "@/hooks/usePhaseColor"
 import type { ConversationTurn } from "./types"
 import { TurnHeader } from "./TurnHeader"
-import { MessageContent } from "./MessageContent"
+import { MessageContent, extractTextContent } from "./MessageContent"
 import { AssistantContent } from "./AssistantContent"
 import { ToolTimeline } from "../tools"
 import { SubagentPanel, type SubagentProgress, type RecentTool } from "../subagent"
@@ -30,6 +32,54 @@ export interface TurnGroupProps {
   showToolTimeline?: boolean
   /** Optional class name */
   className?: string
+}
+
+/**
+ * Small copy button that appears on hover over a message.
+ * Shows a checkmark briefly after copying.
+ */
+function CopyButton({ text, className }: { text: string; className?: string }) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = useCallback(async () => {
+    if (!text) return
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Fallback for older browsers
+      const textarea = document.createElement("textarea")
+      textarea.value = text
+      textarea.style.position = "fixed"
+      textarea.style.opacity = "0"
+      document.body.appendChild(textarea)
+      textarea.select()
+      document.execCommand("copy")
+      document.body.removeChild(textarea)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }, [text])
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={cn(
+        "inline-flex items-center justify-center rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+        "opacity-0 group-hover:opacity-100 focus:opacity-100",
+        className
+      )}
+      aria-label={copied ? "Copied" : "Copy message"}
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-green-500" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" />
+      )}
+    </button>
+  )
 }
 
 /**
@@ -52,6 +102,7 @@ export interface TurnGroupProps {
  * - Optional separate tool timeline (legacy mode)
  * - Subagent panel integration
  * - Streaming support for assistant message
+ * - Copy button on hover for user and assistant messages
  *
  * @example
  * ```tsx
@@ -83,9 +134,12 @@ export function TurnGroup({
     >
       {/* User message */}
       {turn.userMessage && (
-        <div className="space-y-0.5">
+        <div className="group relative space-y-0.5">
           {/* <TurnHeader role="user" /> */}
           <MessageContent message={turn.userMessage} />
+          <div className="flex justify-end">
+            <CopyButton text={extractTextContent(turn.userMessage)} />
+          </div>
         </div>
       )}
 
@@ -108,7 +162,7 @@ export function TurnGroup({
 
       {/* Assistant message with interleaved tools (default) or plain content (legacy) */}
       {turn.assistantMessage && (
-        <div className="space-y-0.5">
+        <div className="group relative space-y-0.5">
           <TurnHeader role="assistant" phase={phase} />
           {showToolTimeline ? (
             <MessageContent
@@ -120,6 +174,11 @@ export function TurnGroup({
               message={turn.assistantMessage}
               isStreaming={turn.isStreaming}
             />
+          )}
+          {!turn.isStreaming && (
+            <div className="flex justify-start pl-3">
+              <CopyButton text={extractTextContent(turn.assistantMessage)} />
+            </div>
           )}
         </div>
       )}

--- a/apps/web/src/components/app/project/ProjectLayout.tsx
+++ b/apps/web/src/components/app/project/ProjectLayout.tsx
@@ -568,8 +568,7 @@ export const ProjectLayout = observer(function ProjectLayout() {
   }, [])
 
   const handleRefresh = useCallback(() => {
-    // TODO: Refresh preview iframe
-    console.log("Refresh preview")
+    setCodeRefreshTrigger((prev) => prev + 1)
   }, [])
 
   const handleOpenExternal = useCallback(async () => {

--- a/apps/web/src/components/app/shared/ThemeSelector.tsx
+++ b/apps/web/src/components/app/shared/ThemeSelector.tsx
@@ -75,7 +75,9 @@ export function ThemeSelector({
             disabled={disabled}
           >
             <Palette className="h-4 w-4" />
-            <span className="hidden sm:inline text-xs">Theme</span>
+            <span className="hidden sm:inline text-xs">
+              {selectedTheme ? selectedTheme.name : "Theme"}
+            </span>
             <ChevronDown className="h-3 w-3 opacity-50" />
           </Button>
         ) : (


### PR DESCRIPTION

<img width="731" height="822" alt="image" src="https://github.com/user-attachments/assets/5875d0b0-fa28-410c-950e-c0e56312f349" />
<img width="1281" height="413" alt="image" src="https://github.com/user-attachments/assets/19546220-790c-4f8b-8998-759c3df2bfce" />

<img width="982" height="313" alt="image" src="https://github.com/user-attachments/assets/155dfbb5-f8a1-483d-9eb6-786c030b3dce" />

<img width="1038" height="327" alt="image" src="https://github.com/user-attachments/assets/1977793e-73ee-41d3-b554-60c2161a4b9b" />

## Fix: Theme selector display, chat copy button, and preview refresh

### Summary
Fixes three UI bugs reported during QA testing.

### Changes

#### 1. Theme selector shows selected theme name
**File:** `apps/web/src/components/app/shared/ThemeSelector.tsx`

The compact variant of the theme selector (used on the homepage) always displayed the static text "Theme" regardless of which theme was selected. Now it displays the selected theme's name (e.g. "Harvest", "Glacier") and falls back to "Theme" when nothing is selected.

#### 2. Copy-on-hover for chat messages
**Files:** `apps/web/src/components/app/chat/turns/TurnGroup.tsx`, `apps/web/src/components/app/chat/turns/MessageContent.tsx`

Added a copy button that appears on hover for both user and assistant messages — similar to Lovable.dev's UX. Clicking the button copies the message text to clipboard and briefly shows a ✓ checkmark as confirmation. The button is hidden while the assistant is still streaming.

#### 3. Preview refresh button is now functional
**File:** `apps/web/src/components/app/project/ProjectLayout.tsx`

The refresh icon in the preview toolbar was a stub (`console.log("Refresh preview")`). It now increments `codeRefreshTrigger` which triggers the existing `forceRefresh` mechanism in `RuntimePreviewPanel` — showing a rebuild overlay and reloading the iframe on build success.
