### PR TITLE
fix : project setting routing correction

### DIFF
--- a/apps/web/src/pages/AllProjectsPage.tsx
+++ b/apps/web/src/pages/AllProjectsPage.tsx
@@ -1106,7 +1106,7 @@ export const AllProjectsPage = observer(function AllProjectsPage() {
                           </DropdownMenuItem>
                           <DropdownMenuItem onClick={(e) => {
                             e.stopPropagation()
-                            handleProjectClick(project)
+                            navigate(`/projects/${project.id}/settings?tab=project`)
                           }}>
                             <Settings className="mr-2 h-4 w-4" />
                             Settings
@@ -1318,7 +1318,7 @@ export const AllProjectsPage = observer(function AllProjectsPage() {
                             </DropdownMenuItem>
                             <DropdownMenuItem onClick={(e) => {
                               e.stopPropagation()
-                              handleProjectClick(project)
+                              navigate(`/projects/${project.id}/settings?tab=project`)
                             }}>
                               <Settings className="mr-2 h-4 w-4" />
                               Settings


### PR DESCRIPTION
Problem: In apps/web/src/pages/AllProjectsPage.tsx, the "Settings" dropdown menu item (in both grid and list views) was calling handleProjectClick(project), which navigates to /projects/${project.id} — the project chat/editor screen.

Fix: Changed both occurrences to navigate to /projects/${project.id}/settings?tab=project instead, which is the correct project settings route (matching the existing route defined in App.tsx at line 163).