### PR TITLE
Add Running… indicator to chat when agent is actively streaming

### DIFF
--- a/apps/web/src/components/app/chat/turns/AssistantContent.tsx
+++ b/apps/web/src/components/app/chat/turns/AssistantContent.tsx
@@ -304,6 +304,22 @@ export function AssistantContent({
 
         return null
       })}
+
+      {/* Thinking indicator — visible while the agent is still streaming */}
+      {isStreaming && (
+        <div
+          data-testid="thinking-indicator"
+          aria-label="Agent is running"
+          aria-busy="true"
+          className="flex items-center gap-1.5 px-3 py-2 text-muted-foreground"
+        >
+          <span className="relative flex h-2 w-2">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-muted-foreground/40" />
+            <span className="relative inline-flex h-2 w-2 rounded-full bg-muted-foreground/60" />
+          </span>
+          <span className="text-[11px] animate-pulse">Running…</span>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
<img width="557" height="416" alt="image" src="https://github.com/user-attachments/assets/375ce8f3-bd66-460f-a0e9-011d1b1619ea" />

## Problem

There was no visual cue in the chat to indicate the agent was still working once it started producing output (text or tool calls). The existing loading dots only showed *before* the first assistant message arrived — once a tool call like `template_copy` appeared, the indicator vanished, leaving users unsure whether the agent was still running or had stalled.

## Solution

Added a persistent **"Running…"** indicator with an animated ping dot at the bottom of the assistant's response in `AssistantContent`. It appears whenever `isStreaming` is true and disappears automatically when the stream completes.

**Coverage is now:**
| State | Indicator |
|---|---|
| Waiting for first response | Bouncing dots (existing, in `TurnGroup`) |
| Assistant responding with tools/text, still streaming | "Running…" ping indicator ✨ **new** |
| Stream complete | Nothing — copy button appears |

## Changes

- `apps/web/src/components/app/chat/turns/AssistantContent.tsx` — Added a `"Running…"` indicator (`data-testid="thinking-indicator"`) rendered at the bottom of the parts list when `isStreaming` is true. Uses a ping-dot animation + pulsing text for subtle but clear visibility.