### PR TITLE
Fix: Black screen after Stripe subscription checkout redirect

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -3514,8 +3514,8 @@ app.post('/api/billing/checkout', async (c) => {
 
     // Include workspace ID in URLs for proper navigation after checkout
     const frontendUrl = getFrontendUrl()
-    const successUrl = `${frontendUrl}/app?workspace=${workspaceId}&checkout=success&session_id={CHECKOUT_SESSION_ID}`
-    const cancelUrl = `${frontendUrl}/app?workspace=${workspaceId}&checkout=canceled`
+    const successUrl = `${frontendUrl}/?workspace=${workspaceId}&checkout=success&session_id={CHECKOUT_SESSION_ID}`
+    const cancelUrl = `${frontendUrl}/?workspace=${workspaceId}&checkout=canceled`
 
     // Create Stripe checkout session
     const session = await stripe.checkout.sessions.create({


### PR DESCRIPTION

<img width="1919" height="966" alt="image" src="https://github.com/user-attachments/assets/887f8fb5-3616-4232-a008-6641f3601abd" />

### Problem
After completing a Stripe checkout for a pro subscription, users were redirected to `https://studio-staging.shogo.ai/app?workspace=...&checkout=success`, which resulted in a black screen with only the sidebar visible.

### Root Cause
The Stripe checkout success/cancel URLs were redirecting to `/app`, but the React Router configuration has no `/app` route. The routes are:
- `/` → `WorkspaceLayout` (index route inside `AppShell`)
- `/billing` → `AppBillingPage`
- `/*` → catch-all that renders `AppShell`

When Stripe redirected to `/app`, the catch-all route matched and rendered `AppShell` (sidebar), but since `app` doesn't match any child route, the `<Outlet />` inside `AppShell` rendered nothing, resulting in a blank/black main content area.

### Solution
Changed the Stripe checkout redirect URLs from `/app?...` to `/?...` in `apps/api/src/server.ts`:


Now users are redirected to the root `/` route, which properly renders `WorkspaceLayout`. The existing `useEffect` hook in `AppShell` already handles the `workspace` and `checkout` query parameters to:
- Show success/cancel toast notifications
- Switch to the correct workspace
- Clean up URL parameters