### PR TITLE
Added a password visibility eye toggle to both signup and signin form

### DIFF
--- a/apps/web/src/components/app/auth/SignInForm.tsx
+++ b/apps/web/src/components/app/auth/SignInForm.tsx
@@ -9,6 +9,7 @@
 
 import { useState, type FormEvent } from "react"
 import { observer } from "mobx-react-lite"
+import { Eye, EyeOff } from "lucide-react"
 import { useDomains } from "@/contexts/DomainProvider"
 import { useSession } from "@/contexts/SessionProvider"
 import { clearUserLocalStorage } from "@/lib/clear-user-storage"
@@ -36,6 +37,7 @@ export const SignInForm = observer(function SignInForm({ onSuccess }: SignInForm
   const session = useSession()
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
+  const [showPassword, setShowPassword] = useState(false)
 
   const isLoading = auth.authStatus === "loading"
 
@@ -92,16 +94,32 @@ export const SignInForm = observer(function SignInForm({ onSuccess }: SignInForm
             Forgot password?
           </a>
         </div>
-        <Input
-          id="signin-password"
-          type="password"
-          placeholder="Enter your password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          disabled={isLoading}
-          required
-          autoComplete="current-password"
-        />
+        <div className="relative">
+          <Input
+            id="signin-password"
+            type={showPassword ? "text" : "password"}
+            placeholder="Enter your password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            disabled={isLoading}
+            required
+            autoComplete="current-password"
+            className="pr-10"
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+            disabled={isLoading}
+            aria-label={showPassword ? "Hide password" : "Show password"}
+          >
+            {showPassword ? (
+              <EyeOff className="h-4 w-4" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
+          </button>
+        </div>
       </div>
 
       <Button

--- a/apps/web/src/components/app/auth/SignUpForm.tsx
+++ b/apps/web/src/components/app/auth/SignUpForm.tsx
@@ -11,6 +11,7 @@
 
 import { useState, useMemo, type FormEvent } from "react"
 import { observer } from "mobx-react-lite"
+import { CheckCircle2, XCircle, AlertCircle, Eye, EyeOff } from "lucide-react"
 import { useDomains } from "@/contexts/DomainProvider"
 import { useSession } from "@/contexts/SessionProvider"
 import { clearUserLocalStorage } from "@/lib/clear-user-storage"
@@ -18,7 +19,6 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { cn } from "@/lib/utils"
-import { CheckCircle2, XCircle, AlertCircle } from "lucide-react"
 
 /**
  * Email validation with proper domain validation
@@ -128,6 +128,7 @@ export const SignUpForm = observer(function SignUpForm() {
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const [emailTouched, setEmailTouched] = useState(false)
+  const [showPassword, setShowPassword] = useState(false)
 
   const isLoading = auth.authStatus === "loading"
 
@@ -218,14 +219,30 @@ export const SignUpForm = observer(function SignUpForm() {
 
       <div className="space-y-2">
         <Label htmlFor="signup-password">Password</Label>
-        <Input
-          id="signup-password"
-          type="password"
-          placeholder="Enter your password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          disabled={isLoading}
-        />
+        <div className="relative">
+          <Input
+            id="signup-password"
+            type={showPassword ? "text" : "password"}
+            placeholder="Enter your password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            disabled={isLoading}
+            className="pr-10"
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+            disabled={isLoading}
+            aria-label={showPassword ? "Hide password" : "Show password"}
+          >
+            {showPassword ? (
+              <EyeOff className="h-4 w-4" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
+          </button>
+        </div>
         {/* Password strength indicator */}
         {password.length > 0 && (
           <div className="space-y-1.5">


### PR DESCRIPTION

<img width="807" height="694" alt="image" src="https://github.com/user-attachments/assets/75827667-36df-49c7-a06f-e8fb0f91b62f" />

Added a password visibility toggle to both the Sign In and Sign Up forms.

## Changes Made:

1. **SignInForm.tsx**:
   - Added `Eye` and `EyeOff` icons from `lucide-react`
   - Added `showPassword` state to track visibility
   - Wrapped the password input in a relative container
   - Added a toggle button with eye icons positioned on the right side of the input
   - Input type toggles between `"password"` and `"text"` based on visibility state

2. **SignUpForm.tsx**:
   - Same changes as SignInForm
   - The toggle works alongside the existing password strength indicator

## Features:
- Eye icon when password is hidden; EyeOff when visible
- Button positioned on the right side of the input
- Hover effect for better UX
- Proper accessibility with `aria-label`
- Disabled state when form is loading
- Smooth transition on icon color change

Users can now toggle password visibility during registration and sign-in to verify their input. The implementation follows the existing design patterns and uses the same icon library (`lucide-react`) already used in the codebase.