### PR TITLE
feat: add 10 bundled skills — calendar, social-monitor, jira, stock-price etc

### DIFF
--- a/packages/agent-runtime/src/bundled-skills/api-monitor.md
+++ b/packages/agent-runtime/src/bundled-skills/api-monitor.md
@@ -1,0 +1,59 @@
+---
+name: api-monitor
+version: 1.0.0
+description: Monitor API endpoints for uptime, response time, and health status
+trigger: "api status|check endpoint|uptime|is it up|health check|monitor url|ping|status page"
+tools: [web_fetch, memory_read, memory_write]
+---
+
+# API & Endpoint Monitor
+
+Check API endpoints for availability, response time, and health.
+
+## Commands
+
+**Check endpoint:** Test a single URL
+- Send a request and report status code, response time, and body preview
+- Flag errors (timeouts, 4xx, 5xx)
+
+**Bulk check:** Test multiple endpoints at once
+- Read a list of URLs from a config or memory
+- Report status for all endpoints in a table
+
+**Set up monitoring:** Save endpoints for regular heartbeat checks
+- Store URL list in memory
+- Check on every heartbeat tick and alert on failures
+
+**History:** Show uptime history for monitored endpoints
+- Read from memory logs
+- Calculate uptime percentage
+
+## Workflow
+
+1. **Fetch** each endpoint using web_fetch
+2. **Record** status code and response time
+3. **Compare** to previous checks (from memory) to detect changes
+4. **Alert** on status changes (was up, now down — or vice versa)
+5. **Save** results to memory for trend tracking
+
+## Output Format
+
+**API Health Dashboard** — Checked at 14:30 UTC
+
+| Endpoint | Status | Response | Change |
+|----------|--------|----------|--------|
+| api.example.com/health | ✅ 200 OK | 145ms | — |
+| api.example.com/v2/users | ✅ 200 OK | 230ms | — |
+| payments.example.com | 🔴 503 Error | timeout | ⚠️ Was OK 1h ago |
+| cdn.example.com/assets | ✅ 200 OK | 45ms | — |
+
+**Uptime (24h):** 97.5% | **Incidents:** 1 (payments API)
+
+## Guidelines
+
+- Default timeout: 10 seconds
+- Report both status code and response time
+- Use memory to track status over time
+- On heartbeat, only alert if status CHANGED (avoid spam)
+- Include helpful next steps when an endpoint is down
+

--- a/packages/agent-runtime/src/bundled-skills/calendar-manage.md
+++ b/packages/agent-runtime/src/bundled-skills/calendar-manage.md
@@ -1,0 +1,54 @@
+---
+name: calendar-manage
+version: 1.0.0
+description: Create, list, update, and manage calendar events and appointments
+trigger: "calendar|schedule|appointment|event|meeting at|book time|free time|availability"
+tools: [read_file, write_file, memory_read, memory_write]
+---
+
+# Calendar Manager
+
+Manage a calendar of events and appointments stored in the workspace calendar.md file.
+
+## Commands
+
+**Add event:** Create a new calendar event
+- Parse date, time, duration, and attendees from natural language
+- Detect conflicts with existing events
+- Append to calendar.md in chronological order
+
+**List events:** Show upcoming events
+- Filter by day, week, or date range
+- Highlight events happening today
+- Show conflicts or double-bookings
+
+**Update event:** Modify an existing event
+- Change time, date, duration, or attendees
+- Mark as cancelled if needed
+
+**Check availability:** Find free time slots
+- Scan calendar for gaps on a given day
+- Suggest available meeting times
+
+## File Format (calendar.md)
+
+```markdown
+# Calendar
+
+## 2026-02-24 (Monday)
+- 09:00–09:30 | Team standup | Attendees: Team
+- 14:00–15:00 | Client meeting | Attendees: Jane, Bob
+- 16:30–17:00 | 1:1 with manager
+
+## 2026-02-25 (Tuesday)
+- 10:00–11:00 | Sprint planning
+- ~~13:00–14:00 | Cancelled: Vendor demo~~
+```
+
+## Guidelines
+
+- Always check for conflicts before adding events
+- Show times in 24h format for clarity
+- When listing, highlight "now" and "next" events
+- Offer to set reminders via memory_write for important events
+

--- a/packages/agent-runtime/src/bundled-skills/ci-cd-status.md
+++ b/packages/agent-runtime/src/bundled-skills/ci-cd-status.md
@@ -1,0 +1,67 @@
+---
+name: ci-cd-status
+version: 1.0.0
+description: Check CI/CD pipeline status — GitHub Actions, builds, deployments, and test results
+trigger: "ci status|pipeline|build status|deploy status|github actions|workflow|tests passing|build failed"
+tools: [exec, web_fetch]
+---
+
+# CI/CD Pipeline Status
+
+Check the status of CI/CD pipelines, builds, and deployments.
+
+## Supported Platforms
+
+- **GitHub Actions** — via `gh` CLI or web_fetch
+- **Generic CI** — via web_fetch to status pages
+
+## Commands
+
+**Pipeline status:** Check current build/deploy status
+- Show running, passed, and failed workflows
+- Display commit that triggered the build
+- Show duration and failure details
+
+**Recent runs:** List recent pipeline executions
+- Filter by branch, workflow name, or status
+- Show success rate over last N runs
+
+**Test results:** Summarize test outcomes
+- Total tests, passed, failed, skipped
+- List failing test names if available
+
+**Deploy status:** Check deployment state
+- Current deployed version/commit
+- Last deployment time
+- Environment (staging, production)
+
+## Workflow
+
+1. Try `gh run list` and `gh run view` via exec (preferred)
+2. Fall back to web_fetch on GitHub repository actions page
+3. Parse and present results in a clear format
+
+## Output Format
+
+**Repository:** owner/repo
+**Branch:** main
+
+| Workflow | Status | Duration | Commit | Triggered |
+|----------|--------|----------|--------|-----------|
+| CI Tests | ✅ Pass | 4m 32s | abc1234 | 2h ago |
+| Deploy Prod | ✅ Pass | 2m 15s | abc1234 | 2h ago |
+| Nightly E2E | 🔴 Fail | 12m 08s | def5678 | 8h ago |
+
+**Failing:** Nightly E2E
+- ❌ `test/e2e/checkout.spec.ts` — Timeout waiting for element
+- ❌ `test/e2e/login.spec.ts` — Expected 200, got 503
+
+**Success rate (last 7 days):** 94% (47/50 runs passed)
+
+## Guidelines
+
+- Always show the most recent run first
+- Highlight failures prominently with error details
+- For GitHub Actions, use `gh` CLI when available (faster, structured data)
+- If no CI platform is detected, suggest setting one up
+

--- a/packages/agent-runtime/src/bundled-skills/customer-support.md
+++ b/packages/agent-runtime/src/bundled-skills/customer-support.md
@@ -1,0 +1,70 @@
+---
+name: customer-support
+version: 1.0.0
+description: Triage and respond to customer support tickets, FAQs, and inquiries
+trigger: "support ticket|customer issue|help request|complaint|refund|bug report from user|customer question"
+tools: [read_file, write_file, memory_read, memory_write, web_fetch]
+---
+
+# Customer Support Agent
+
+Triage, categorize, and respond to customer support inquiries.
+
+## Workflow
+
+1. **Receive** the support request (via message, email, or webhook)
+2. **Categorize** the issue:
+   - 🐛 Bug report
+   - 💳 Billing / refund
+   - ❓ How-to / FAQ
+   - 🔧 Technical issue
+   - 💡 Feature request
+   - 📦 Order / shipping
+3. **Search** memory and knowledge base for similar past issues
+4. **Draft** a response based on category and context
+5. **Escalate** if the issue requires human intervention
+6. **Log** the interaction to memory for future reference
+
+## Response Guidelines
+
+- Be empathetic and professional
+- Acknowledge the issue clearly
+- Provide actionable steps or solutions
+- Include relevant links or documentation
+- Set expectations for resolution time
+- Escalate billing disputes and security issues immediately
+
+## Ticket Format (support-log.md)
+
+```markdown
+## Ticket #2026-0224-001
+- **Date:** 2026-02-24 14:30
+- **Customer:** jane@example.com
+- **Category:** 🐛 Bug Report
+- **Priority:** High
+- **Status:** Open
+- **Summary:** Login page returns 500 error on mobile Safari
+- **Response:** Acknowledged, forwarded to engineering team
+- **Resolution:** [pending]
+```
+
+## Output Format
+
+**Ticket #2026-0224-001** | 🐛 Bug Report | Priority: High
+
+**Customer:** jane@example.com
+**Issue:** Login page returns 500 error on mobile Safari
+
+**Suggested Response:**
+> Hi Jane, thank you for reporting this issue. We've identified the problem with our login page on mobile Safari and our engineering team is working on a fix. We expect to have this resolved within 24 hours. In the meantime, you can log in using Chrome or Firefox on mobile. We apologize for the inconvenience.
+
+**Action:** Escalate to engineering | **ETA:** 24h
+
+## Guidelines
+
+- Always log interactions to support-log.md for tracking
+- Check memory for past interactions with the same customer
+- Never share internal system details or credentials in responses
+- For billing issues, confirm amounts before processing any changes
+- Flag potential security issues immediately
+

--- a/packages/agent-runtime/src/bundled-skills/database-query.md
+++ b/packages/agent-runtime/src/bundled-skills/database-query.md
@@ -1,0 +1,70 @@
+---
+name: database-query
+version: 1.0.0
+description: Run SQL queries against databases and present results in a readable format
+trigger: "query database|sql|run query|database|show tables|select from|db query|data from table"
+tools: [exec, read_file, write_file]
+---
+
+# Database Query Runner
+
+Execute SQL queries against databases and present results clearly.
+
+## Supported Databases
+
+- **SQLite** — via `sqlite3` CLI
+- **PostgreSQL** — via `psql` CLI
+- **MySQL** — via `mysql` CLI
+- **Any MCP database server** — if installed
+
+## Commands
+
+**Run query:** Execute a SQL query
+- Parse natural language into SQL
+- Show results as a formatted table
+- Warn about destructive operations (DELETE, DROP, TRUNCATE)
+
+**Show tables:** List all tables in a database
+- Include column names and types
+- Show row counts if possible
+
+**Describe table:** Show table schema
+- Column names, types, constraints
+- Primary keys and foreign keys
+- Sample data (first 5 rows)
+
+**Export results:** Save query results to a file
+- CSV, JSON, or markdown table format
+
+## Workflow
+
+1. **Identify** the database type and connection string
+2. **Translate** natural language to SQL (if not raw SQL)
+3. **Validate** the query — warn on destructive operations
+4. **Execute** via the appropriate CLI tool
+5. **Format** results as a readable table
+6. **Save** to file if requested
+
+## Output Format
+
+**Database:** myapp.db (SQLite)
+**Query:** `SELECT name, email, plan FROM users WHERE plan = 'pro' LIMIT 10`
+**Rows:** 10 of 234 total
+
+| name | email | plan |
+|------|-------|------|
+| Alice Johnson | alice@example.com | pro |
+| Bob Smith | bob@example.com | pro |
+| Carol Lee | carol@example.com | pro |
+
+**Execution time:** 12ms
+
+## Safety Guidelines
+
+- **NEVER** run DROP, TRUNCATE, or DELETE without explicit user confirmation
+- Always use LIMIT on SELECT queries (default: 100 rows)
+- Show the SQL query before executing for transparency
+- For production databases, default to read-only operations
+- Warn if connecting to a production database
+- Recommend backing up before any write operations
+

--- a/packages/agent-runtime/src/bundled-skills/jira-tickets.md
+++ b/packages/agent-runtime/src/bundled-skills/jira-tickets.md
@@ -1,0 +1,55 @@
+---
+name: jira-tickets
+version: 1.0.0
+description: Manage and track Jira, Linear, or GitHub Issues — list, create, update, and prioritize tickets
+trigger: "jira|ticket|issue|linear|backlog|sprint|kanban|bug report|feature request"
+tools: [web_fetch, read_file, write_file, exec]
+---
+
+# Issue Tracker Management
+
+Manage tickets and issues across popular project management tools.
+
+## Supported Platforms
+
+- **Jira** — via REST API or web scraping
+- **Linear** — via GraphQL API
+- **GitHub Issues** — via `gh` CLI or web_fetch
+
+## Commands
+
+**List tickets:** Show open issues with filters
+- Filter by status (open, in progress, done)
+- Filter by assignee, label, or priority
+- Sort by creation date, priority, or last updated
+
+**Create ticket:** Create a new issue
+- Parse title, description, priority, and labels from natural language
+- Assign to team member if specified
+
+**Update ticket:** Change status, priority, or assignee
+- Support transitions (To Do → In Progress → Done)
+
+**Sprint summary:** Show current sprint status
+- Tickets completed vs remaining
+- Blocked tickets
+- Velocity metrics
+
+## Output Format
+
+**Sprint: Sprint 42** | Feb 17–28, 2026
+**Progress:** ████████░░ 80% (8/10 tickets)
+
+| Key | Title | Status | Priority | Assignee |
+|-----|-------|--------|----------|----------|
+| PROJ-123 | Fix login bug | 🔵 In Progress | High | @alice |
+| PROJ-124 | Add dark mode | ⬜ To Do | Medium | @bob |
+| PROJ-125 | Update docs | ✅ Done | Low | @carol |
+
+## Guidelines
+
+- Try `gh` CLI first for GitHub Issues
+- For Jira/Linear, use web_fetch with API endpoints if tokens are available
+- Fall back to tracking issues locally in issues.md if no API access
+- Always show priority and status clearly
+

--- a/packages/agent-runtime/src/bundled-skills/pdf-summarize.md
+++ b/packages/agent-runtime/src/bundled-skills/pdf-summarize.md
@@ -1,0 +1,61 @@
+---
+name: pdf-summarize
+version: 1.0.0
+description: Extract text from PDFs and documents, then summarize the content
+trigger: "pdf|summarize document|read document|extract from pdf|document summary|paper summary"
+tools: [exec, read_file, write_file, web_fetch]
+---
+
+# PDF & Document Summarizer
+
+Extract text from PDF files or document URLs and provide structured summaries.
+
+## Workflow
+
+1. **Locate the document:**
+   - If a URL is provided, download using web_fetch
+   - If a local file, read from workspace
+
+2. **Extract text:**
+   - Use `pdftotext` CLI tool (exec) for PDF files
+   - Fall back to `strings` command if pdftotext unavailable
+   - For web pages, use web_fetch directly
+
+3. **Analyze and summarize:**
+   - Identify document type (research paper, report, legal, invoice)
+   - Extract key sections, headings, and main points
+   - Generate a structured summary
+
+4. **Save if requested:**
+   - Write summary to a markdown file
+   - Include source reference and extraction date
+
+## Output Format
+
+**Document:** Annual Report 2025.pdf
+**Type:** Financial Report | **Pages:** 42 | **Words:** ~18,500
+
+### Key Takeaways
+1. Revenue grew 23% YoY to $4.2B
+2. New product line launched in Q3
+3. Headcount increased to 12,500 employees
+
+### Executive Summary
+[2-3 paragraph summary of the document]
+
+### Important Figures
+- Revenue: $4.2B (+23%)
+- Net Income: $890M (+15%)
+- R&D Spend: $620M (14.8% of revenue)
+
+### Action Items / Recommendations
+- [If applicable, list action items from the document]
+
+## Guidelines
+
+- For research papers, focus on abstract, methodology, results, and conclusions
+- For legal documents, highlight key terms, obligations, and dates
+- For invoices/receipts, extract line items, totals, and payment terms
+- Always mention the source file and extraction date
+- Warn if text extraction quality is poor (scanned PDFs may need OCR)
+

--- a/packages/agent-runtime/src/bundled-skills/slack-notify.md
+++ b/packages/agent-runtime/src/bundled-skills/slack-notify.md
@@ -1,0 +1,64 @@
+---
+name: slack-notify
+version: 1.0.0
+description: Send formatted notifications and messages to Slack channels
+trigger: "notify slack|slack message|send to slack|post to slack|slack alert|slack channel"
+tools: [web_fetch, read_file]
+---
+
+# Slack Notifications
+
+Send formatted notifications and messages to Slack channels via webhooks or the Slack API.
+
+## Commands
+
+**Send message:** Post a message to a Slack channel
+- Support plain text and formatted messages
+- Include emoji, mentions, and links
+
+**Send alert:** Post an urgent notification
+- Use red/warning formatting
+- Mention specific users or @channel/@here
+
+**Send report:** Post a structured report
+- Format data as Slack blocks (tables, sections, dividers)
+- Include action buttons if supported
+
+## Workflow
+
+1. **Format** the message content with Slack markdown
+2. **Send** via Slack webhook URL (if configured) using web_fetch
+3. **Confirm** delivery status
+
+## Message Format (Slack Webhook)
+
+```json
+{
+  "text": "Fallback text for notifications",
+  "blocks": [
+    {
+      "type": "header",
+      "text": { "type": "plain_text", "text": "📊 Daily Report" }
+    },
+    {
+      "type": "section",
+      "text": { "type": "mrkdwn", "text": "*Revenue:* $12,450\n*Orders:* 89\n*Active users:* 1,234" }
+    }
+  ]
+}
+```
+
+## Output Format
+
+✅ Message sent to #general
+- Content: "Daily Report — Revenue up 12%..."
+- Timestamp: 2026-02-24 14:30:00 UTC
+
+## Guidelines
+
+- Use Slack mrkdwn format (*bold*, _italic_, `code`, >quote)
+- Keep messages concise — Slack truncates long messages
+- Use @channel sparingly (only for urgent alerts)
+- If no webhook URL is configured, provide instructions to set one up
+- Respect rate limits (1 message per second per webhook)
+

--- a/packages/agent-runtime/src/bundled-skills/social-monitor.md
+++ b/packages/agent-runtime/src/bundled-skills/social-monitor.md
@@ -1,0 +1,48 @@
+---
+name: social-monitor
+version: 1.0.0
+description: Monitor social media platforms for mentions, trends, and updates
+trigger: "twitter|tweet|reddit|linkedin|social media|trending|mentions|hashtag|subreddit"
+tools: [web_fetch, memory_read, memory_write]
+---
+
+# Social Media Monitor
+
+Monitor social media platforms for relevant content and trends.
+
+## Supported Platforms
+
+**Twitter/X:** Search for mentions, hashtags, or user activity
+**Reddit:** Monitor subreddits, search posts, track discussions
+**LinkedIn:** Check for posts, articles, and company updates
+**Hacker News:** Monitor front page and search for topics
+
+## Workflow
+
+1. **Identify the platform** and search terms from the user's request
+2. **Fetch** content using web_fetch (public feeds, search pages)
+3. **Extract** relevant posts, mentions, or trends
+4. **Summarize** findings with links, engagement metrics, and sentiment
+5. **Save** to memory for tracking changes over time
+
+## Output Format
+
+**Platform:** Twitter/X
+**Search:** "AI agents" | **Period:** Last 24h
+
+**Top Mentions:**
+- @user: "Post content..." — ❤️ 245 🔄 89 — 3h ago
+- @user2: "Post content..." — ❤️ 120 🔄 34 — 6h ago
+
+**Trending Hashtags:** #AIAgents, #MCP, #Automation
+
+**Sentiment:** Mostly positive (72%), Neutral (20%), Negative (8%)
+
+## Guidelines
+
+- Use web_fetch to access public pages and RSS feeds
+- For Reddit, fetch from old.reddit.com or JSON APIs (.json suffix)
+- Track mentions over time using memory to detect trend changes
+- Report engagement metrics when available (likes, shares, comments)
+- Flag any negative mentions or potential PR issues
+

--- a/packages/agent-runtime/src/bundled-skills/stock-price.md
+++ b/packages/agent-runtime/src/bundled-skills/stock-price.md
@@ -1,0 +1,56 @@
+---
+name: stock-price
+version: 1.0.0
+description: Get stock prices, crypto prices, market data, and set price alerts
+trigger: "stock|share price|market|crypto|bitcoin|ethereum|portfolio|ticker|nasdaq|s&p|nifty"
+tools: [web_fetch, memory_read, memory_write]
+---
+
+# Stock & Crypto Price Checker
+
+Fetch real-time and historical price data for stocks, cryptocurrencies, and market indices.
+
+## Capabilities
+
+**Price check:** Get current price for a stock or crypto
+- Support ticker symbols (AAPL, TSLA, BTC, ETH)
+- Show price change (absolute and percentage)
+- Include volume and market cap when available
+
+**Market overview:** Summarize major indices
+- S&P 500, NASDAQ, Dow Jones
+- Key crypto (BTC, ETH, SOL)
+- Regional markets if requested (NIFTY, FTSE, Nikkei)
+
+**Price alerts:** Set alerts for price thresholds
+- Save to memory for checking on heartbeat ticks
+- Alert when price crosses above/below target
+
+**Portfolio tracking:** Track a portfolio of holdings
+- Calculate total value and daily change
+- Show per-holding performance
+
+## Output Format
+
+**AAPL (Apple Inc.)** — $187.45
+📈 +$2.30 (+1.24%) today
+Volume: 52.3M | Market Cap: $2.89T | P/E: 29.8
+
+**BTC (Bitcoin)** — $97,234.50
+📉 -$1,245.00 (-1.26%) today
+24h Volume: $38.2B | Market Cap: $1.91T
+
+## Data Sources
+
+- Use web_fetch to query financial data from public sources
+- Yahoo Finance, Google Finance, CoinGecko for crypto
+- Parse the response for relevant price data
+- Cache recent lookups in memory to avoid redundant fetches
+
+## Guidelines
+
+- Always show currency (USD, EUR, etc.)
+- Include daily change with direction emoji (📈/📉)
+- For portfolios, calculate weighted returns
+- Remind users that data may be delayed (15-20 min for free sources)
+


### PR DESCRIPTION
## feat: Add 10 new bundled skills

Adds 10 new bundled skills to close the gap with OpenClaw's skill ecosystem (24 → 34 total).

**New skills:**
- `calendar-manage` — Event scheduling, conflict detection, free slot finder
- `social-monitor` — Twitter/X, Reddit, LinkedIn, HN tracking
- `jira-tickets` — Jira/Linear/GitHub Issues management
- `stock-price` — Stock & crypto prices, portfolio tracking
- `pdf-summarize` — PDF text extraction and summarization
- `ci-cd-status` — GitHub Actions, build & deploy status
- `api-monitor` — Endpoint uptime and health monitoring
- `slack-notify` — Formatted Slack channel notifications
- `customer-support` — Support ticket triage and response drafting
- `database-query` — SQL query runner (SQLite/Postgres/MySQL)

All skills follow the existing markdown + YAML frontmatter format. No code changes — just `.md` files in `bundled-skills/`.