### PR TITLE
move all raw API calls to SDK layer and fix invitation accept/de…

### DIFF
--- a/apps/mobile/app/(app)/settings.tsx
+++ b/apps/mobile/app/(app)/settings.tsx
@@ -60,6 +60,7 @@ import {
 import { useDomainActions } from '@shogo/shared-app/domain'
 import { useActiveWorkspace } from '../../hooks/useActiveWorkspace'
 import { setActiveWorkspaceId } from '../../lib/workspace-store'
+import { api } from '../../lib/api'
 import { useBillingData } from '@shogo/shared-app/hooks'
 import {
   PRO_TIERS,
@@ -327,7 +328,7 @@ const WorkspaceSettingsTab = observer(function WorkspaceSettingsTab() {
     if (!currentWorkspace?.id || !isDeleteConfirmed) return
     setIsDeleting(true)
     try {
-      await actions.deleteWorkspaceWithMembers(currentWorkspace.id)
+      await actions.deleteWorkspace(currentWorkspace.id)
       setIsDeleteDialogOpen(false)
       router.replace('/(app)')
     } catch (error) {
@@ -550,12 +551,12 @@ const WorkspaceSettingsTab = observer(function WorkspaceSettingsTab() {
                   setLeaveError(null)
                   try {
                     const wsId = currentWorkspace?.id
-                    if (!wsId) {
+                    if (!wsId || !http) {
                       setLeaveError('Missing workspace information.')
                       setIsLeaving(false)
                       return
                     }
-                    await http.post(`/api/workspaces/${wsId}/leave`)
+                    await api.leaveWorkspace(http, wsId)
                     await workspaces.loadAll()
                     const remaining = workspaces.all
                     if (remaining.length > 0) {
@@ -708,7 +709,7 @@ function AccountTab() {
     if (deleteConfirmText !== 'DELETE' || !user?.id || !http) return
     setIsDeleting(true)
     try {
-      await http.delete(`/api/users/${user.id}`)
+      await api.deleteAccount(http, user.id)
       await signOut()
       router.replace('/(auth)/sign-in')
     } catch (error) {
@@ -1428,33 +1429,23 @@ const PeopleTab = observer(function PeopleTab() {
 
       if (http) {
         try {
-          const res = await http.get<{ ok: boolean; items?: any[] }>(
-            `/api/members?workspaceId=${ws.id}`
-          )
-          if (res.data?.ok && res.data.items) {
-            const map: Record<string, { name: string; email: string }> = {}
-            for (const item of res.data.items) {
-              if (item.user && typeof item.user === 'object' && item.user.id) {
-                map[item.user.id] = {
-                  name: item.user.name || '',
-                  email: item.user.email || '',
-                }
+          const items = await api.getWorkspaceMembers(http, ws.id)
+          const map: Record<string, { name: string; email: string }> = {}
+          for (const item of items) {
+            if (item.user && typeof item.user === 'object' && item.user.id) {
+              map[item.user.id] = {
+                name: item.user.name || '',
+                email: item.user.email || '',
               }
             }
-            setUserMap(map)
           }
+          setUserMap(map)
         } catch {}
 
         if (user?.email) {
           try {
-            const invRes = await http.get<{ ok: boolean; items?: any[] }>(
-              `/api/invitations?email=${encodeURIComponent(user.email)}`
-            )
-            if (invRes.data?.ok && invRes.data.items) {
-              setReceivedInvites(
-                invRes.data.items.filter((i: any) => i.status === 'pending')
-              )
-            }
+            const pending = await api.getReceivedInvitations(http, user.email)
+            setReceivedInvites(pending)
           } catch {}
         }
       }
@@ -1831,17 +1822,13 @@ const PeopleTab = observer(function PeopleTab() {
                       <View className="flex-row gap-2">
                         <Pressable
                           onPress={async () => {
-                            setReceivedInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
                             try {
-                              if (http) {
-                                await http.patch(`/api/invitations/${inv.id}`, { status: 'accepted' })
-                                await http.post('/api/members', {
-                                  userId: user?.id,
-                                  workspaceId: inv.workspaceId,
-                                  role: inv.role,
-                                  isBillingAdmin: false,
-                                })
-                              }
+                              await actions.acceptInvitation(inv.id, user?.id || '', {
+                                workspaceId: inv.workspaceId,
+                                role: inv.role,
+                                projectId: inv.projectId,
+                              })
+                              setReceivedInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
                             } catch {}
                             loadPeopleData()
                           }}
@@ -1851,11 +1838,9 @@ const PeopleTab = observer(function PeopleTab() {
                         </Pressable>
                         <Pressable
                           onPress={async () => {
-                            setReceivedInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
                             try {
-                              if (http) {
-                                await http.patch(`/api/invitations/${inv.id}`, { status: 'declined' })
-                              }
+                              await actions.declineInvitation(inv.id)
+                              setReceivedInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
                             } catch {}
                             loadPeopleData()
                           }}

--- a/apps/mobile/components/layout/AppSidebar.tsx
+++ b/apps/mobile/components/layout/AppSidebar.tsx
@@ -876,13 +876,9 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
 
   const loadInvites = useCallback(() => {
     if (!http || !user?.email) return
-    http.get<{ ok: boolean; items?: any[] }>(
-      `/api/invitations?email=${encodeURIComponent(user.email)}`
-    ).then((res) => {
-      if (res.data?.ok && res.data.items) {
-        setPendingInvites(res.data.items.filter((i: any) => i.status === 'pending'))
-      }
-    }).catch(() => {})
+    api.getReceivedInvitations(http, user.email)
+      .then(setPendingInvites)
+      .catch(() => {})
   }, [http, user?.email])
 
   useEffect(() => { loadInvites() }, [loadInvites])
@@ -1303,17 +1299,13 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
                       <View className="flex-row gap-2">
                         <Pressable
                           onPress={async () => {
-                            setPendingInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
                             try {
-                              if (http) {
-                                await http.patch(`/api/invitations/${inv.id}`, { status: 'accepted' })
-                                await http.post('/api/members', {
-                                  userId: user?.id,
-                                  workspaceId: inv.workspaceId,
-                                  role: inv.role,
-                                  isBillingAdmin: false,
-                                })
-                              }
+                              await actions.acceptInvitation(inv.id, user?.id || '', {
+                                workspaceId: inv.workspaceId,
+                                role: inv.role,
+                                projectId: inv.projectId,
+                              })
+                              setPendingInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
                             } catch {}
                             loadInvites()
                             workspaces.loadAll().catch(() => {})
@@ -1324,11 +1316,9 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
                         </Pressable>
                         <Pressable
                           onPress={async () => {
-                            setPendingInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
                             try {
-                              if (http) {
-                                await http.patch(`/api/invitations/${inv.id}`, { status: 'declined' })
-                              }
+                              await actions.declineInvitation(inv.id)
+                              setPendingInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
                             } catch {}
                             loadInvites()
                           }}

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -170,6 +170,38 @@ export const api = {
     return res.data
   },
 
+  // ─── Workspace ─────────────────────────────────────────
+
+  async leaveWorkspace(http: HttpClient, workspaceId: string) {
+    const res = await http.post<{ ok: boolean }>(`/api/workspaces/${workspaceId}/leave`)
+    return res.data
+  },
+
+  // ─── Members ──────────────────────────────────────────
+
+  async getWorkspaceMembers(http: HttpClient, workspaceId: string) {
+    const res = await http.get<{ ok: boolean; items?: Array<{ user?: { id: string; name?: string; email?: string } }> }>(
+      `/api/members?workspaceId=${workspaceId}`,
+    )
+    return res.data?.items ?? []
+  },
+
+  // ─── Invitations ──────────────────────────────────────
+
+  async getReceivedInvitations(http: HttpClient, email: string) {
+    const res = await http.get<{ ok: boolean; items?: any[] }>(
+      `/api/invitations?email=${encodeURIComponent(email)}`,
+    )
+    return (res.data?.items ?? []).filter((i: any) => i.status === 'pending')
+  },
+
+  // ─── Account ──────────────────────────────────────────
+
+  async deleteAccount(http: HttpClient, userId: string) {
+    const res = await http.delete<{ ok: boolean }>(`/api/users/${userId}`)
+    return res.data
+  },
+
   // ─── Admin ───────────────────────────────────────────────
 
   async getMe(http: HttpClient) {

--- a/packages/domain-stores/src/domain-actions.ts
+++ b/packages/domain-stores/src/domain-actions.ts
@@ -181,35 +181,51 @@ export function createDomainActions(store: IDomainStore) {
     // =========================================================================
 
     /**
-     * Accept an invitation and create membership
+     * Accept an invitation and create membership.
+     * Pass invitationData when the invitation was loaded outside the
+     * collection (e.g. received invitations fetched by email) so the
+     * action has the data needed for membership creation.
      */
-    acceptInvitation: async (invitationId: string, userId: string) => {
-      const invitation = store.invitationCollection.get(invitationId)
+    acceptInvitation: async (
+      invitationId: string,
+      userId: string,
+      invitationData?: { workspaceId: string; role: string; projectId?: string },
+    ) => {
+      // Ensure the invitation is in the local collection
+      let invitation = store.invitationCollection.get(invitationId)
       if (!invitation) {
+        await store.invitationCollection.loadById(invitationId)
+        invitation = store.invitationCollection.get(invitationId)
+      }
+
+      const data = invitation ?? invitationData
+      if (!data) {
         throw new Error("Invitation not found")
       }
 
-      // 1. Update invitation status
       await store.invitationCollection.update(invitationId, {
         status: "accepted",
       })
 
-      // 2. Create membership based on invitation
       await store.memberCollection.create({
         userId,
-        workspaceId: invitation.workspaceId,
-        role: invitation.role as any,
+        workspaceId: data.workspaceId,
+        role: data.role as any,
         isBillingAdmin: false,
-        ...(invitation.projectId ? { projectId: invitation.projectId } : {}),
+        ...(data.projectId ? { projectId: data.projectId } : {}),
       })
 
-      return invitation
+      return data
     },
 
     /**
-     * Decline an invitation
+     * Decline an invitation.
+     * Loads the invitation into the collection first if not already present.
      */
     declineInvitation: async (invitationId: string) => {
+      if (!store.invitationCollection.get(invitationId)) {
+        await store.invitationCollection.loadById(invitationId)
+      }
       return store.invitationCollection.update(invitationId, {
         status: "declined",
       })
@@ -362,18 +378,12 @@ export function createDomainActions(store: IDomainStore) {
     // =========================================================================
 
     /**
-     * Delete workspace with all members
+     * Delete workspace — members, projects, etc. are cascade-deleted by the DB.
+     * Do NOT delete members before the workspace: the API beforeDelete hook
+     * verifies the caller is still an owner/member, so removing your own
+     * membership first causes a 400 "Access denied".
      */
     deleteWorkspaceWithMembers: async (workspaceId: string) => {
-      // Delete all members first
-      const members = store.memberCollection.all.filter(
-        (m: any) => m.workspaceId === workspaceId && !m.projectId
-      )
-      for (const member of members) {
-        await store.memberCollection.delete(member.id)
-      }
-
-      // Then delete workspace
       return store.workspaceCollection.delete(workspaceId)
     },
 


### PR DESCRIPTION
…cline

- Replace all raw http.patch/post/delete/get calls in settings.tsx and AppSidebar.tsx with SDK domain actions and api helpers
- Add leaveWorkspace, deleteAccount, getWorkspaceMembers, and getReceivedInvitations helpers to lib/api.ts
- Fix acceptInvitation/declineInvitation domain actions to load invitations into collection via loadById before updating, so received invitations from other workspaces work correctly
- Fix deleteWorkspaceWithMembers — let DB cascade handle member cleanup instead of deleting members first (which removed the caller's own membership and caused a 400 on workspace delete)