### PR TITLE
Added message editing with file revert and canvas reset

### DIFF
--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -197,6 +197,10 @@ export default observer(function ProjectLayout() {
     [applyMessage],
   )
 
+  const handleEditReset = useCallback(() => {
+    applyMessage({ type: 'clearAll' })
+  }, [applyMessage])
+
   // Auto-capture thumbnail when the agent finishes building the canvas UI (web only).
   const thumbnailCapturedRef = useRef(false)
   const hasCanvasUI = activeSurface && activeSurface.components.size > 0 && activeSurface.components.has('root')
@@ -448,6 +452,7 @@ export default observer(function ProjectLayout() {
       initialImageData={capturedInitialImageData}
       billingData={billingData}
       onCanvasPreview={handleCanvasPreview}
+      onEditReset={handleEditReset}
       className="flex-1"
     />
   )

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -42,6 +42,7 @@ import {
 } from "@shogo/shared-app/chat"
 import { useChatTransportConfig } from "@shogo/shared-app/chat"
 import { useSDKDomains, useDomainActions } from "@shogo/shared-app/domain"
+import { useCheckpoints } from "@shogo/shared-app"
 import { cn } from "@shogo/shared-ui/primitives"
 import { API_URL } from "../../lib/api"
 import { authClient } from "../../lib/auth-client"
@@ -184,6 +185,8 @@ export interface ChatPanelProps {
   projectType?: "APP" | "AGENT"
   /** Called with canvas preview components streamed through the chat channel */
   onCanvasPreview?: (surfaceId: string, components: any[]) => void
+  /** Called when user edits a message — parent should reset canvas/runtime state */
+  onEditReset?: () => void
   /** Legacy domain stores (platformFeatures, componentBuilder) — optional on mobile */
   legacyDomains?: {
     platformFeatures?: any
@@ -508,11 +511,15 @@ export const ChatPanel = observer(function ChatPanel({
   onCreateTheme,
   projectType,
   onCanvasPreview,
+  onEditReset,
   legacyDomains,
   billingData,
 }: ChatPanelProps) {
   const { studioChat } = useSDKDomains()
   const actions = useDomainActions()
+  const { createCheckpoint, rollback: rollbackCheckpoint } = useCheckpoints(projectId)
+
+  const preMessageCheckpointsRef = useRef<string[]>([])
 
   const platformFeatures = legacyDomains?.platformFeatures
   const componentBuilder = legacyDomains?.componentBuilder
@@ -1690,6 +1697,14 @@ export const ChatPanel = observer(function ChatPanel({
         })
       })
 
+      // Auto-checkpoint: snapshot project state before the agent makes changes
+      const cp = await createCheckpoint({
+        message: `Pre-message: ${trimmedContent.slice(0, 80)}`,
+      })
+      if (cp?.id) {
+        preMessageCheckpointsRef.current.push(cp.id)
+      }
+
       isSendingMessageRef.current = true
 
       actions
@@ -1750,6 +1765,7 @@ export const ChatPanel = observer(function ChatPanel({
       projectId,
       agentMode,
       actions,
+      createCheckpoint,
     ]
   )
 
@@ -1796,6 +1812,7 @@ export const ChatPanel = observer(function ChatPanel({
       setMessageQueue([])
       isProcessingQueueRef.current = false
     }
+    preMessageCheckpointsRef.current = []
   }, [currentSessionId])
 
   const handleRemoveQueuedMessage = useCallback((messageId: string) => {
@@ -1923,6 +1940,78 @@ export const ChatPanel = observer(function ChatPanel({
     }
   }, [messages, sendMessage, setMessages])
 
+  // Edit message: revert files, clear canvas/agent context, delete messages, resend
+  const handleEditMessage = useCallback(
+    async (messageId: string, newContent: string) => {
+      if (!currentSessionId || isStreaming) return
+      if (!newContent.trim()) return
+
+      const messageIndex = messages.findIndex((m) => m.id === messageId)
+      if (messageIndex === -1) return
+
+      setMessages(messages.slice(0, messageIndex))
+      setMessageQueue([])
+      isSendingMessageRef.current = true
+
+      try {
+        // 1. Rollback project files to pre-message checkpoint
+        const userMsgCountBeforeEdit = messages
+          .slice(0, messageIndex + 1)
+          .filter((m) => m.role === "user").length
+        const checkpointIdx = userMsgCountBeforeEdit - 1
+        const checkpointId = preMessageCheckpointsRef.current[checkpointIdx]
+
+        if (checkpointId) {
+          const success = await rollbackCheckpoint(checkpointId)
+          if (success) {
+            preMessageCheckpointsRef.current = preMessageCheckpointsRef.current.slice(0, checkpointIdx)
+          }
+        }
+
+        // 2. Wipe agent context so next message starts a fresh session
+        ccSessionIdRef.current = undefined
+        setCcSessionId(undefined)
+        if (currentSessionId) {
+          studioChat.chatSessionCollection
+            .update(currentSessionId, { claudeCodeSessionId: undefined })
+            .catch(() => {})
+        }
+
+        // 3. Clear canvas surfaces + refresh file tree
+        onEditReset?.()
+        onFilesChanged?.(["*"])
+
+        // 4. Delete chat messages from DB
+        try {
+          await studioChat.chatMessageCollection.loadAll({ sessionId: currentSessionId })
+        } catch {
+          // Continue with existing store data
+        }
+
+        const allPersisted = studioChat.chatMessageCollection.all
+          .filter((msg: any) => msg.sessionId === currentSessionId)
+          .sort((a: any, b: any) => (a.createdAt || 0) - (b.createdAt || 0))
+
+        let cutoffIdx = allPersisted.findIndex((m: any) => m.id === messageId)
+        if (cutoffIdx === -1) {
+          cutoffIdx = Math.min(messageIndex, allPersisted.length)
+        }
+
+        await Promise.allSettled(
+          allPersisted.slice(cutoffIdx).map((msg: any) =>
+            studioChat.chatMessageCollection.delete(msg.id)
+          )
+        )
+      } catch (err) {
+        console.warn("[ChatPanel] Error during edit cleanup:", err)
+      }
+
+      // 5. Send the edited message (keeps isSendingMessageRef true throughout)
+      await sendMessageInternal(newContent.trim())
+    },
+    [currentSessionId, isStreaming, messages, setMessages, sendMessageInternal, studioChat, rollbackCheckpoint, onFilesChanged, onEditReset]
+  )
+
   const messageListMessages = messages.map((msg) => ({
     id: msg.id,
     role: msg.role as "user" | "assistant",
@@ -2010,6 +2099,7 @@ export const ChatPanel = observer(function ChatPanel({
                 }
                 recentTools={recentTools as RecentToolType[]}
                 subagentToolCalls={accumulatedSubagentTools}
+                onEditMessage={handleEditMessage}
               />
             ) : !isStreaming && !isInitialLoadComplete && currentSessionId ? (
               <View className="flex-col items-center justify-center flex-1 gap-3">

--- a/apps/mobile/components/chat/turns/TurnGroup.tsx
+++ b/apps/mobile/components/chat/turns/TurnGroup.tsx
@@ -3,12 +3,13 @@
  *
  * Container for a complete conversation turn (user message + tool calls + assistant response).
  * Renders tool calls interleaved within assistant content.
+ * Supports inline message editing (ChatGPT/Cursor-style).
  */
 
-import { useState, useCallback } from "react"
-import { View, Text, Pressable } from "react-native"
+import { useState, useCallback, useRef, useEffect } from "react"
+import { View, Text, Pressable, TextInput, Platform, type NativeSyntheticEvent, type TextInputKeyPressEventData } from "react-native"
 import * as Clipboard from "expo-clipboard"
-import { Copy, Check } from "lucide-react-native"
+import { Copy, Check, Pencil, X, ArrowUp } from "lucide-react-native"
 import { cn } from "@shogo/shared-ui/primitives"
 import { usePhaseColor } from "@/hooks/usePhaseColor"
 import type { ConversationTurn } from "./types"
@@ -24,6 +25,8 @@ export interface TurnGroupProps {
   activeSubagents?: SubagentProgress[]
   recentTools?: RecentTool[]
   showToolTimeline?: boolean
+  onEditMessage?: (messageId: string, newContent: string) => void
+  isStreaming?: boolean
   className?: string
 }
 
@@ -59,15 +62,118 @@ function CopyButton({ text, className }: { text: string; className?: string }) {
   )
 }
 
+function EditableUserMessage({
+  messageId,
+  originalText,
+  onSubmit,
+  onCancel,
+}: {
+  messageId: string
+  originalText: string
+  onSubmit: (messageId: string, newContent: string) => void
+  onCancel: () => void
+}) {
+  const [editText, setEditText] = useState(originalText)
+  const inputRef = useRef<TextInput>(null)
+
+  useEffect(() => {
+    setTimeout(() => inputRef.current?.focus(), 100)
+  }, [])
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = editText.trim()
+    if (trimmed) {
+      onSubmit(messageId, trimmed)
+    } else {
+      onCancel()
+    }
+  }, [editText, messageId, onSubmit, onCancel])
+
+  return (
+    <View className="max-w-[85%] ml-auto gap-2">
+      <View className="rounded-xl border border-primary/40 bg-muted/50 overflow-hidden">
+        <TextInput
+          ref={inputRef}
+          value={editText}
+          onChangeText={setEditText}
+          multiline
+          className="px-3 py-2 text-xs text-foreground min-h-[40px] max-h-[200px] outline-none"
+          textAlignVertical="top"
+          onKeyPress={(e: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
+            const nativeEvent = e.nativeEvent as TextInputKeyPressEventData & { shiftKey?: boolean }
+            if (Platform.OS === "web" && nativeEvent.key === "Enter" && !nativeEvent.shiftKey) {
+              e.preventDefault?.()
+              handleSubmit()
+            }
+          }}
+        />
+      </View>
+      <View className="flex-row justify-end gap-2">
+        <Pressable
+          onPress={onCancel}
+          className="flex-row items-center gap-1.5 rounded-lg border border-border px-3 py-1.5"
+        >
+          <X className="h-3 w-3 text-muted-foreground" size={12} />
+          <Text className="text-xs text-muted-foreground font-medium">
+            Cancel
+          </Text>
+        </Pressable>
+        <Pressable
+          onPress={handleSubmit}
+          disabled={!editText.trim()}
+          className={cn(
+            "flex-row items-center gap-1.5 rounded-lg px-3 py-1.5 bg-primary",
+            !editText.trim() && "opacity-50"
+          )}
+        >
+          <ArrowUp className="h-3 w-3 text-primary-foreground" size={12} />
+          <Text className="text-xs text-primary-foreground font-medium">
+            Send
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  )
+}
+
 export function TurnGroup({
   turn,
   phase,
   activeSubagents = [],
   recentTools = [],
   showToolTimeline = false,
+  onEditMessage,
+  isStreaming = false,
   className,
 }: TurnGroupProps) {
   const colors = usePhaseColor(phase || "")
+  const [isEditing, setIsEditing] = useState(false)
+  const [isHovered, setIsHovered] = useState(false)
+
+  const canEdit = !!onEditMessage && !isStreaming && !!turn.userMessage
+
+  const handleStartEdit = useCallback(() => {
+    if (canEdit) setIsEditing(true)
+  }, [canEdit])
+
+  const handleCancelEdit = useCallback(() => {
+    setIsEditing(false)
+  }, [])
+
+  const handleSubmitEdit = useCallback(
+    (messageId: string, newContent: string) => {
+      onEditMessage?.(messageId, newContent)
+    },
+    [onEditMessage]
+  )
+
+  const hoverHandlers: Record<string, () => void> =
+    Platform.OS === "web" && canEdit
+      ? {
+          onMouseEnter: () => setIsHovered(true),
+          onMouseLeave: () => setIsHovered(false),
+        }
+      : {}
 
   return (
     <View
@@ -80,10 +186,36 @@ export function TurnGroup({
       {/* User message */}
       {turn.userMessage && (
         <View className="gap-0.5">
-          <MessageContent message={turn.userMessage} />
-          <View className="flex-row justify-end">
-            <CopyButton text={extractTextContent(turn.userMessage)} />
-          </View>
+          {isEditing ? (
+            <EditableUserMessage
+              messageId={turn.userMessage.id}
+              originalText={extractTextContent(turn.userMessage)}
+              onSubmit={handleSubmitEdit}
+              onCancel={handleCancelEdit}
+            />
+          ) : (
+            <View {...hoverHandlers}>
+              <MessageContent message={turn.userMessage} />
+              <View className="flex-row justify-end items-center gap-0.5">
+                {canEdit && (
+                  <Pressable
+                    onPress={handleStartEdit}
+                    className={cn(
+                      "items-center justify-center rounded-md p-1",
+                      Platform.OS === "web" && !isHovered && "opacity-0"
+                    )}
+                    accessibilityLabel="Edit message"
+                  >
+                    <Pencil
+                      className="h-3.5 w-3.5 text-muted-foreground"
+                      size={14}
+                    />
+                  </Pressable>
+                )}
+                <CopyButton text={extractTextContent(turn.userMessage)} />
+              </View>
+            </View>
+          )}
         </View>
       )}
 

--- a/apps/mobile/components/chat/turns/TurnList.tsx
+++ b/apps/mobile/components/chat/turns/TurnList.tsx
@@ -19,6 +19,7 @@ export interface TurnListProps {
   activeSubagents?: SubagentProgress[]
   recentTools?: RecentTool[]
   subagentToolCalls?: ToolCallData[]
+  onEditMessage?: (messageId: string, newContent: string) => void
   className?: string
 }
 
@@ -29,6 +30,7 @@ export function TurnList({
   activeSubagents = [],
   recentTools = [],
   subagentToolCalls,
+  onEditMessage,
   className,
 }: TurnListProps) {
   const turns = useTurnGrouping(messages, isStreaming, subagentToolCalls)
@@ -42,6 +44,8 @@ export function TurnList({
           phase={phase}
           activeSubagents={index === turns.length - 1 ? activeSubagents : []}
           recentTools={index === turns.length - 1 ? recentTools : []}
+          onEditMessage={onEditMessage}
+          isStreaming={isStreaming}
         />
       ))}
     </View>

--- a/packages/shared-app/src/dynamic-app/types.ts
+++ b/packages/shared-app/src/dynamic-app/types.ts
@@ -97,6 +97,10 @@ export interface ConfigureApiMessage {
   }>
 }
 
+export interface ClearAllMessage {
+  type: 'clearAll'
+}
+
 export type DynamicAppMessage =
   | CreateSurfaceMessage
   | UpdateComponentsMessage
@@ -104,6 +108,7 @@ export type DynamicAppMessage =
   | DeleteSurfaceMessage
   | DeleteComponentsMessage
   | ConfigureApiMessage
+  | ClearAllMessage
 
 // ---------------------------------------------------------------------------
 // Surface State (client-side)

--- a/packages/shared-app/src/hooks/useCheckpoints.ts
+++ b/packages/shared-app/src/hooks/useCheckpoints.ts
@@ -6,9 +6,13 @@
  * - Create new checkpoints
  * - Rollback to previous checkpoints
  * - Get checkpoint diffs
+ *
+ * Uses the SDK HttpClient (via useSDKHttp) for all API calls, ensuring
+ * correct base URL and auth in both dev and production.
  */
 
-import { useState, useEffect, useCallback, useMemo } from "react"
+import { useState, useEffect, useCallback } from "react"
+import { useSDKHttp } from "../domain"
 
 /**
  * Checkpoint data from the API
@@ -64,48 +68,49 @@ export interface CheckpointDiff {
  * Return type for useCheckpoints hook
  */
 export interface CheckpointsState {
-  /** List of checkpoints for the project */
   checkpoints: Checkpoint[]
-  /** Git status for the project */
   gitStatus: GitStatus | null
-  /** Whether data is loading */
   isLoading: boolean
-  /** Whether a mutation is in progress */
   isMutating: boolean
-  /** Error state */
   error: Error | null
-  /** Create a new checkpoint */
   createCheckpoint: (options: {
     message: string
     name?: string
     description?: string
     includeDatabase?: boolean
   }) => Promise<Checkpoint | null>
-  /** Rollback to a checkpoint */
   rollback: (checkpointId: string, includeDatabase?: boolean) => Promise<boolean>
-  /** Get diff for a checkpoint */
   getDiff: (checkpointId: string) => Promise<CheckpointDiff | null>
-  /** Refetch checkpoints */
   refetch: () => void
+}
+
+interface CheckpointsApiResponse {
+  ok?: boolean
+  checkpoints?: Array<Checkpoint & { message?: string }>
+  hasMore?: boolean
+}
+
+interface CheckpointCreateResponse {
+  ok?: boolean
+  checkpoint?: Checkpoint
+}
+
+interface GitStatusResponse extends GitStatus {
+  ok?: boolean
 }
 
 /**
  * Hook for managing project checkpoints (version control).
  *
- * @param projectId - The project to manage checkpoints for
- *
  * @example
  * ```tsx
- * const { checkpoints, createCheckpoint, rollback, isLoading } = useCheckpoints(projectId)
- *
- * // Create a checkpoint
+ * const { checkpoints, createCheckpoint, rollback } = useCheckpoints(projectId)
  * await createCheckpoint({ message: "Added authentication" })
- *
- * // Rollback to a previous checkpoint
  * await rollback(checkpointId)
  * ```
  */
 export function useCheckpoints(projectId: string | undefined): CheckpointsState {
+  const http = useSDKHttp()
   const [checkpoints, setCheckpoints] = useState<Checkpoint[]>([])
   const [gitStatus, setGitStatus] = useState<GitStatus | null>(null)
   const [isLoading, setIsLoading] = useState(false)
@@ -113,7 +118,6 @@ export function useCheckpoints(projectId: string | undefined): CheckpointsState 
   const [error, setError] = useState<Error | null>(null)
   const [refetchCounter, setRefetchCounter] = useState(0)
 
-  // Fetch checkpoints
   useEffect(() => {
     if (!projectId) {
       setCheckpoints([])
@@ -128,51 +132,40 @@ export function useCheckpoints(projectId: string | undefined): CheckpointsState 
       setError(null)
 
       try {
-        // Fetch checkpoints and git status in parallel
-        const [checkpointsRes, statusRes] = await Promise.all([
-          fetch(`/api/projects/${projectId}/checkpoints`),
-          fetch(`/api/projects/${projectId}/git/status`),
+        const [checkpointsRes, statusRes] = await Promise.allSettled([
+          http.get<CheckpointsApiResponse>(`/api/projects/${projectId}/checkpoints`),
+          http.get<GitStatusResponse>(`/api/projects/${projectId}/git/status`),
         ])
 
         if (cancelled) return
 
-        if (checkpointsRes.ok) {
-          const data: any = await checkpointsRes.json()
-          const mappedCheckpoints = (data.checkpoints || []).map((cp: any) => ({
+        if (checkpointsRes.status === "fulfilled" && checkpointsRes.value.data?.checkpoints) {
+          const mapped = checkpointsRes.value.data.checkpoints.map((cp) => ({
             ...cp,
             commitMessage: cp.message || cp.commitMessage,
           }))
-          setCheckpoints(mappedCheckpoints)
+          setCheckpoints(mapped)
         } else {
-          // Checkpoints endpoint may not exist if no git repo yet
           setCheckpoints([])
         }
 
-        if (statusRes.ok) {
-          const data: any = await statusRes.json()
-          setGitStatus(data as GitStatus)
+        if (statusRes.status === "fulfilled" && statusRes.value.data) {
+          setGitStatus(statusRes.value.data as GitStatus)
         } else {
           setGitStatus(null)
         }
       } catch (err) {
         if (cancelled) return
-        console.error("[useCheckpoints] Error fetching checkpoints:", err)
         setError(err instanceof Error ? err : new Error("Failed to fetch checkpoints"))
       } finally {
-        if (!cancelled) {
-          setIsLoading(false)
-        }
+        if (!cancelled) setIsLoading(false)
       }
     }
 
     fetchCheckpoints()
+    return () => { cancelled = true }
+  }, [projectId, http, refetchCounter])
 
-    return () => {
-      cancelled = true
-    }
-  }, [projectId, refetchCounter])
-
-  // Create checkpoint
   const createCheckpoint = useCallback(
     async (options: {
       message: string
@@ -186,32 +179,27 @@ export function useCheckpoints(projectId: string | undefined): CheckpointsState 
       setError(null)
 
       try {
-        const response = await fetch(`/api/projects/${projectId}/checkpoints`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(options),
-        })
+        const res = await http.post<CheckpointCreateResponse>(
+          `/api/projects/${projectId}/checkpoints`,
+          options
+        )
 
-        if (!response.ok) {
-          const errorData: any = await response.json()
-          throw new Error(errorData.error?.message || "Failed to create checkpoint")
+        if (!res.data?.ok || !res.data.checkpoint) {
+          throw new Error("Failed to create checkpoint")
         }
 
-        const data: any = await response.json()
-        setCheckpoints((prev) => [data.checkpoint, ...prev])
-        return data.checkpoint
+        setCheckpoints((prev) => [res.data!.checkpoint!, ...prev])
+        return res.data.checkpoint
       } catch (err) {
-        console.error("[useCheckpoints] Error creating checkpoint:", err)
         setError(err instanceof Error ? err : new Error("Failed to create checkpoint"))
         return null
       } finally {
         setIsMutating(false)
       }
     },
-    [projectId]
+    [projectId, http]
   )
 
-  // Rollback to checkpoint
   const rollback = useCallback(
     async (checkpointId: string, includeDatabase?: boolean): Promise<boolean> => {
       if (!projectId) return false
@@ -220,60 +208,43 @@ export function useCheckpoints(projectId: string | undefined): CheckpointsState 
       setError(null)
 
       try {
-        const response = await fetch(
+        const res = await http.post<{ ok?: boolean }>(
           `/api/projects/${projectId}/checkpoints/${checkpointId}/rollback`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ includeDatabase }),
-          }
+          { includeDatabase }
         )
 
-        if (!response.ok) {
-          const errorData: any = await response.json()
-          throw new Error(errorData.error?.message || "Failed to rollback")
+        if (!res.data?.ok) {
+          throw new Error("Failed to rollback")
         }
 
-        // Refetch checkpoints after rollback
         setRefetchCounter((c) => c + 1)
-        
         return true
       } catch (err) {
-        console.error("[useCheckpoints] Error rolling back:", err)
         setError(err instanceof Error ? err : new Error("Failed to rollback"))
         return false
       } finally {
         setIsMutating(false)
       }
     },
-    [projectId]
+    [projectId, http]
   )
 
-  // Get diff for checkpoint
   const getDiff = useCallback(
     async (checkpointId: string): Promise<CheckpointDiff | null> => {
       if (!projectId) return null
 
       try {
-        const response = await fetch(
+        const res = await http.get<CheckpointDiff>(
           `/api/projects/${projectId}/checkpoints/${checkpointId}/diff`
         )
-
-        if (!response.ok) {
-          return null
-        }
-
-        const data: any = await response.json()
-        return data as CheckpointDiff
-      } catch (err) {
-        console.error("[useCheckpoints] Error getting diff:", err)
+        return res.data ?? null
+      } catch {
         return null
       }
     },
-    [projectId]
+    [projectId, http]
   )
 
-  // Refetch function
   const refetch = useCallback(() => {
     setRefetchCounter((c) => c + 1)
   }, [])


### PR DESCRIPTION
Enable editing any user message in a completed chat conversation. Editing truncates the conversation from that point, reverts project files via git checkpoint rollback, clears the canvas/dynamic-app surfaces, wipes the agent session context, and resends the edited message for a fresh response — matching ChatGPT/Cursor edit behavior.

- TurnGroup: inline edit UI with pencil icon (hover-reveal on web), editable textarea, Cancel/Send buttons, Enter key support
- TurnList: forward onEditMessage + isStreaming props
- ChatPanel: handleEditMessage orchestrates the full edit flow — auto-checkpoint before each message, SDK-based message deletion, checkpoint rollback, CC session clear, canvas reset callback
- _layout: handleEditReset clears dynamic-app surfaces via clearAll
- types: add ClearAllMessage to DynamicAppMessage union
