### PR TITLE
fix: code block copy button and horizontal scroll in web chat

### DIFF
--- a/apps/mobile/components/chat/MarkdownText.web.tsx
+++ b/apps/mobile/components/chat/MarkdownText.web.tsx
@@ -1,5 +1,6 @@
-import React, { memo } from "react"
+import React, { memo, useRef, useEffect, useCallback } from "react"
 import { Streamdown } from "streamdown"
+import { code } from "@streamdown/code"
 import "streamdown/styles.css"
 
 export interface MarkdownTextProps {
@@ -9,17 +10,84 @@ export interface MarkdownTextProps {
 }
 
 const linkSafetyOff = { enabled: false as const }
+const plugins = { code }
 
 export const MarkdownText = memo(
   function MarkdownText({ children, className, isStreaming }: MarkdownTextProps) {
+    const containerRef = useRef<HTMLDivElement>(null)
+
+    const handleClick = useCallback((e: MouseEvent) => {
+      const container = containerRef.current
+      if (!container) return
+
+      const { clientX: x, clientY: y } = e
+
+      // Check copy buttons by bounding rect since CSS stacking prevents normal hit-testing
+      const copyBtns = container.querySelectorAll<HTMLElement>(
+        '[data-streamdown="code-block-copy-button"]'
+      )
+      for (const btn of copyBtns) {
+        const r = btn.getBoundingClientRect()
+        if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) {
+          e.preventDefault()
+          e.stopPropagation()
+
+          const codeBlock = btn.closest('[data-streamdown="code-block"]')
+          const pre = codeBlock?.querySelector("pre")
+          const text = pre?.textContent ?? ""
+          if (!text) return
+
+          navigator.clipboard.writeText(text).then(() => {
+            btn.dataset.copied = "true"
+
+            const rect = btn.getBoundingClientRect()
+            const tip = document.createElement("span")
+            tip.textContent = "Copied!"
+            tip.className = "sdw-copy-toast"
+            tip.style.top = `${rect.top + rect.height / 2}px`
+            tip.style.left = `${rect.left - 6}px`
+            document.body.appendChild(tip)
+
+            setTimeout(() => {
+              delete btn.dataset.copied
+              tip.remove()
+            }, 1500)
+          }).catch(() => {})
+          return
+        }
+      }
+
+      // Also check download buttons
+      const dlBtns = container.querySelectorAll<HTMLElement>(
+        '[data-streamdown="code-block-download-button"]'
+      )
+      for (const btn of dlBtns) {
+        const r = btn.getBoundingClientRect()
+        if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) {
+          btn.click()
+          return
+        }
+      }
+    }, [])
+
+    useEffect(() => {
+      const el = containerRef.current
+      if (!el) return
+      el.addEventListener("click", handleClick, true)
+      return () => el.removeEventListener("click", handleClick, true)
+    }, [handleClick])
+
     return (
-      <Streamdown
-        className={className}
-        isAnimating={isStreaming}
-        linkSafety={linkSafetyOff}
-      >
-        {children || ""}
-      </Streamdown>
+      <div ref={containerRef}>
+        <Streamdown
+          className={className}
+          isAnimating={isStreaming}
+          linkSafety={linkSafetyOff}
+          plugins={plugins}
+        >
+          {children || ""}
+        </Streamdown>
+      </div>
     )
   },
   (prev, next) =>

--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -2,6 +2,45 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Streamdown code blocks: ensure scroll + proper sizing inside prose containers */
+.prose pre,
+.prose-sm pre {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+/* Code block copy button: visual feedback on successful copy */
+[data-streamdown="code-block-copy-button"][data-copied="true"] {
+  color: rgb(var(--color-primary));
+}
+
+.sdw-copy-toast {
+  position: fixed;
+  transform: translateY(-50%) translateX(-100%);
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: rgb(var(--color-muted));
+  color: rgb(var(--color-muted-foreground));
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 9999;
+  border: 1px solid rgb(var(--color-border));
+  animation: sdw-toast-in 150ms ease both;
+}
+
+@keyframes sdw-toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(-50%) translateX(-90%);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(-50%) translateX(-100%);
+  }
+}
+
 :root {
   --color-background: 255 255 255;
   --color-foreground: 10 10 10;

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -33,6 +33,7 @@
     "@shogo/shared-ui": "workspace:*",
     "@shogo/ui-kit": "workspace:*",
     "@stardazed/streams-text-encoding": "^1.0.2",
+    "@streamdown/code": "^1.0.3",
     "@ungap/structured-clone": "^1.3.0",
     "ai": "^6.0.97",
     "better-auth": "^1.2.9",

--- a/bun.lock
+++ b/bun.lock
@@ -96,6 +96,7 @@
         "@shogo/shared-ui": "workspace:*",
         "@shogo/ui-kit": "workspace:*",
         "@stardazed/streams-text-encoding": "^1.0.2",
+        "@streamdown/code": "^1.0.3",
         "@ungap/structured-clone": "^1.3.0",
         "ai": "^6.0.97",
         "better-auth": "^1.2.9",
@@ -1486,6 +1487,20 @@
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
+    "@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
+
+    "@shikijs/langs": ["@shikijs/langs@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg=="],
+
+    "@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
+
+    "@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@shogo-ai/sdk": ["@shogo-ai/sdk@workspace:packages/sdk"],
 
     "@shogo/agent-runtime": ["@shogo/agent-runtime@workspace:packages/agent-runtime"],
@@ -1621,6 +1636,8 @@
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@stardazed/streams-text-encoding": ["@stardazed/streams-text-encoding@1.0.2", "", {}, "sha512-f2Z15BId3t44a/u21yYSGXFAkCyKocmAyduoAy7swnZ4xIfbaZlOWsgly/jDNNOuj6hYQN72UaBRe3Z/tOHfqg=="],
+
+    "@streamdown/code": ["@streamdown/code@1.0.3", "", { "dependencies": { "shiki": "^3.19.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-3Ym5TCLcGhrHY2qBaUVWpqNRtxnZvqh4Y5Qm/pTIKA4AmEWwAAoYjZnxG7mOsvOpWVWiDwETjUtchNL1XzQEAw=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.19", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA=="],
 
@@ -2342,6 +2359,8 @@
 
     "hast-util-sanitize": ["hast-util-sanitize@5.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "unist-util-position": "^5.0.0" } }, "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg=="],
 
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
     "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
@@ -2864,6 +2883,10 @@
 
     "onetime": ["onetime@2.0.1", "", { "dependencies": { "mimic-fn": "^1.0.0" } }, "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ=="],
 
+    "oniguruma-parser": ["oniguruma-parser@0.12.1", "", {}, "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.4", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA=="],
+
     "open": ["open@7.4.2", "", { "dependencies": { "is-docker": "^2.0.0", "is-wsl": "^2.1.1" } }, "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q=="],
 
     "openai": ["openai@6.25.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-mEh6VZ2ds2AGGokWARo18aPISI1OhlgdEIC1ewhkZr8pSIT31dec0ecr9Nhxx0JlybyOgoAT1sWeKtwPZzJyww=="],
@@ -3114,6 +3137,12 @@
 
     "regenerator-runtime": ["regenerator-runtime@0.13.11", "", {}, "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="],
 
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
     "regexp-to-ast": ["regexp-to-ast@0.5.0", "", {}, "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="],
 
     "regexpu-core": ["regexpu-core@6.4.0", "", { "dependencies": { "regenerate": "^1.4.2", "regenerate-unicode-properties": "^10.2.2", "regjsgen": "^0.8.0", "regjsparser": "^0.13.0", "unicode-match-property-ecmascript": "^2.0.0", "unicode-match-property-value-ecmascript": "^2.2.1" } }, "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA=="],
@@ -3217,6 +3246,8 @@
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+
+    "shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
 
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 


### PR DESCRIPTION

<img width="918" height="932" alt="image" src="https://github.com/user-attachments/assets/472281ee-6b4c-4800-9839-3882f0d04447" />

Streamdown's copy button was unreachable due to CSS stacking issues in React Native Web. Added coordinate-based click interception with clipboard copy and theme-aware "Copied!" toast. Also enabled syntax highlighting via @streamdown/code and horizontal scroll for long code.
