### PR TITLE
fix: pass pg.Pool directly to PrismaPg constructor instead of wrappin…

### DIFF
--- a/apps/api/src/lib/prisma.ts
+++ b/apps/api/src/lib/prisma.ts
@@ -113,7 +113,7 @@ async function createPrismaClient(): Promise<PrismaClient> {
     idleTimeoutMillis: 30_000,
     connectionTimeoutMillis: 10_000,
   })
-  const adapter = new PrismaPg({ pool })
+  const adapter = new PrismaPg(pool)
   return new PrismaClient({ adapter, log: [...logConfig] })
 }
 


### PR DESCRIPTION
Issue: On line 116, new PrismaPg({ pool }) wraps the pool in an object, but PrismaPg's constructor expects (poolOrConfig: pg.Pool | pg.PoolConfig) as a direct argument. So it treats { pool } as a malformed PoolConfig and every DB query fails with ECONNREFUSED. All /api/workspaces, /api/projects etc. return 500s.
Fix: Changed new PrismaPg({ pool }) → new PrismaPg(pool)