### PR TITLE
connect button bug fix when agent installs 2+ composio tools

### DIFF
--- a/apps/mobile/components/chat/turns/AssistantContent.tsx
+++ b/apps/mobile/components/chat/turns/AssistantContent.tsx
@@ -120,7 +120,7 @@ function extractOrderedParts(message: UIMessage): MessagePart[] {
   return result
 }
 
-const UNGROUPABLE_TOOLS = new Set(["AskUserQuestion", "TodoWrite"])
+const UNGROUPABLE_TOOLS = new Set(["AskUserQuestion", "TodoWrite", "tool_install"])
 const MIN_GROUP_SIZE = 2
 
 function groupConsecutiveParts(parts: MessagePart[]): GroupedMessagePart[] {


### PR DESCRIPTION

Summary
When the agent installs 2+ Composio tools back-to-back, the consecutive tool_install results were grouped into a ToolCallGroup by groupConsecutiveParts, which doesn't render ConnectToolWidget. This hid the OAuth Connect buttons from users, making all multi-tool agents appear broken.
Added "tool_install" to UNGROUPABLE_TOOLS so each install renders individually and the Connect/OAuth button is visible.
Test plan
Create an agent that installs two Composio tools (e.g. Google Calendar + Slack)
Verify Connect buttons appear for both tools in the chat
Complete OAuth flow and verify tools work end-to-end