### PR TITLE
Revert K8s TLS verification change

### DIFF
--- a/apps/api/src/lib/k8s-auth.ts
+++ b/apps/api/src/lib/k8s-auth.ts
@@ -24,11 +24,11 @@ function getKubeConfig(): k8s.KubeConfig {
     require('fs').existsSync(caPath) &&
     require('fs').existsSync(tokenPath)
   ) {
-    const ca = require('fs').readFileSync(caPath, 'utf8')
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
     const token = require('fs').readFileSync(tokenPath, 'utf8')
     const host = `https://${process.env.KUBERNETES_SERVICE_HOST}:${process.env.KUBERNETES_SERVICE_PORT}`
     kc.loadFromOptions({
-      clusters: [{ name: 'in-cluster', server: host, caData: Buffer.from(ca).toString('base64') }],
+      clusters: [{ name: 'in-cluster', server: host, skipTLSVerify: true }],
       users: [{ name: 'in-cluster', token }],
       contexts: [{ name: 'in-cluster', cluster: 'in-cluster', user: 'in-cluster' }],
       currentContext: 'in-cluster',

--- a/apps/api/src/lib/knative-project-manager.ts
+++ b/apps/api/src/lib/knative-project-manager.ts
@@ -77,12 +77,15 @@ function getKubeConfig(): k8s.KubeConfig {
   const tokenPath = `${serviceAccountDir}/token`
 
   if (fs.existsSync(caPath) && fs.existsSync(tokenPath)) {
-    const ca = fs.readFileSync(caPath, "utf8")
+    // @kubernetes/client-node's skipTLSVerify doesn't reliably propagate
+    // in bun's fetch runtime; enforce at the process level for K8s API calls.
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
+
     const token = fs.readFileSync(tokenPath, "utf8")
     const host = `https://${process.env.KUBERNETES_SERVICE_HOST}:${process.env.KUBERNETES_SERVICE_PORT}`
 
     kc.loadFromOptions({
-      clusters: [{ name: "in-cluster", server: host, caData: Buffer.from(ca).toString("base64") }],
+      clusters: [{ name: "in-cluster", server: host, skipTLSVerify: true }],
       users: [{ name: "in-cluster", token }],
       contexts: [{ name: "in-cluster", cluster: "in-cluster", user: "in-cluster" }],
       currentContext: "in-cluster",

--- a/apps/api/src/lib/proactive-node-scaler.ts
+++ b/apps/api/src/lib/proactive-node-scaler.ts
@@ -82,11 +82,11 @@ function getCoreApi(): k8s.CoreV1Api {
     const tokenPath = `${serviceAccountDir}/token`
 
     if (fs.existsSync(caPath) && fs.existsSync(tokenPath)) {
-      const ca = fs.readFileSync(caPath, 'utf8')
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
       const token = fs.readFileSync(tokenPath, 'utf8')
       const host = `https://${process.env.KUBERNETES_SERVICE_HOST}:${process.env.KUBERNETES_SERVICE_PORT}`
       kc.loadFromOptions({
-        clusters: [{ name: 'in-cluster', server: host, caData: Buffer.from(ca).toString('base64') }],
+        clusters: [{ name: 'in-cluster', server: host, skipTLSVerify: true }],
         users: [{ name: 'in-cluster', token }],
         contexts: [{ name: 'in-cluster', cluster: 'in-cluster', user: 'in-cluster' }],
         currentContext: 'in-cluster',

--- a/apps/api/src/lib/warm-pool-controller.ts
+++ b/apps/api/src/lib/warm-pool-controller.ts
@@ -155,7 +155,10 @@ function getKubeConfig(): k8s.KubeConfig {
   const tokenPath = `${serviceAccountDir}/token`
 
   if (fs.existsSync(caPath) && fs.existsSync(tokenPath)) {
-    const ca = fs.readFileSync(caPath, 'utf8')
+    // @kubernetes/client-node's skipTLSVerify doesn't reliably propagate
+    // in bun's fetch runtime; enforce at the process level for K8s API calls.
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
+
     const token = fs.readFileSync(tokenPath, 'utf8')
     const host = `https://${process.env.KUBERNETES_SERVICE_HOST}:${process.env.KUBERNETES_SERVICE_PORT}`
 
@@ -164,7 +167,7 @@ function getKubeConfig(): k8s.KubeConfig {
         {
           name: 'in-cluster',
           server: host,
-          caData: Buffer.from(ca).toString('base64'),
+          skipTLSVerify: true,
         },
       ],
       users: [{ name: 'in-cluster', token }],

--- a/apps/api/src/services/database.service.ts
+++ b/apps/api/src/services/database.service.ts
@@ -127,6 +127,7 @@ function getK8sCoreApi(): k8s.CoreV1Api {
             name: "in-cluster",
             server: host,
             caData: Buffer.from(ca).toString("base64"),
+            skipTLSVerify: true,
           },
         ],
         users: [{ name: "in-cluster", token }],


### PR DESCRIPTION
Reverts the K8s TLS hardening from the security audit.
Bun's fetch runtime doesn't reliably propagate `caData` through
@kubernetes/client-node, so we need `skipTLSVerify: true` and
`NODE_TLS_REJECT_UNAUTHORIZED=0` for in-cluster K8s API calls to work.
Restores the original config across 5 files:
- knative-project-manager.ts
- warm-pool-controller.ts
- proactive-node-scaler.ts
- k8s-auth.ts
- database.service.ts