### PR TITLE
fix: preserve authenticated user ID across Composio tool_install calls

### DIFF
--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -226,8 +226,8 @@ export function integrationRoutes() {
     }
 
     // Check both the authenticated user's entity and the 'default' entity.
-    // The agent runtime uses process.env.USER_ID which may not be set (falls
-    // back to 'default'), while the API has the real auth userId.
+    // The agent runtime prefers the X-User-Id header from the chat request,
+    // falling back to process.env.USER_ID then 'default'.
     const candidateIds = [
       buildComposioUserId(auth.userId, projectId),
       buildComposioUserId('default', projectId),

--- a/packages/agent-runtime/src/gateway-tools.ts
+++ b/packages/agent-runtime/src/gateway-tools.ts
@@ -50,6 +50,8 @@ export interface ToolContext {
   disconnectChannel?: (type: string) => Promise<void>
   /** Lazily-initialized file index engine for RAG over workspace files */
   fileIndexEngine?: FileIndexEngine
+  /** Authenticated user ID from the chat request (for per-user integrations like Composio) */
+  userId?: string
 }
 
 const BLOCKED_COMMANDS = [
@@ -2597,7 +2599,7 @@ Pass "autoBind" with surfaceId/dataPath to target a specific canvas. Pass "bind"
         const composioToolkit = await findComposioToolkit(name)
         if (composioToolkit) {
           try {
-            const userId = process.env.USER_ID || 'default'
+            const userId = ctx.userId || process.env.USER_ID || 'default'
             const initialized = await initComposioSession(userId, ctx.projectId)
             if (initialized) {
               const proxy = await registerToolkitProxyTools(ctx.mcpClientManager, composioToolkit.slug)

--- a/packages/agent-runtime/src/gateway.ts
+++ b/packages/agent-runtime/src/gateway.ts
@@ -915,6 +915,7 @@ export class AgentGateway {
   private workspaceDir: string
   private projectId: string
   private config: GatewayConfig
+  private currentUserId: string | undefined
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null
   private channels: Map<string, ChannelAdapter> = new Map()
   private skills: Skill[] = []
@@ -1569,8 +1570,11 @@ export class AgentGateway {
       session.modelOverride = options.modelOverride
     }
 
-    if (options?.userId && isComposioEnabled()) {
-      await initComposioSession(options.userId, this.projectId)
+    if (options?.userId) {
+      this.currentUserId = options.userId
+      if (isComposioEnabled()) {
+        await initComposioSession(options.userId, this.projectId)
+      }
     }
 
     this.emitLog(`Chat message received (stream): "${text.substring(0, 100)}"`)
@@ -1674,6 +1678,7 @@ export class AgentGateway {
       mcpClientManager: this.mcpClientManager,
       connectChannel: (type, config) => this.connectChannel(type, config),
       disconnectChannel: (type) => this.disconnectChannel(type),
+      userId: this.currentUserId,
     }
 
     const baseTools = isHeartbeat

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -1421,7 +1421,7 @@ app.post('/agent/tools/install', async (c) => {
     const composioToolkit = await findComposioToolkit(id)
     if (composioToolkit) {
       try {
-        const userId = process.env.USER_ID || 'default'
+        const userId = c.req.header('X-User-Id') || process.env.USER_ID || 'default'
         const projectId = process.env.PROJECT_ID || 'default'
         await initComposioSession(userId, projectId)
         const proxy = await registerToolkitProxyTools(mcpMgr, composioToolkit.slug)


### PR DESCRIPTION
**Problem**: Composio OAuth actions (Slack, Google Calendar, etc.) intermittently execute under the wrong user identity — messages get sent to random workspace members instead of the authenticated user.

**Cause:** Two code paths initialize the Composio session with different user IDs:

The chat handler correctly uses the real user ID from the X-User-Id request header
But tool_install (called mid-turn by the agent) overwrites it with process.env.USER_ID, which is never set, so it falls back to 'default'
When both happen in the same chat turn, the session switches from the real user to 'default', and subsequent tool calls run under the wrong identity. When they happen in separate turns, the next chat re-initializes correctly — making the bug intermittent.

**Solution:** Thread the authenticated userId from the chat request through ToolContext so tool_install uses the same identity. Added X-User-Id header reading to the HTTP install endpoint as well. All changes are backward-compatible with fallbacks.

Files changed: gateway-tools.ts, gateway.ts, server.ts, integrations.ts