### PR TITLE
feat: add AWS CLI to agent runtime for live AWS cost dashboards

### DIFF
--- a/packages/agent-runtime/Dockerfile
+++ b/packages/agent-runtime/Dockerfile
@@ -84,7 +84,8 @@ RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" >> /etc/apk/reposito
     apk add --no-cache \
     curl bash git tar gzip \
     'nodejs>22' npm \
-    chromium nss freetype harfbuzz ca-certificates ttf-freefont
+    chromium nss freetype harfbuzz ca-certificates ttf-freefont \
+    aws-cli
 
 ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium-browser
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1


### PR DESCRIPTION
Added AWS CLI to the agent runtime Docker image so users can build live AWS cost dashboards directly through chat. Without this, users would have to install AWS CLI locally, run commands themselves, and upload JSON files manually. With AWS CLI in the runtime, the agent can run aws commands via the exec tool — users just provide their AWS credentials in chat and get a live dashboard that can be refreshed on demand.