### PR TITLE
Fixed Canvas UI rendering 

### DIFF
--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -175,9 +175,18 @@ export default observer(function ProjectLayout() {
 
   const handleUpdateCanvasSettings = useCallback(async (themeSettings: Record<string, unknown>) => {
     if (!projectId) return
-    const merged = { ...(project?.settings ?? {}), ...themeSettings }
-    await actions.updateProject(projectId, { settings: merged })
-    setProject((prev: any) => prev ? { ...prev, settings: merged } : prev)
+    let currentSettings: Record<string, unknown> = {}
+    if (typeof project?.settings === 'string') {
+      try {
+        currentSettings = JSON.parse(project.settings)
+      } catch {}
+    } else if (project?.settings && typeof project.settings === 'object') {
+      currentSettings = project.settings as Record<string, unknown>
+    }
+    const merged = { ...currentSettings, ...themeSettings }
+    const settingsStr = JSON.stringify(merged)
+    await actions.updateProject(projectId, { settings: settingsStr as any })
+    setProject((prev: any) => prev ? { ...prev, settings: settingsStr } : prev)
   }, [projectId, project?.settings, actions])
 
   const allProjects = useMemo(() => {
@@ -207,11 +216,13 @@ export default observer(function ProjectLayout() {
     credentials: Platform.OS === 'web' ? 'include' : 'omit',
     headers: nativeHeaders,
   })
-  const { surfaces, connected, dispatchAction, updateLocalData, reconnect, applyMessage } = useDynamicAppStream(
+  const { surfaces, activeSurfaceId, connected, dispatchAction, updateLocalData, reconnect, applyMessage } = useDynamicAppStream(
     agentUrl,
     nativeHeaders ? { headers: nativeHeaders } : undefined,
   )
-  const activeSurface = surfaces.size > 0 ? Array.from(surfaces.values())[0] : null
+  const activeSurface = useMemo(() => {
+    return activeSurfaceId ? surfaces.get(activeSurfaceId) || null : null
+  }, [surfaces, activeSurfaceId])
 
   // Canvas action handler
   const handleCanvasAction = useCallback(

--- a/apps/mobile/components/dynamic-app/DynamicAppRenderer.tsx
+++ b/apps/mobile/components/dynamic-app/DynamicAppRenderer.tsx
@@ -384,13 +384,21 @@ function useRenderedChildren(
 
 interface MultiSurfaceRendererProps {
   surfaces: Map<string, SurfaceState>
+  activeSurfaceId?: string | null
   agentUrl: string | null
   onAction: (surfaceId: string, name: string, context?: Record<string, unknown>) => void
   onDataChange?: (surfaceId: string, path: string, value: unknown, options?: { persist?: boolean }) => void
 }
 
-export function MultiSurfaceRenderer({ surfaces, agentUrl, onAction, onDataChange }: MultiSurfaceRendererProps) {
-  const surfaceList = useMemo(() => [...surfaces.values()], [surfaces])
+export function MultiSurfaceRenderer({ surfaces, activeSurfaceId, agentUrl, onAction, onDataChange }: MultiSurfaceRendererProps) {
+  if (activeSurfaceId) {
+    const active = surfaces.get(activeSurfaceId)
+    if (active) {
+      return <DynamicAppRenderer surface={active} agentUrl={agentUrl} onAction={onAction} onDataChange={onDataChange} />
+    }
+  }
+
+  const surfaceList = Array.from(surfaces.values())
 
   if (surfaceList.length === 0) {
     return null

--- a/packages/shared-app/src/dynamic-app/types.ts
+++ b/packages/shared-app/src/dynamic-app/types.ts
@@ -99,6 +99,10 @@ export interface ConfigureApiMessage {
   }>
 }
 
+export interface ClearAllMessage {
+  type: 'clearAll'
+}
+
 export type DynamicAppMessage =
   | CreateSurfaceMessage
   | UpdateComponentsMessage
@@ -106,6 +110,7 @@ export type DynamicAppMessage =
   | DeleteSurfaceMessage
   | DeleteComponentsMessage
   | ConfigureApiMessage
+  | ClearAllMessage
 
 // ---------------------------------------------------------------------------
 // Surface State (client-side)

--- a/packages/shared-app/src/dynamic-app/useDynamicAppStream.ts
+++ b/packages/shared-app/src/dynamic-app/useDynamicAppStream.ts
@@ -34,6 +34,7 @@ export interface DynamicAppStreamOptions {
 
 export function useDynamicAppStream(agentUrl: string | null, options?: DynamicAppStreamOptions) {
   const [surfaces, setSurfaces] = useState<Map<string, SurfaceState>>(new Map())
+  const [activeSurfaceId, setActiveSurfaceId] = useState<string | null>(null)
   const [connected, setConnected] = useState(false)
   const [connecting, setConnecting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -44,6 +45,12 @@ export function useDynamicAppStream(agentUrl: string | null, options?: DynamicAp
   const receivedFirstMessage = useRef(false)
 
   const applyMessage = useCallback((msg: DynamicAppMessage) => {
+    if (msg.type === 'createSurface' || msg.type === 'updateComponents' || msg.type === 'updateData') {
+      setActiveSurfaceId(msg.surfaceId)
+    } else if (msg.type === 'clearAll') {
+      setActiveSurfaceId(null)
+    }
+
     setSurfaces((prev) => {
       const next = new Map(prev)
       const now = new Date().toISOString()
@@ -265,6 +272,7 @@ export function useDynamicAppStream(agentUrl: string | null, options?: DynamicAp
         next.set(surfaceId, { ...surface, dataModel: newDataModel, updatedAt: new Date().toISOString() })
         return next
       })
+      setActiveSurfaceId(surfaceId)
 
       if (options?.persist && agentUrl) {
         fetch(`${agentUrl}/agent/dynamic-app/data-change`, {
@@ -289,11 +297,12 @@ export function useDynamicAppStream(agentUrl: string | null, options?: DynamicAp
       reconnectTimeoutRef.current = null
     }
     setSurfaces(new Map())
+    setActiveSurfaceId(null)
     setConnected(false)
     setError(null)
     reconnectAttemptRef.current = 0
     connect()
   }, [connect])
 
-  return { surfaces, connected, connecting, error, dispatchAction, updateLocalData, reconnect, applyMessage }
+  return { surfaces, activeSurfaceId, setActiveSurfaceId, connected, connecting, error, dispatchAction, updateLocalData, reconnect, applyMessage }
 }


### PR DESCRIPTION

<img width="1512" height="982" alt="Screenshot 2026-03-13 at 1 31 22 PM" src="https://github.com/user-attachments/assets/9099b776-14fd-4562-ae6e-9cf3b89df065" />


- Refactored MultiSurfaceRenderer to look up active surface ID in O(1) instead of sorting O(n log n)

- Extracted setActiveSurfaceId from setSurfaces functional updater to fix double-rendering and canvas_update lag

- Fixed Prisma project.update() crash by parsing existing settings and stringifying payload on theme change in _layout.tsx

- Added ClearAllMessage interface to DynamicAppMessage types


