### PR TITLE
fix : add 'chat' to mainSessionIds so owner sessions bypass sandbox

### DIFF
--- a/packages/agent-runtime/src/gateway.ts
+++ b/packages/agent-runtime/src/gateway.ts
@@ -1148,6 +1148,7 @@ export class AgentGateway {
       model: { provider: 'anthropic', name: 'claude-sonnet-4-6' },
       maxSessionMessages: 30,
       canvasEnabled: true,
+      mainSessionIds: ['chat'],
     }
     const configPath = join(this.workspaceDir, 'config.json')
     if (existsSync(configPath)) {


### PR DESCRIPTION
Issue: On Kubernetes (staging/production), the exec tool runs all commands inside a Docker sandbox (ubuntu:22.04 container) with no network access. The sandbox is designed to bypass "main" sessions (the owner chatting via the web UI), but mainSessionIds was never set in the gateway config defaults — it was always undefined, which defaulted to an empty array []. So the 'chat' session ID (used by web UI chats) was never recognized as "main," and every exec call was sandboxed, including the owner's. This blocked AWS CLI, Python, curl — everything.

Fix: Added mainSessionIds: ['chat'] to the gateway config defaults. Now when a user chats via the web UI (session ID 'chat'), the sandbox check sees it's a main session and runs commands natively in the agent runtime container — with AWS CLI installed, with network access, with everything available.

