### PR TITLE
Remove non-functional CTAs and add billing error feedback

### DIFF
--- a/apps/mobile/app/(app)/settings.tsx
+++ b/apps/mobile/app/(app)/settings.tsx
@@ -77,6 +77,7 @@ import {
 import { TierSelector } from '../../components/billing/TierSelector'
 import { FeatureList } from '../../components/billing/FeatureList'
 import { SecuritySettingsPanel } from '../../components/security/SecuritySettingsPanel'
+import { useToast, Toast, ToastTitle, ToastDescription } from '@/components/ui/toast'
 import {
   Card,
   CardContent,
@@ -899,6 +900,7 @@ const BillingTab = observer(function BillingTab() {
   const { user } = useAuth()
   const actions = useDomainActions()
   const currentWorkspace = useActiveWorkspace()
+  const toast = useToast()
 
   const {
     subscription,
@@ -965,8 +967,20 @@ const BillingTab = observer(function BillingTab() {
           Linking.openURL(data.url)
         }
       }
-    } catch (e) {
+    } catch (e: any) {
       console.warn('Portal session failed:', e)
+      toast.show({
+        placement: 'top',
+        duration: 5000,
+        render: ({ id }) => (
+          <Toast nativeID={id} variant="outline" action="error">
+            <ToastTitle>Unable to open billing portal</ToastTitle>
+            <ToastDescription>
+              Something went wrong. Please try again or contact support.
+            </ToastDescription>
+          </Toast>
+        ),
+      })
     } finally {
       setIsPortalLoading(false)
     }


### PR DESCRIPTION
**Remove non-functional CTAs and add billing error feedback

1. Remove placeholder "Set username" button from Workspace settings
<img width="1919" height="787" alt="image" src="https://github.com/user-attachments/assets/f83ecd76-22a1-4d8e-926a-d0ca0aecd73d" />

2. Remove non-functional "Export" button from People tab
<img width="1919" height="561" alt="image" src="https://github.com/user-attachments/assets/c4321522-83f1-45fc-a809-11c749d033f2" />

4. Add error toast when Manage billing portal fails (was silently failing)**
<img width="1914" height="585" alt="image" src="https://github.com/user-attachments/assets/3c7057bf-ea18-4add-af0d-dd24163aa9d4" />
