### PR TITLE
fix: channel routes, webchat embed, proxy and local dev behavior

### DIFF
--- a/apps/api/src/routes/ai-proxy.ts
+++ b/apps/api/src/routes/ai-proxy.ts
@@ -1265,7 +1265,7 @@ async function recordImageUsage(
 // Routes
 // =============================================================================
 
-const isLocalDev = process.env.NODE_ENV !== 'production' && !process.env.K_SERVICE
+const isLocalDev = process.env.SHOGO_LOCAL_MODE === 'true'
 
 export function aiProxyRoutes() {
   const router = new Hono()


### PR DESCRIPTION
## Summary

- Exempt public channel paths from runtime auth; allow 127.0.0.1 CORS
- Register channel adapters synchronously; webchat widget derives base URL from script src
- Fall back to direct Anthropic key only when AI proxy token setup fails
- Use `SHOGO_LOCAL_MODE` for local dev detection instead of `NODE_ENV`/`K_SERVICE`
- Return user-facing errors instead of HEARTBEAT_OK for non-heartbeat failures

## Channels fixed

- **Webhook**: returns normal reply payloads instead of `HEARTBEAT_OK` during valid message flows
- **WebChat**: widget config/API base path resolution fixed so bubble renders correctly
- **Telegram**: inbound handling path fixed so messages produce replies end-to-end

## Test plan

- [x] Verified main chat remains functional
- [x] Verified Webhook returns normal reply payloads
- [x] Verified WebChat bubble renders and can send/receive messages
- [x] Verified Telegram receives inbound messages and returns replies


Made with [Cursor](https://cursor.com)