### PR TITLE
fix(chat): preserve AI SDK messages when loading older history

### DIFF
--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -1639,21 +1639,28 @@ export const ChatPanel = observer(function ChatPanel({
 
     isLoadingOlderRef.current = true
 
-    const currentMsgs = studioChat.chatMessageCollection.all
-      .filter((msg: any) => msg.sessionId === currentSessionId)
-    const currentCount = currentMsgs.length
+    const existingMobxIds = new Set(
+      studioChat.chatMessageCollection.all
+        .filter((msg: any) => msg.sessionId === currentSessionId)
+        .map((msg: any) => msg.id)
+    )
 
     try {
       await studioChat.chatMessageCollection.loadPage(
         { sessionId: currentSessionId },
-        { limit: MESSAGE_PAGE_SIZE, offset: currentCount },
+        { limit: MESSAGE_PAGE_SIZE, offset: existingMobxIds.size },
       )
 
-      const allLoaded = studioChat.chatMessageCollection.all
-        .filter((msg: any) => msg.sessionId === currentSessionId)
+      const newlyLoaded = studioChat.chatMessageCollection.all
+        .filter((msg: any) => msg.sessionId === currentSessionId && !existingMobxIds.has(msg.id))
         .sort((a: any, b: any) => (a.createdAt || 0) - (b.createdAt || 0))
 
-      const aiMessages = allLoaded.map((msg: any) => {
+      if (newlyLoaded.length === 0) {
+        isLoadingOlderRef.current = false
+        return
+      }
+
+      const olderMessages = newlyLoaded.map((msg: any) => {
         const baseMessage: any = {
           id: msg.id,
           role: msg.role as "user" | "assistant",
@@ -1669,7 +1676,7 @@ export const ChatPanel = observer(function ChatPanel({
         return baseMessage
       })
 
-      setMessages(aiMessages)
+      setMessages((currentMessages) => [...olderMessages, ...currentMessages])
     } catch (err) {
       console.error("[ChatPanel] Failed to load older messages:", err)
     } finally {


### PR DESCRIPTION
## Summary

- Fix `handleLoadOlderMessages` in `ChatPanel.tsx` which was replacing the entire AI SDK message array with MobX-only data, causing recently received assistant responses to vanish when scrolling up to load older messages.
- The fix now snapshots existing MobX IDs before the API call, identifies only the newly loaded older messages, and **prepends** them to the current AI SDK state using the functional form of `setMessages` — preserving all in-flight and unpersisted messages.

Closes #200

## Test plan

- [ ] Open a chat session with enough history to enable "Load earlier messages"
- [ ] Send a new message and wait for the assistant response to complete
- [ ] Scroll up to trigger older message loading
- [ ] Verify the assistant response (and user message) remain visible
- [ ] Verify older messages are correctly prepended at the top
- [ ] Verify scroll position is preserved (doesn't jump) after loading older messages
- [ ] Test during active streaming: scroll up should be blocked by the `isStreamingRef` guard
