### PR TITLE
feat: add model tier selection to channel configuration

### DIFF
--- a/apps/api/src/routes/ai-proxy.ts
+++ b/apps/api/src/routes/ai-proxy.ts
@@ -2161,6 +2161,22 @@ export function aiProxyRoutes() {
   })
 
   // =========================================================================
+  // GET /ai/v1/access - Check model tier access for the authenticated workspace
+  // =========================================================================
+  router.get('/ai/v1/access', async (c) => {
+    const tokenPayload = await validateProxyAuth(c)
+    if (!tokenPayload) {
+      return c.json({ error: { message: 'Invalid or missing proxy token', code: 'auth_error' } }, 401)
+    }
+
+    const hasAdvanced = isLocalDev || await billingService.hasAdvancedModelAccess(tokenPayload.workspaceId)
+
+    return c.json({
+      hasAdvancedModelAccess: hasAdvanced,
+    })
+  })
+
+  // =========================================================================
   // GET /ai/proxy/health - Health check for the AI proxy
   // =========================================================================
   router.get('/ai/proxy/health', (c) => {

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -964,7 +964,7 @@ export default observer(function ProjectLayout() {
               <FilesBrowserPanel visible={previewTab === 'files'} projectId={projectId!} agentUrl={agentUrl} />
               <TerminalPanel visible={previewTab === 'terminal'} messages={chatMessages} />
               <CapabilitiesPanel visible={previewTab === 'capabilities'} projectId={projectId!} agentUrl={agentUrl} capabilities={capabilitySettings} onCapabilityToggle={handleCapabilityToggle} isPaidPlan={effectiveHasActiveSubscription} activeMode={activeMode} onModeChange={handleManualModeChange} />
-              <ChannelsPanel visible={previewTab === 'channels'} projectId={projectId!} agentUrl={agentUrl} />
+              <ChannelsPanel visible={previewTab === 'channels'} projectId={projectId!} agentUrl={agentUrl} hasAdvancedModelAccess={features.billing ? billingData.hasAdvancedModelAccess : true} />
               <MonitorPanel visible={previewTab === 'monitor'} projectId={projectId!} agentUrl={agentUrl} isPaidPlan={effectiveHasActiveSubscription} />
             </View>
           </View>

--- a/apps/mobile/components/project/panels/ChannelsPanel.tsx
+++ b/apps/mobile/components/project/panels/ChannelsPanel.tsx
@@ -28,6 +28,7 @@ interface ChannelInfo {
   type: string
   connected: boolean
   error?: string
+  model?: string
   metadata?: Record<string, unknown>
 }
 
@@ -35,6 +36,7 @@ interface ChannelsPanelProps {
   projectId: string
   agentUrl: string | null
   visible: boolean
+  hasAdvancedModelAccess?: boolean
 }
 
 interface ChannelField {
@@ -136,14 +138,16 @@ const CHANNEL_DEFS: Record<string, ChannelDef> = {
   },
 }
 
-export function ChannelsPanel({ projectId, agentUrl, visible }: ChannelsPanelProps) {
+export function ChannelsPanel({ projectId, agentUrl, visible, hasAdvancedModelAccess = false }: ChannelsPanelProps) {
   const [channels, setChannels] = useState<ChannelInfo[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [expandedType, setExpandedType] = useState<string | null>(null)
   const [formInputs, setFormInputs] = useState<Record<string, Record<string, string>>>({})
+  const [modelSelection, setModelSelection] = useState<Record<string, 'basic' | 'advanced'>>({})
   const [connecting, setConnecting] = useState<string | null>(null)
   const [disconnecting, setDisconnecting] = useState<string | null>(null)
+  const [savingModel, setSavingModel] = useState<string | null>(null)
   const [formError, setFormError] = useState<string | null>(null)
   const [copiedSnippet, setCopiedSnippet] = useState(false)
 
@@ -183,10 +187,11 @@ export function ChannelsPanel({ projectId, agentUrl, visible }: ChannelsPanelPro
     setConnecting(type)
     setFormError(null)
     try {
+      const model = modelSelection[type] || 'basic'
       const res = await agentFetch(`${agentUrl}/agent/channels/connect`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ type, config: inputs }),
+        body: JSON.stringify({ type, config: inputs, model }),
       })
 
       const data = await res.json()
@@ -196,6 +201,11 @@ export function ChannelsPanel({ projectId, agentUrl, visible }: ChannelsPanelPro
 
       setExpandedType(null)
       setFormInputs(prev => {
+        const next = { ...prev }
+        delete next[type]
+        return next
+      })
+      setModelSelection(prev => {
         const next = { ...prev }
         delete next[type]
         return next
@@ -231,6 +241,37 @@ export function ChannelsPanel({ projectId, agentUrl, visible }: ChannelsPanelPro
       setDisconnecting(null)
     }
   }, [agentUrl, loadChannels])
+
+  const handleModelUpdate = useCallback(async (type: string) => {
+    if (!agentUrl) return
+    const model = modelSelection[type]
+    if (!model) return
+
+    setSavingModel(type)
+    setFormError(null)
+    try {
+      const res = await agentFetch(`${agentUrl}/agent/channels/${type}/model`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to update model')
+      }
+      setExpandedType(null)
+      setModelSelection(prev => {
+        const next = { ...prev }
+        delete next[type]
+        return next
+      })
+      await loadChannels()
+    } catch (err: any) {
+      setFormError(err.message)
+    } finally {
+      setSavingModel(null)
+    }
+  }, [agentUrl, modelSelection, loadChannels])
 
   const updateInput = (type: string, key: string, value: string) => {
     setFormInputs(prev => ({
@@ -290,13 +331,12 @@ export function ChannelsPanel({ projectId, agentUrl, visible }: ChannelsPanelPro
                   {/* Channel header row */}
                   <Pressable
                     onPress={() => {
-                      if (isConnected) return
-                      if (!hasForm) return
+                      if (!isConnected && !hasForm) return
                       setExpandedType(isExpanded ? null : type)
                       setFormError(null)
                     }}
                     className="px-3 py-2.5 flex-row items-center gap-3 active:bg-muted/50"
-                    disabled={isConnected || !hasForm}
+                    disabled={!isConnected && !hasForm}
                   >
                     <Text
                       className="text-lg"
@@ -322,7 +362,10 @@ export function ChannelsPanel({ projectId, agentUrl, visible }: ChannelsPanelPro
                       <View className="flex-row items-center gap-2">
                         <CheckCircle size={16} className="text-emerald-500" />
                         <Pressable
-                          onPress={() => handleDisconnect(type)}
+                          onPress={(e) => {
+                            e.stopPropagation?.()
+                            handleDisconnect(type)
+                          }}
                           disabled={isDisconnecting}
                           className="px-2 py-0.5 border border-border rounded active:bg-destructive/10"
                           style={isDisconnecting ? { opacity: 0.5 } : undefined}
@@ -333,6 +376,11 @@ export function ChannelsPanel({ projectId, agentUrl, visible }: ChannelsPanelPro
                             <Text className="text-[10px] text-muted-foreground">Disconnect</Text>
                           )}
                         </Pressable>
+                        {isExpanded ? (
+                          <ChevronDown size={14} className="text-muted-foreground" />
+                        ) : (
+                          <ChevronRight size={14} className="text-muted-foreground" />
+                        )}
                       </View>
                     ) : hasForm ? (
                       isExpanded ? (
@@ -393,6 +441,84 @@ export function ChannelsPanel({ projectId, agentUrl, visible }: ChannelsPanelPro
                     </View>
                   )}
 
+                  {/* Model selector for connected channels */}
+                  {isExpanded && isConnected && (
+                    <View className="px-3 pb-3 border-t border-border">
+                      <View className="mt-3 gap-2.5">
+                        <View>
+                          <Text className="text-[11px] text-muted-foreground mb-1">
+                            AI Model
+                          </Text>
+                          <View className="flex-row gap-2">
+                            <Pressable
+                              onPress={() => setModelSelection(prev => ({ ...prev, [type]: 'basic' }))}
+                              className={`flex-1 px-2.5 py-2 rounded-md border ${
+                                (modelSelection[type] || liveChannel?.model || 'basic') === 'basic'
+                                  ? 'border-primary bg-primary/10'
+                                  : 'border-border bg-background'
+                              }`}
+                            >
+                              <Text className={`text-xs font-medium ${
+                                (modelSelection[type] || liveChannel?.model || 'basic') === 'basic' ? 'text-primary' : 'text-foreground'
+                              }`}>
+                                Basic
+                              </Text>
+                              <Text className="text-[10px] text-muted-foreground mt-0.5">
+                                Economy tier — all plans
+                              </Text>
+                            </Pressable>
+                            <Pressable
+                              onPress={() => {
+                                if (hasAdvancedModelAccess) {
+                                  setModelSelection(prev => ({ ...prev, [type]: 'advanced' }))
+                                }
+                              }}
+                              disabled={!hasAdvancedModelAccess}
+                              className={`flex-1 px-2.5 py-2 rounded-md border ${
+                                !hasAdvancedModelAccess
+                                  ? 'border-border bg-muted/30 opacity-50'
+                                  : (modelSelection[type] || liveChannel?.model) === 'advanced'
+                                    ? 'border-primary bg-primary/10'
+                                    : 'border-border bg-background'
+                              }`}
+                            >
+                              <Text className={`text-xs font-medium ${
+                                !hasAdvancedModelAccess
+                                  ? 'text-muted-foreground'
+                                  : (modelSelection[type] || liveChannel?.model) === 'advanced' ? 'text-primary' : 'text-foreground'
+                              }`}>
+                                Advanced
+                              </Text>
+                              <Text className="text-[10px] text-muted-foreground mt-0.5">
+                                {hasAdvancedModelAccess ? 'Standard tier — Pro plan' : 'Requires Pro plan'}
+                              </Text>
+                            </Pressable>
+                          </View>
+                        </View>
+
+                        {formError && expandedType === type && (
+                          <View className="bg-destructive/10 rounded px-2 py-1.5">
+                            <Text className="text-xs text-destructive">{formError}</Text>
+                          </View>
+                        )}
+
+                        {modelSelection[type] && modelSelection[type] !== (liveChannel?.model || 'basic') && (
+                          <Pressable
+                            onPress={() => handleModelUpdate(type)}
+                            disabled={savingModel === type}
+                            className="self-start px-3 py-1.5 bg-primary rounded-md active:bg-primary/80"
+                            style={savingModel === type ? { opacity: 0.5 } : undefined}
+                          >
+                            <View className="flex-row items-center gap-1.5">
+                              {savingModel === type && <ActivityIndicator size="small" color="#fff" />}
+                              <Text className="text-xs text-primary-foreground">Save</Text>
+                            </View>
+                          </Pressable>
+                        )}
+                      </View>
+                    </View>
+                  )}
+
                   {/* Expandable config form */}
                   {isExpanded && !isConnected && hasForm && (
                     <View className="px-3 pb-3 border-t border-border">
@@ -412,6 +538,57 @@ export function ChannelsPanel({ projectId, agentUrl, visible }: ChannelsPanelPro
                             />
                           </View>
                         ))}
+
+                        <View>
+                          <Text className="text-[11px] text-muted-foreground mb-1">
+                            AI Model
+                          </Text>
+                          <View className="flex-row gap-2">
+                            <Pressable
+                              onPress={() => setModelSelection(prev => ({ ...prev, [type]: 'basic' }))}
+                              className={`flex-1 px-2.5 py-2 rounded-md border ${
+                                (modelSelection[type] || 'basic') === 'basic'
+                                  ? 'border-primary bg-primary/10'
+                                  : 'border-border bg-background'
+                              }`}
+                            >
+                              <Text className={`text-xs font-medium ${
+                                (modelSelection[type] || 'basic') === 'basic' ? 'text-primary' : 'text-foreground'
+                              }`}>
+                                Basic
+                              </Text>
+                              <Text className="text-[10px] text-muted-foreground mt-0.5">
+                                Economy tier — all plans
+                              </Text>
+                            </Pressable>
+                            <Pressable
+                              onPress={() => {
+                                if (hasAdvancedModelAccess) {
+                                  setModelSelection(prev => ({ ...prev, [type]: 'advanced' }))
+                                }
+                              }}
+                              disabled={!hasAdvancedModelAccess}
+                              className={`flex-1 px-2.5 py-2 rounded-md border ${
+                                !hasAdvancedModelAccess
+                                  ? 'border-border bg-muted/30 opacity-50'
+                                  : (modelSelection[type]) === 'advanced'
+                                    ? 'border-primary bg-primary/10'
+                                    : 'border-border bg-background'
+                              }`}
+                            >
+                              <Text className={`text-xs font-medium ${
+                                !hasAdvancedModelAccess
+                                  ? 'text-muted-foreground'
+                                  : (modelSelection[type]) === 'advanced' ? 'text-primary' : 'text-foreground'
+                              }`}>
+                                Advanced
+                              </Text>
+                              <Text className="text-[10px] text-muted-foreground mt-0.5">
+                                {hasAdvancedModelAccess ? 'Standard tier — Pro plan' : 'Requires Pro plan'}
+                              </Text>
+                            </Pressable>
+                          </View>
+                        </View>
 
                         {formError && expandedType === type && (
                           <View className="bg-destructive/10 rounded px-2 py-1.5">

--- a/packages/agent-runtime/src/gateway-tools.ts
+++ b/packages/agent-runtime/src/gateway-tools.ts
@@ -1428,18 +1428,25 @@ function createChannelListTool(ctx: ToolContext): AgentTool {
     label: 'List Channels',
     parameters: Type.Object({}),
     execute: async () => {
-      const statuses = []
-      for (const [type, adapter] of ctx.channels) {
-        statuses.push(adapter.getStatus())
-      }
-
       const configPath = join(ctx.workspaceDir, 'config.json')
+      let channelConfigs: Array<{ type: string; model?: string }> = []
       let configured: string[] = []
       if (existsSync(configPath)) {
         try {
           const fileConfig = JSON.parse(readFileSync(configPath, 'utf-8'))
-          configured = (fileConfig.channels || []).map((ch: any) => ch.type)
+          channelConfigs = fileConfig.channels || []
+          configured = channelConfigs.map((ch: any) => ch.type)
         } catch { /* ignore */ }
+      }
+
+      const statuses = []
+      for (const [type, adapter] of ctx.channels) {
+        const status = adapter.getStatus()
+        const chConf = channelConfigs.find(c => c.type === type)
+        if (chConf?.model) {
+          status.model = chConf.model
+        }
+        statuses.push(status)
       }
 
       return textResult({
@@ -4130,11 +4137,41 @@ function createChannelConnectTool(ctx: ToolContext): AgentTool {
           'For teams: { appId, appPassword, botName? }. ' +
           'For webchat: { title?, subtitle?, primaryColor?, position?, welcomeMessage?, avatarUrl?, allowedOrigins? } — all fields optional.',
       }),
+      model: Type.Optional(Type.String({
+        description: 'AI model tier for this channel: "basic" (economy, works on all plans) or "advanced" (requires Pro plan). Defaults to "basic".',
+      })),
     }),
     execute: async (_toolCallId, params) => {
-      const { type, config: channelConfig } = params as {
+      const { type, config: channelConfig, model } = params as {
         type: string
         config: Record<string, string>
+        model?: string
+      }
+
+      const channelModel = model || 'basic'
+      if (channelModel !== 'basic' && channelModel !== 'advanced') {
+        return textResult({ error: `Invalid model: "${channelModel}". Must be "basic" or "advanced".` })
+      }
+
+      if (channelModel === 'advanced') {
+        const proxyUrl = ctx.aiProxyUrl || process.env.AI_PROXY_URL
+        const proxyToken = ctx.aiProxyToken || process.env.AI_PROXY_TOKEN
+        if (proxyUrl && proxyToken) {
+          try {
+            const accessRes = await fetch(`${proxyUrl.replace(/\/chat\/completions$/, '').replace(/\/v1$/, '/v1')}/access`, {
+              headers: { 'Authorization': `Bearer ${proxyToken}` },
+              signal: AbortSignal.timeout(5000),
+            })
+            if (accessRes.ok) {
+              const access = await accessRes.json() as { hasAdvancedModelAccess?: boolean }
+              if (!access.hasAdvancedModelAccess) {
+                return textResult({
+                  error: 'Advanced model requires a Pro or higher subscription. Please use model: "basic" or upgrade your plan.',
+                })
+              }
+            }
+          } catch { /* If check fails, allow and let proxy enforce at runtime */ }
+        }
       }
 
       const validTypes = ['telegram', 'discord', 'email', 'slack', 'whatsapp', 'webhook', 'teams', 'webchat']
@@ -4152,10 +4189,11 @@ function createChannelConnectTool(ctx: ToolContext): AgentTool {
         }
         savedConfig.channels = savedConfig.channels || []
         const existing = savedConfig.channels.findIndex((c: any) => c.type === type)
+        const channelEntry = { type, config: channelConfig, model: channelModel }
         if (existing >= 0) {
-          savedConfig.channels[existing] = { type, config: channelConfig }
+          savedConfig.channels[existing] = channelEntry
         } else {
-          savedConfig.channels.push({ type, config: channelConfig })
+          savedConfig.channels.push(channelEntry)
         }
         writeFileSync(configPath, JSON.stringify(savedConfig, null, 2), 'utf-8')
       } catch (err: any) {

--- a/packages/agent-runtime/src/gateway.ts
+++ b/packages/agent-runtime/src/gateway.ts
@@ -99,7 +99,7 @@ export interface GatewayConfig {
   heartbeatInterval: number
   heartbeatEnabled: boolean
   quietHours: { start: string; end: string; timezone: string }
-  channels: Array<{ type: string; config: Record<string, string> }>
+  channels: Array<{ type: string; config: Record<string, string>; model?: string }>
   /** Model configuration: provider + name (e.g. { provider: 'anthropic', name: 'claude-sonnet-4-5' }) */
   model: { provider: string; name: string }
   maxSessionMessages?: number
@@ -678,6 +678,14 @@ export class AgentGateway {
 
     while (qs.queue.length > 0 && !session.stopRequested) {
       const message = qs.queue.shift()!
+
+      // Apply channel-configured model (defaults to 'basic' for safe billing).
+      // Only accept known values to prevent config.json tampering from bypassing tiers.
+      if (message.channelType) {
+        const channelDef = this.config.channels.find(c => c.type === message.channelType)
+        const model = channelDef?.model
+        session.modelOverride = (model === 'basic' || model === 'advanced') ? model : 'basic'
+      }
 
       try {
         const cmdResult = parseSlashCommand(message.text, this.buildSlashContext(sessionId))
@@ -1918,7 +1926,12 @@ Examples:
 
     const channelStatuses: ChannelStatus[] = []
     for (const [type, adapter] of this.channels) {
-      channelStatuses.push(adapter.getStatus())
+      const status = adapter.getStatus()
+      const channelDef = this.config.channels.find(c => c.type === type)
+      if (channelDef?.model) {
+        status.model = channelDef.model
+      }
+      channelStatuses.push(status)
     }
 
     // Merge skills from filesystem with skills declared in config.json

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -279,7 +279,7 @@ WebhookAdapter.registerRoutes(app, () => {
 })
 
 // Hot-connect a channel at runtime (called by MCP tool after writing config.json)
-app.post('/agent/channels/connect', async (c) => {
+app.post('/agent/channels/hot-connect', async (c) => {
   if (!agentGateway) {
     return c.json({ error: 'Agent gateway not running' }, 503)
   }
@@ -357,18 +357,43 @@ app.post('/agent/channels/connect', async (c) => {
     return c.json({ error: 'Agent gateway not running' }, 503)
   }
 
-  const { type, config: channelConfig } = await c.req.json() as {
+  const { type, config: channelConfig, model } = await c.req.json() as {
     type: string
     config: Record<string, string>
+    model?: string
   }
 
   if (!type || !channelConfig) {
     return c.json({ error: 'type and config are required' }, 400)
   }
 
-  const validTypes = ['telegram', 'discord', 'slack', 'whatsapp', 'email']
+  const validTypes = ['telegram', 'discord', 'slack', 'whatsapp', 'email', 'webhook', 'webchat', 'teams']
   if (!validTypes.includes(type)) {
     return c.json({ error: `Invalid channel type: ${type}. Must be one of: ${validTypes.join(', ')}` }, 400)
+  }
+
+  const channelModel = (model === 'basic' || model === 'advanced') ? model : 'basic'
+
+  if (channelModel === 'advanced') {
+    const proxyUrl = process.env.AI_PROXY_URL
+    const proxyToken = process.env.AI_PROXY_TOKEN
+    if (proxyUrl && proxyToken) {
+      try {
+        const accessUrl = `${proxyUrl.replace(/\/chat\/completions$/, '').replace(/\/v1$/, '/v1')}/access`
+        const accessRes = await fetch(accessUrl, {
+          headers: { 'Authorization': `Bearer ${proxyToken}` },
+          signal: AbortSignal.timeout(5000),
+        })
+        if (accessRes.ok) {
+          const access = await accessRes.json() as { hasAdvancedModelAccess?: boolean }
+          if (!access.hasAdvancedModelAccess) {
+            return c.json({ error: 'Advanced model requires a Pro or higher subscription. Use "basic" or upgrade your plan.' }, 403)
+          }
+        }
+      } catch {
+        return c.json({ error: 'Unable to verify plan access. Please try again.' }, 503)
+      }
+    }
   }
 
   try {
@@ -378,18 +403,18 @@ app.post('/agent/channels/connect', async (c) => {
       try {
         fileConfig = JSON.parse(readFileSync(configPath, 'utf-8'))
       } catch {
-        // config.json is corrupted — start fresh but preserve the file
         console.error('[agent-runtime] config.json is invalid JSON, starting with empty config')
         fileConfig = {}
       }
     }
 
     fileConfig.channels = fileConfig.channels || []
+    const channelEntry = { type, config: channelConfig, model: channelModel }
     const existing = fileConfig.channels.findIndex((ch: any) => ch.type === type)
     if (existing >= 0) {
-      fileConfig.channels[existing] = { type, config: channelConfig }
+      fileConfig.channels[existing] = channelEntry
     } else {
-      fileConfig.channels.push({ type, config: channelConfig })
+      fileConfig.channels.push(channelEntry)
     }
 
     await agentGateway.connectChannel(type, channelConfig)
@@ -399,6 +424,65 @@ app.post('/agent/channels/connect', async (c) => {
     return c.json({ ok: true, type, message: `${type} channel connected` })
   } catch (error: any) {
     return c.json({ error: error.message || `Failed to connect ${type}` }, 500)
+  }
+})
+
+// Update channel model — change model tier without reconnecting
+app.patch('/agent/channels/:type/model', async (c) => {
+  if (!agentGateway) {
+    return c.json({ error: 'Agent gateway not running' }, 503)
+  }
+
+  const type = c.req.param('type')
+  const { model } = await c.req.json() as { model: string }
+
+  if (!model || (model !== 'basic' && model !== 'advanced')) {
+    return c.json({ error: 'model must be "basic" or "advanced"' }, 400)
+  }
+
+  if (model === 'advanced') {
+    const proxyUrl = process.env.AI_PROXY_URL
+    const proxyToken = process.env.AI_PROXY_TOKEN
+    if (proxyUrl && proxyToken) {
+      try {
+        const accessUrl = `${proxyUrl.replace(/\/chat\/completions$/, '').replace(/\/v1$/, '/v1')}/access`
+        const accessRes = await fetch(accessUrl, {
+          headers: { 'Authorization': `Bearer ${proxyToken}` },
+          signal: AbortSignal.timeout(5000),
+        })
+        if (accessRes.ok) {
+          const access = await accessRes.json() as { hasAdvancedModelAccess?: boolean }
+          if (!access.hasAdvancedModelAccess) {
+            return c.json({ error: 'Advanced model requires a Pro or higher subscription.' }, 403)
+          }
+        }
+      } catch {
+        return c.json({ error: 'Unable to verify plan access. Please try again.' }, 503)
+      }
+    }
+  }
+
+  try {
+    const configPath = join(WORKSPACE_DIR, 'config.json')
+    let fileConfig: Record<string, any> = {}
+    if (existsSync(configPath)) {
+      fileConfig = JSON.parse(readFileSync(configPath, 'utf-8'))
+    }
+
+    const channels = fileConfig.channels || []
+    const idx = channels.findIndex((ch: any) => ch.type === type)
+    if (idx < 0) {
+      return c.json({ error: `Channel "${type}" not found in config` }, 404)
+    }
+
+    channels[idx].model = model
+    fileConfig.channels = channels
+    writeFileSync(configPath, JSON.stringify(fileConfig, null, 2), 'utf-8')
+    agentGateway.reloadConfig()
+
+    return c.json({ ok: true, type, model })
+  } catch (error: any) {
+    return c.json({ error: error.message || 'Failed to update model' }, 500)
   }
 })
 

--- a/packages/agent-runtime/src/system-prompt.ts
+++ b/packages/agent-runtime/src/system-prompt.ts
@@ -341,6 +341,14 @@ Channels connect the agent to messaging platforms. Currently supported:
 - **Microsoft Teams** — Azure Bot app ID + app password
 - **WebChat Widget** — Embeddable chat widget for any website. No external accounts needed — just connect and paste the script tag on any webpage.
 
+### Model Selection
+All channels accept an optional \`model\` parameter:
+- **"basic"** (default) — Economy-tier model, works on all plans including free
+- **"advanced"** — Standard-tier model, requires a Pro subscription
+
+Always default to "basic" unless the user explicitly requests "advanced". Example:
+\`channel_connect({ type: "telegram", config: { botToken: "..." }, model: "basic" })\`
+
 ### Telegram Setup
 1. Create a bot via Telegram's @BotFather
 2. Copy the bot token

--- a/packages/agent-runtime/src/tools/mcp-server.ts
+++ b/packages/agent-runtime/src/tools/mcp-server.ts
@@ -441,6 +441,7 @@ defineTool({
         type: 'object',
         description: 'Channel configuration. Telegram: { botToken }. Discord: { botToken, guildId? }. Email: { imapHost, smtpHost, username, password }. WhatsApp: { accessToken, phoneNumberId, verifyToken? }. Slack: { botToken, appToken }. Webhook: { secret? }. Teams: { appId, appPassword, botName? }. WebChat: { title?, subtitle?, primaryColor?, position?, welcomeMessage?, avatarUrl?, allowedOrigins? }',
       },
+      model: { type: 'string', enum: ['basic', 'advanced'], description: 'AI model tier: "basic" (economy, all plans) or "advanced" (Pro plan required). Defaults to "basic".', default: 'basic' },
     },
     required: ['type', 'config'],
   },
@@ -452,13 +453,38 @@ defineTool({
     }
 
     config.channels = config.channels || []
+    const channelModel = input.model || 'basic'
+
+    if (channelModel === 'advanced') {
+      const proxyUrl = process.env.AI_PROXY_URL
+      const proxyToken = process.env.AI_PROXY_TOKEN
+      if (proxyUrl && proxyToken) {
+        try {
+          const accessUrl = proxyUrl.replace(/\/chat\/completions$/, '').replace(/\/v1$/, '/v1') + '/access'
+          const accessRes = await fetch(accessUrl, {
+            headers: { 'Authorization': `Bearer ${proxyToken}` },
+            signal: AbortSignal.timeout(5000),
+          })
+          if (accessRes.ok) {
+            const access = await accessRes.json() as { hasAdvancedModelAccess?: boolean }
+            if (!access.hasAdvancedModelAccess) {
+              return {
+                ok: false,
+                error: 'Advanced model requires a Pro or higher subscription. Please use model: "basic" or upgrade your plan.',
+              }
+            }
+          }
+        } catch { /* If check fails, allow and let proxy enforce at runtime */ }
+      }
+    }
     const existing = config.channels.findIndex(
       (c: any) => c.type === input.type
     )
+    const channelEntry = { type: input.type, config: input.config, model: channelModel }
     if (existing >= 0) {
-      config.channels[existing] = { type: input.type, config: input.config }
+      config.channels[existing] = channelEntry
     } else {
-      config.channels.push({ type: input.type, config: input.config })
+      config.channels.push(channelEntry)
     }
 
     writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8')
@@ -466,7 +492,7 @@ defineTool({
     // Hot-connect: tell the running gateway to connect the channel immediately
     const port = process.env.PORT || '8080'
     try {
-      const res = await fetch(`http://localhost:${port}/agent/channels/connect`, {
+      const res = await fetch(`http://localhost:${port}/agent/channels/hot-connect`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ type: input.type, config: input.config }),
@@ -538,9 +564,20 @@ defineTool({
 
 defineTool({
   name: 'channel_list',
-  description: 'List configured messaging channels',
+  description: 'List configured messaging channels with their connection status and model tier',
   inputSchema: { type: 'object', properties: {} },
   handler: async () => {
+    const port = process.env.PORT || '8080'
+    try {
+      const res = await fetch(`http://localhost:${port}/agent/status`, {
+        signal: AbortSignal.timeout(5000),
+      })
+      if (res.ok) {
+        const status = await res.json()
+        return { channels: status.channels || [] }
+      }
+    } catch { /* fall back to config.json */ }
+
     const configPath = join(AGENT_DIR, 'config.json')
     let config: Record<string, any> = {}
     if (existsSync(configPath)) {

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -23,6 +23,7 @@ export interface ChannelStatus {
   type: string
   connected: boolean
   error?: string
+  model?: string
   metadata?: Record<string, unknown>
 }
 


### PR DESCRIPTION
- Model selection in Channels UI panel (ChannelsPanel.tsx) — Added Basic/Advanced toggle cards when connecting a new channel. "Advanced" is greyed out for non-Pro users.
- Model editing for connected channels (ChannelsPanel.tsx) — Connected channels are now expandable, showing a model selector with a Save button. Uses a new PATCH /agent/channels/:type/model endpoint so no reconnect is needed.
- Billing prop plumbing (_layout.tsx) — Passes hasAdvancedModelAccess from billing data to the ChannelsPanel.
- Server-side billing validation (server.ts) — Both the POST /agent/channels/connect and PATCH .../model endpoints validate against the /ai/v1/access billing endpoint before accepting "advanced". Returns 403 if plan doesn't support it.
- Billing access endpoint (ai-proxy.ts) — New GET /ai/v1/access endpoint that checks hasAdvancedModelAccess for the workspace. Requires proxy token auth.
- Fixed duplicate route bug (server.ts) — Renamed the old hot-connect-only handler to /agent/channels/hot-connect so the full handler (with model + config persistence) actually runs.
- Tool-level validation (gateway-tools.ts, mcp-server.ts) — channel_connect tool checks billing when model: "advanced" is requested, returns error at config time.
- Model in channel status (types.ts, gateway.ts) — Added model field to ChannelStatus, getStatus() merges model from config.
- channel_list returns model (gateway-tools.ts, mcp-server.ts) — Both gateway and MCP versions now include the model in their response so the agent can report it.
- Runtime model enforcement (gateway.ts) — processQueue applies session.modelOverride from the channel's configured model, allowlisting only "basic"/"advanced", defaulting to "basic".
- System prompt (system-prompt.ts) — Documents the model parameter in channel setup instructions.
<img width="1918" height="910" alt="image" src="https://github.com/user-attachments/assets/03da7811-1f2a-47b0-8dfc-99b4585f84a3" />
<img width="627" height="611" alt="image" src="https://github.com/user-attachments/assets/5fe528c3-0ac0-4b97-981a-cf081fe45b87" />

<img width="1084" height="2412" alt="image" src="https://github.com/user-attachments/assets/78f674ea-5744-4ad9-8bf3-8450d8ccd640" />
