### PR TITLE
fix: secure webchat widget for public access on staging/production

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -725,7 +725,12 @@ const getAllowedOrigins = (): string[] => {
 // Enable CORS for development and production
 const allowedOrigins = getAllowedOrigins()
 app.use('/*', cors({
-  origin: (origin) => {
+  origin: (origin, c) => {
+    // Webchat widget requests come from external websites — allow any origin
+    const reqPath = new URL(c.req.url).pathname
+    if (/\/api\/projects\/[^/]+\/agent-proxy\/agent\/channels\/webchat\//.test(reqPath)) {
+      return origin || '*'
+    }
     // Allow requests with no origin (mobile apps, curl, React Native on Android/iOS)
     if (!origin) return `http://localhost:${VITE_PORT}`
     const isDevOrLocal = process.env.NODE_ENV !== 'production' || process.env.SHOGO_LOCAL_MODE === 'true'
@@ -747,6 +752,11 @@ app.use('/*', cors({
 // Skips webhook and internal endpoints that use their own auth (signatures, tokens).
 app.use('/api/*', csrf({
   origin: (origin, c) => {
+    // Webchat widget POST requests come from external websites
+    const csrfPath = new URL(c.req.url).pathname
+    if (/\/api\/projects\/[^/]+\/agent-proxy\/agent\/channels\/webchat\//.test(csrfPath)) {
+      return true
+    }
     // Allow requests with no origin (server-to-server, mobile apps, curl)
     if (!origin) return true
     const isDevOrLocal = process.env.NODE_ENV !== 'production' || process.env.SHOGO_LOCAL_MODE === 'true'
@@ -770,6 +780,22 @@ app.use('/api/*', rateLimiter('global', {
   skipPrefixes: ['/api/ai/', '/api/internal/', '/api/health', '/api/warm-pool/status'],
 }))
 
+function isWebchatProxyPath(path: string): boolean {
+  return /^\/api\/projects\/[^/]+\/agent-proxy\/agent\/channels\/webchat\//.test(path)
+}
+
+function isAllowedUnauthWebchatProxyPath(path: string): boolean {
+  if (!isWebchatProxyPath(path)) return false
+  const match = path.match(/^\/api\/projects\/[^/]+\/agent-proxy(\/agent\/channels\/webchat\/.*)$/)
+  const relative = match?.[1] || ''
+  return relative === '/agent/channels/webchat/widget.js' ||
+    relative === '/agent/channels/webchat/health' ||
+    relative === '/agent/channels/webchat/config' ||
+    relative === '/agent/channels/webchat/session' ||
+    relative === '/agent/channels/webchat/message' ||
+    relative.startsWith('/agent/channels/webchat/events/')
+}
+
 // Auth middleware — extract session for ALL /api/* routes so c.get('auth') is
 // always populated, then require authentication except for known public paths.
 app.use('/api/*', authMiddleware)
@@ -792,10 +818,18 @@ app.use(
       '/api/api-keys/validate',
     ]
     if (publicPrefixes.some((p) => path.startsWith(p))) return next()
+    // Webchat uses widget/session token auth in agent-runtime (not Shogo user sessions).
+    if (isAllowedUnauthWebchatProxyPath(path)) return next()
     return requireAuth(c, next)
   }
 )
-app.use('/api/projects/:projectId/*', requireProjectAccess)
+app.use('/api/projects/:projectId/*', async (c, next) => {
+  const path = new URL(c.req.url).pathname
+  if (isAllowedUnauthWebchatProxyPath(path)) {
+    return next()
+  }
+  return requireProjectAccess(c, next)
+})
 
 // Better Auth handler - mounted BEFORE other /api/* routes
 // Handles all authentication endpoints: sign-up, sign-in, sign-out, session, OAuth callbacks, etc.
@@ -1947,18 +1981,26 @@ app.all('/api/projects/:projectId/agent-proxy/*', async (c) => {
   }
 
   const projectId = c.req.param('projectId')
-
-  const userId = await getAuthUserId(c)
-  if (!userId) {
-    return c.json({ error: { code: 'unauthorized', message: 'Authentication required' } }, 401)
-  }
-  const workspaceId = await verifyProjectAccess(userId, projectId)
-  if (!workspaceId) {
-    return c.json({ error: { code: 'forbidden', message: 'No access to this project' } }, 403)
-  }
-
   const path = c.req.path.replace(`/api/projects/${projectId}/agent-proxy`, '') || '/'
   const qs = new URL(c.req.url).search
+
+  const isWebchatPath =
+    path === '/agent/channels/webchat/widget.js' ||
+    path === '/agent/channels/webchat/health' ||
+    path === '/agent/channels/webchat/config' ||
+    path === '/agent/channels/webchat/session' ||
+    path === '/agent/channels/webchat/message' ||
+    path.startsWith('/agent/channels/webchat/events/')
+  if (!isWebchatPath) {
+    const userId = await getAuthUserId(c)
+    if (!userId) {
+      return c.json({ error: { code: 'unauthorized', message: 'Authentication required' } }, 401)
+    }
+    const workspaceId = await verifyProjectAccess(userId, projectId)
+    if (!workspaceId) {
+      return c.json({ error: { code: 'forbidden', message: 'No access to this project' } }, 403)
+    }
+  }
 
   let podUrl: string
 
@@ -1986,6 +2028,13 @@ app.all('/api/projects/:projectId/agent-proxy/*', async (c) => {
   if (contentType) headers.set('content-type', contentType)
   const accept = c.req.header('accept')
   if (accept) headers.set('accept', accept)
+  if (isWebchatPath) {
+    const fwdHeaders = ['origin', 'x-webchat-widget-key', 'x-webchat-session-token', 'x-webchat-session'] as const
+    for (const h of fwdHeaders) {
+      const v = c.req.header(h)
+      if (v) headers.set(h, v)
+    }
+  }
   const { deriveRuntimeToken } = await import('./lib/runtime-token')
   headers.set('x-runtime-token', deriveRuntimeToken(projectId))
 

--- a/packages/agent-runtime/src/channels/webchat.ts
+++ b/packages/agent-runtime/src/channels/webchat.ts
@@ -43,12 +43,18 @@ export interface WebChatConfig {
   welcomeMessage: string
   avatarUrl: string
   allowedOrigins: string
+  widgetSecret: string
 }
 
 interface PendingResponse {
   resolve: (text: string) => void
   chunks: string[]
   timer: ReturnType<typeof setTimeout>
+}
+
+interface SessionAuthToken {
+  sessionId: string
+  expiresAt: number
 }
 
 const DEFAULT_CONFIG: WebChatConfig = {
@@ -59,6 +65,7 @@ const DEFAULT_CONFIG: WebChatConfig = {
   welcomeMessage: '',
   avatarUrl: '',
   allowedOrigins: '*',
+  widgetSecret: '',
 }
 
 export class WebChatAdapter implements ChannelAdapter {
@@ -74,6 +81,7 @@ export class WebChatAdapter implements ChannelAdapter {
 
   /** Pending responses keyed by correlationId */
   private pendingResponses = new Map<string, PendingResponse>()
+  private sessionAuthTokens = new Map<string, SessionAuthToken>()
 
   private replyTimeoutMs = 120_000
 
@@ -86,6 +94,7 @@ export class WebChatAdapter implements ChannelAdapter {
       welcomeMessage: config.welcomeMessage || DEFAULT_CONFIG.welcomeMessage,
       avatarUrl: config.avatarUrl || DEFAULT_CONFIG.avatarUrl,
       allowedOrigins: config.allowedOrigins || DEFAULT_CONFIG.allowedOrigins,
+      widgetSecret: config.widgetSecret || randomUUID(),
     }
 
     this.connected = true
@@ -104,6 +113,7 @@ export class WebChatAdapter implements ChannelAdapter {
     this.pendingResponses.clear()
     this.sseClients.clear()
     this.sessions.clear()
+    this.sessionAuthTokens.clear()
     this.connected = false
     console.log('[WebChat] Disconnected')
   }
@@ -153,6 +163,43 @@ export class WebChatAdapter implements ChannelAdapter {
 
   getConfig(): WebChatConfig {
     return { ...this.config }
+  }
+
+  getWidgetSecret(): string {
+    return this.config.widgetSecret
+  }
+
+  validateWidgetSecret(secret: string | null | undefined): boolean {
+    if (!this.config.widgetSecret) return true
+    return secret === this.config.widgetSecret
+  }
+
+  issueSessionAuthToken(sessionId: string): { token: string; expiresInSeconds: number } {
+    this.pruneExpiredTokens()
+    const token = randomUUID()
+    const expiresInSeconds = 10 * 60
+    const expiresAt = Date.now() + (expiresInSeconds * 1000)
+    this.sessionAuthTokens.set(token, { sessionId, expiresAt })
+    return { token, expiresInSeconds }
+  }
+
+  validateSessionAuthToken(token: string | null | undefined, sessionId: string): boolean {
+    if (!token) return false
+    const record = this.sessionAuthTokens.get(token)
+    if (!record) return false
+    if (record.expiresAt < Date.now()) {
+      this.sessionAuthTokens.delete(token)
+      return false
+    }
+    return record.sessionId === sessionId
+  }
+
+  private pruneExpiredTokens(): void {
+    if (this.sessionAuthTokens.size < 500) return
+    const now = Date.now()
+    for (const [token, record] of this.sessionAuthTokens) {
+      if (record.expiresAt < now) this.sessionAuthTokens.delete(token)
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -243,7 +290,8 @@ export class WebChatAdapter implements ChannelAdapter {
   // ---------------------------------------------------------------------------
 
   isOriginAllowed(origin: string | undefined): boolean {
-    if (this.config.allowedOrigins === '*') return true
+    // Even with wildcard mode, require an Origin header to block basic non-browser scraping.
+    if (this.config.allowedOrigins === '*') return !!origin
     if (!origin) return false
     const allowed = this.config.allowedOrigins.split(',').map(o => o.trim())
     return allowed.includes(origin)
@@ -268,11 +316,33 @@ export class WebChatAdapter implements ChannelAdapter {
   // ---------------------------------------------------------------------------
 
   static registerRoutes(app: any, getAdapter: () => WebChatAdapter | null): void {
+    app.use('/agent/channels/webchat/*', async (c: any, next: any) => {
+      const origin = c.req.header('origin') || '*'
+      if (c.req.method === 'OPTIONS') {
+        return new Response(null, {
+          status: 204,
+          headers: {
+            'Access-Control-Allow-Origin': origin,
+            'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type, X-WebChat-Widget-Key, X-WebChat-Session-Token, X-WebChat-Session',
+            'Access-Control-Max-Age': '86400',
+          },
+        })
+      }
+      await next()
+      c.res.headers.set('Access-Control-Allow-Origin', origin)
+    })
+
     // Get widget configuration (used by the embedded widget to initialize)
     app.get('/agent/channels/webchat/config', (c: any) => {
       const adapter = getAdapter()
       if (!adapter || !adapter.connected) {
         return c.json({ error: 'WebChat channel not connected' }, 503)
+      }
+
+      const widgetKey = c.req.header('x-webchat-widget-key')
+      if (!adapter.validateWidgetSecret(widgetKey)) {
+        return c.json({ error: 'Invalid or missing widget key' }, 403)
       }
 
       const origin = c.req.header('origin')
@@ -298,6 +368,11 @@ export class WebChatAdapter implements ChannelAdapter {
         return c.json({ error: 'WebChat channel not connected' }, 503)
       }
 
+      const widgetKey = c.req.header('x-webchat-widget-key')
+      if (!adapter.validateWidgetSecret(widgetKey)) {
+        return c.json({ error: 'Invalid or missing widget key' }, 403)
+      }
+
       const origin = c.req.header('origin')
       if (!adapter.isOriginAllowed(origin)) {
         return c.json({ error: 'Origin not allowed' }, 403)
@@ -305,7 +380,13 @@ export class WebChatAdapter implements ChannelAdapter {
 
       const sessionId = c.req.header('x-webchat-session')
       const session = adapter.getOrCreateSession(sessionId || undefined)
-      return c.json({ sessionId: session.id, created: !sessionId })
+      const auth = adapter.issueSessionAuthToken(session.id)
+      return c.json({
+        sessionId: session.id,
+        created: !sessionId,
+        sessionToken: auth.token,
+        sessionTokenExpiresIn: auth.expiresInSeconds,
+      })
     })
 
     // Send a message from the widget
@@ -329,11 +410,15 @@ export class WebChatAdapter implements ChannelAdapter {
 
       const message = body.message
       const sessionId = body.sessionId
+      const sessionToken = c.req.header('x-webchat-session-token')
       if (!message || typeof message !== 'string') {
         return c.json({ error: 'Missing required field: "message"' }, 400)
       }
       if (!sessionId) {
         return c.json({ error: 'Missing required field: "sessionId"' }, 400)
+      }
+      if (!adapter.validateSessionAuthToken(sessionToken, sessionId)) {
+        return c.json({ error: 'Invalid or expired session token' }, 403)
       }
 
       try {
@@ -363,6 +448,10 @@ export class WebChatAdapter implements ChannelAdapter {
       }
 
       const sessionId = c.req.param('sessionId')
+      const sessionToken = new URL(c.req.url).searchParams.get('sessionToken')
+      if (!adapter.validateSessionAuthToken(sessionToken, sessionId)) {
+        return c.json({ error: 'Invalid or expired session token' }, 403)
+      }
 
       return new Response(
         new ReadableStream({
@@ -417,7 +506,7 @@ export class WebChatAdapter implements ChannelAdapter {
       )
     })
 
-    // Serve the embeddable widget JavaScript
+    // Serve the embeddable widget JavaScript (fully public — no secret needed)
     app.get('/agent/channels/webchat/widget.js', (c: any) => {
       const adapter = getAdapter()
       const baseUrl = new URL(c.req.url)
@@ -467,7 +556,25 @@ function generateWidgetScript(agentBaseUrl: string): string {
     } catch(e) {}
     return '${fallbackUrl}';
   })();
+  var SCRIPT_WIDGET_KEY = (function() {
+    try {
+      var s = document.currentScript;
+      if (!s || !s.src) return "";
+      var url = new URL(s.src);
+      return url.searchParams.get("widgetKey") || "";
+    } catch(e) {
+      return "";
+    }
+  })();
+  function wcUrl(path, query) {
+    var url = AGENT_URL + path;
+    if (query) {
+      url += (path.indexOf("?") === -1 ? "?" : "&") + query;
+    }
+    return url;
+  }
   var SESSION_KEY = "shogo_webchat_session";
+  var SESSION_TOKEN_KEY = "shogo_webchat_session_token";
   var HISTORY_KEY = "shogo_webchat_history";
 
   var config = null;
@@ -481,6 +588,12 @@ function generateWidgetScript(agentBaseUrl: string): string {
   }
   function storeSession(id) {
     try { localStorage.setItem(SESSION_KEY, id); } catch(e) {}
+  }
+  function getStoredSessionToken() {
+    try { return localStorage.getItem(SESSION_TOKEN_KEY); } catch(e) { return null; }
+  }
+  function storeSessionToken(token) {
+    try { localStorage.setItem(SESSION_TOKEN_KEY, token); } catch(e) {}
   }
   function getStoredHistory() {
     try {
@@ -496,7 +609,15 @@ function generateWidgetScript(agentBaseUrl: string): string {
   }
 
   function init() {
-    fetch(AGENT_URL + "/agent/channels/webchat/config")
+    if (!SCRIPT_WIDGET_KEY) {
+      console.warn("[Shogo WebChat] Missing widgetKey in script URL.");
+      return;
+    }
+    fetch(wcUrl("/agent/channels/webchat/config"), {
+      headers: {
+        "X-WebChat-Widget-Key": SCRIPT_WIDGET_KEY
+      }
+    })
       .then(function(r) { return r.json(); })
       .then(function(cfg) {
         config = cfg;
@@ -510,17 +631,23 @@ function generateWidgetScript(agentBaseUrl: string): string {
 
   function initSession() {
     var existing = getStoredSession();
-    fetch(AGENT_URL + "/agent/channels/webchat/session", {
+    var headers = {
+      "Content-Type": "application/json",
+      "X-WebChat-Widget-Key": SCRIPT_WIDGET_KEY
+    };
+    if (existing) headers["X-WebChat-Session"] = existing;
+    fetch(wcUrl("/agent/channels/webchat/session"), {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...(existing ? { "X-WebChat-Session": existing } : {})
-      },
+      headers: headers,
     })
     .then(function(r) { return r.json(); })
     .then(function(data) {
+      if (!data.sessionId || !data.sessionToken) {
+        throw new Error("Missing session credentials");
+      }
       sessionId = data.sessionId;
       storeSession(sessionId);
+      storeSessionToken(data.sessionToken);
       connectSSE();
     })
     .catch(function(err) {
@@ -530,7 +657,9 @@ function generateWidgetScript(agentBaseUrl: string): string {
 
   function connectSSE() {
     if (!sessionId) return;
-    var es = new EventSource(AGENT_URL + "/agent/channels/webchat/events/" + sessionId);
+    var token = getStoredSessionToken();
+    if (!token) return;
+    var es = new EventSource(wcUrl("/agent/channels/webchat/events/" + sessionId, "sessionToken=" + encodeURIComponent(token)));
 
     es.addEventListener("message", function(e) {
       try {
@@ -555,9 +684,12 @@ function generateWidgetScript(agentBaseUrl: string): string {
     addMessage("user", text);
     setLoading(true);
 
-    fetch(AGENT_URL + "/agent/channels/webchat/message", {
+    fetch(wcUrl("/agent/channels/webchat/message"), {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "X-WebChat-Session-Token": getStoredSessionToken() || ""
+      },
       body: JSON.stringify({ message: text, sessionId: sessionId })
     })
     .then(function(r) { return r.json(); })

--- a/packages/agent-runtime/src/gateway-tools.ts
+++ b/packages/agent-runtime/src/gateway-tools.ts
@@ -32,6 +32,7 @@ import { loadAllSkills, loadBundledSkills, searchSkills } from './skills'
 import { getDynamicAppManager, getByPointer } from './dynamic-app-manager'
 import { CanvasStreamParser } from './canvas-stream-parser'
 import { withPermissionGate, assertWithinWorkspace as assertWithinWorkspaceSecure, type PermissionEngine } from './permission-engine'
+import { deriveApiUrl } from './internal-api'
 import {
   CANVAS_COMPONENT_SCHEMA,
   BASIC_CANVAS_COMPONENT_SCHEMA,
@@ -4142,6 +4143,11 @@ function createChannelConnectTool(ctx: ToolContext): AgentTool {
         return textResult({ error: `Invalid channel type: ${type}. Must be one of: ${validTypes.join(', ')}` })
       }
 
+      if (type === 'webchat' && !channelConfig.widgetSecret) {
+        const { randomUUID } = await import('crypto')
+        channelConfig.widgetSecret = randomUUID()
+      }
+
       try {
         const { existsSync, readFileSync, writeFileSync } = await import('fs')
         const { join } = await import('path')
@@ -4167,8 +4173,15 @@ function createChannelConnectTool(ctx: ToolContext): AgentTool {
           await ctx.connectChannel(type, channelConfig)
 
           if (type === 'webchat') {
-            const port = process.env.PORT || '8080'
-            const widgetUrl = `http://localhost:${port}/agent/channels/webchat/widget.js`
+            const widgetKey = encodeURIComponent(channelConfig.widgetSecret || '')
+            const widgetPath = `/agent/channels/webchat/widget.js?widgetKey=${widgetKey}`
+            let widgetUrl: string
+            if (process.env.KUBERNETES_SERVICE_HOST) {
+              const apiUrl = deriveApiUrl()
+              widgetUrl = `${apiUrl}/api/projects/${ctx.projectId}/agent-proxy${widgetPath}`
+            } else {
+              widgetUrl = `http://localhost:${process.env.PORT || '8080'}${widgetPath}`
+            }
             return textResult({
               ok: true,
               message: [

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -366,9 +366,14 @@ app.post('/agent/channels/connect', async (c) => {
     return c.json({ error: 'type and config are required' }, 400)
   }
 
-  const validTypes = ['telegram', 'discord', 'slack', 'whatsapp', 'email']
+  const validTypes = ['telegram', 'discord', 'slack', 'whatsapp', 'email', 'webhook', 'teams', 'webchat']
   if (!validTypes.includes(type)) {
     return c.json({ error: `Invalid channel type: ${type}. Must be one of: ${validTypes.join(', ')}` }, 400)
+  }
+
+  if (type === 'webchat' && !channelConfig.widgetSecret) {
+    const { randomUUID } = await import('crypto')
+    channelConfig.widgetSecret = randomUUID()
   }
 
   try {

--- a/packages/agent-runtime/src/tools/mcp-server.ts
+++ b/packages/agent-runtime/src/tools/mcp-server.ts
@@ -11,7 +11,9 @@
 
 import { existsSync, readFileSync, writeFileSync, readdirSync, unlinkSync, mkdirSync, rmSync, statSync } from 'fs'
 import { join, resolve, extname, dirname } from 'path'
+import { randomUUID } from 'crypto'
 import { isPreinstalledMcpId, isMcpServerAllowed, getPreinstalledPackages, getCatalogEntry } from '../mcp-catalog'
+import { deriveApiUrl } from '../internal-api'
 
 /**
  * Resolve a path ensuring it stays within the given base directory.
@@ -451,6 +453,10 @@ defineTool({
       config = JSON.parse(readFileSync(configPath, 'utf-8'))
     }
 
+    if (input.type === 'webchat' && !input.config.widgetSecret) {
+      input.config.widgetSecret = randomUUID()
+    }
+
     config.channels = config.channels || []
     const existing = config.channels.findIndex(
       (c: any) => c.type === input.type
@@ -474,7 +480,15 @@ defineTool({
       })
       if (res.ok) {
         if (input.type === 'webchat') {
-          const localWidgetUrl = `http://localhost:${port}/agent/channels/webchat/widget.js`
+          const widgetKey = encodeURIComponent(input.config.widgetSecret || '')
+          const widgetPath = `/agent/channels/webchat/widget.js?widgetKey=${widgetKey}`
+          let widgetUrl: string
+          if (process.env.KUBERNETES_SERVICE_HOST) {
+            const apiUrl = deriveApiUrl()
+            widgetUrl = `${apiUrl}/api/projects/${PROJECT_ID}/agent-proxy${widgetPath}`
+          } else {
+            widgetUrl = `http://localhost:${port}${widgetPath}`
+          }
           return {
             ok: true,
             message: [
@@ -482,14 +496,14 @@ defineTool({
               ``,
               `Tell the user to add this single script tag before the closing </body> tag on their website:`,
               ``,
-              `<script src="${localWidgetUrl}"></script>`,
+              `<script src="${widgetUrl}"></script>`,
               ``,
               `A chat bubble will appear on the page. Visitors click it to chat with the agent directly. No other setup, libraries, or accounts needed.`,
               ``,
               `The user can also find the embed snippet in the Channels panel.`,
             ].join('\n'),
-            embedSnippet: `<script src="${localWidgetUrl}"></script>`,
-            widgetUrl: localWidgetUrl,
+            embedSnippet: `<script src="${widgetUrl}"></script>`,
+            widgetUrl,
           }
         }
         return {

--- a/packages/shared-runtime/src/server-framework.ts
+++ b/packages/shared-runtime/src/server-framework.ts
@@ -224,7 +224,7 @@ export async function createRuntimeApp(config: RuntimeAppConfig): Promise<Runtim
       return allowed[0] || origin
     },
     allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-    allowHeaders: ['Content-Type', 'Authorization', 'X-Runtime-Token', 'X-Session-Id', 'X-User-Id', 'X-Billing-User-Id'],
+    allowHeaders: ['Content-Type', 'Authorization', 'X-Runtime-Token', 'X-Session-Id', 'X-User-Id', 'X-Billing-User-Id', 'X-WebChat-Widget-Key', 'X-WebChat-Session-Token', 'X-WebChat-Session'],
     credentials: true,
   }))
 

--- a/test-webchat.html
+++ b/test-webchat.html
@@ -80,6 +80,6 @@
     
     Or the direct agent runtime URL (usually port 5200+).
   -->
-  <script src="http://localhost:6200/agent/channels/webchat/widget.js"></script>
+  <script src="http://localhost:6200/agent/channels/webchat/widget.js?widgetKey=8d574529-0032-4f14-ae66-c46b51d52e88"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Replaces the previously rejected blanket auth bypass with a proper **widget-key + session-token authentication model** for the webchat widget, so anonymous website visitors can chat without Shogo accounts while preventing unauthorized access.

<img width="1916" height="936" alt="image" src="https://github.com/user-attachments/assets/94b68c55-4917-4b1e-a3a0-30df19202ea3" />


### What changed

**Security model (widget-key + session-token):**
- Per-project `widgetSecret` (UUID) auto-generated on webchat channel connect, stored in `config.json`
- `widgetKey` passed as query param in `<script src>` tag (publishable key model, same as Stripe `pk_live_`)
- `/config` and `/session` endpoints validate `X-WebChat-Widget-Key` header
- `/session` issues short-lived (10-min) session tokens bound to specific session IDs
- `/message` and `/events/:sessionId` require valid session token
- Expired tokens auto-pruned to prevent memory leaks (threshold: 500 entries)

**API proxy (apps/api/src/server.ts):**
- Explicit path allowlist for webchat auth bypass (not blanket) — `widget.js`, `health`, `config`, `session`, `message`, `events/:id`
- CORS origin callback allows any origin for webchat proxy paths
- CSRF bypass for webchat POST requests (cross-origin by design)
- Forward `Origin`, `X-WebChat-Widget-Key`, `X-WebChat-Session-Token`, `X-WebChat-Session` headers to agent runtime

**Agent runtime CORS (webchat.ts + shared server-framework.ts):**
- Added CORS middleware to webchat routes handling OPTIONS preflight with custom headers
- Added `X-WebChat-Widget-Key`, `X-WebChat-Session-Token`, `X-WebChat-Session` to shared-runtime CORS `allowHeaders`

**Widget URL fix (gateway-tools.ts + mcp-server.ts):**
- Widget URL now uses `deriveApiUrl()` in Kubernetes (was hardcoded `localhost:8080`)
- URL includes `widgetKey` query parameter
- Routes through API proxy path: `/api/projects/:id/agent-proxy/agent/channels/webchat/widget.js?widgetKey=...`

### Security audit

| Check | Result |
|---|---|
| Can someone with only a project ID send messages? | **No** — widget key required |
| Can widget keys be brute-forced? | **No** — UUID v4 (128-bit entropy) |
| Is widgetSecret leaked in API responses? | **No** — excluded from all responses |
| Is auth bypass scoped properly? | **Yes** — 6 explicit paths, not blanket |
| Are session tokens properly validated? | **Yes** — expiry + session binding |
| Memory leak risk? | **Mitigated** — pruning at 500 entries |

### Files changed
- `apps/api/src/server.ts` — proxy auth bypass, CORS/CSRF, header forwarding
- `packages/agent-runtime/src/channels/webchat.ts` — widget key + session token auth, CORS middleware
- `packages/agent-runtime/src/gateway-tools.ts` — widget URL generation
- `packages/agent-runtime/src/server.ts` — webchat in valid channel types, widgetSecret generation
- `packages/agent-runtime/src/tools/mcp-server.ts` — widget URL generation
- `packages/shared-runtime/src/server-framework.ts` — CORS allowHeaders
- `test-webchat.html` — updated test file with widgetKey

## Test plan
- [x] Connect webchat channel locally → verify widgetSecret generated in config
- [x] Load test-webchat.html → widget renders without CORS errors
- [x] Send message → agent responds through widget
- [ ] Deploy to staging → verify widget URL uses proper API proxy path (not localhost:8080)
- [ ] Test without widgetKey → verify 403 on /config and /session
- [ ] Test with expired session token → verify 403 on /message

