### PR TITLE
fix: persist canvas surface selection across reconnects and page loads

### DIFF
--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -259,10 +259,26 @@ export default observer(function ProjectLayout() {
     },
   )
   const [userSelectedSurfaceId, setUserSelectedSurfaceId] = useState<string | null>(null)
+  const mountTimeRef = useRef(Date.now())
+
+  // Restore last-viewed surface from AsyncStorage
+  useEffect(() => {
+    if (!projectId) return
+    AsyncStorage.getItem(`shogo:lastCanvasSurface:${projectId}`).then((savedId) => {
+      if (savedId) setUserSelectedSurfaceId(savedId)
+    }).catch(() => {})
+  }, [projectId])
 
   const effectiveSurfaceId = userSelectedSurfaceId && surfaces.has(userSelectedSurfaceId)
     ? userSelectedSurfaceId
     : activeSurfaceId
+
+  // Persist active surface selection to AsyncStorage
+  useEffect(() => {
+    if (projectId && effectiveSurfaceId) {
+      AsyncStorage.setItem(`shogo:lastCanvasSurface:${projectId}`, effectiveSurfaceId).catch(() => {})
+    }
+  }, [projectId, effectiveSurfaceId])
 
   const activeSurface = useMemo(() => {
     return effectiveSurfaceId ? surfaces.get(effectiveSurfaceId) || null : null
@@ -275,9 +291,15 @@ export default observer(function ProjectLayout() {
     [surfaces],
   )
 
-  // Auto-switch to new surfaces created by the agent
+  // Auto-switch to new surfaces created by the agent.
+  // Suppressed for the first 2 s after mount so the SSE replay doesn't
+  // override the surface selection we just restored from AsyncStorage.
   const prevActiveSurfaceIdRef = useRef(activeSurfaceId)
   useEffect(() => {
+    if (Date.now() - mountTimeRef.current < 2000) {
+      prevActiveSurfaceIdRef.current = activeSurfaceId
+      return
+    }
     if (activeSurfaceId && activeSurfaceId !== prevActiveSurfaceIdRef.current) {
       setUserSelectedSurfaceId(null)
     }

--- a/packages/shared-app/src/dynamic-app/useDynamicAppStream.ts
+++ b/packages/shared-app/src/dynamic-app/useDynamicAppStream.ts
@@ -47,9 +47,7 @@ export function useDynamicAppStream(agentUrl: string | null, options?: DynamicAp
   const receivedFirstMessage = useRef(false)
 
   const applyMessage = useCallback((msg: DynamicAppMessage) => {
-    if (msg.type === 'createSurface' || msg.type === 'updateComponents' || msg.type === 'updateData') {
-      setActiveSurfaceId(msg.surfaceId)
-    } else if (msg.type === 'clearAll') {
+    if (msg.type === 'clearAll') {
       setActiveSurfaceId(null)
     }
 
@@ -60,6 +58,7 @@ export function useDynamicAppStream(agentUrl: string | null, options?: DynamicAp
       switch (msg.type) {
         case 'createSurface': {
           if (!next.has(msg.surfaceId)) {
+            setActiveSurfaceId(msg.surfaceId)
             next.set(msg.surfaceId, {
               surfaceId: msg.surfaceId,
               title: msg.title,


### PR DESCRIPTION
## Summary

- **Fixes the SSE reconnect surface-switching bug**: `setActiveSurfaceId` was being called on every `updateComponents` and `updateData` message during the SSE initial replay, causing the last surface in iteration order to always become active — regardless of what the user was viewing. Now only genuinely new `createSurface` events trigger auto-switch.
- **Persists the user's surface selection to AsyncStorage** (key: `shogo:lastCanvasSurface:{projectId}`), so returning to a project always restores the last-viewed dashboard.
- **Suppresses auto-switch for 2 s after mount** so the SSE replay doesn't override the restored selection from AsyncStorage.

## Test plan

- [ ] Open a project with 2+ canvas surfaces (e.g. Campaign Overview + Ad Rankings)
- [ ] Select the first surface, then switch browser tabs for ~2 minutes
- [ ] Return — should still be on the same surface (not the last one in creation order)
- [ ] Hard-refresh the page — should restore the last-viewed surface from AsyncStorage
- [ ] Have the agent create a new surface during live operation — should auto-navigate to it
- [ ] Manually switch surfaces — selection should persist to AsyncStorage

Closes #207