### PR TITLE
fix: remove silent widgetSecret auto-generation from connect 

### DIFF
--- a/packages/agent-runtime/src/channels/webchat.ts
+++ b/packages/agent-runtime/src/channels/webchat.ts
@@ -94,7 +94,7 @@ export class WebChatAdapter implements ChannelAdapter {
       welcomeMessage: config.welcomeMessage || DEFAULT_CONFIG.welcomeMessage,
       avatarUrl: config.avatarUrl || DEFAULT_CONFIG.avatarUrl,
       allowedOrigins: config.allowedOrigins || DEFAULT_CONFIG.allowedOrigins,
-      widgetSecret: config.widgetSecret || randomUUID(),
+      widgetSecret: config.widgetSecret || '',
     }
 
     this.connected = true
@@ -170,7 +170,7 @@ export class WebChatAdapter implements ChannelAdapter {
   }
 
   validateWidgetSecret(secret: string | null | undefined): boolean {
-    if (!this.config.widgetSecret) return true
+    if (!this.config.widgetSecret) return false
     return secret === this.config.widgetSecret
   }
 

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -396,11 +396,6 @@ app.post('/agent/channels/connect', async (c) => {
     }
   }
 
-  if (type === 'webchat' && !channelConfig.widgetSecret) {
-    const { randomUUID } = await import('crypto')
-    channelConfig.widgetSecret = randomUUID()
-  }
-
   try {
     const configPath = join(WORKSPACE_DIR, 'config.json')
     let fileConfig: Record<string, any> = {}


### PR DESCRIPTION
widgetSecret should only be generated in the tool layer (gateway-tools
and mcp-server) where it gets persisted to config.json. The connect()
method and hot-connect endpoint now use whatever is in the config,
and validateWidgetSecret rejects requests when no secret is configured.
