### PR TITLE
fix: white text on email CTA buttons and fix email preview crash

### DIFF
--- a/apps/mobile/components/email/EmailPreviewDev.tsx
+++ b/apps/mobile/components/email/EmailPreviewDev.tsx
@@ -6,16 +6,10 @@
  * Follows the same sidebar-picker pattern as DynamicAppDevPreview.
  */
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { View, Pressable, ScrollView, Platform } from 'react-native'
 import { Text } from '@/components/ui/text'
-import {
-  shogoTemplates,
-  interpolate,
-  EMAIL_CONSTANTS,
-  DARK_STYLE_OVERRIDES,
-  type EmailTemplate,
-} from '@shogo-ai/sdk/email'
+import type { EmailTemplate } from '@shogo-ai/sdk/email'
 
 const SAMPLE_DATA: Record<string, Record<string, unknown>> = {
   welcome: {
@@ -161,19 +155,50 @@ function formatTemplateName(name: string): string {
 }
 
 export function EmailPreviewDev() {
-  const [activeTemplate, setActiveTemplate] = useState<string>(shogoTemplates[0]?.name ?? 'welcome')
-  const [darkMode, setDarkMode] = useState(false)
-  const categories = useMemo(() => categorize(shogoTemplates as EmailTemplate[]), [])
+  const [sdkMod, setSdkMod] = useState<{
+    shogoTemplates: EmailTemplate[]
+    interpolate: (t: string, d: Record<string, unknown>) => string
+    DARK_STYLE_OVERRIDES: string
+  } | null>(null)
 
-  const selected = (shogoTemplates as EmailTemplate[]).find((t) => t.name === activeTemplate)
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const mod = await import('@shogo-ai/sdk/email')
+      if (!cancelled) {
+        setSdkMod({
+          shogoTemplates: (mod.shogoTemplates ?? []) as EmailTemplate[],
+          interpolate: mod.interpolate,
+          DARK_STYLE_OVERRIDES: mod.DARK_STYLE_OVERRIDES,
+        })
+      }
+    })()
+    return () => { cancelled = true }
+  }, [])
+
+  const templates = sdkMod?.shogoTemplates ?? []
+  const [activeTemplate, setActiveTemplate] = useState<string>('welcome')
+  const [darkMode, setDarkMode] = useState(false)
+  const categories = useMemo(() => categorize(templates), [templates])
+
+  const selected = templates.find((t) => t.name === activeTemplate)
   const sampleData = SAMPLE_DATA[activeTemplate] ?? { appName: 'Shogo', currentYear: new Date().getFullYear() }
 
-  const renderedSubject = selected ? interpolate(selected.subject, { ...selected.defaults, ...sampleData }) : ''
-  let renderedHtml = selected ? interpolate(selected.html, { ...selected.defaults, ...sampleData }) : ''
+  const interp = sdkMod?.interpolate ?? ((t: string) => t)
+  const renderedSubject = selected ? interp(selected.subject, { ...selected.defaults, ...sampleData }) : ''
+  let renderedHtml = selected ? interp(selected.html, { ...selected.defaults, ...sampleData }) : ''
 
-  if (darkMode && renderedHtml) {
-    const forceDarkCSS = `<style>${DARK_STYLE_OVERRIDES}</style>`
+  if (darkMode && renderedHtml && sdkMod?.DARK_STYLE_OVERRIDES) {
+    const forceDarkCSS = `<style>${sdkMod.DARK_STYLE_OVERRIDES}</style>`
     renderedHtml = renderedHtml.replace('</head>', `${forceDarkCSS}</head>`)
+  }
+
+  if (!sdkMod) {
+    return (
+      <View className="flex-1 items-center justify-center bg-background">
+        <Text className="text-sm text-muted-foreground">Loading email templates…</Text>
+      </View>
+    )
   }
 
   return (
@@ -183,7 +208,7 @@ export function EmailPreviewDev() {
         <View className="px-4 py-3 border-b border-border">
           <Text className="text-base font-semibold text-foreground">Email Preview</Text>
           <Text className="text-xs text-muted-foreground mt-0.5">
-            {shogoTemplates.length} templates
+            {templates.length} templates
           </Text>
         </View>
         <ScrollView className="flex-1" contentContainerStyle={{ paddingBottom: 24 }}>

--- a/packages/sdk/src/email/templates/auth/email-verification.ts
+++ b/packages/sdk/src/email/templates/auth/email-verification.ts
@@ -17,7 +17,7 @@ export const emailVerificationTemplate: EmailTemplate<{
       Please confirm your email address by clicking the button below.
       This helps us keep your account secure.
     </p>
-    <a href="{{verifyUrl}}" class="email-btn">Verify Email</a>
+    <a href="{{verifyUrl}}" class="email-btn" style="color:#ffffff;text-decoration:none;">Verify Email</a>
     <hr class="email-divider">
     <p class="email-muted">This link expires in {{expiresIn}}.</p>
     <p class="email-muted">

--- a/packages/sdk/src/email/templates/auth/password-reset.ts
+++ b/packages/sdk/src/email/templates/auth/password-reset.ts
@@ -17,7 +17,7 @@ export const passwordResetTemplate: EmailTemplate<{
       We received a request to reset the password for your account.
       Click the button below to choose a new one:
     </p>
-    <a href="{{resetUrl}}" class="email-btn">Reset Password</a>
+    <a href="{{resetUrl}}" class="email-btn" style="color:#ffffff;text-decoration:none;">Reset Password</a>
     <hr class="email-divider">
     <p class="email-muted">This link expires in {{expiresIn}}.</p>
     <p class="email-muted">

--- a/packages/sdk/src/email/templates/auth/welcome.ts
+++ b/packages/sdk/src/email/templates/auth/welcome.ts
@@ -17,7 +17,7 @@ export const welcomeTemplate: EmailTemplate<{
       Thanks for signing up. You now have access to build, deploy, and
       collaborate on AI-powered apps — all from one place.
     </p>
-    <a href="{{loginUrl}}" class="email-btn">Get Started</a>
+    <a href="{{loginUrl}}" class="email-btn" style="color:#ffffff;text-decoration:none;">Get Started</a>
     <hr class="email-divider">
     <p class="email-muted">
       If you have any questions, just reply to this email — we're happy to help.

--- a/packages/sdk/src/email/templates/billing/payment-failed.ts
+++ b/packages/sdk/src/email/templates/billing/payment-failed.ts
@@ -24,7 +24,7 @@ export const paymentFailedTemplate: EmailTemplate<{
       Please update your payment method to keep your plan active and avoid
       any interruption to your workspace.
     </p>
-    <a href="{{retryUrl}}" class="email-btn-danger">Update Payment Method</a>
+    <a href="{{retryUrl}}" class="email-btn-danger" style="color:#ffffff;text-decoration:none;">Update Payment Method</a>
     <hr class="email-divider">
     <p class="email-muted">
       If you believe this is a mistake, please reply to this email or

--- a/packages/sdk/src/email/templates/billing/plan-upgraded.ts
+++ b/packages/sdk/src/email/templates/billing/plan-upgraded.ts
@@ -35,7 +35,7 @@ export const planUpgradedTemplate: EmailTemplate<{
       </tr>
     </table>
     <br>
-    <a href="{{dashboardUrl}}" class="email-btn">Go to Dashboard</a>
+    <a href="{{dashboardUrl}}" class="email-btn" style="color:#ffffff;text-decoration:none;">Go to Dashboard</a>
     <hr class="email-divider">
     <p class="email-muted">
       Manage your subscription anytime from Settings &rarr; Plans &amp; Credits.

--- a/packages/sdk/src/email/templates/invitation/project-invite.ts
+++ b/packages/sdk/src/email/templates/invitation/project-invite.ts
@@ -20,7 +20,7 @@ export const projectInviteTemplate: EmailTemplate<{
       <strong>{{projectName}}</strong> project as
       <span class="email-badge">{{role}}</span>.
     </p>
-    <a href="{{acceptUrl}}" class="email-btn">Accept Invitation</a>
+    <a href="{{acceptUrl}}" class="email-btn" style="color:#ffffff;text-decoration:none;">Accept Invitation</a>
     <hr class="email-divider">
     <p class="email-muted">
       If you weren't expecting this, you can safely ignore this email.

--- a/packages/sdk/src/email/templates/invitation/workspace-invite.ts
+++ b/packages/sdk/src/email/templates/invitation/workspace-invite.ts
@@ -23,7 +23,7 @@ export const workspaceInviteTemplate: EmailTemplate<{
       Accept the invitation to start collaborating on projects, share
       resources, and build together.
     </p>
-    <a href="{{acceptUrl}}" class="email-btn">Accept Invitation</a>
+    <a href="{{acceptUrl}}" class="email-btn" style="color:#ffffff;text-decoration:none;">Accept Invitation</a>
     <hr class="email-divider">
     <p class="email-muted">
       If you weren't expecting this, you can safely ignore this email.


### PR DESCRIPTION

<img width="644" height="561" alt="image" src="https://github.com/user-attachments/assets/e7f93f5f-d7e7-48a3-ad45-160bcb200c6e" />

- Add inline style="color:#ffffff" to all email-btn and email-btn-danger anchor tags so button text renders white in Gmail and other clients that strip <style> blocks for links.
- Fix EmailPreviewDev crash caused by circular dependency making shogoTemplates undefined at import time — use dynamic import instead.

Templates fixed: email-verification, welcome, password-reset, workspace-invite, project-invite, plan-upgraded, payment-failed.
