### PR TITLE
fix(mobile): PostHog touch autocapture vs React Navigation v7

### DIFF
--- a/apps/mobile/contexts/posthog.tsx
+++ b/apps/mobile/contexts/posthog.tsx
@@ -22,7 +22,11 @@ export function PostHogProvider({ children }: { children: ReactNode }) {
       }}
       autocapture={{
         captureScreens: false,
-        captureTouches: !isWeb,
+        // Touch autocapture walks the tree and can call React Navigation hooks. React
+        // Navigation v7 (used by Expo Router) only allows those inside a screen; taps
+        // on nested UI then throw "Couldn't find a navigation context". Screen views
+        // are tracked manually via posthog.screen(pathname) in (app)/_layout.tsx.
+        captureTouches: false,
       }}
     >
       {children}


### PR DESCRIPTION
## Problem
Tapping controls such as the Usage & Credits period selector (7d / 30d / 90d / 1y) on Profile threw:

`Error: Couldn't find a navigation context. Have you wrapped your app with 'NavigationContainer'?`

The stack pointed at `SharedAnalytics` `Pressable`, but that component does not use navigation.

## Cause
`posthog-react-native` was configured with `captureTouches: true` on native. Touch autocapture can call React Navigation hooks (e.g. for route metadata). React Navigation v7 (used by Expo Router) restricts those hooks to components rendered **inside** a navigator screen, so taps on nested UI outside that context throw.

## Fix
Set `captureTouches: false`. Screen tracking is unchanged: `posthog.screen(pathname)` in `apps/mobile/app/(app)/_layout.tsx` still runs on navigation.

## Trade-off
PostHog will no longer autocapture individual touch events on mobile. Lifecycle and manual screen events remain.

Made with [Cursor](https://cursor.com)