### PR TITLE
fix(mobile): two-column Projects grid on native

### DIFF
--- a/apps/mobile/app/(app)/projects/index.tsx
+++ b/apps/mobile/app/(app)/projects/index.tsx
@@ -219,6 +219,7 @@ export default observer(function AllProjectsPage() {
   const actions = useDomainActions()
   const toast = useToast()
   const { width } = useWindowDimensions()
+  const isNativeMobile = Platform.OS === 'ios' || Platform.OS === 'android'
 
   type VisibilityFilter = 'any' | 'public' | 'private'
   type StatusFilter = 'any' | 'draft' | 'active' | 'archived'
@@ -246,8 +247,8 @@ export default observer(function AllProjectsPage() {
   const [renameFolderValue, setRenameFolderValue] = useState('')
   const [singleDeleteFolder, setSingleDeleteFolder] = useState<Folder | null>(null)
 
-  // Determine grid columns based on screen width
-  const numColumns = viewMode === 'grid' ? 3 : 1
+  // Native phones: 2 columns for readable titles and touch targets; web keeps 3-up grid.
+  const numColumns = viewMode === 'grid' ? (isNativeMobile ? 2 : 3) : 1
 
   // Find current workspace
   const workspaces = store?.workspaceCollection?.all ?? []


### PR DESCRIPTION
Closes UX density issue for project cards on phone-sized screens.

## What
- Native (iOS/Android) grid view uses **2 columns** instead of 3.
- Web keeps the existing 3-column grid.

## Why
More horizontal space per card improves title legibility and tap comfort without changing features.

Tracked in #223

Made with [Cursor](https://cursor.com)