### PR TITLE
fix(mobile): project card title and metadata layout on native

### DIFF
--- a/apps/mobile/app/(app)/projects/index.tsx
+++ b/apps/mobile/app/(app)/projects/index.tsx
@@ -702,7 +702,13 @@ export default observer(function AllProjectsPage() {
             onPress={handleCreateProject}
             className="flex-1 m-1.5 rounded-2xl border-2 border-dashed border-border overflow-hidden"
           >
-            <View className="flex-1 items-center justify-center" style={{ minHeight: 180 }}>
+            <View
+              className="flex-1 items-center justify-center"
+              style={{
+                minHeight:
+                  Platform.OS === 'ios' || Platform.OS === 'android' ? 168 : 180,
+              }}
+            >
               <View className="w-12 h-12 rounded-full bg-muted items-center justify-center mb-2">
                 <Plus size={24} className="text-muted-foreground" />
               </View>
@@ -802,6 +808,7 @@ export default observer(function AllProjectsPage() {
             isSelected={isSelected}
             isStarred={isStarred}
             selectMode={selectMode}
+            compact={Platform.OS === 'ios' || Platform.OS === 'android'}
             className="flex-1 m-1.5"
             onPress={() => {
               if (selectMode) {

--- a/apps/mobile/components/home/ProjectCard.tsx
+++ b/apps/mobile/components/home/ProjectCard.tsx
@@ -182,33 +182,62 @@ export function ProjectCard({
       </View>
 
       {/* Info */}
-      <View className={compact ? 'px-3 py-2.5' : 'px-4 py-3.5'}>
-        <View className="flex-row items-center gap-2.5">
-          {renderLeading?.()}
-          <View className="flex-1 min-w-0">
-            <Text
-              className={cn(
-                'font-semibold text-card-foreground',
-                compact ? 'text-[13px]' : 'text-[15px]',
-              )}
-              numberOfLines={1}
-            >
-              {name || 'Untitled'}
-            </Text>
-            {subtitle ? (
+      <View className={compact ? 'px-3 py-3' : 'px-4 py-3.5'}>
+        {compact && (renderLeading || renderTrailing) ? (
+          <View className="gap-2">
+            <View className="flex-row items-start gap-2">
+              <View className="flex-1 min-w-0">
+                <Text
+                  className="font-semibold text-[14px] leading-[18px] text-card-foreground"
+                  numberOfLines={2}
+                >
+                  {name || 'Untitled'}
+                </Text>
+              </View>
+              {renderTrailing?.()}
+            </View>
+            <View className="flex-row items-center gap-2 min-w-0">
+              {renderLeading?.()}
+              <View className="flex-1 min-w-0">
+                {subtitle ? (
+                  <Text
+                    className="text-[11px] leading-[16px] text-muted-foreground"
+                    numberOfLines={2}
+                  >
+                    {subtitle}
+                  </Text>
+                ) : null}
+              </View>
+            </View>
+          </View>
+        ) : (
+          <View className="flex-row items-center gap-2.5">
+            {renderLeading?.()}
+            <View className="flex-1 min-w-0">
               <Text
                 className={cn(
-                  'mt-0.5 leading-[18px] text-muted-foreground',
-                  compact ? 'text-[11px]' : 'text-[13px]',
+                  'font-semibold text-card-foreground',
+                  compact ? 'text-[14px] leading-[18px]' : 'text-[15px]',
                 )}
-                numberOfLines={compact ? 1 : 2}
+                numberOfLines={compact ? 2 : 1}
               >
-                {subtitle}
+                {name || 'Untitled'}
               </Text>
-            ) : null}
+              {subtitle ? (
+                <Text
+                  className={cn(
+                    'mt-0.5 leading-[18px] text-muted-foreground',
+                    compact ? 'text-[11px]' : 'text-[13px]',
+                  )}
+                  numberOfLines={compact ? 2 : 2}
+                >
+                  {subtitle}
+                </Text>
+              ) : null}
+            </View>
+            {renderTrailing?.()}
           </View>
-          {renderTrailing?.()}
-        </View>
+        )}
       </View>
     </Pressable>
   )


### PR DESCRIPTION
Improves information hierarchy on `ProjectCard` when used from the All Projects grid on native.

## What
- Enables `compact` mode for project cards in the native grid.
- When leading/trailing slots are present (avatar + menu), **title sits on its own row** (up to 2 lines) with the overflow menu aligned to the first row; **avatar + edited line** on the second row.
- Other compact cards (e.g. home) get two-line titles/subtitles where applicable.
- Create-project placeholder height aligned with compact cards on native.

## Why
Avoids single-line truncation like "N…" and separates primary label from secondary metadata and actions.

Tracked in #223. **Merge after** `fix/native-projects-grid-two-columns` if you want the easiest rebase path (same files as the touch-target PR).

Made with [Cursor](https://cursor.com)