### PR TITLE
fix(mobile): improve project card readability, layout, and touch targets on native

### DIFF
--- a/apps/mobile/app/(app)/projects/index.tsx
+++ b/apps/mobile/app/(app)/projects/index.tsx
@@ -853,11 +853,21 @@ export default observer(function AllProjectsPage() {
                 trigger={(triggerProps) => (
                   <Pressable
                     {...triggerProps}
+                    hitSlop={
+                      Platform.OS === 'ios' || Platform.OS === 'android'
+                        ? { top: 6, bottom: 6, left: 6, right: 6 }
+                        : undefined
+                    }
                     onPress={(e) => {
                       e.stopPropagation()
                       setActionMenuProjectId((prev) => (prev === project.id ? null : project.id))
                     }}
-                    className="w-6 h-6 items-center justify-center"
+                    className={cn(
+                      'items-center justify-center rounded-lg active:bg-muted/80',
+                      Platform.OS === 'ios' || Platform.OS === 'android'
+                        ? 'w-11 h-11'
+                        : 'w-6 h-6',
+                    )}
                   >
                     <MoreHorizontal size={16} className="text-muted-foreground" />
                   </Pressable>

--- a/apps/mobile/components/home/ProjectCard.tsx
+++ b/apps/mobile/components/home/ProjectCard.tsx
@@ -83,6 +83,7 @@ export function ProjectCard({
 }: ProjectCardProps) {
   const color = getProjectAccentColor(name)
   const initial = name?.charAt(0)?.toUpperCase() || 'P'
+  const isNativeMobile = Platform.OS === 'ios' || Platform.OS === 'android'
 
   const subtitle = description || (updatedAt
     ? `Edited ${formatDistanceAgo(updatedAt)}`
@@ -94,17 +95,27 @@ export function ProjectCard({
     <Pressable
       onPress={onPress}
       onLongPress={onLongPress}
+      android_ripple={
+        Platform.OS === 'android'
+          ? { color: 'rgba(255,255,255,0.08)', foreground: true }
+          : undefined
+      }
       className={cn(
         'rounded-2xl overflow-hidden border border-border bg-card',
         isSelected && 'border-2 border-primary',
         className,
       )}
-      style={Platform.OS === 'web' ? {
-        boxShadow: isDark
-          ? '0 1px 3px rgba(0,0,0,0.3), 0 1px 2px rgba(0,0,0,0.2)'
-          : '0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)',
-        transition: 'box-shadow 0.2s, transform 0.2s',
-      } as any : {}}
+      style={(state) => [
+        Platform.OS === 'web'
+          ? ({
+              boxShadow: isDark
+                ? '0 1px 3px rgba(0,0,0,0.3), 0 1px 2px rgba(0,0,0,0.2)'
+                : '0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)',
+              transition: 'box-shadow 0.2s, transform 0.2s',
+            } as any)
+          : null,
+        isNativeMobile && state.pressed ? { opacity: 0.93 } : null,
+      ]}
     >
       {/* Header */}
       <View
@@ -158,15 +169,19 @@ export function ProjectCard({
         {onStarToggle && (
           <Pressable
             onPress={onStarToggle}
+            hitSlop={isNativeMobile ? { top: 10, bottom: 10, left: 10, right: 10 } : undefined}
             className={cn(
-              'absolute top-2 right-2 p-1.5 rounded-md',
+              'absolute top-1.5 right-1.5 rounded-lg items-center justify-center',
               isStarred ? 'bg-yellow-500/20' : 'bg-background/60',
+              isNativeMobile ? 'p-2 min-w-[40px] min-h-[40px]' : 'p-1.5',
             )}
           >
             <Star
-              size={14}
-              style={{ color: isStarred ? '#eab308' : undefined }}
-              className={isStarred ? undefined : 'text-muted-foreground/50'}
+              size={isNativeMobile ? 16 : 14}
+              style={{
+                color: isStarred ? '#eab308' : isNativeMobile ? '#94a3b8' : undefined,
+              }}
+              className={isStarred || isNativeMobile ? undefined : 'text-muted-foreground/50'}
               fill={isStarred ? '#eab308' : 'transparent'}
             />
           </Pressable>


### PR DESCRIPTION
## Summary
<img width="361" height="765" alt="Screenshot 2026-03-30 at 4 29 49 PM" src="https://github.com/user-attachments/assets/8008defc-935b-4936-855c-2a5004486d02" />

Improves the project card UX on native iOS/Android screens. No changes to web, backend, or features.

- **2-column grid** on native instead of 3 — gives cards enough width for readable titles and comfortable taps
- **Better title/metadata hierarchy** — project name gets up to 2 lines on its own row; avatar + edited timestamp sit below; overflow menu stays aligned to the title
- **Clearer touch feedback** — Android ripple + iOS pressed opacity on the card; star button enlarged to ~40pt with hitSlop and better inactive contrast; overflow menu enlarged to ~44pt on native

## Files changed
- `apps/mobile/components/home/ProjectCard.tsx` — card layout, press states, star/touch sizing
- `apps/mobile/app/(app)/projects/index.tsx` — grid columns, compact mode, menu trigger sizing

## Test plan
- [x] Open Projects page on iOS simulator/device — verify 2-column grid
- [x] Open Projects page on Android emulator/device — verify 2-column grid + ripple on card tap
- [x] Confirm long project names wrap to 2 lines instead of truncating to "N…"
- [ ] Tap star icon — confirm enlarged target, visible active/inactive states
- [ ] Tap overflow menu (⋮) — confirm it opens without accidentally navigating into the project
- [ ] Verify web layout is unchanged (still 3 columns, no ripple)

Closes #223

Made with [Cursor](https://cursor.com)