### PR TITLE
Fix: Hide sidebar on billing page when navigating from project chat

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -10,6 +10,7 @@
  *  - Home page (wide): sidebar visible, NO header
  *  - List pages (wide): sidebar visible, NO header (sidebar provides nav)
  *  - Project detail (wide): NO sidebar (project provides its own top bar)
+ *  - Billing page (wide): NO sidebar (standalone full-width page)
  *  - All pages (narrow): hamburger header + drawer sidebar
  *
  * Auth guard redirects unauthenticated users to sign-in.
@@ -39,6 +40,7 @@ export default function AppLayout() {
     && pathname !== '/projects'
     && pathname !== '/(app)/projects'
   const isSettingsPage = pathname === '/settings' || pathname === '/(app)/settings' || pathname.includes('/settings')
+  const isBillingPage = pathname === '/billing' || pathname === '/(app)/billing'
 
   usePostHogIdentify()
   const posthog = usePostHogSafe()
@@ -83,7 +85,7 @@ export default function AppLayout() {
   if (isLoading) return null
   if (!isAuthenticated) return null
 
-  const showSidebar = isWide && !isProjectDetail && !isSettingsPage
+  const showSidebar = isWide && !isProjectDetail && !isSettingsPage && !isBillingPage
 
   return (
     <DomainProvider>
@@ -92,7 +94,7 @@ export default function AppLayout() {
           {showSidebar && <AppSidebar />}
 
           <View className="flex-1">
-            {!isWide && !isProjectDetail && <AppHeader onMenuPress={openDrawer} />}
+            {!isWide && !isProjectDetail && !isBillingPage && <AppHeader onMenuPress={openDrawer} />}
             <View className="flex-1">
               <Slot />
             </View>


### PR DESCRIPTION
## Summary
- Hides the sidebar and mobile hamburger header when the user navigates to the billing page (e.g. from toggling advanced mode in a project chat)
- Adds `isBillingPage` path detection to the app layout and extends the `showSidebar` condition to exclude the billing route
- Prevents the confusing UX where the main-site sidebar was visible on the billing page after navigating from a project

## Test plan
- [ ] Navigate to a project, toggle advanced mode (without credits) to trigger billing page redirect
- [ ] Verify the sidebar is **not** visible on the billing page on wide screens
- [ ] Verify the hamburger header is **not** visible on the billing page on narrow screens
- [ ] Verify the sidebar still appears on other pages (home, list pages) as expected
- [ ] Verify exiting the billing page restores the expected layout
