### PR TITLE
fix: billing page back button doesn't work on direct navigation

### DIFF
--- a/apps/mobile/app/(app)/billing.tsx
+++ b/apps/mobile/app/(app)/billing.tsx
@@ -274,7 +274,7 @@ export default observer(function BillingPage() {
     >
       {/* Header */}
       <View className="flex-row items-center gap-3 mb-6">
-        <Pressable onPress={() => router.back()}>
+        <Pressable onPress={() => router.canGoBack() ? router.back() : router.replace('/(app)')}>
           <ArrowLeft size={20} className="text-foreground" />
         </Pressable>
         <View className="flex-1">


### PR DESCRIPTION
## Summary

- The back button (arrow) on the `/billing` page uses `router.back()`, which does nothing when there's no navigation history (e.g. when a user navigates directly to the billing URL or opens it in a new tab).
- Added a `router.canGoBack()` guard that falls back to `router.replace('/(app)')` (home) when there's no history — matching the pattern already used by the settings and api-keys pages.


https://github.com/user-attachments/assets/9d5bf168-2ec8-4d37-a879-02de8ba013e9

