### PR TITLE
fix(mobile): drawer + workspace navigation and native keyboard focus

### DIFF
--- a/apps/mobile/app/(app)/new-workspace.tsx
+++ b/apps/mobile/app/(app)/new-workspace.tsx
@@ -144,7 +144,7 @@ export default function NewWorkspacePage() {
   return (
     <ScrollView
       className="flex-1 bg-background"
-      contentContainerStyle={{ padding: 16, paddingBottom: 60 }}
+      contentContainerClassName="p-4 pb-[60px]"
       showsVerticalScrollIndicator={false}
     >
       {/* Header */}
@@ -174,7 +174,7 @@ export default function NewWorkspacePage() {
             placeholder="e.g. My Team, Acme Corp"
             placeholderTextColor="#9ca3af"
             className="border border-border rounded-md px-3 py-2.5 text-sm text-foreground bg-background"
-            autoFocus
+            autoFocus={Platform.OS === 'web'}
           />
         </CardContent>
       </Card>
@@ -291,7 +291,7 @@ export default function NewWorkspacePage() {
 
         {/* Business Plan */}
         <View className="md:flex-1 md:w-0">
-          <View className="items-center" style={{ marginBottom: -12, zIndex: 1 }}>
+          <View className="items-center -mb-3 z-10">
             <Badge className="bg-primary">
               <Text className="text-xs text-primary-foreground font-medium">Most Popular</Text>
             </Badge>

--- a/apps/mobile/components/layout/AppSidebar.tsx
+++ b/apps/mobile/components/layout/AppSidebar.tsx
@@ -929,7 +929,7 @@ function CreateWorkspaceModal({
             placeholder="Enter workspace name"
             placeholderTextColor="#9ca3af"
             className="border border-border rounded-md px-3 py-2 text-sm text-foreground bg-background mb-4"
-            autoFocus
+            autoFocus={Platform.OS === 'web'}
             onSubmitEditing={handleSubmit}
           />
           <View className="flex-row gap-2 justify-end">
@@ -1123,11 +1123,13 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
     () => {
       if (allWorkspaces.length >= 1) {
         router.push('/(app)/new-workspace' as any)
+        if (!isWide) onClose?.()
       } else {
         setCreateWorkspaceOpen(true)
+        if (!isWide) onClose?.()
       }
     },
-    [allWorkspaces.length, router]
+    [allWorkspaces.length, router, isWide, onClose]
   )
 
   const handleCreateWorkspaceSubmit = useCallback(
@@ -1210,7 +1212,10 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
           workspacePlan={workspacePlan}
           allPlans={allPlans}
           showBilling={features.billing}
-          onNavigate={(href) => { router.push(href as any); onNavPress() }}
+          onNavigate={(href) => {
+            if (!isWide) onClose?.()
+            router.push(href as any)
+          }}
           onSwitchWorkspace={handleSwitchWorkspace}
           onCreateWorkspace={handleCreateWorkspace}
           localMode={localMode}


### PR DESCRIPTION
Fixes #24
<img width="362" height="774" alt="Screenshot 2026-04-01 at 1 20 54 PM" src="https://github.com/user-attachments/assets/cd45bea0-4b1a-4fc0-a142-d9062b1abb81" />
0

### Changes
- **Narrow layouts:** Close the slide-over drawer before navigating from the workspace switcher (Settings, Invite, Billing links) so the drawer does not stay on top of the next screen.
- **Create workspace:** After `router.push` to the new-workspace flow (or when opening the first-workspace modal), close the drawer when `!isWide`.
- **Native keyboard:** `autoFocus` on workspace name fields only when `Platform.OS === 'web'` in `CreateWorkspaceModal` and on the new-workspace page.
- **Styling:** Use `contentContainerClassName` and Tailwind classes instead of inline styles where touched on the new-workspace screen.

### Test plan
- [x] Narrow / mobile: Workspace menu → Settings — drawer closes, settings visible.
- [x] Narrow: Create new workspace — navigates to new-workspace (or modal) with drawer closed.
- [x] iOS/Android: Workspace name fields do not auto-open keyboard until tap.
- [x] Web: Autofocus on workspace name unchanged.
