### PR TITLE
UI suggestion: color-code Plan (amber) and Ask (emerald) on mobile chat input

### DIFF
--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -721,14 +721,44 @@ export function ChatInput({
                 <Pressable
                   {...triggerProps}
                   disabled={disabled || isStreaming}
-                  className="h-7 flex-row items-center gap-1 rounded-md px-2 bg-muted/50"
+                  className={cn(
+                    "h-7 flex-row items-center gap-1 rounded-md px-2",
+                    interactionMode === "agent" && "bg-muted/50",
+                    interactionMode === "plan" &&
+                      "border border-amber-500/45 bg-amber-500/12",
+                    interactionMode === "ask" &&
+                      "border border-emerald-500/45 bg-emerald-500/12"
+                  )}
                   testID="interaction-mode-trigger"
                 >
-                  <currentInteractionConfig.Icon className="h-3 w-3 text-muted-foreground" size={12} />
-                  <Text className="text-xs text-muted-foreground">
+                  <currentInteractionConfig.Icon
+                    className={cn(
+                      "h-3 w-3",
+                      interactionMode === "agent" && "text-muted-foreground",
+                      interactionMode === "plan" && "text-amber-400",
+                      interactionMode === "ask" && "text-emerald-400"
+                    )}
+                    size={12}
+                  />
+                  <Text
+                    className={cn(
+                      "text-xs",
+                      interactionMode === "agent" && "text-muted-foreground",
+                      interactionMode === "plan" && "text-amber-400",
+                      interactionMode === "ask" && "text-emerald-400"
+                    )}
+                  >
                     {currentInteractionConfig.label}
                   </Text>
-                  <ChevronDown className="h-2.5 w-2.5 text-muted-foreground/60" size={10} />
+                  <ChevronDown
+                    className={cn(
+                      "h-2.5 w-2.5",
+                      interactionMode === "agent" && "text-muted-foreground/60",
+                      interactionMode === "plan" && "text-amber-400/80",
+                      interactionMode === "ask" && "text-emerald-400/80"
+                    )}
+                    size={10}
+                  />
                 </Pressable>
               )}
             >
@@ -746,14 +776,47 @@ export function ChatInput({
                         }}
                         className={cn(
                           "flex-row items-center gap-3 p-3 rounded-lg mb-1",
-                          isSelected && "bg-accent"
+                          isSelected &&
+                            mode.id === "agent" &&
+                            "bg-accent",
+                          isSelected &&
+                            mode.id === "plan" &&
+                            "border border-amber-500/35 bg-amber-500/12",
+                          isSelected &&
+                            mode.id === "ask" &&
+                            "border border-emerald-500/35 bg-emerald-500/12"
                         )}
                       >
                         <View className="w-8 items-center">
-                          <mode.Icon className="h-3.5 w-3.5 text-muted-foreground" size={14} />
+                          <mode.Icon
+                            className={cn(
+                              "h-3.5 w-3.5",
+                              isSelected &&
+                                mode.id === "plan" &&
+                                "text-amber-400",
+                              isSelected &&
+                                mode.id === "ask" &&
+                                "text-emerald-400",
+                              (!isSelected || mode.id === "agent") &&
+                                "text-muted-foreground"
+                            )}
+                            size={14}
+                          />
                         </View>
                         <View className="flex-1">
-                          <Text className="font-medium text-sm text-foreground">
+                          <Text
+                            className={cn(
+                              "font-medium text-sm",
+                              isSelected &&
+                                mode.id === "plan" &&
+                                "text-amber-400",
+                              isSelected &&
+                                mode.id === "ask" &&
+                                "text-emerald-400",
+                              (!isSelected || mode.id === "agent") &&
+                                "text-foreground"
+                            )}
+                          >
                             {mode.label}
                           </Text>
                           <Text className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
<img width="291" height="280" alt="Screenshot 2026-04-01 at 3 32 44 PM" src="https://github.com/user-attachments/assets/e9e10d6a-7afc-459b-ac6a-5306295eb18f" />
<img width="75" height="34" alt="Screenshot 2026-04-01 at 3 32 58 PM" src="https://github.com/user-attachments/assets/a04cbcbc-925f-4ef4-92d9-6efbad79f881" />
<img width="83" height="45" alt="Screenshot 2026-04-01 at 3 33 09 PM" src="https://github.com/user-attachments/assets/c3339a37-e0a1-4e2d-97c9-b0dea745f4d6" />

This is a **UI/UX suggestion** (not a bugfix): make the active interaction mode easier to scan by giving **Plan** an amber tint and **Ask** an emerald tint when that mode is selected. **Agent** keeps the existing neutral styling.

## Changes

- Toolbar trigger: subtle tinted background + border and matching icon/label/chevron for Plan and Ask when active.
- Mode menu: selected row uses the same treatment; Agent continues to use `bg-accent`.
- Implemented with Tailwind classes via `cn()` only (no inline `style`).

## Scope

Single-purpose branch: `ui/mobile-interaction-mode-selector-colors` — mobile `ChatInput` interaction mode selector only.


Made with [Cursor](https://cursor.com)