### PR TITLE
fix(mobile): authenticate API keys screen with domain HttpClient

### DIFF
--- a/apps/mobile/app/(app)/api-keys.tsx
+++ b/apps/mobile/app/(app)/api-keys.tsx
@@ -32,8 +32,8 @@ import {
 } from 'lucide-react-native'
 import { PlatformApi, type ApiKeyInfo } from '@shogo-ai/sdk'
 import { useAuth } from '../../contexts/auth'
+import { useDomainHttp } from '../../contexts/domain'
 import { useActiveWorkspace } from '../../hooks/useActiveWorkspace'
-import { createHttpClient } from '../../lib/api'
 import {
   Card,
   CardContent,
@@ -47,8 +47,9 @@ export default function ApiKeysPage() {
   const router = useRouter()
   const { user } = useAuth()
   const workspace = useActiveWorkspace()
+  const http = useDomainHttp()
 
-  const platform = useMemo(() => new PlatformApi(createHttpClient()), [])
+  const platform = useMemo(() => new PlatformApi(http), [http])
 
   const [keys, setKeys] = useState<ApiKeyInfo[]>([])
   const [isLoading, setIsLoading] = useState(true)


### PR DESCRIPTION
## Problem
Creating an API key on mobile failed with `Authentication required` because requests did not include the session cookie.

## Change
- `apps/mobile/app/(app)/api-keys.tsx`: build `PlatformApi` from `useDomainHttp()` instead of `createHttpClient()`.

On native, the domain client attaches the Better Auth cookie from SecureStore (see `DomainProvider`). Web continues to use `credentials: 'include'` via the same provider.

Fixes #246

Made with [Cursor](https://cursor.com)