### PR TITLE
fix(mobile): scope integrations card to Chat tab on native phone

### DIFF
--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -761,6 +761,10 @@ export default observer(function ProjectLayout() {
       pendingToolInstalls.length > 0
     )
 
+  /** Native phone + narrow layout: float only on Chat tab (not Canvas / Files / Terminal / …). Web, tablet, and wide layouts unchanged. */
+  const showIntegrationsCardUi =
+    showIntegrationsCard && (!nativePhone || isWide || activeTab === 'chat')
+
   const narrowOnCanvas = !isWide && activeTab === 'canvas'
   /** Native-only: float above Files / Terminal / … (those layers use z-20). Omit on Expo web so web layout stays unchanged. */
   const showNativeNarrowChatFab = narrowOnCanvas && Platform.OS !== 'web'
@@ -1031,7 +1035,7 @@ export default observer(function ProjectLayout() {
           </View>
 
           {/* Floating integrations card */}
-          {showIntegrationsCard && (
+          {showIntegrationsCardUi && (
             <View
               className={cn(
                 'absolute z-30',


### PR DESCRIPTION
## Summary
<img width="600" height="1304" alt="image" src="https://github.com/user-attachments/assets/f0dd011b-5357-4236-845d-96c5390cc2af" />
<img width="526" height="1150" alt="image" src="https://github.com/user-attachments/assets/6e537d1c-5327-41ea-81c1-a8fd28a1c3c2" />

Restores the behavior from [PR #212](https://github.com/shogo-labs/shogo-ai/pull/212) / [2974fce](https://github.com/shogo-labs/shogo-ai/commit/2974fcec3ae7a9381d7a9a4e9607d210b357b2b3): on **native phone + narrow layout**, the floating `IntegrationsCard` (connect tools / template integrations) only appears when the **Chat** tab is active—not on Canvas, Files, Terminal, Capabilities, etc.

## Change

- `showIntegrationsCardUi = showIntegrationsCard && (!nativePhone || isWide || activeTab === 'chat')`
- Floating card uses `showIntegrationsCardUi` instead of `showIntegrationsCard`.

Closes #248

Made with [Cursor](https://cursor.com)