### PR TITLE
fix(mobile): persist active workspace id on native for settings

### DIFF
--- a/apps/mobile/lib/workspace-store.ts
+++ b/apps/mobile/lib/workspace-store.ts
@@ -4,12 +4,19 @@ import { Platform } from 'react-native'
 
 const STORAGE_KEY = 'shogo:active-workspace-id'
 
+let nativeActiveWorkspaceId: string | null = null
+
 export function getActiveWorkspaceId(): string | null {
-  if (Platform.OS !== 'web' || typeof window === 'undefined') return null
+  if (Platform.OS !== 'web' || typeof window === 'undefined') {
+    return nativeActiveWorkspaceId
+  }
   return window.localStorage.getItem(STORAGE_KEY)
 }
 
 export function setActiveWorkspaceId(id: string): void {
-  if (Platform.OS !== 'web' || typeof window === 'undefined') return
+  if (Platform.OS !== 'web' || typeof window === 'undefined') {
+    nativeActiveWorkspaceId = id
+    return
+  }
   window.localStorage.setItem(STORAGE_KEY, id)
 }


### PR DESCRIPTION
Fixes #252
<img width="364" height="436" alt="Screenshot 2026-04-01 at 6 16 47 PM" src="https://github.com/user-attachments/assets/7b1c70f7-7e2b-4168-8e81-485a97b3b779" />
<img width="400" height="573" alt="Screenshot 2026-04-01 at 6 16 57 PM" src="https://github.com/user-attachments/assets/4abc0a89-d125-4073-ad46-6b7783a8610e" />

## Problem

On iOS/Android, `getActiveWorkspaceId` / `setActiveWorkspaceId` in `workspace-store.ts` were no-ops (web-only `localStorage`). The sidebar kept the real selection in React state, but `useActiveWorkspace()` (used by Settings) always fell back to the first workspace—so users saw their personal workspace in Settings and could not leave a workspace they had joined.

## Change

Store the active workspace id in module-level memory on native when not on web, mirroring what localStorage does on web.

## Testing

- Switch to a non-personal workspace in the sidebar, open Settings → Workspace: name and **Leave workspace** should match that workspace.
- Web behavior unchanged (still uses `localStorage`).

Made with [Cursor](https://cursor.com)