### PR TITLE
fix(mobile): sync received invitations between Inbox and Settings

### DIFF
--- a/apps/mobile/app/(app)/settings.tsx
+++ b/apps/mobile/app/(app)/settings.tsx
@@ -70,6 +70,7 @@ import {
   UsageBreakdownSection,
 } from '../../components/analytics/SharedAnalytics'
 import { useToast, Toast, ToastTitle, ToastDescription } from '@/components/ui/toast'
+import { invitationEvents } from '../../lib/invitation-events'
 import {
   Card,
   CardContent,
@@ -1013,6 +1014,8 @@ const PeopleTab = observer(function PeopleTab() {
 
   useEffect(() => { loadPeopleData() }, [loadPeopleData])
 
+  useEffect(() => invitationEvents.subscribe(loadPeopleData), [loadPeopleData])
+
   const ROLE_PRIORITY: Record<string, number> = { owner: 0, admin: 1, member: 2, viewer: 3 }
 
   const workspaceMembers = useMemo(() => {
@@ -1525,6 +1528,7 @@ const PeopleTab = observer(function PeopleTab() {
                               setReceivedInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
                             } catch {}
                             loadPeopleData()
+                            invitationEvents.emit()
                             setProcessingInvite(null)
                           }}
                           className={cn('flex-1 h-10 bg-primary rounded-lg items-center justify-center', processingInvite?.id === inv.id && 'opacity-50')}
@@ -1544,6 +1548,7 @@ const PeopleTab = observer(function PeopleTab() {
                               setReceivedInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
                             } catch {}
                             loadPeopleData()
+                            invitationEvents.emit()
                             setProcessingInvite(null)
                           }}
                           className={cn('flex-1 h-10 border border-border rounded-lg items-center justify-center', processingInvite?.id === inv.id && 'opacity-50')}

--- a/apps/mobile/components/layout/AppSidebar.tsx
+++ b/apps/mobile/components/layout/AppSidebar.tsx
@@ -87,6 +87,7 @@ import { api } from '../../lib/api'
 import { trackPurchase } from '../../lib/tracking'
 import { getActiveWorkspaceId, setActiveWorkspaceId } from '../../lib/workspace-store'
 import { usePlatformConfig } from '../../lib/platform-config'
+import { invitationEvents } from '../../lib/invitation-events'
 
 function getInitials(name: string | null | undefined): string {
   if (!name) return '?'
@@ -1013,6 +1014,8 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
 
   useEffect(() => { loadInvites() }, [loadInvites])
 
+  useEffect(() => invitationEvents.subscribe(loadInvites), [loadInvites])
+
   // Detect return from Stripe checkout: verify payment, provision subscription, reload
   useEffect(() => {
     if (Platform.OS !== 'web' || typeof window === 'undefined') return
@@ -1477,6 +1480,7 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
                               setPendingInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
                             } catch {}
                             loadInvites()
+                            invitationEvents.emit()
                             workspaces.loadAll().catch((e) => console.error('[AppSidebar] Failed to reload workspaces:', e))
                             setProcessingInvite(null)
                           }}
@@ -1497,6 +1501,7 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
                               setPendingInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
                             } catch {}
                             loadInvites()
+                            invitationEvents.emit()
                             setProcessingInvite(null)
                           }}
                           className={cn('flex-1 h-8 border border-border rounded-md items-center justify-center', processingInvite?.id === inv.id && 'opacity-50')}

--- a/apps/mobile/lib/invitation-events.ts
+++ b/apps/mobile/lib/invitation-events.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+type Listener = () => void
+
+const listeners = new Set<Listener>()
+
+/**
+ * Lightweight pub/sub so that Inbox (AppSidebar) and Settings > People >
+ * Invitations stay in sync after accept / decline on either surface.
+ */
+export const invitationEvents = {
+  subscribe(fn: Listener) {
+    listeners.add(fn)
+    return () => { listeners.delete(fn) }
+  },
+
+  emit() {
+    listeners.forEach((fn) => fn())
+  },
+}


### PR DESCRIPTION
## Problem
<img width="403" height="240" alt="Screenshot 2026-04-01 at 6 28 23 PM" src="https://github.com/user-attachments/assets/04bdfc6a-b864-495c-9ee6-3f884a0d6061" />
<img width="402" height="449" alt="Screenshot 2026-04-01 at 6 28 37 PM" src="https://github.com/user-attachments/assets/5d15c46e-1890-40bb-afe0-f995452b43d6" />
Received workspace invitations appeared in both the **Inbox** (sidebar) and **Settings → People → Invitations**, but accepting or declining in one place did not update the other on mobile.

## Solution
- Add `apps/mobile/lib/invitation-events.ts`: a small pub/sub so both surfaces reload their pending-invite lists when either completes accept/decline.
- `AppSidebar` subscribes to refresh `loadInvites`; `PeopleTab` subscribes to refresh `loadPeopleData`. Each emits after a successful accept/decline.

## Scope
Mobile app only (`apps/mobile`); no web changes.

Fixes #254

Made with [Cursor](https://cursor.com)