### PR TITLE
fix(agent-runtime): re-enable create_plan tool for Plans tab

### DIFF
--- a/packages/agent-runtime/src/gateway-tools.ts
+++ b/packages/agent-runtime/src/gateway-tools.ts
@@ -5032,7 +5032,7 @@ export function createTools(ctx: ToolContext, extraTools?: AgentTool[]): AgentTo
     g(createTranscribeAudioTool(ctx), 'network'),
     createHeartbeatConfigureTool(ctx),
     createHeartbeatStatusTool(ctx),
-    // createCreatePlanTool(ctx), // disabled: plan mode tool removed from agent
+    createCreatePlanTool(ctx),
   ]
 
   // Self-referencing getter for tools that need the full tool list (skill)


### PR DESCRIPTION
Closes #256
<img width="1512" height="982" alt="Screenshot 2026-04-01 at 10 22 19 PM" src="https://github.com/user-attachments/assets/040b3a64-95d9-4bf0-9d16-d8f873072b53" />
<img width="1512" height="982" alt="Screenshot 2026-04-01 at 10 28 07 PM" src="https://github.com/user-attachments/assets/b710a2d7-a591-4863-972f-505505d6dd75" />

## What changed
- Register `createCreatePlanTool(ctx)` again in `createTools()` (`packages/agent-runtime/src/gateway-tools.ts`).

## Why
Plan mode and the Plans UI expect the `create_plan` tool to write `.shogo/plans/*.plan.md` and emit `data-plan`. The tool implementation existed but was commented out, so nothing was persisted and the Plans panel stayed empty.

## Testing
- Manual: use Plan mode in a project chat, have the agent call `create_plan`; confirm files under `.shogo/plans/` and entries in the Plans panel after refresh.

Made with [Cursor](https://cursor.com)