### PR TITLE
fix: clean up orphaned DomainMappings and guard DynChart against null data

### DIFF
--- a/apps/api/src/lib/warm-pool-controller.ts
+++ b/apps/api/src/lib/warm-pool-controller.ts
@@ -768,6 +768,7 @@ export class WarmPoolController {
    *  1. Remove from in-memory assigned map
    *  2. Clear knativeServiceName in the database
    *  3. Delete the old Knative Service (async, best-effort)
+   *  4. Delete the preview DomainMapping (async, best-effort)
    *
    * The next chat/runtime request triggers getProjectPodUrl() which
    * claims a new warm pod from the pool.
@@ -818,6 +819,17 @@ export class WarmPoolController {
         }
       })()
     }
+
+    // Delete the preview DomainMapping (best-effort, non-blocking)
+    ;(async () => {
+      try {
+        const { getKnativeProjectManager } = await import('./knative-project-manager')
+        const manager = getKnativeProjectManager()
+        await manager.deletePreviewDomainMapping(projectId)
+      } catch (err: any) {
+        console.error(`[WarmPool] evictProject: failed to delete DomainMapping for ${projectId} (non-fatal):`, err.message)
+      }
+    })()
 
     console.log(`[WarmPool] evictProject: evicted project ${projectId} from ${oldServiceName || '(not found)'}`)
     return { evicted: !!oldServiceName, oldService: oldServiceName }
@@ -1062,7 +1074,7 @@ export class WarmPoolController {
         console.log(
           `[WarmPool GC] Deleting orphaned promoted pod ${pod.serviceName} (project ${pod.projectId} no longer maps to it)`
         )
-        this.deleteWarmPodService(pod.serviceName).catch((err) => {
+        this.deleteWarmPodService(pod.serviceName, pod.projectId).catch((err) => {
           console.error(`[WarmPool GC] Failed to delete orphan ${pod.serviceName}:`, err.message)
         })
         orphansDeleted++
@@ -1263,7 +1275,7 @@ export class WarmPoolController {
           continue
         }
 
-        this.deleteWarmPodService(svc.name).catch((err) => {
+        this.deleteWarmPodService(svc.name, svc.projectId ?? undefined).catch((err) => {
           console.error(`[WarmPool GC:namespace] Failed to delete ${svc.name}:`, err.message)
         })
         deleted++
@@ -1835,9 +1847,11 @@ export class WarmPoolController {
   }
 
   /**
-   * Delete a warm pool Knative Service.
+   * Delete a warm pool Knative Service and its associated DomainMapping.
+   * When projectId is provided, also cleans up the preview DomainMapping
+   * to prevent orphaned DomainMappings that continuously fail to reconcile.
    */
-  private async deleteWarmPodService(serviceName: string): Promise<void> {
+  private async deleteWarmPodService(serviceName: string, projectId?: string): Promise<void> {
     try {
       const api = getCustomApi()
       await api.deleteNamespacedCustomObject({
@@ -1851,6 +1865,16 @@ export class WarmPoolController {
     } catch (err: any) {
       if (err?.code !== 404 && err?.response?.statusCode !== 404) {
         throw err
+      }
+    }
+
+    if (projectId) {
+      try {
+        const { getKnativeProjectManager } = await import('./knative-project-manager')
+        const manager = getKnativeProjectManager()
+        await manager.deletePreviewDomainMapping(projectId)
+      } catch (err: any) {
+        console.error(`[WarmPool] Failed to delete DomainMapping for project ${projectId} (non-fatal):`, err.message)
       }
     }
   }

--- a/apps/mobile/components/dynamic-app/components/data.tsx
+++ b/apps/mobile/components/dynamic-app/components/data.tsx
@@ -221,7 +221,7 @@ function ChartLegend({ data, palette }: { data: ChartDataPoint[]; palette?: stri
 
 export function DynChart({
   type = 'bar',
-  data = [],
+  data: rawData,
   title,
   height = 200,
   showLegend,
@@ -231,6 +231,7 @@ export function DynChart({
   colors,
   className,
 }: ChartProps) {
+  const data = Array.isArray(rawData) ? rawData : []
   if (data.length === 0) {
     return (
       <View className={cn('flex items-center justify-center', className)} style={{ height }}>

--- a/packages/canvas-runtime/src/components/canvas/data.tsx
+++ b/packages/canvas-runtime/src/components/canvas/data.tsx
@@ -186,7 +186,8 @@ function getColor(d: ChartDataPoint, i: number, palette?: string[]): string {
   return d.color || (palette ?? DEFAULT_COLORS)[i % (palette ?? DEFAULT_COLORS).length]
 }
 
-export function DynChart({ type = 'bar', data = [], title, height = 200, showLegend, colors, className }: DynChartProps) {
+export function DynChart({ type = 'bar', data: rawData, title, height = 200, showLegend, colors, className }: DynChartProps) {
+  const data = Array.isArray(rawData) ? rawData : []
   if (data.length === 0) {
     return (
       <div className={cn('flex items-center justify-center', className)} style={{ height }}>


### PR DESCRIPTION
## Summary

- **DomainMapping leak fix**: All warm pool cleanup paths (`deleteWarmPodService`, `evictProject`, `gcPromotedPods`, `gcOrphanedServices`) were deleting Knative Services but leaving their DomainMappings behind. This caused perpetual Knative reconciliation errors (`"warm-pool-211e340d" not found`) and 502 proxy errors for affected projects. Each path now also calls `deletePreviewDomainMapping()` (best-effort, non-fatal).
- **DynChart crash fix**: The default parameter `data = []` did not guard against explicit `null` from LLM-generated chart props, causing `t.map is not a function` crashes on `studio.shogo.ai`. Both web and mobile `DynChart` components now use `Array.isArray(rawData) ? rawData : []`.

## Root cause

When a warm pool pod is deleted by GC (orphan detection or scaled-to-zero cleanup) or eviction, the Knative Service is removed but the DomainMapping that references it is not. The DomainMapping's `spec.ref` points to the deleted service, so the Knative networking controller continuously fails to reconcile, logging errors every few seconds. Any HTTP request hitting that domain returns 502.

## Changes

| File | Change |
|---|---|
| `apps/api/src/lib/warm-pool-controller.ts` | `deleteWarmPodService()` now accepts optional `projectId` and deletes the DomainMapping; `evictProject()` adds explicit DomainMapping cleanup; `gcPromotedPods()` and `gcOrphanedServices()` pass `projectId` to deletion |
| `apps/mobile/components/dynamic-app/components/data.tsx` | `DynChart` uses `Array.isArray()` guard instead of default parameter |
| `packages/canvas-runtime/src/components/canvas/data.tsx` | Same `Array.isArray()` guard for web canvas `DynChart` |

## Test plan

- [ ] Deploy to staging and verify that when a warm pod is GC'd, its DomainMapping is also deleted
- [ ] Verify `kubectl get domainmappings -n workspaces` shows no orphaned mappings after GC cycles
- [ ] Test `DynChart` with `data: null`, `data: undefined`, and `data: []` — should render "No chart data" placeholder instead of crashing

