### PR TITLE
fix: increase project chat stream timeouts to prevent mid-response cutoffs

### DIFF
--- a/apps/api/src/routes/project-chat.ts
+++ b/apps/api/src/routes/project-chat.ts
@@ -109,7 +109,7 @@ async function trackUsageFromStream(
   let reasoningStartedAt: number | null = null
   let streamInterrupted = false
 
-  const PER_CHUNK_IDLE_TIMEOUT_MS = 45_000
+  const PER_CHUNK_IDLE_TIMEOUT_MS = 120_000
 
   try {
     while (true) {
@@ -668,7 +668,7 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
       const MAX_RETRIES = 30
       const BASE_DELAY_MS = 500
       const MAX_DELAY_MS = 4000
-      const FETCH_TIMEOUT_MS = 120_000
+      const FETCH_TIMEOUT_MS = 600_000
       let lastError: Error | null = null
 
       for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {


### PR DESCRIPTION
## Summary

- **FETCH_TIMEOUT_MS** (`AbortSignal.timeout` on the proxy fetch to the agent pod) increased from **120s to 600s** (10 min). The previous 2-minute hard cap was measured from request start, not last chunk — agent sessions with many tool calls (17-46 per turn observed) easily exceeded this, causing `TimeoutError (code 23)` that killed the underlying connection and both sides of the `tee()` stream.
- **PER_CHUNK_IDLE_TIMEOUT_MS** (tracking stream reader idle timeout) increased from **45s to 120s** (2 min). Slow external API calls (e.g. Composio/Meta Ads) create gaps between chunks that exceeded the previous threshold, marking the stream as interrupted.

## Evidence from server logs

- `Stream interrupted (23), persisting 93 chars accumulated so far` — AbortSignal firing at 120s
- `Stream interrupted (chunk idle timeout), persisting 125 chars accumulated so far` — 45s idle timeout during tool execution
- Multiple `TimeoutError: The operation timed out.` (DOMException code 23) throughout the session

## Test plan

- [ ] Send a chat message to a project that triggers many tool calls (e.g. Composio integration setup)
- [ ] Verify the stream completes without mid-response cutoffs
- [ ] Confirm no `TimeoutError` or `chunk idle timeout` in server logs for sessions under 10 minutes


Made with [Cursor](https://cursor.com)