### PR TITLE
fix: Windows LSP binary resolution and chokidar file watcher

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "@prisma/adapter-libsql": "^7.3.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/pg": "^8.20.0",
+        "chokidar": "3",
         "concurrently": "^9.2.1",
         "jsonwebtoken": "^9.0.3",
         "pg": "^8.20.0",
@@ -1939,7 +1940,7 @@
 
     "chevrotain": ["chevrotain@10.5.0", "", { "dependencies": { "@chevrotain/cst-dts-gen": "10.5.0", "@chevrotain/gast": "10.5.0", "@chevrotain/types": "10.5.0", "@chevrotain/utils": "10.5.0", "lodash": "4.17.21", "regexp-to-ast": "0.5.0" } }, "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A=="],
 
-    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+    "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
@@ -2349,7 +2350,7 @@
 
     "glob": ["glob@9.3.5", "", { "dependencies": { "fs.realpath": "^1.0.0", "minimatch": "^8.0.2", "minipass": "^4.2.4", "path-scurry": "^1.6.1" } }, "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q=="],
 
-    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "global-dirs": ["global-dirs@0.1.1", "", { "dependencies": { "ini": "^1.3.4" } }, "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg=="],
 
@@ -2965,7 +2966,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
@@ -3139,7 +3140,7 @@
 
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
 
-    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+    "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
@@ -3765,13 +3766,13 @@
 
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
-    "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
     "better-opn/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
     "bplist-creator/stream-buffers": ["stream-buffers@2.2.0", "", {}, "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg=="],
 
     "bun-types/@types/node": ["@types/node@24.10.13", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg=="],
+
+    "c12/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "c12/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
@@ -3817,11 +3818,11 @@
 
     "expo-updates/glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
-    "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
     "fbjs/promise": ["promise@7.3.1", "", { "dependencies": { "asap": "~2.0.3" } }, "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="],
 
     "fbjs/ua-parser-js": ["ua-parser-js@1.0.41", "", { "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug=="],
+
+    "fdir/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
@@ -3844,8 +3845,6 @@
     "jest-mock/@types/node": ["@types/node@24.10.13", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg=="],
 
     "jest-util/@types/node": ["@types/node@24.10.13", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg=="],
-
-    "jest-util/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "jest-worker/@types/node": ["@types/node@24.10.13", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg=="],
 
@@ -3894,8 +3893,6 @@
     "metro-symbolicate/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
 
     "metro-transform-worker/metro-source-map": ["metro-source-map@0.83.3", "", { "dependencies": { "@babel/traverse": "^7.25.3", "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3", "@babel/types": "^7.25.2", "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-symbolicate": "0.83.3", "nullthrows": "^1.1.1", "ob1": "0.83.3", "source-map": "^0.5.6", "vlq": "^1.0.0" } }, "sha512-xkC3qwUBh2psVZgVavo8+r2C9Igkk3DibiOXSAht1aYRRcztEZNFtAMtfSB7sdO2iFMx2Mlyu++cBxz/fhdzQg=="],
-
-    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "mlly/pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
@@ -3987,13 +3984,17 @@
 
     "tailwind-variants/tailwind-merge": ["tailwind-merge@1.14.0", "", {}, "sha512-3mFKyCo/MBcgyOTlrY8T7odzZFx+w+qKSMAmdFzRvqBfLlSigU6TZnlFHK0lkMwj9Bj8OYU+9yW9lmGuS0QEnQ=="],
 
-    "tailwindcss/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+    "tailwindcss/glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "test-exclude/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "test-exclude/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "tsup/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "unified/is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
@@ -4155,6 +4156,8 @@
 
     "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
+    "c12/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
     "chrome-launcher/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "chromium-edge-launcher/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
@@ -4229,11 +4232,9 @@
 
     "rimraf/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
-    "tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "tailwindcss/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
-
     "test-exclude/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "tsup/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
@@ -4296,8 +4297,6 @@
     "ora/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 
     "react-native/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
-
-    "tailwindcss/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "@babel/highlight/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@prisma/adapter-libsql": "^7.3.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/pg": "^8.20.0",
+    "chokidar": "3",
     "concurrently": "^9.2.1",
     "jsonwebtoken": "^9.0.3",
     "pg": "^8.20.0",

--- a/packages/agent-runtime/src/__tests__/lsp-smoke.test.ts
+++ b/packages/agent-runtime/src/__tests__/lsp-smoke.test.ts
@@ -11,11 +11,13 @@
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
 import { mkdirSync, writeFileSync, rmSync, readFileSync, copyFileSync, existsSync } from 'fs'
 import { join, resolve } from 'path'
-import { TSLanguageServer } from '@shogo/shared-runtime'
+import { TSLanguageServer, resolveBin } from '@shogo/shared-runtime'
 
 const WORKSPACE = '/tmp/test-lsp-smoke'
 const CANVAS_GLOBALS_SRC = resolve(__dirname, '../../../canvas-runtime/src/canvas-globals.d.ts')
-const TS_LS_BIN = resolve(__dirname, '../../node_modules/.bin/typescript-language-server')
+const pkgDir = resolve(__dirname, '../..')
+const tsResult = resolveBin('typescript-language-server', [pkgDir], 'lib/cli.mjs')
+const TS_LS_BIN = tsResult?.resolved ?? resolve(pkgDir, 'node_modules/.bin/typescript-language-server')
 
 const TSCONFIG = JSON.stringify({
   compilerOptions: {

--- a/packages/agent-runtime/src/__tests__/workspace-lsp-manager.test.ts
+++ b/packages/agent-runtime/src/__tests__/workspace-lsp-manager.test.ts
@@ -11,11 +11,14 @@ import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
 import { mkdirSync, writeFileSync, rmSync, copyFileSync, existsSync } from 'fs'
 import { join, resolve } from 'path'
 import { realpathSync } from 'node:fs'
-import { WorkspaceLSPManager } from '@shogo/shared-runtime'
+import { WorkspaceLSPManager, resolveBin } from '@shogo/shared-runtime'
 
 const WORKSPACE = realpathSync('/tmp') + '/test-workspace-lsp-mgr'
-const TS_BIN = resolve(__dirname, '../../node_modules/.bin/typescript-language-server')
-const PY_BIN = resolve(__dirname, '../../node_modules/.bin/pyright')
+const pkgDir = resolve(__dirname, '../..')
+const tsResult = resolveBin('typescript-language-server', [pkgDir], 'lib/cli.mjs')
+const pyResult = resolveBin('pyright', [pkgDir])
+const TS_BIN = tsResult?.resolved ?? resolve(pkgDir, 'node_modules/.bin/typescript-language-server')
+const PY_BIN = pyResult?.resolved ?? resolve(pkgDir, 'node_modules/.bin/pyright')
 const CANVAS_GLOBALS_SRC = resolve(__dirname, '../../../canvas-runtime/src/canvas-globals.d.ts')
 
 const TSCONFIG = JSON.stringify({

--- a/packages/agent-runtime/src/gateway.ts
+++ b/packages/agent-runtime/src/gateway.ts
@@ -50,7 +50,7 @@ import {
 import { CODE_AGENT_GENERAL_GUIDE } from './code-agent-prompt'
 import { UI_UX_DESIGN_GUIDE } from './ui-ux-guide-prompt'
 import { MCPClientManager, type MCPServerConfig, type RemoteMCPServerConfig } from './mcp-client'
-import { WorkspaceLSPManager } from '@shogo/shared-runtime'
+import { WorkspaceLSPManager, resolveBin } from '@shogo/shared-runtime'
 import { initComposioSession, resetComposioSession, isComposioEnabled, isComposioInitialized } from './composio'
 import { deriveApiUrl, getInternalHeaders } from './internal-api'
 import type { FilePart } from './file-attachment-utils'
@@ -636,12 +636,16 @@ export class AgentGateway {
   private async startLSP(): Promise<void> {
     try {
       const thisDir = dirname(fileURLToPath(import.meta.url))
-      const tsBin = join(thisDir, '..', 'node_modules', '.bin', 'typescript-language-server')
-      const pyBin = join(thisDir, '..', 'node_modules', '.bin', 'pyright')
+      const pkgDir = join(thisDir, '..')
+      const searchDirs = [pkgDir]
+
+      const tsResult = resolveBin('typescript-language-server', searchDirs, 'lib/cli.mjs')
+      const pyResult = resolveBin('pyright', searchDirs)
+
       this.lspManager = new WorkspaceLSPManager({
         projectDir: this.workspaceDir,
-        tsServerBin: existsSync(tsBin) ? tsBin : undefined,
-        pyrightBin: existsSync(pyBin) ? pyBin : undefined,
+        tsServerBin: tsResult?.resolved,
+        pyrightBin: pyResult?.resolved,
       })
       await this.lspManager.startAll()
       console.log(`${this.logPrefix} LSP ready for workspace: ${this.workspaceDir}`)

--- a/packages/shared-runtime/src/__tests__/lsp-bin-resolution.test.ts
+++ b/packages/shared-runtime/src/__tests__/lsp-bin-resolution.test.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdirSync, writeFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { resolveBin } from '../lsp-service'
+
+const TMP = join(process.env.TEMP ?? process.env.TMPDIR ?? '/tmp', 'test-lsp-bin-resolution')
+const IS_WINDOWS = process.platform === 'win32'
+
+function touch(path: string) {
+  writeFileSync(path, '', 'utf-8')
+}
+
+describe('resolveBin', () => {
+  beforeEach(() => {
+    rmSync(TMP, { recursive: true, force: true })
+  })
+
+  afterEach(() => {
+    rmSync(TMP, { recursive: true, force: true })
+  })
+
+  test('finds extensionless binary in .bin/ (POSIX)', () => {
+    const dir = join(TMP, 'pkg-a')
+    mkdirSync(join(dir, 'node_modules', '.bin'), { recursive: true })
+    touch(join(dir, 'node_modules', '.bin', 'typescript-language-server'))
+
+    const result = resolveBin('typescript-language-server', [dir])
+    expect(result).toBeTruthy()
+    expect(result!.resolved).toBe(join(dir, 'node_modules', '.bin', 'typescript-language-server'))
+    expect(result!.viaBun).toBe(false)
+  })
+
+  if (IS_WINDOWS) {
+    test('finds .exe shim in .bin/ on Windows', () => {
+      const dir = join(TMP, 'pkg-b')
+      mkdirSync(join(dir, 'node_modules', '.bin'), { recursive: true })
+      touch(join(dir, 'node_modules', '.bin', 'typescript-language-server.exe'))
+
+      const result = resolveBin('typescript-language-server', [dir])
+      expect(result).toBeTruthy()
+      expect(result!.resolved).toBe(join(dir, 'node_modules', '.bin', 'typescript-language-server.exe'))
+      expect(result!.viaBun).toBe(false)
+    })
+
+    test('finds .cmd shim in .bin/ on Windows', () => {
+      const dir = join(TMP, 'pkg-c')
+      mkdirSync(join(dir, 'node_modules', '.bin'), { recursive: true })
+      touch(join(dir, 'node_modules', '.bin', 'typescript-language-server.cmd'))
+
+      const result = resolveBin('typescript-language-server', [dir])
+      expect(result).toBeTruthy()
+      expect(result!.resolved).toBe(join(dir, 'node_modules', '.bin', 'typescript-language-server.cmd'))
+      expect(result!.viaBun).toBe(false)
+    })
+
+    test('prefers extensionless over .exe when both exist', () => {
+      const dir = join(TMP, 'pkg-d')
+      mkdirSync(join(dir, 'node_modules', '.bin'), { recursive: true })
+      touch(join(dir, 'node_modules', '.bin', 'typescript-language-server'))
+      touch(join(dir, 'node_modules', '.bin', 'typescript-language-server.exe'))
+
+      const result = resolveBin('typescript-language-server', [dir])
+      expect(result).toBeTruthy()
+      expect(result!.resolved).toBe(join(dir, 'node_modules', '.bin', 'typescript-language-server'))
+    })
+  }
+
+  test('falls back to direct module entry point when .bin/ has no match', () => {
+    const dir = join(TMP, 'pkg-e')
+    mkdirSync(join(dir, 'node_modules', 'typescript-language-server', 'lib'), { recursive: true })
+    touch(join(dir, 'node_modules', 'typescript-language-server', 'lib', 'cli.mjs'))
+
+    const result = resolveBin('typescript-language-server', [dir], 'lib/cli.mjs')
+    expect(result).toBeTruthy()
+    expect(result!.resolved).toBe(
+      join(dir, 'node_modules', 'typescript-language-server', 'lib', 'cli.mjs'),
+    )
+    expect(result!.viaBun).toBe(true)
+  })
+
+  test('searches multiple directories in order', () => {
+    const dirA = join(TMP, 'search-a')
+    const dirB = join(TMP, 'search-b')
+    mkdirSync(join(dirA, 'node_modules', '.bin'), { recursive: true })
+    mkdirSync(join(dirB, 'node_modules', '.bin'), { recursive: true })
+    touch(join(dirB, 'node_modules', '.bin', 'pyright'))
+
+    const result = resolveBin('pyright', [dirA, dirB])
+    expect(result).toBeTruthy()
+    expect(result!.resolved).toBe(join(dirB, 'node_modules', '.bin', 'pyright'))
+  })
+
+  test('first directory wins when both have the binary', () => {
+    const dirA = join(TMP, 'first-a')
+    const dirB = join(TMP, 'first-b')
+    mkdirSync(join(dirA, 'node_modules', '.bin'), { recursive: true })
+    mkdirSync(join(dirB, 'node_modules', '.bin'), { recursive: true })
+    touch(join(dirA, 'node_modules', '.bin', 'pyright'))
+    touch(join(dirB, 'node_modules', '.bin', 'pyright'))
+
+    const result = resolveBin('pyright', [dirA, dirB])
+    expect(result).toBeTruthy()
+    expect(result!.resolved).toBe(join(dirA, 'node_modules', '.bin', 'pyright'))
+  })
+
+  test('returns undefined when nothing found and no directEntryPath', () => {
+    const dir = join(TMP, 'empty')
+    mkdirSync(dir, { recursive: true })
+
+    const result = resolveBin('nonexistent-server', [dir])
+    expect(result).toBeUndefined()
+  })
+
+  test('returns undefined when nothing found even with directEntryPath', () => {
+    const dir = join(TMP, 'empty2')
+    mkdirSync(dir, { recursive: true })
+
+    const result = resolveBin('nonexistent-server', [dir], 'lib/cli.mjs')
+    expect(result).toBeUndefined()
+  })
+
+  test('does not accept bare name without filesystem check', () => {
+    const dir = join(TMP, 'no-bare')
+    mkdirSync(dir, { recursive: true })
+
+    const result = resolveBin('typescript-language-server', [dir])
+    expect(result).toBeUndefined()
+  })
+})

--- a/packages/shared-runtime/src/index.ts
+++ b/packages/shared-runtime/src/index.ts
@@ -93,6 +93,7 @@ export {
   LSPServerManager,
   lspManager,
   WorkspaceLSPManager,
+  resolveBin,
   type LSPMessage,
   type LSPDiagnostic,
   type TSLanguageServerOptions,

--- a/packages/shared-runtime/src/lsp-service.ts
+++ b/packages/shared-runtime/src/lsp-service.ts
@@ -12,6 +12,44 @@ import { spawn, type Subprocess } from 'bun'
 import { existsSync, mkdirSync, writeFileSync, unlinkSync } from 'fs'
 import { join, dirname } from 'path'
 
+const IS_WINDOWS = process.platform === 'win32'
+const WIN_BIN_EXTENSIONS = ['.exe', '.cmd']
+
+/**
+ * Resolve a Node CLI binary across platforms.
+ *
+ * On Windows, Bun creates `.exe` / `.bunx` shims in `node_modules/.bin/`
+ * instead of extensionless POSIX scripts, so a bare `existsSync(…/.bin/name)`
+ * will fail. This helper checks the extensionless path first, then Windows
+ * shim extensions, then falls back to the module's JS entry point
+ * (bypassing `.bin/` entirely, like the Vite workaround in manager.ts).
+ */
+export function resolveBin(
+  name: string,
+  searchDirs: string[],
+  directEntryPath?: string,
+): { resolved: string; viaBun: boolean } | undefined {
+  for (const dir of searchDirs) {
+    const base = join(dir, 'node_modules', '.bin', name)
+    if (existsSync(base)) return { resolved: base, viaBun: false }
+    if (IS_WINDOWS) {
+      for (const ext of WIN_BIN_EXTENSIONS) {
+        const withExt = base + ext
+        if (existsSync(withExt)) return { resolved: withExt, viaBun: false }
+      }
+    }
+  }
+
+  if (directEntryPath) {
+    for (const dir of searchDirs) {
+      const entry = join(dir, 'node_modules', name, directEntryPath)
+      if (existsSync(entry)) return { resolved: entry, viaBun: true }
+    }
+  }
+
+  return undefined
+}
+
 export interface LSPMessage {
   jsonrpc: '2.0'
   id?: number | string
@@ -82,28 +120,55 @@ export class TSLanguageServer {
   async start(): Promise<void> {
     if (this.process) return
 
-    const possiblePaths = [
-      ...(this.serverBin ? [this.serverBin] : []),
-      ...this.fallbackBinNames.flatMap(name => [
-        join(this.projectDir, 'node_modules', '.bin', name),
-        join(dirname(dirname(import.meta.path)), 'node_modules', '.bin', name),
-        name,
-      ]),
+    const searchDirs = [
+      this.projectDir,
+      dirname(dirname(import.meta.path)),
     ]
 
-    let serverPath = this.fallbackBinNames[0] ?? 'typescript-language-server'
-    for (const p of possiblePaths) {
-      if (this.fallbackBinNames.includes(p) || existsSync(p)) {
-        serverPath = p
-        break
+    let serverPath: string | undefined
+    let spawnViaBun = false
+
+    if (this.serverBin) {
+      if (existsSync(this.serverBin)) {
+        serverPath = this.serverBin
+      } else if (IS_WINDOWS) {
+        for (const ext of WIN_BIN_EXTENSIONS) {
+          if (existsSync(this.serverBin + ext)) {
+            serverPath = this.serverBin + ext
+            break
+          }
+        }
       }
     }
 
-    console.log(`[${this.label}] Starting ${serverPath}`)
+    if (!serverPath) {
+      for (const name of this.fallbackBinNames) {
+        const result = resolveBin(name, searchDirs, 'lib/cli.mjs')
+        if (result) {
+          serverPath = result.resolved
+          spawnViaBun = result.viaBun
+          break
+        }
+      }
+    }
+
+    if (!serverPath) {
+      const tried = this.fallbackBinNames.join(', ')
+      throw new Error(
+        `[${this.label}] Could not find language server binary (${tried}). ` +
+        `Searched: ${searchDirs.map(d => join(d, 'node_modules', '.bin')).join(', ')}`,
+      )
+    }
+
+    console.log(`[${this.label}] Starting ${serverPath}${spawnViaBun ? ' (via bun)' : ''}`)
     console.log(`[${this.label}] Project directory: ${this.projectDir}`)
 
+    const cmd = spawnViaBun
+      ? ['bun', serverPath, '--stdio', ...this.serverArgs]
+      : [serverPath, '--stdio', ...this.serverArgs]
+
     try {
-      this.process = spawn([serverPath, '--stdio', ...this.serverArgs], {
+      this.process = spawn(cmd, {
         cwd: this.projectDir,
         env: { ...process.env },
         stdin: 'pipe',
@@ -565,20 +630,24 @@ export class WorkspaceLSPManager {
   }
 
   private async detectPyright(): Promise<void> {
-    const possiblePaths = [
-      ...(this.pyrightBin ? [this.pyrightBin] : []),
-      join(this.projectDir, 'node_modules', '.bin', 'pyright'),
-      join(dirname(dirname(import.meta.path)), 'node_modules', '.bin', 'pyright'),
-      'pyright',
-    ]
-    for (const p of possiblePaths) {
-      if (p === 'pyright' || existsSync(p)) {
-        this.pyrightBin = p
-        this.pyAvailable = true
-        console.log(`[LSP-PY] Pyright CLI available at: ${p}`)
-        return
-      }
+    if (this.pyrightBin && existsSync(this.pyrightBin)) {
+      this.pyAvailable = true
+      console.log(`[LSP-PY] Pyright CLI available at: ${this.pyrightBin}`)
+      return
     }
+
+    const searchDirs = [
+      this.projectDir,
+      dirname(dirname(import.meta.path)),
+    ]
+    const result = resolveBin('pyright', searchDirs)
+    if (result) {
+      this.pyrightBin = result.resolved
+      this.pyAvailable = true
+      console.log(`[LSP-PY] Pyright CLI available at: ${result.resolved}`)
+      return
+    }
+
     console.log('[LSP-PY] Pyright not found — Python linting disabled')
   }
 

--- a/scripts/watch-api.ts
+++ b/scripts/watch-api.ts
@@ -1,26 +1,31 @@
 /**
  * Custom file watcher for the API server.
  *
- * Replaces `bun --watch` to avoid the EBUSY / integer-overflow crash on Windows
- * caused by heavy filesystem activity in the workspaces/ directory.
+ * Uses chokidar instead of raw fs.watch for reliable file-watching on Windows.
+ * chokidar deduplicates events, waits for writes to finish, and avoids the
+ * phantom-change storms that plague fs.watch({ recursive: true }) on NTFS.
  *
  * Only watches apps/api/src and packages/ — ignores workspaces/, node_modules/, etc.
  */
 
 import { spawn, type Subprocess } from "bun";
-import { watch, type FSWatcher } from "fs";
+import chokidar from "chokidar";
 import { resolve, relative, sep } from "path";
+import { createConnection } from "net";
 
 const ROOT = resolve(import.meta.dir, "..");
 const ENTRY = resolve(ROOT, "apps/api/src/entry.ts");
+const API_PORT = Number(process.env.API_PORT ?? 8002);
 
 const WATCH_DIRS = [
   resolve(ROOT, "apps/api/src"),
   resolve(ROOT, "packages"),
 ];
 
-const IGNORE = ["node_modules", ".git", "dist", "build", "generated", "workspaces", ".canvas-state.json"];
-const EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".json"]);
+const DEBOUNCE_MS = 800;
+const KILL_TIMEOUT_MS = 5_000;
+const PORT_WAIT_MS = 10_000;
+const PORT_POLL_INTERVAL_MS = 300;
 
 let child: Subprocess | null = null;
 let restartTimer: ReturnType<typeof setTimeout> | null = null;
@@ -28,8 +33,28 @@ let generation = 0;
 let waitingForChange = false;
 let restarting = false;
 let restartQueued = false;
-const DEBOUNCE_MS = 300;
-const KILL_TIMEOUT_MS = 5_000;
+
+function isPortFree(port: number): Promise<boolean> {
+  return new Promise((res) => {
+    const socket = createConnection({ port, host: "127.0.0.1" });
+    socket.once("connect", () => {
+      socket.destroy();
+      res(false);
+    });
+    socket.once("error", () => {
+      res(true);
+    });
+  });
+}
+
+async function waitForPortRelease(port: number): Promise<boolean> {
+  const deadline = Date.now() + PORT_WAIT_MS;
+  while (Date.now() < deadline) {
+    if (await isPortFree(port)) return true;
+    await new Promise((r) => setTimeout(r, PORT_POLL_INTERVAL_MS));
+  }
+  return false;
+}
 
 async function startServer() {
   if (restarting) {
@@ -52,6 +77,13 @@ async function startServer() {
 
       await oldChild.exited;
       clearTimeout(killTimeout);
+    }
+
+    const portFree = await waitForPortRelease(API_PORT);
+    if (!portFree) {
+      console.log(`[watch-api] Port ${API_PORT} still in use after ${PORT_WAIT_MS / 1000}s — waiting for file change to retry...`);
+      waitingForChange = true;
+      return;
     }
 
     waitingForChange = false;
@@ -81,49 +113,53 @@ async function startServer() {
   }
 }
 
-function shouldIgnore(filename: string | null): boolean {
-  if (!filename) return true;
-  if (IGNORE.some((dir) => filename.includes(dir))) return true;
-  const ext = filename.slice(filename.lastIndexOf("."));
-  return !EXTENSIONS.has(ext);
-}
-
-function scheduleRestart(file: string) {
+function scheduleRestart(filePath: string) {
   if (restartTimer) clearTimeout(restartTimer);
   restartTimer = setTimeout(() => {
-    const rel = relative(ROOT, file);
+    const rel = relative(ROOT, filePath);
     console.log(`[watch-api] Change detected: ${rel} — restarting...`);
     startServer();
   }, DEBOUNCE_MS);
 }
 
-const watchers: FSWatcher[] = [];
+const watcher = chokidar.watch(WATCH_DIRS, {
+  ignored: [
+    "**/node_modules/**",
+    "**/.git/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/generated/**",
+    "**/workspaces/**",
+    "**/.canvas-state.json",
+  ],
+  ignoreInitial: true,
+  awaitWriteFinish: {
+    stabilityThreshold: 300,
+    pollInterval: 100,
+  },
+});
 
-for (const dir of WATCH_DIRS) {
-  try {
-    const w = watch(dir, { recursive: true }, (_event, filename) => {
-      if (!shouldIgnore(filename)) {
-        scheduleRestart(resolve(dir, filename ?? ""));
-      }
-    });
-    watchers.push(w);
+watcher.on("change", (filePath) => scheduleRestart(filePath));
+watcher.on("add", (filePath) => scheduleRestart(filePath));
+watcher.on("unlink", (filePath) => scheduleRestart(filePath));
+
+watcher.on("ready", () => {
+  for (const dir of WATCH_DIRS) {
     console.log(`[watch-api] Watching ${relative(ROOT, dir)}${sep}`);
-  } catch (err: any) {
-    console.warn(`[watch-api] Could not watch ${dir}: ${err.message}`);
   }
+  console.log("[watch-api] Starting API server...");
+  startServer();
+});
+
+watcher.on("error", (err) => {
+  console.warn(`[watch-api] Watcher error: ${err.message}`);
+});
+
+function cleanup() {
+  watcher.close();
+  child?.kill();
+  process.exit(0);
 }
 
-process.on("SIGINT", () => {
-  for (const w of watchers) w.close();
-  child?.kill();
-  process.exit(0);
-});
-
-process.on("SIGTERM", () => {
-  for (const w of watchers) w.close();
-  child?.kill();
-  process.exit(0);
-});
-
-console.log("[watch-api] Starting API server...");
-startServer();
+process.on("SIGINT", cleanup);
+process.on("SIGTERM", cleanup);


### PR DESCRIPTION
## Summary

- **LSP binary resolution**: On Windows, Bun creates `.exe`/`.cmd` shims in `node_modules/.bin/` instead of extensionless POSIX scripts, so bare `existsSync(.bin/name)` fails. Added a `resolveBin()` helper that checks the extensionless path first, then Windows shim extensions, then falls back to the module's JS entry point (e.g. `lib/cli.mjs`). Fixes `ENOENT: no such file or directory, uv_spawn 'typescript-language-server'` on Windows.
- **File watcher**: Replaced raw `fs.watch` with **chokidar** for reliable file watching on Windows. chokidar deduplicates events, waits for writes to finish (`awaitWriteFinish`), and avoids phantom-change storms that plague `fs.watch({ recursive: true })` on NTFS. Also added port-release checking before server restart to avoid EADDRINUSE.

## Files changed

| File | Change |
|------|--------|
| `packages/shared-runtime/src/lsp-service.ts` | New `resolveBin()` helper, Windows-aware LSP binary lookup |
| `packages/shared-runtime/src/index.ts` | Export `resolveBin` |
| `packages/agent-runtime/src/gateway.ts` | Use new bin resolution in gateway |
| `scripts/watch-api.ts` | Rewrite to use chokidar + port-release wait |
| `package.json` / `bun.lock` | Add chokidar@3 dependency |
| `packages/shared-runtime/src/__tests__/lsp-bin-resolution.test.ts` | Tests for resolveBin |
| `packages/agent-runtime/src/__tests__/*` | Updated tests for LSP changes |

## Test plan

- [ ] Start dev server on Windows — verify `typescript-language-server` resolves without ENOENT
- [ ] Modify a file in `apps/api/src/` — verify the watcher detects the change and restarts
- [ ] Verify no phantom restarts or duplicate events from the watcher
