### PR TITLE
fix: resolve ripgrep binary, strip PORT from exec env, suppress timeout spam

### DIFF
--- a/apps/api/src/routes/project-chat.ts
+++ b/apps/api/src/routes/project-chat.ts
@@ -113,10 +113,17 @@ async function trackUsageFromStream(
 
   try {
     while (true) {
-      const idleTimeout = new Promise<{ done: true; value: undefined }>((_, reject) =>
-        setTimeout(() => reject(new Error('chunk idle timeout')), PER_CHUNK_IDLE_TIMEOUT_MS)
-      )
-      const { done, value } = await Promise.race([reader.read(), idleTimeout])
+      let idleTimer: ReturnType<typeof setTimeout> | undefined
+      const idleTimeout = new Promise<{ done: true; value: undefined }>((_, reject) => {
+        idleTimer = setTimeout(() => reject(new Error('chunk idle timeout')), PER_CHUNK_IDLE_TIMEOUT_MS)
+      })
+      let result: { done: boolean; value: Uint8Array | undefined }
+      try {
+        result = await Promise.race([reader.read(), idleTimeout]) as any
+      } finally {
+        clearTimeout(idleTimer)
+      }
+      const { done, value } = result!
       if (done) break
       buffer += decoder.decode(value, { stream: true })
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -706,6 +706,12 @@ app.onError((err, c) => {
 // Process-level handlers: catch unhandled promise rejections and uncaught
 // exceptions that escape Hono's error boundary. Log them instead of crashing.
 process.on('unhandledRejection', (reason: any) => {
+  // AbortSignal.timeout() DOMExceptions are noisy and expected during cold
+  // starts / retries — log a single line instead of the full object.
+  if (reason?.name === 'TimeoutError' || reason?.name === 'AbortError') {
+    console.warn('[API] Suppressed timeout rejection:', reason.message)
+    return
+  }
   console.error('[API] Unhandled promise rejection:', reason?.message || reason)
   if (reason?.stack) {
     console.error('[API] Stack:', reason.stack)
@@ -2225,8 +2231,8 @@ app.all('/api/projects/:projectId/agent-proxy/*', async (c) => {
 
       if ((isTransient || isTimeout) && attempt < MAX_RETRIES) {
         const delay = Math.min(BASE_DELAY_MS * Math.pow(2, attempt - 1), MAX_DELAY_MS)
-        if (attempt === 1) {
-          console.log(`[AgentProxy] ${c.req.method} ${path} connection failed, retrying (cold start?)...`)
+        if (attempt <= 2) {
+          console.log(`[AgentProxy] ${c.req.method} ${path} ${isTimeout ? 'timeout' : 'connection failed'}, retrying in ${delay}ms (attempt ${attempt}/${MAX_RETRIES})`)
         }
         await new Promise(resolve => setTimeout(resolve, delay))
         continue

--- a/bun.lock
+++ b/bun.lock
@@ -184,6 +184,7 @@
         "@shogo/model-catalog": "workspace:*",
         "@shogo/shared-runtime": "workspace:*",
         "@sinclair/typebox": "^0.34.48",
+        "@vscode/ripgrep": "^1.17.1",
         "ai": "^6.0.73",
         "chromium-bidi": "^15.0.0",
         "hono": "^4.7.10",
@@ -1762,6 +1763,8 @@
 
     "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
 
+    "@vscode/ripgrep": ["@vscode/ripgrep@1.17.1", "", { "dependencies": { "https-proxy-agent": "^7.0.2", "proxy-from-env": "^1.1.0", "yauzl": "^2.9.2" } }, "sha512-xTs7DGyAO3IsJYOCTBP8LnTvPiYVKEuyv8s0xyJDBXfs8rhBfqnZPvb6xDT+RnwWzcXqW27xLS/aGrkjX7lNWw=="],
+
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
 
     "@zone-eu/mailsplit": ["@zone-eu/mailsplit@5.4.8", "", { "dependencies": { "libbase64": "1.3.0", "libmime": "5.3.7", "libqp": "2.1.1" } }, "sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA=="],
@@ -1901,6 +1904,8 @@
     "bser": ["bser@2.1.1", "", { "dependencies": { "node-int64": "^0.4.0" } }, "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ=="],
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
@@ -2275,6 +2280,8 @@
     "fbjs": ["fbjs@3.0.5", "", { "dependencies": { "cross-fetch": "^3.1.5", "fbjs-css-vars": "^1.0.0", "loose-envify": "^1.0.0", "object-assign": "^4.1.0", "promise": "^7.1.1", "setimmediate": "^1.0.5", "ua-parser-js": "^1.0.35" } }, "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg=="],
 
     "fbjs-css-vars": ["fbjs-css-vars@1.0.2", "", {}, "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="],
+
+    "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -2946,6 +2953,8 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
+
     "perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
 
     "pg": ["pg@8.20.0", "", { "dependencies": { "pg-connection-string": "^2.12.0", "pg-pool": "^3.13.0", "pg-protocol": "^1.13.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA=="],
@@ -3581,6 +3590,8 @@
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -42,6 +42,7 @@
     "@shogo/model-catalog": "workspace:*",
     "@shogo/shared-runtime": "workspace:*",
     "@sinclair/typebox": "^0.34.48",
+    "@vscode/ripgrep": "^1.17.1",
     "ai": "^6.0.73",
     "chromium-bidi": "^15.0.0",
     "hono": "^4.7.10",

--- a/packages/agent-runtime/src/__tests__/gateway-tools.test.ts
+++ b/packages/agent-runtime/src/__tests__/gateway-tools.test.ts
@@ -48,6 +48,40 @@ describe('gateway-tools', () => {
     rmSync(TEST_DIR, { recursive: true, force: true })
   })
 
+  describe('grep', () => {
+    test('finds a pattern in workspace files', async () => {
+      writeFileSync(join(TEST_DIR, 'sample.ts'), 'const foo = 42\nconst bar = 99\n')
+      const result = await exec(createCtx(), 'grep', { pattern: 'foo' })
+      expect(result.count).toBeGreaterThanOrEqual(1)
+      expect(result.matches.some((m: any) => m.text.includes('foo'))).toBe(true)
+    })
+
+    test('returns zero matches for absent pattern', async () => {
+      writeFileSync(join(TEST_DIR, 'sample.ts'), 'const bar = 99\n')
+      const result = await exec(createCtx(), 'grep', { pattern: 'zzz_never_exists_zzz' })
+      expect(result.count).toBe(0)
+      expect(result.matches).toHaveLength(0)
+    })
+
+    test('does not error with "command not found"', async () => {
+      writeFileSync(join(TEST_DIR, 'sample.ts'), 'hello world\n')
+      const result = await exec(createCtx(), 'grep', { pattern: 'hello' })
+      // Should succeed — either via rg or the JS fallback
+      expect(result.error).toBeUndefined()
+      expect(result.count).toBeGreaterThanOrEqual(1)
+    })
+
+    test('reports matches with file and line number', async () => {
+      writeFileSync(join(TEST_DIR, 'multi.ts'), 'line_one\nfind_me_here\nline_three\n')
+      const result = await exec(createCtx(), 'grep', { pattern: 'find_me_here' })
+      expect(result.count).toBe(1)
+      const match = result.matches[0]
+      expect(match.text).toContain('find_me_here')
+      expect(match.line).toBe(2)
+      expect(match.file).toContain('multi.ts')
+    })
+  })
+
   describe('exec', () => {
     test('runs a simple command', async () => {
       const result = await exec(createCtx(), 'exec', { command: 'echo hello' })

--- a/packages/agent-runtime/src/__tests__/rg-resolve.test.ts
+++ b/packages/agent-runtime/src/__tests__/rg-resolve.test.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import { describe, test, expect } from 'bun:test'
+import { existsSync } from 'fs'
+import { resolveRgPath } from '../rg-resolve'
+
+describe('resolveRgPath', () => {
+  test('returns a non-empty string', () => {
+    const rg = resolveRgPath()
+    expect(typeof rg).toBe('string')
+    expect(rg.length).toBeGreaterThan(0)
+  })
+
+  test('resolves to a real file from @vscode/ripgrep', () => {
+    const rg = resolveRgPath()
+    // If @vscode/ripgrep is installed, the path should point to an actual binary
+    if (rg !== 'rg') {
+      expect(existsSync(rg)).toBe(true)
+    }
+  })
+
+  test('resolved path contains rg in its name', () => {
+    const rg = resolveRgPath()
+    const lower = rg.toLowerCase()
+    expect(lower).toContain('rg')
+  })
+
+  test('returns the same value on subsequent calls (cached)', () => {
+    const first = resolveRgPath()
+    const second = resolveRgPath()
+    expect(first).toBe(second)
+  })
+})

--- a/packages/agent-runtime/src/__tests__/sandbox-exec-port-strip.test.ts
+++ b/packages/agent-runtime/src/__tests__/sandbox-exec-port-strip.test.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdirSync, writeFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { sandboxExec, RUNTIME_ONLY_VARS, stripRuntimeVars } from '../sandbox-exec'
+
+describe('stripRuntimeVars', () => {
+  test('removes PORT and VITE_PORT from env object', () => {
+    const env: Record<string, string | undefined> = {
+      HOME: '/home/user',
+      PORT: '38554',
+      VITE_PORT: '37554',
+      NODE_ENV: 'development',
+    }
+    stripRuntimeVars(env)
+    expect(env.PORT).toBeUndefined()
+    expect(env.VITE_PORT).toBeUndefined()
+    expect(env.HOME).toBe('/home/user')
+    expect(env.NODE_ENV).toBe('development')
+  })
+
+  test('is a no-op when runtime vars are absent', () => {
+    const env: Record<string, string | undefined> = {
+      HOME: '/home/user',
+      NODE_ENV: 'test',
+    }
+    stripRuntimeVars(env)
+    expect(env.HOME).toBe('/home/user')
+    expect(env.NODE_ENV).toBe('test')
+    expect(Object.keys(env)).toHaveLength(2)
+  })
+
+  test('RUNTIME_ONLY_VARS includes PORT and VITE_PORT', () => {
+    expect(RUNTIME_ONLY_VARS).toContain('PORT')
+    expect(RUNTIME_ONLY_VARS).toContain('VITE_PORT')
+  })
+})
+
+describe('sandboxExec PORT isolation', () => {
+  let workDir: string
+  const savedPort = process.env.PORT
+  const savedVitePort = process.env.VITE_PORT
+
+  beforeEach(() => {
+    workDir = join(tmpdir(), `shogo-port-test-${Date.now()}`)
+    mkdirSync(workDir, { recursive: true })
+    // Simulate the runtime having PORT set (as RuntimeManager does)
+    process.env.PORT = '38554'
+    process.env.VITE_PORT = '37554'
+  })
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true })
+    if (savedPort !== undefined) process.env.PORT = savedPort
+    else delete process.env.PORT
+    if (savedVitePort !== undefined) process.env.VITE_PORT = savedVitePort
+    else delete process.env.VITE_PORT
+  })
+
+  // sandboxExec uses Git Bash on Windows, so always use bash syntax
+  test('exec does not leak PORT to child processes', () => {
+    const result = sandboxExec({
+      command: 'echo ${PORT:-unset}',
+      workspaceDir: workDir,
+      sandboxConfig: { enabled: false },
+    })
+
+    // The child should NOT see 38554 — it should be empty or "unset"
+    expect(result.stdout).not.toContain('38554')
+  })
+
+  test('exec does not leak VITE_PORT to child processes', () => {
+    const result = sandboxExec({
+      command: 'echo ${VITE_PORT:-unset}',
+      workspaceDir: workDir,
+      sandboxConfig: { enabled: false },
+    })
+
+    expect(result.stdout).not.toContain('37554')
+  })
+
+  test('workspace .env PORT still takes effect', () => {
+    writeFileSync(join(workDir, '.env'), 'PORT=3001\n')
+
+    const result = sandboxExec({
+      command: 'echo ${PORT:-unset}',
+      workspaceDir: workDir,
+      sandboxConfig: { enabled: false },
+    })
+
+    // The workspace .env PORT=3001 should be visible
+    expect(result.stdout).toContain('3001')
+  })
+
+  test('non-PORT env vars still pass through', () => {
+    process.env.__SHOGO_TEST_VAR = 'visible'
+
+    const result = sandboxExec({
+      command: 'echo ${__SHOGO_TEST_VAR:-unset}',
+      workspaceDir: workDir,
+      sandboxConfig: { enabled: false },
+    })
+
+    expect(result.stdout).toContain('visible')
+    delete process.env.__SHOGO_TEST_VAR
+  })
+})

--- a/packages/agent-runtime/src/gateway-tools.ts
+++ b/packages/agent-runtime/src/gateway-tools.ts
@@ -36,6 +36,7 @@ import { withPermissionGate, assertWithinWorkspace as assertWithinWorkspaceSecur
 import { deriveApiUrl, derivePublicApiUrl } from './internal-api'
 import { getCanvasRuntimeErrors, clearCanvasRuntimeErrors } from './canvas-runtime-errors'
 import { FileStateCache } from './file-state-cache'
+import { resolveRgPath } from './rg-resolve'
 
 const CANVAS_CODE_RE = /^canvas\/[^/]+\.(js|jsx|ts|tsx)$/
 import {
@@ -561,7 +562,8 @@ function createGrepTool(ctx: ToolContext): AgentTool {
         : ctx.workspaceDir
 
       const sq = (s: string) => "'" + s.replace(/'/g, "'\\''") + "'"
-      const args = ['rg', '--json', '-e', sq(pattern), '--max-count', String(max_results)]
+      const rgBin = resolveRgPath().replace(/\\/g, '/')
+      const args = [sq(rgBin), '--json', '-e', sq(pattern), '--max-count', String(max_results)]
       if (context_lines > 0) args.push('-C', String(context_lines))
       if (include) args.push('--glob', sq(include))
       args.push('--', sq(targetPath))

--- a/packages/agent-runtime/src/rg-resolve.ts
+++ b/packages/agent-runtime/src/rg-resolve.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Resolves the ripgrep binary path.
+ *
+ * Prefers the bundled @vscode/ripgrep binary (guaranteed cross-platform),
+ * then falls back to a bare 'rg' on PATH.
+ */
+
+import { existsSync } from 'fs'
+
+let _resolved: string | undefined
+
+export function resolveRgPath(): string {
+  if (_resolved !== undefined) return _resolved
+
+  try {
+    const { rgPath } = require('@vscode/ripgrep') as { rgPath: string }
+    if (rgPath && existsSync(rgPath)) {
+      _resolved = rgPath
+      return _resolved
+    }
+  } catch { /* package not installed — fall through */ }
+
+  _resolved = 'rg'
+  return _resolved
+}

--- a/packages/agent-runtime/src/sandbox-exec.ts
+++ b/packages/agent-runtime/src/sandbox-exec.ts
@@ -218,6 +218,18 @@ export interface SandboxExecResult {
   sandboxed: boolean
 }
 
+// Internal runtime env vars that must not leak to agent-spawned child
+// processes.  PORT / VITE_PORT are set by RuntimeManager for the agent
+// server itself; if they leak, user servers try to bind the same port
+// → EADDRINUSE.  Workspace .env values are merged *after* stripping
+// so explicit user PORT overrides still take effect.
+export const RUNTIME_ONLY_VARS = ['PORT', 'VITE_PORT']
+
+export function stripRuntimeVars(env: Record<string, string | undefined>): typeof env {
+  for (const key of RUNTIME_ONLY_VARS) delete env[key]
+  return env
+}
+
 function shouldSandbox(opts: SandboxExecOptions): boolean {
   const config = { ...DEFAULT_SANDBOX, ...opts.sandboxConfig }
   if (!config.enabled) return false
@@ -268,7 +280,7 @@ export function sandboxExec(opts: SandboxExecOptions): SandboxExecResult {
       timeout: opts.timeout || 300_000,
       encoding: 'utf-8',
       maxBuffer: 1024 * 1024,
-      env: getSanitizedEnv(),
+      env: stripRuntimeVars(getSanitizedEnv()),
     })
     return { stdout: stdout.trim(), stderr: '', exitCode: 0, sandboxed: true }
   } catch (err: any) {
@@ -284,12 +296,13 @@ export function sandboxExec(opts: SandboxExecOptions): SandboxExecResult {
 function nativeExec(command: string, cwd: string, timeout?: number): SandboxExecResult {
   const shell = resolveShell()
   try {
+    const baseEnv = stripRuntimeVars(getSanitizedEnv())
     const stdout = execSync(command, {
       cwd,
       timeout: timeout || 300_000,
       encoding: 'utf-8',
       maxBuffer: 1024 * 1024,
-      env: { ...getSanitizedEnv(), ...loadWorkspaceEnv(cwd) },
+      env: { ...baseEnv, ...loadWorkspaceEnv(cwd) },
       ...(shell ? { shell } : {}),
     })
     return { stdout: stdout.trim(), stderr: '', exitCode: 0, sandboxed: false }


### PR DESCRIPTION
## Summary

- **Fix ripgrep resolution**: Install `@vscode/ripgrep` and resolve the bundled binary path instead of relying on bare `rg` on PATH. Backslashes are normalized to forward slashes for Git Bash compatibility. The existing JS fallback remains as a safety net.
- **Fix PORT leak to exec**: Strip `PORT` and `VITE_PORT` from the environment passed to `nativeExec` and Docker exec, preventing user servers from colliding with the agent runtime port (EADDRINUSE). Workspace `.env` PORT still takes effect since it merges after stripping.
- **Suppress TimeoutError spam**: Cancel idle timeout timers in the streaming reader to prevent unhandled rejections, filter `TimeoutError`/`AbortError` in the `unhandledRejection` handler with a single-line `console.warn`, and log concise retry messages in the agent proxy.

## Test plan

- [x] `rg-resolve.test.ts` (4 tests): Validates binary resolution, file existence, name, and caching
- [x] `sandbox-exec-port-strip.test.ts` (7 tests): Validates `stripRuntimeVars` unit logic, PORT/VITE_PORT not leaking, workspace `.env` override, and non-PORT passthrough
- [x] `gateway-tools.test.ts` (4 new grep tests): Validates pattern matching, zero-match, no "command not found", and match metadata
- [x] Existing `sandbox-exec.test.ts` (5 tests): Confirmed no regressions
- [ ] Manual: Start Shogo locally, open a project, verify grep tool calls succeed without "rg: command not found"
- [ ] Manual: Verify agent `exec("bun run server.tsx")` uses port 3001 (not the runtime port)
- [ ] Manual: Verify terminal is no longer flooded with DOMException TimeoutError objects
