### PR TITLE
fix: even out send button padding in CompactChatInput

### DIFF
--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -327,8 +327,8 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
             />
           </View>
 
-          {/* Action bar */}
-          <View className="px-4 pt-0 pb-1 flex-row items-center justify-between gap-2">
+          {/* Action bar: items-center keeps all controls on one horizontal line; pr-2.5 matches the visual gap from send to card bottom (centering offset + pb-1) */}
+          <View className="flex-row items-center justify-between gap-2 pl-4 pr-2.5 pt-0 pb-1">
             <View className="flex-row items-center gap-1 flex-1 min-w-0">
               <Pressable
                 onPress={handleAttachClick}


### PR DESCRIPTION
## Summary
- Adjusts the action bar's right padding in `CompactChatInput` from `px-4` to `pl-4 pr-2.5` so the gap from the send button to the card's right edge matches the visual gap to the bottom edge (~10px).
- The send button (`h-8` / 32px) is vertically centered in a 44px row, creating ~6px below it plus `pb-1` (4px) = ~10px to the card bottom. `pr-2.5` (10px) now matches that.
<img width="544" height="352" alt="image" src="https://github.com/user-attachments/assets/c1c8a2a9-6630-4468-b9bd-e71a134382e6" />
