### PR TITLE
fix(mobile): restore back-to-dashboard on wide project chat bar

### DIFF
--- a/apps/mobile/components/project/ProjectTopBar.tsx
+++ b/apps/mobile/components/project/ProjectTopBar.tsx
@@ -507,7 +507,7 @@ export function ProjectTopBar({
         style={{ width: chatFullscreenSidebarWidth ?? (isChatCollapsed ? undefined : chatPanelWidth) }}
       >
         <View className="flex-row items-center gap-0.5 flex-shrink-0">
-          {/* <BarIconButton icon={ArrowLeft} onPress={handleBack} title="Back to dashboard" /> */}
+          <BarIconButton icon={ArrowLeft} onPress={handleBack} title="Back to dashboard" />
 
           <Popover
             placement="bottom"


### PR DESCRIPTION
Closes #332
<img width="168" height="44" alt="Screenshot 2026-04-09 at 1 44 14 PM" src="https://github.com/user-attachments/assets/c44d35b2-0520-4712-bffb-f67ef4a46477" />
Restores the `ArrowLeft` / back-to-dashboard control in `ProjectTopBar` for the wide (two-zone) layout. It was still enabled on narrow viewports but had been commented out for desktop/fullscreen chat, so users lost navigation back to the app home.

**Testing:** Open a project on a wide viewport (or fullscreen chat); confirm the back button appears left of the project name and returns to `/(app)`.

Made with [Cursor](https://cursor.com)