### PR TITLE
fix(desktop): use NODE_ENV=development and skip path sandbox in local mode

### DIFF
--- a/apps/desktop/src/local-server.ts
+++ b/apps/desktop/src/local-server.ts
@@ -279,7 +279,7 @@ export async function startLocalServer(): Promise<void> {
     API_PORT: String(apiPort),
     PORT: String(apiPort),
     RUNTIME_BASE_PORT: String(RUNTIME_BASE_PORT),
-    NODE_ENV: IS_DEV ? 'development' : 'production',
+    NODE_ENV: 'development',
     BETTER_AUTH_SECRET: getOrCreateAuthSecret(),
     BETTER_AUTH_URL: `http://localhost:${apiPort}`,
     BUN_INSTALL_CACHE_DIR: path.join(getWorkspacesDir(), '..', '.bun-cache'),

--- a/packages/agent-runtime/src/permission-engine.ts
+++ b/packages/agent-runtime/src/permission-engine.ts
@@ -770,6 +770,7 @@ export function withPermissionGate(
 
 export function assertWithinWorkspace(workspaceDir: string, filePath: string): string {
   const resolved = resolve(workspaceDir, filePath)
+  if (process.env.SHOGO_LOCAL_MODE === 'true') return resolved
   if (!resolved.startsWith(workspaceDir)) {
     throw new Error(`Path outside workspace: ${filePath}`)
   }


### PR DESCRIPTION
## Summary

- **Fix Vite not installing on Windows desktop**: The packaged app set `NODE_ENV=production` for the API server, causing `npm install` to skip devDependencies (including Vite). Every workspace runtime failed with `bun: command not found: vite`. Changed to always use `NODE_ENV=development`.
- **Remove path sandbox in local/desktop mode**: `assertWithinWorkspace` was blocking the agent from accessing any path outside its workspace directory, even on desktop where users expect full filesystem access. Now skips the check when `SHOGO_LOCAL_MODE=true`, consistent with how other restrictions (MCP allowlists) are already relaxed in local mode.

## Test plan

- [ ] Build and package the desktop app on Windows
- [ ] Create a new project — verify `npm install` installs devDependencies (vite should appear in `node_modules/.bin/`)
- [ ] Verify the Vite dev server starts successfully (logs should show `Vite ready for <project> on port <port>`)
- [ ] Ask the agent to read a file outside the workspace (e.g. `D:\some\path`) — should succeed on desktop
- [ ] Verify cloud/hosted deployments still enforce the workspace sandbox (`SHOGO_LOCAL_MODE` is not set)
