### PR TITLE
fix(web): Remove orange line on homepage chat composer focus

### DIFF
--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -199,9 +199,12 @@
   --color-brand-landing: 226 121 39;
 }
 
-/* Override browser default blue focus ring with theme accent on all inputs/textareas */
-input:focus,
-textarea:focus {
+/* Override browser default blue focus ring with theme accent on inputs/textareas.
+   Exclude .outline-none — RN Web chat composers use outline-none; forcing outline-color
+   with !important would override transparent and draw a visible orange line (often
+   clipped to a horizontal segment next to the toolbar). */
+input:focus:not(.outline-none),
+textarea:focus:not(.outline-none) {
   outline-color: rgb(var(--color-ring)) !important;
 }
 


### PR DESCRIPTION
## Summary
Fixes an extra orange horizontal line between the prompt text area and toolbar on the homepage chat input (web).

## Cause
Global `textarea:focus` set `outline-color` with `!important`, which overrode Tailwind `outline-none` on RN Web composers and drew a visible orange outline (often clipped to a line by `overflow-hidden`).

## Change
Scope the global focus outline-color rule to `:not(.outline-none)` so composers that intentionally use `outline-none` keep no visible ring.

**Files:** `apps/mobile/global.css`

## Before
<img width="950" height="362" alt="image" src="https://github.com/user-attachments/assets/bbc7ce2d-c415-41d9-a374-75eb3f9e2166" />

## After
<img width="894" height="316" alt="image" src="https://github.com/user-attachments/assets/3574c657-e209-4b82-9eb0-d83f46b24420" />

