### PR TITLE
fix(vm): correct stuck download status when images already exist on disk

### DIFF
--- a/apps/api/src/routes/vm.ts
+++ b/apps/api/src/routes/vm.ts
@@ -162,16 +162,22 @@ let vmDownloadState: VMDownloadState = {
 }
 
 export function getVMDownloadState(): VMDownloadState {
+  if (
+    (vmDownloadState.status === 'downloading' || vmDownloadState.status === 'extracting') &&
+    checkImagesPresent()
+  ) {
+    vmDownloadState = { status: 'complete', percent: 100, bytesDownloaded: 0, totalBytes: 0 }
+  }
   return { ...vmDownloadState }
 }
 
 export async function triggerVMImageDownload(): Promise<void> {
-  if (vmDownloadState.status === 'downloading' || vmDownloadState.status === 'extracting') {
+  if (checkImagesPresent()) {
+    vmDownloadState = { status: 'complete', percent: 100, bytesDownloaded: 0, totalBytes: 0 }
     return
   }
 
-  if (checkImagesPresent()) {
-    vmDownloadState = { status: 'complete', percent: 100, bytesDownloaded: 0, totalBytes: 0 }
+  if (vmDownloadState.status === 'downloading' || vmDownloadState.status === 'extracting') {
     return
   }
 


### PR DESCRIPTION
## Summary
- The in-memory `vmDownloadState` could get permanently stuck at `"downloading"` (e.g. 60%) if the HTTP download stream stalled due to a network timeout, even though the VM image files were already fully present on disk from a previous session.
- This caused the frontend to show an endless **"Downloading sandbox"** banner, blocking project usage.
- `getVMDownloadState()` now checks the filesystem when the in-memory status is `"downloading"` or `"extracting"` and corrects to `"complete"` if images exist.
- `triggerVMImageDownload()` now checks `checkImagesPresent()` **before** the in-flight guard, so a stuck download cannot prevent the filesystem truth from being recognized.

## After
<img width="1919" height="969" alt="image" src="https://github.com/user-attachments/assets/96a389b4-17dc-424e-8650-5a341592448d" />

## Before
<img width="1024" height="486" alt="image" src="https://github.com/user-attachments/assets/516e531b-60d5-45e7-bb92-a740fbc6d3b2" />

