### PR TITLE
fix(desktop): Windows VM isolation, LSP crash, and warm pool reliability

### DIFF
--- a/apps/api/src/lib/instance-tunnel.ts
+++ b/apps/api/src/lib/instance-tunnel.ts
@@ -41,6 +41,7 @@ let heartbeatTimer: ReturnType<typeof setInterval> | null = null
 let stopped = false
 let currentPollInterval = DEFAULT_POLL_INTERVAL_S
 let wsReconnectAttempt = 0
+let lastHeartbeatError: string | null = null
 const activeAbortControllers = new Map<string, AbortController>()
 
 function getApiPort(): number {
@@ -141,6 +142,10 @@ async function heartbeatLoop() {
   try {
     const result = await sendHeartbeat()
     currentPollInterval = result.nextPollIn || DEFAULT_POLL_INTERVAL_S
+    if (lastHeartbeatError) {
+      console.log('[InstanceTunnel] Heartbeat recovered')
+      lastHeartbeatError = null
+    }
 
     if (result.wsRequested && !ws) {
       console.log('[InstanceTunnel] Cloud requested WebSocket — connecting...')
@@ -148,7 +153,10 @@ async function heartbeatLoop() {
       return
     }
   } catch (err: any) {
-    console.error(`[InstanceTunnel] Heartbeat error: ${err.message}`)
+    if (err.message !== lastHeartbeatError) {
+      console.error(`[InstanceTunnel] Heartbeat error: ${err.message}`)
+      lastHeartbeatError = err.message
+    }
     currentPollInterval = DEFAULT_POLL_INTERVAL_S
   }
 

--- a/apps/api/src/lib/vm-warm-pool-controller.ts
+++ b/apps/api/src/lib/vm-warm-pool-controller.ts
@@ -54,6 +54,8 @@ export interface VMManagerInterface {
  */
 export type VMManagerFactory = () => VMManagerInterface
 
+const MAX_CONSECUTIVE_FAILURES = 3
+
 export class VMWarmPoolController {
   private available = new Map<string, VMPodInfo>()
   private assigned = new Map<string, VMPodInfo>()
@@ -62,6 +64,7 @@ export class VMWarmPoolController {
   private vmOverlayPaths = new Map<string, string>()
   private reconcileTimer: ReturnType<typeof setInterval> | null = null
   private started = false
+  private consecutiveBootFailures = 0
   private managerFactory: VMManagerFactory
 
   constructor(
@@ -81,8 +84,12 @@ export class VMWarmPoolController {
     console.log(`[VMWarmPool] Starting VM warm pool controller (poolSize: ${this.poolSize})`)
 
     // Kill orphaned QEMU and VM helper processes from a previous server session
-    try { execSync('pkill -f qemu-system', { stdio: 'pipe' }) } catch {}
-    try { execSync('pkill -f shogo-vm', { stdio: 'pipe' }) } catch {}
+    if (process.platform === 'win32') {
+      try { execSync('taskkill /F /IM qemu-system-x86_64.exe', { stdio: 'pipe' }) } catch {}
+    } else {
+      try { execSync('pkill -f qemu-system', { stdio: 'pipe' }) } catch {}
+      try { execSync('pkill -f shogo-vm', { stdio: 'pipe' }) } catch {}
+    }
 
     // Purge stale overlay disk images from previous sessions
     if (this.vmConfig.overlayPath) {
@@ -179,8 +186,16 @@ export class VMWarmPoolController {
 
   /**
    * Get the URL for a project, claiming and assigning a VM if needed.
+   * Throws immediately if recent boots have all failed, so the caller
+   * can fall back to local RuntimeManager without a multi-minute wait.
    */
   async getProjectUrl(projectId: string): Promise<string> {
+    if (this.consecutiveBootFailures >= MAX_CONSECUTIVE_FAILURES) {
+      throw new Error(
+        `VM warm pool disabled after ${this.consecutiveBootFailures} consecutive boot failures`
+      )
+    }
+
     const existing = this.assigned.get(projectId)
     if (existing) {
       const age = Date.now() - (existing.assignedAt || 0)
@@ -263,6 +278,10 @@ export class VMWarmPoolController {
     const needed = this.poolSize - this.available.size
     if (needed <= 0) return
 
+    if (this.consecutiveBootFailures >= MAX_CONSECUTIVE_FAILURES) {
+      return
+    }
+
     console.log(`[VMWarmPool] Reconcile: need ${needed} more VMs (available: ${this.available.size}, target: ${this.poolSize})`)
 
     const bootPromises = []
@@ -299,8 +318,10 @@ export class VMWarmPoolController {
       this.vmManagers.set(handle.id, mgr)
       if (config.overlayPath) this.vmOverlayPaths.set(handle.id, config.overlayPath)
 
-      await this.waitForHealth(handle.agentUrl)
+      const boundMgr = mgr
+      await this.waitForHealth(handle.agentUrl, () => boundMgr.isRunning(handle))
 
+      this.consecutiveBootFailures = 0
       return {
         id: `vm-${handle.id}`,
         vmId: handle.id,
@@ -309,9 +330,10 @@ export class VMWarmPoolController {
         ready: true,
       }
     } catch (err: any) {
-      console.error('[VMWarmPool] Boot failed:', err.message)
+      this.consecutiveBootFailures++
+      console.error(`[VMWarmPool] Boot failed (${this.consecutiveBootFailures}/${MAX_CONSECUTIVE_FAILURES}): ${err.message}`)
       if (vmId) {
-        try { await mgr?.stopVM(vmId) } catch {}
+        try { await mgr?.stopVM(vmId as any) } catch {}
         this.vmHandles.delete(vmId)
         this.vmManagers.delete(vmId)
         this.cleanupOverlay(vmId)
@@ -321,8 +343,11 @@ export class VMWarmPoolController {
     }
   }
 
-  private async waitForHealth(url: string): Promise<void> {
+  private async waitForHealth(url: string, isAlive?: () => boolean): Promise<void> {
     for (let i = 0; i < HEALTH_CHECK_RETRIES; i++) {
+      if (isAlive && !isAlive()) {
+        throw new Error('VM process exited before becoming healthy')
+      }
       try {
         const res = await fetch(`${url}/health`, {
           signal: AbortSignal.timeout(2000),

--- a/apps/api/src/lib/warm-pool-controller.ts
+++ b/apps/api/src/lib/warm-pool-controller.ts
@@ -943,6 +943,7 @@ export class WarmPoolController {
     usedCpuMillis: number
     limitCpuMillis: number
   } | null> {
+    if (process.env.SHOGO_LOCAL_MODE === 'true') return null
     try {
       const coreApi = getCoreApi()
       const nodeResponse = await coreApi.listNode()

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shogo",
   "productName": "Shogo",
-  "version": "0.1.0",
+  "version": "1.2.20",
   "description": "Shogo Desktop - Local open-source edition",
   "author": "Shogo Team",
   "private": true,

--- a/apps/desktop/src/vm/index.ts
+++ b/apps/desktop/src/vm/index.ts
@@ -126,7 +126,8 @@ function getQemuPath(): string {
   if (isElectron()) {
     const { app } = require('electron')
     if (!app.isPackaged) return findQemuBinary()
-    return path.join(process.resourcesPath!, 'vm', 'qemu-system-x86_64.exe')
+    const bundled = path.join(process.resourcesPath!, 'vm', 'qemu-system-x86_64.exe')
+    if (fs.existsSync(bundled)) return bundled
   }
   return findQemuBinary()
 }

--- a/apps/desktop/src/vm/win32-vm-manager.ts
+++ b/apps/desktop/src/vm/win32-vm-manager.ts
@@ -37,6 +37,14 @@ export class Win32VMManager implements VMManager {
   async startVM(config: VMConfig): Promise<VMHandle> {
     if (this.vmRunning) throw new Error('VM already running')
 
+    const kernel = path.join(this.vmImageDir, 'vmlinuz')
+    const initrd = path.join(this.vmImageDir, 'initrd.img')
+    if (!fs.existsSync(kernel) || !fs.existsSync(initrd)) {
+      throw new Error(
+        `VM images not found at ${this.vmImageDir} — download required via Settings > VM`
+      )
+    }
+
     const vmId = crypto.randomUUID()
     const dataDir = this.getVMDataDir(vmId)
     fs.mkdirSync(dataDir, { recursive: true })
@@ -253,8 +261,8 @@ export class Win32VMManager implements VMManager {
     if (!fs.existsSync(source)) throw new Error(`Base VM image not found: ${source}`)
 
     const qemuImg = path.join(path.dirname(this.qemuPath), 'qemu-img.exe')
-    execSync(`"${qemuImg}" create -f qcow2 -b "${source}" -F qcow2 "${overlayPath}"`, { stdio: 'pipe', timeout: 10000 })
-    execSync(`"${qemuImg}" resize "${overlayPath}" 10G`, { stdio: 'pipe', timeout: 10000 })
+    execSync(`"${qemuImg}" create -f qcow2 -b "${source}" -F qcow2 "${overlayPath}"`, { stdio: 'pipe', timeout: 60000 })
+    execSync(`"${qemuImg}" resize "${overlayPath}" 10G`, { stdio: 'pipe', timeout: 60000 })
   }
 
   private getVMDataDir(vmId: string): string {

--- a/packages/shared-runtime/src/lsp-service.ts
+++ b/packages/shared-runtime/src/lsp-service.ts
@@ -29,15 +29,26 @@ export function resolveBin(
   searchDirs: string[],
   directEntryPath?: string,
 ): { resolved: string; viaBun: boolean } | undefined {
+  const isBunRuntime = typeof Bun !== 'undefined'
+
+  // On Windows under Bun, .bin shims (.cmd wrappers, extensionless bash scripts)
+  // can't be executed by Bun. Use the direct JS entry point instead.
+  if (IS_WINDOWS && isBunRuntime && directEntryPath) {
+    for (const dir of searchDirs) {
+      const entry = join(dir, 'node_modules', name, directEntryPath)
+      if (existsSync(entry)) return { resolved: entry, viaBun: true }
+    }
+  }
+
   for (const dir of searchDirs) {
     const base = join(dir, 'node_modules', '.bin', name)
-    if (existsSync(base)) return { resolved: base, viaBun: false }
     if (IS_WINDOWS) {
       for (const ext of WIN_BIN_EXTENSIONS) {
         const withExt = base + ext
         if (existsSync(withExt)) return { resolved: withExt, viaBun: false }
       }
     }
+    if (existsSync(base)) return { resolved: base, viaBun: false }
   }
 
   if (directEntryPath) {


### PR DESCRIPTION
## Summary

Fixes multiple Windows desktop issues that prevented chat from loading and caused noisy error logs:

- **QEMU detection**: Packaged app now falls back to system-installed QEMU (`C:\Program Files\qemu\`) when the bundled binary isn't present, enabling VM isolation on Windows
- **LSP crash**: On Windows under Bun, `.cmd` shims can't be executed by Bun. `resolveBin` now prefers the direct JS entry point (`lib/cli.mjs`) so the TypeScript Language Server starts correctly
- **VM warm pool reliability**: Health checks abort immediately when QEMU dies (instead of polling a dead port for ~4 minutes). After 3 consecutive boot failures, the warm pool is disabled and chat falls back to local RuntimeManager instantly
- **qemu-img timeout**: Increased overlay creation timeout from 10s to 60s to prevent ETIMEDOUT on first run (Windows Defender scanning)
- **VM image validation**: Checks that `vmlinuz` and `initrd.img` exist before spawning QEMU to prevent silent SeaBIOS/iPXE fallback
- **Windows orphan cleanup**: Uses `taskkill` instead of Unix `pkill` to clean up stale QEMU processes
- **K8s noise in local mode**: `getCapacitySummary()` returns null in `SHOGO_LOCAL_MODE` to avoid K8s client errors
- **Log deduplication**: InstanceTunnel heartbeat 401 errors only logged once per distinct error

## Files changed

| File | Change |
|------|--------|
| `apps/desktop/src/vm/index.ts` | QEMU path fallback to system install |
| `packages/shared-runtime/src/lsp-service.ts` | Bun + Windows LSP binary resolution |
| `apps/api/src/lib/vm-warm-pool-controller.ts` | Fast-fail, failure tracking, taskkill |
| `apps/desktop/src/vm/win32-vm-manager.ts` | Image validation, qemu-img timeout |
| `apps/api/src/lib/warm-pool-controller.ts` | Skip K8s calls in local mode |
| `apps/api/src/lib/instance-tunnel.ts` | Deduplicate heartbeat error logs |

## Test plan

- [ ] Install on Windows with system QEMU at `C:\Program Files\qemu\`
- [ ] Verify VM isolation detects system QEMU correctly
- [ ] Open a chat -- should fall back to local RuntimeManager if VM images not downloaded
- [ ] Verify no more `getCapacitySummary` errors in logs
- [ ] Verify InstanceTunnel 401 only logged once, not every 60s
- [ ] Download VM images via Settings > VM, then verify QEMU boots with direct kernel (no SeaBIOS/iPXE)
