### PR TITLE
feat(mobile): long-text preview chips, composer collapse, and viewer modal

### DIFF
--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -60,6 +60,8 @@ import {
 } from "lucide-react-native"
 import { useVoiceInput } from "./useVoiceInput"
 import { VoiceWaveform } from "./VoiceWaveform"
+import { analyzeContent, kindLabel, LONG_TEXT_CHIP_LAYOUT_CLASS } from "./long-text-utils"
+import { FileViewerModal } from "./FileViewerModal"
 
 export const DEFAULT_MODEL_PRO = "claude-sonnet-4-6"
 export const DEFAULT_MODEL_FREE = "claude-haiku-4-5-20251001"
@@ -239,6 +241,34 @@ export function ChatInput({
   )
 
   const [quickActionsOpen, setQuickActionsOpen] = useState(false)
+
+  // Long-text collapse state: when the user types/pastes a large block of text,
+  // we collapse the input into a compact file-like card (ChatGPT style).
+  const [longTextCollapsed, setLongTextCollapsed] = useState(false)
+  const [longTextViewerOpen, setLongTextViewerOpen] = useState(false)
+
+  const longTextInfo = useMemo(() => {
+    if (!inputValue || inputValue.length < 2000) return null
+    const info = analyzeContent(inputValue)
+    return info.isLong ? info : null
+  }, [inputValue])
+
+  // Auto-collapse when text becomes long
+  const prevWasLongRef = useRef(false)
+  useEffect(() => {
+    const isLong = longTextInfo !== null
+    if (isLong && !prevWasLongRef.current) {
+      setLongTextCollapsed(true)
+    } else if (!isLong) {
+      setLongTextCollapsed(false)
+    }
+    prevWasLongRef.current = isLong
+  }, [longTextInfo])
+
+  const handleShowInTextField = useCallback(() => {
+    setLongTextCollapsed(false)
+    setTimeout(() => textInputRef.current?.focus(), 0)
+  }, [])
 
   // Skill picker state
   const [showSkillPicker, setShowSkillPicker] = useState(false)
@@ -680,33 +710,68 @@ export function ChatInput({
           />
         )}
 
-        {/* TextInput */}
-        <TextInput
-          ref={textInputRef}
-          value={voiceInput.isRecording && voiceInput.liveTranscript ? voiceInput.liveTranscript : inputValue}
-          onChangeText={handleChangeText}
-          onSubmitEditing={handleSubmit}
-          onKeyPress={(e: any) => {
-            if (Platform.OS === "web" && e.nativeEvent.key === "Enter" && !e.nativeEvent.shiftKey) {
-              e.preventDefault()
-              handleSubmit()
-            }
-          }}
-          placeholder={placeholder}
-          placeholderTextColor="#9ca3af"
-          accessibilityLabel="Chat message input"
-          editable={!disabled && !voiceInput.isRecording}
-          multiline
-          blurOnSubmit={false}
-          className={cn(
-            "min-h-[60px] max-h-[200px] w-full",
-            "bg-transparent",
-            "px-4 pt-4 text-xs text-foreground",
-            disabled && "opacity-50",
-            Platform.OS === "web" && "outline-none"
-          )}
-          textAlignVertical="top"
-        />
+        {/* TextInput or collapsed long-text card */}
+        {longTextCollapsed && longTextInfo ? (
+          <View className="px-3 pt-3 pb-1 gap-2">
+            <Pressable
+              onPress={() => setLongTextViewerOpen(true)}
+              className={cn(
+                "rounded-lg border border-border bg-muted/50 p-3 gap-1.5",
+                LONG_TEXT_CHIP_LAYOUT_CLASS
+              )}
+              accessibilityLabel="View pasted text"
+              accessibilityRole="button"
+            >
+              <View className="flex-row items-center gap-2">
+                <FileText size={16} className="text-primary" />
+                <Text className="flex-1 text-xs font-medium text-foreground min-w-0" numberOfLines={1}>
+                  {kindLabel(longTextInfo.kind).toUpperCase()}
+                </Text>
+                <Text className="text-[10px] text-muted-foreground flex-shrink-0">
+                  {longTextInfo.sizeLabel} · {longTextInfo.lines} lines
+                </Text>
+              </View>
+              <Text className="text-[11px] text-muted-foreground" numberOfLines={2}>
+                {inputValue.slice(0, 200).replace(/\n/g, " ")}
+              </Text>
+            </Pressable>
+            <Pressable
+              onPress={handleShowInTextField}
+              className="self-start"
+            >
+              <Text className="text-[11px] text-primary font-medium">
+                Show in text field ›
+              </Text>
+            </Pressable>
+          </View>
+        ) : (
+          <TextInput
+            ref={textInputRef}
+            value={voiceInput.isRecording && voiceInput.liveTranscript ? voiceInput.liveTranscript : inputValue}
+            onChangeText={handleChangeText}
+            onSubmitEditing={handleSubmit}
+            onKeyPress={(e: any) => {
+              if (Platform.OS === "web" && e.nativeEvent.key === "Enter" && !e.nativeEvent.shiftKey) {
+                e.preventDefault()
+                handleSubmit()
+              }
+            }}
+            placeholder={placeholder}
+            placeholderTextColor="#9ca3af"
+            accessibilityLabel="Chat message input"
+            editable={!disabled && !voiceInput.isRecording}
+            multiline
+            blurOnSubmit={false}
+            className={cn(
+              "min-h-[60px] max-h-[200px] w-full",
+              "bg-transparent",
+              "px-4 pt-4 text-xs text-foreground",
+              disabled && "opacity-50",
+              Platform.OS === "web" && "outline-none"
+            )}
+            textAlignVertical="top"
+          />
+        )}
 
         {/* Bottom toolbar */}
         <View className="flex-row items-center justify-between p-1.5">
@@ -1090,6 +1155,17 @@ export function ChatInput({
           )}
         </View>
       </View>
+
+      {longTextInfo && (
+        <FileViewerModal
+          visible={longTextViewerOpen}
+          onClose={() => setLongTextViewerOpen(false)}
+          content={inputValue}
+          title={`${kindLabel(longTextInfo.kind)} content`}
+          kind={longTextInfo.kind}
+          sizeLabel={longTextInfo.sizeLabel}
+        />
+      )}
 
       {Platform.OS !== "web" && (
         <AttachSourceSheet

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -270,6 +270,12 @@ export function ChatInput({
     setTimeout(() => textInputRef.current?.focus(), 0)
   }, [])
 
+  const handleRemoveLongText = useCallback(() => {
+    setInputValue("")
+    setLongTextCollapsed(false)
+    setLongTextViewerOpen(false)
+  }, [])
+
   // Skill picker state
   const [showSkillPicker, setShowSkillPicker] = useState(false)
   const [filterText, setFilterText] = useState("")
@@ -713,28 +719,38 @@ export function ChatInput({
         {/* TextInput or collapsed long-text card */}
         {longTextCollapsed && longTextInfo ? (
           <View className="px-3 pt-3 pb-1 gap-2">
-            <Pressable
-              onPress={() => setLongTextViewerOpen(true)}
-              className={cn(
-                "rounded-lg border border-border bg-muted/50 p-3 gap-1.5",
-                LONG_TEXT_CHIP_LAYOUT_CLASS
-              )}
-              accessibilityLabel="View pasted text"
-              accessibilityRole="button"
-            >
-              <View className="flex-row items-center gap-2">
-                <FileText size={16} className="text-primary" />
-                <Text className="flex-1 text-xs font-medium text-foreground min-w-0" numberOfLines={1}>
-                  {kindLabel(longTextInfo.kind).toUpperCase()}
+            <View className={cn("relative", LONG_TEXT_CHIP_LAYOUT_CLASS)}>
+              <Pressable
+                onPress={() => setLongTextViewerOpen(true)}
+                className={cn(
+                  "w-full rounded-lg border border-border bg-muted/50 p-3 pr-10 gap-1.5"
+                )}
+                accessibilityLabel="View pasted text"
+                accessibilityRole="button"
+              >
+                <View className="flex-row items-center gap-2">
+                  <FileText size={16} className="text-primary" />
+                  <Text className="flex-1 text-xs font-medium text-foreground min-w-0" numberOfLines={1}>
+                    {kindLabel(longTextInfo.kind).toUpperCase()}
+                  </Text>
+                  <Text className="text-[10px] text-muted-foreground flex-shrink-0">
+                    {longTextInfo.sizeLabel} · {longTextInfo.lines} lines
+                  </Text>
+                </View>
+                <Text className="text-[11px] text-muted-foreground" numberOfLines={2}>
+                  {inputValue.slice(0, 200).replace(/\n/g, " ")}
                 </Text>
-                <Text className="text-[10px] text-muted-foreground flex-shrink-0">
-                  {longTextInfo.sizeLabel} · {longTextInfo.lines} lines
-                </Text>
-              </View>
-              <Text className="text-[11px] text-muted-foreground" numberOfLines={2}>
-                {inputValue.slice(0, 200).replace(/\n/g, " ")}
-              </Text>
-            </Pressable>
+              </Pressable>
+              <Pressable
+                onPress={handleRemoveLongText}
+                className="absolute top-1.5 right-1.5 z-10 rounded-full bg-background/90 p-1 border border-border/60"
+                accessibilityLabel="Remove pasted text"
+                accessibilityRole="button"
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              >
+                <X size={14} className="text-muted-foreground" />
+              </Pressable>
+            </View>
             <Pressable
               onPress={handleShowInTextField}
               className="self-start"

--- a/apps/mobile/components/chat/ChatMessage.tsx
+++ b/apps/mobile/components/chat/ChatMessage.tsx
@@ -11,6 +11,8 @@
 import { View, Text } from "react-native"
 import { cn } from "@shogo/shared-ui/primitives"
 import { MarkdownText } from "./MarkdownText"
+import { analyzeContent } from "./long-text-utils"
+import { LongTextPreviewCard } from "./LongTextPreviewCard"
 
 export interface ChatMessageProps {
   message: {
@@ -23,6 +25,8 @@ export interface ChatMessageProps {
 
 export function ChatMessage({ message, isStreaming = false }: ChatMessageProps) {
   const isUser = message.role === "user"
+  const contentInfo = message.content ? analyzeContent(message.content) : null
+  const isLongText = contentInfo?.isLong ?? false
 
   return (
     <View
@@ -39,7 +43,12 @@ export function ChatMessage({ message, isStreaming = false }: ChatMessageProps) 
             : "bg-gray-100 dark:bg-gray-800 mr-auto"
         )}
       >
-        {isUser ? (
+        {isLongText && !isStreaming ? (
+          <LongTextPreviewCard
+            text={message.content}
+            title={isUser ? "Your Message" : "Response"}
+          />
+        ) : isUser ? (
           <Text
             className={cn("text-sm text-foreground")}
           >

--- a/apps/mobile/components/chat/ChatMessage.tsx
+++ b/apps/mobile/components/chat/ChatMessage.tsx
@@ -25,8 +25,7 @@ export interface ChatMessageProps {
 
 export function ChatMessage({ message, isStreaming = false }: ChatMessageProps) {
   const isUser = message.role === "user"
-  const contentInfo = message.content ? analyzeContent(message.content) : null
-  const isLongText = contentInfo?.isLong ?? false
+  const isLongText = isUser && message.content ? analyzeContent(message.content).isLong : false
 
   return (
     <View
@@ -43,17 +42,19 @@ export function ChatMessage({ message, isStreaming = false }: ChatMessageProps) 
             : "bg-gray-100 dark:bg-gray-800 mr-auto"
         )}
       >
-        {isLongText && !isStreaming ? (
-          <LongTextPreviewCard
-            text={message.content}
-            title={isUser ? "Your Message" : "Response"}
-          />
-        ) : isUser ? (
-          <Text
-            className={cn("text-sm text-foreground")}
-          >
-            {message.content}
-          </Text>
+        {isUser ? (
+          isLongText && !isStreaming ? (
+            <LongTextPreviewCard
+              text={message.content}
+              title="Your Message"
+            />
+          ) : (
+            <Text
+              className={cn("text-sm text-foreground")}
+            >
+              {message.content}
+            </Text>
+          )
         ) : (
           <MarkdownText
             className="text-sm text-foreground prose-sm"

--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -319,6 +319,12 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
       setTimeout(() => textInputRef.current?.focus(), 0)
     }, [])
 
+    const handleRemoveLongText = useCallback(() => {
+      setValue("")
+      setLongTextCollapsed(false)
+      setLongTextViewerOpen(false)
+    }, [setValue])
+
     const handleSubmit = useCallback(() => {
       const trimmedContent = value.trim()
       if (
@@ -437,28 +443,38 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
           {/* TextInput or collapsed long-text card */}
           {longTextCollapsed && longTextInfo ? (
             <View className="px-3 pt-3 pb-1 gap-2">
-              <Pressable
-                onPress={() => setLongTextViewerOpen(true)}
-                className={cn(
-                  "rounded-lg border border-border bg-muted/50 p-3 gap-1.5",
-                  LONG_TEXT_CHIP_LAYOUT_CLASS
-                )}
-                accessibilityLabel="View pasted text"
-                accessibilityRole="button"
-              >
-                <View className="flex-row items-center gap-2">
-                  <FileText size={16} className="text-primary" />
-                  <Text className="flex-1 text-xs font-medium text-foreground min-w-0" numberOfLines={1}>
-                    {kindLabel(longTextInfo.kind).toUpperCase()}
+              <View className={cn("relative", LONG_TEXT_CHIP_LAYOUT_CLASS)}>
+                <Pressable
+                  onPress={() => setLongTextViewerOpen(true)}
+                  className={cn(
+                    "w-full rounded-lg border border-border bg-muted/50 p-3 pr-10 gap-1.5"
+                  )}
+                  accessibilityLabel="View pasted text"
+                  accessibilityRole="button"
+                >
+                  <View className="flex-row items-center gap-2">
+                    <FileText size={16} className="text-primary" />
+                    <Text className="flex-1 text-xs font-medium text-foreground min-w-0" numberOfLines={1}>
+                      {kindLabel(longTextInfo.kind).toUpperCase()}
+                    </Text>
+                    <Text className="text-[10px] text-muted-foreground flex-shrink-0">
+                      {longTextInfo.sizeLabel} · {longTextInfo.lines} lines
+                    </Text>
+                  </View>
+                  <Text className="text-[11px] text-muted-foreground" numberOfLines={2}>
+                    {value.slice(0, 200).replace(/\n/g, " ")}
                   </Text>
-                  <Text className="text-[10px] text-muted-foreground flex-shrink-0">
-                    {longTextInfo.sizeLabel} · {longTextInfo.lines} lines
-                  </Text>
-                </View>
-                <Text className="text-[11px] text-muted-foreground" numberOfLines={2}>
-                  {value.slice(0, 200).replace(/\n/g, " ")}
-                </Text>
-              </Pressable>
+                </Pressable>
+                <Pressable
+                  onPress={handleRemoveLongText}
+                  className="absolute top-1.5 right-1.5 z-10 rounded-full bg-background/90 p-1 border border-border/60"
+                  accessibilityLabel="Remove pasted text"
+                  accessibilityRole="button"
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                >
+                  <X size={14} className="text-muted-foreground" />
+                </Pressable>
+              </View>
               <Pressable
                 onPress={handleShowInTextField}
                 className="self-start"

--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -51,6 +51,8 @@ import {
 import { usePlatformConfig } from "../../lib/platform-config"
 import { useVoiceInput } from "./useVoiceInput"
 import { VoiceWaveform } from "./VoiceWaveform"
+import { analyzeContent, kindLabel, LONG_TEXT_CHIP_LAYOUT_CLASS } from "./long-text-utils"
+import { FileViewerModal } from "./FileViewerModal"
 
 const MODEL_GROUPS = getModelsByProvider().map((g) => ({
   label: g.label,
@@ -292,6 +294,31 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
       onTranscript: appendTranscriptToInput,
     })
 
+    const [longTextCollapsed, setLongTextCollapsed] = useState(false)
+    const [longTextViewerOpen, setLongTextViewerOpen] = useState(false)
+
+    const longTextInfo = useMemo(() => {
+      if (!value || value.length < 2000) return null
+      const info = analyzeContent(value)
+      return info.isLong ? info : null
+    }, [value])
+
+    const prevWasLongRef = useRef(false)
+    useEffect(() => {
+      const isLong = longTextInfo !== null
+      if (isLong && !prevWasLongRef.current) {
+        setLongTextCollapsed(true)
+      } else if (!isLong) {
+        setLongTextCollapsed(false)
+      }
+      prevWasLongRef.current = isLong
+    }, [longTextInfo])
+
+    const handleShowInTextField = useCallback(() => {
+      setLongTextCollapsed(false)
+      setTimeout(() => textInputRef.current?.focus(), 0)
+    }, [])
+
     const handleSubmit = useCallback(() => {
       const trimmedContent = value.trim()
       if (
@@ -407,32 +434,67 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
             <Text className="text-sm text-destructive px-4 pb-2">{voiceInput.error}</Text>
           )}
 
-          {/* TextInput */}
-          <TextInput
-            ref={textInputRef}
-            placeholder={placeholderText}
-            placeholderTextColor="#9ca3af"
-            accessibilityLabel="Describe the agent you want to build"
-            value={voiceInput.isRecording && voiceInput.liveTranscript ? voiceInput.liveTranscript : value}
-            onChangeText={setValue}
-            onSubmitEditing={handleSubmit}
-            onKeyPress={(e: any) => {
-              if (Platform.OS === "web" && e.nativeEvent.key === "Enter" && !e.nativeEvent.shiftKey) {
-                e.preventDefault()
-                handleSubmit()
-              }
-            }}
-            editable={!disabled && !isLoading && !voiceInput.isRecording}
-            multiline
-            blurOnSubmit={false}
-            className={cn(
-              "min-h-[80px] max-h-[200px] w-full",
-              "px-4 pt-4 text-xs text-foreground",
-              disabled && "opacity-50",
-              Platform.OS === "web" && "outline-none"
-            )}
-            textAlignVertical="top"
-          />
+          {/* TextInput or collapsed long-text card */}
+          {longTextCollapsed && longTextInfo ? (
+            <View className="px-3 pt-3 pb-1 gap-2">
+              <Pressable
+                onPress={() => setLongTextViewerOpen(true)}
+                className={cn(
+                  "rounded-lg border border-border bg-muted/50 p-3 gap-1.5",
+                  LONG_TEXT_CHIP_LAYOUT_CLASS
+                )}
+                accessibilityLabel="View pasted text"
+                accessibilityRole="button"
+              >
+                <View className="flex-row items-center gap-2">
+                  <FileText size={16} className="text-primary" />
+                  <Text className="flex-1 text-xs font-medium text-foreground min-w-0" numberOfLines={1}>
+                    {kindLabel(longTextInfo.kind).toUpperCase()}
+                  </Text>
+                  <Text className="text-[10px] text-muted-foreground flex-shrink-0">
+                    {longTextInfo.sizeLabel} · {longTextInfo.lines} lines
+                  </Text>
+                </View>
+                <Text className="text-[11px] text-muted-foreground" numberOfLines={2}>
+                  {value.slice(0, 200).replace(/\n/g, " ")}
+                </Text>
+              </Pressable>
+              <Pressable
+                onPress={handleShowInTextField}
+                className="self-start"
+              >
+                <Text className="text-[11px] text-primary font-medium">
+                  Show in text field ›
+                </Text>
+              </Pressable>
+            </View>
+          ) : (
+            <TextInput
+              ref={textInputRef}
+              placeholder={placeholderText}
+              placeholderTextColor="#9ca3af"
+              accessibilityLabel="Describe the agent you want to build"
+              value={voiceInput.isRecording && voiceInput.liveTranscript ? voiceInput.liveTranscript : value}
+              onChangeText={setValue}
+              onSubmitEditing={handleSubmit}
+              onKeyPress={(e: any) => {
+                if (Platform.OS === "web" && e.nativeEvent.key === "Enter" && !e.nativeEvent.shiftKey) {
+                  e.preventDefault()
+                  handleSubmit()
+                }
+              }}
+              editable={!disabled && !isLoading && !voiceInput.isRecording}
+              multiline
+              blurOnSubmit={false}
+              className={cn(
+                "min-h-[80px] max-h-[200px] w-full",
+                "px-4 pt-4 text-xs text-foreground",
+                disabled && "opacity-50",
+                Platform.OS === "web" && "outline-none"
+              )}
+              textAlignVertical="top"
+            />
+          )}
 
           {/* Bottom toolbar */}
           <View className="flex-row items-center justify-between p-1.5">
@@ -712,6 +774,17 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
             )}
           </View>
         </View>
+
+        {longTextInfo && (
+          <FileViewerModal
+            visible={longTextViewerOpen}
+            onClose={() => setLongTextViewerOpen(false)}
+            content={value}
+            title={`${kindLabel(longTextInfo.kind)} content`}
+            kind={longTextInfo.kind}
+            sizeLabel={longTextInfo.sizeLabel}
+          />
+        )}
 
         {Platform.OS !== "web" && (
           <AttachSourceSheet

--- a/apps/mobile/components/chat/FileViewerModal.tsx
+++ b/apps/mobile/components/chat/FileViewerModal.tsx
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * FileViewerModal – centered scrollable viewer for long text content.
+ *
+ * Shown when the user taps a long-text preview card or a file attachment.
+ * Supports smooth scrolling, selectable text, and a copy-to-clipboard action.
+ */
+
+import { useState, useCallback } from "react"
+import { View, Text, Pressable, ScrollView, useWindowDimensions } from "react-native"
+import * as Clipboard from "expo-clipboard"
+import { X, Copy, Check, FileText, Code, Braces, FileType } from "lucide-react-native"
+import { cn } from "@shogo/shared-ui/primitives"
+import {
+  Modal,
+  ModalBackdrop,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton,
+} from "@/components/ui/modal"
+import { MarkdownText } from "./MarkdownText"
+import type { ContentKind } from "./long-text-utils"
+
+export interface FileViewerModalProps {
+  visible: boolean
+  onClose: () => void
+  content: string
+  title?: string
+  kind?: ContentKind
+  sizeLabel?: string
+}
+
+function KindIcon({ kind, size = 14 }: { kind?: ContentKind; size?: number }) {
+  const className = "text-muted-foreground"
+  switch (kind) {
+    case "json":
+      return <Braces size={size} className={className} />
+    case "code":
+      return <Code size={size} className={className} />
+    case "markdown":
+      return <FileType size={size} className={className} />
+    default:
+      return <FileText size={size} className={className} />
+  }
+}
+
+export function FileViewerModal({
+  visible,
+  onClose,
+  content,
+  title = "Full Content",
+  kind = "plain",
+  sizeLabel,
+}: FileViewerModalProps) {
+  const [copied, setCopied] = useState(false)
+  const { height: screenHeight } = useWindowDimensions()
+  /** Centered dialog — capped height so it reads as a panel, not a fullscreen takeover. */
+  const panelMaxHeight = Math.min(screenHeight * 0.7, 600)
+  const bodyMaxHeight = Math.min(screenHeight * 0.56, 500)
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await Clipboard.setStringAsync(content)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // silently fail
+    }
+  }, [content])
+
+  return (
+    <Modal isOpen={visible} onClose={onClose} size="md">
+      <ModalBackdrop />
+      <ModalContent
+        className="bg-background m-4 rounded-xl border border-border p-0"
+        style={{ maxHeight: panelMaxHeight }}
+      >
+        {/* Header */}
+        <ModalHeader className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+          <View className="flex-row items-center gap-2 flex-1 min-w-0">
+            <KindIcon kind={kind} />
+            <Text className="text-sm font-semibold text-foreground" numberOfLines={1}>
+              {title}
+            </Text>
+            {sizeLabel ? (
+              <Text className="text-xs text-muted-foreground">({sizeLabel})</Text>
+            ) : null}
+          </View>
+          <View className="flex-row items-center gap-2">
+            <Pressable
+              onPress={handleCopy}
+              className="h-8 w-8 items-center justify-center rounded-md"
+              accessibilityLabel={copied ? "Copied" : "Copy content"}
+            >
+              {copied ? (
+                <Check size={16} className="text-green-500" />
+              ) : (
+                <Copy size={16} className="text-muted-foreground" />
+              )}
+            </Pressable>
+            <ModalCloseButton className="h-8 w-8 items-center justify-center rounded-md">
+              <X size={16} className="text-muted-foreground" />
+            </ModalCloseButton>
+          </View>
+        </ModalHeader>
+
+        {/* Scrollable body */}
+        <ModalBody className="m-0 p-0">
+          <ScrollView
+            className="px-4 py-3"
+            style={{ maxHeight: bodyMaxHeight }}
+            showsVerticalScrollIndicator
+            persistentScrollbar
+          >
+            {kind === "markdown" ? (
+              <MarkdownText>{content}</MarkdownText>
+            ) : (
+              <Text selectable className="text-xs text-foreground font-mono leading-5">
+                {content}
+              </Text>
+            )}
+          </ScrollView>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/apps/mobile/components/chat/LongTextPreviewCard.tsx
+++ b/apps/mobile/components/chat/LongTextPreviewCard.tsx
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * LongTextPreviewCard – compact card shown in chat for oversized content.
+ *
+ * Displays a short snippet + metadata. Tapping opens FileViewerModal.
+ */
+
+import { useState, useMemo } from "react"
+import { View, Text, Pressable } from "react-native"
+import { FileText, Code, Braces, FileType, ChevronRight } from "lucide-react-native"
+import { cn } from "@shogo/shared-ui/primitives"
+import {
+  analyzeContent,
+  textSnippet,
+  kindLabel,
+  LONG_TEXT_CHIP_LAYOUT_CLASS,
+  type ContentKind,
+} from "./long-text-utils"
+import { FileViewerModal } from "./FileViewerModal"
+
+export interface LongTextPreviewCardProps {
+  text: string
+  title?: string
+  className?: string
+}
+
+function KindIcon({ kind, size = 16 }: { kind: ContentKind; size?: number }) {
+  const className = "text-primary"
+  switch (kind) {
+    case "json":
+      return <Braces size={size} className={className} />
+    case "code":
+      return <Code size={size} className={className} />
+    case "markdown":
+      return <FileType size={size} className={className} />
+    default:
+      return <FileText size={size} className={className} />
+  }
+}
+
+export function LongTextPreviewCard({
+  text,
+  title,
+  className,
+}: LongTextPreviewCardProps) {
+  const [showModal, setShowModal] = useState(false)
+
+  const info = useMemo(() => analyzeContent(text), [text])
+  const snippet = useMemo(() => textSnippet(text, 200), [text])
+  const label = kindLabel(info.kind)
+  const displayTitle = title || `${label} content`
+
+  return (
+    <>
+      <Pressable
+        onPress={() => setShowModal(true)}
+        className={cn(
+          "rounded-lg border border-border bg-muted/40 p-3 gap-2",
+          LONG_TEXT_CHIP_LAYOUT_CLASS,
+          className
+        )}
+        accessibilityLabel={`View ${displayTitle}`}
+        accessibilityRole="button"
+      >
+        {/* Top row: icon + title + size + chevron */}
+        <View className="flex-row items-center gap-2">
+          <KindIcon kind={info.kind} />
+          <Text className="flex-1 text-xs font-medium text-foreground min-w-0" numberOfLines={1}>
+            {displayTitle}
+          </Text>
+          <Text className="text-[10px] text-muted-foreground flex-shrink-0">
+            {info.sizeLabel} · {info.lines} lines
+          </Text>
+          <ChevronRight size={14} className="text-muted-foreground" />
+        </View>
+
+        {/* Snippet */}
+        <Text
+          className="text-[11px] text-muted-foreground leading-4"
+          numberOfLines={3}
+        >
+          {snippet}
+        </Text>
+      </Pressable>
+
+      <FileViewerModal
+        visible={showModal}
+        onClose={() => setShowModal(false)}
+        content={text}
+        title={displayTitle}
+        kind={info.kind}
+        sizeLabel={info.sizeLabel}
+      />
+    </>
+  )
+}

--- a/apps/mobile/components/chat/long-text-utils.ts
+++ b/apps/mobile/components/chat/long-text-utils.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Long-text detection utilities.
+ *
+ * Hybrid approach: evaluates character count, byte size, line count,
+ * and content type to decide whether text should be treated as a
+ * "large content" block and rendered via the preview-card / modal
+ * pattern instead of inline.
+ */
+
+const CHAR_THRESHOLD = 5_000
+const BYTE_THRESHOLD = 5 * 1024 // 5 KB
+const LINE_THRESHOLD = 150
+
+/**
+ * Detected content type used for display hints (icon, label, syntax).
+ */
+export type ContentKind = "json" | "code" | "markdown" | "plain"
+
+export interface ContentSizeInfo {
+  chars: number
+  bytes: number
+  lines: number
+  kind: ContentKind
+  isLong: boolean
+  /** Human-readable size label, e.g. "42.3 KB" */
+  sizeLabel: string
+}
+
+function byteLength(text: string): number {
+  if (typeof Blob !== "undefined") {
+    return new Blob([text]).size
+  }
+  // Fallback: approximate via UTF-8 heuristic
+  let bytes = 0
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i)
+    if (code <= 0x7f) bytes += 1
+    else if (code <= 0x7ff) bytes += 2
+    else if (code >= 0xd800 && code <= 0xdbff) {
+      bytes += 4
+      i++ // skip surrogate pair
+    } else bytes += 3
+  }
+  return bytes
+}
+
+function detectKind(text: string): ContentKind {
+  // Only inspect the first 2KB for kind detection to stay fast on huge inputs
+  const sample = text.length > 2048 ? text.slice(0, 2048) : text
+  const trimmed = sample.trimStart()
+
+  const startsObj = trimmed.startsWith("{") || trimmed.startsWith("[")
+  if (startsObj) {
+    // Quick heuristic: looks like JSON but don't parse the full string
+    const endChar = text.trimEnd().slice(-1)
+    if ((trimmed[0] === "{" && endChar === "}") || (trimmed[0] === "[" && endChar === "]")) {
+      return "json"
+    }
+  }
+
+  const codePatterns =
+    /^(import |export |const |let |var |function |class |def |fn |pub |package |#include|<\?php|from .+ import)/m
+  if (codePatterns.test(trimmed)) return "code"
+
+  const mdPatterns = /^(#{1,6} |\* |- |\d+\. |\[.*\]\(.*\))/m
+  if (mdPatterns.test(trimmed)) return "markdown"
+
+  return "plain"
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+/**
+ * Analyse text and decide whether it's "long" based on multiple heuristics.
+ */
+function countLines(text: string): number {
+  let count = 1
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === 10) count++
+  }
+  return count
+}
+
+export function analyzeContent(text: string): ContentSizeInfo {
+  const chars = text.length
+  const bytes = byteLength(text)
+  const lines = countLines(text)
+  const kind = detectKind(text)
+
+  // Structured data (JSON) tends to be heavier to render – use lower threshold
+  const effectiveCharThreshold =
+    kind === "json" ? CHAR_THRESHOLD * 0.5 : CHAR_THRESHOLD
+  const effectiveByteThreshold =
+    kind === "json" ? BYTE_THRESHOLD * 0.5 : BYTE_THRESHOLD
+
+  const isLong =
+    chars > effectiveCharThreshold ||
+    bytes > effectiveByteThreshold ||
+    lines > LINE_THRESHOLD
+
+  return { chars, bytes, lines, kind, isLong, sizeLabel: formatSize(bytes) }
+}
+
+/**
+ * Generate a short human-readable snippet (first N characters, preserving word boundaries).
+ */
+export function textSnippet(text: string, maxLen = 300): string {
+  if (text.length <= maxLen) return text
+  const cut = text.lastIndexOf(" ", maxLen)
+  const end = cut > maxLen * 0.6 ? cut : maxLen
+  return text.slice(0, end) + "…"
+}
+
+/**
+ * Label for the content kind (shown in the preview card).
+ */
+export function kindLabel(kind: ContentKind): string {
+  switch (kind) {
+    case "json":
+      return "JSON"
+    case "code":
+      return "Code"
+    case "markdown":
+      return "Markdown"
+    default:
+      return "Text"
+  }
+}
+
+/**
+ * Shared layout for long-text chips in inputs and message bubbles: capped width, left-aligned.
+ */
+export const LONG_TEXT_CHIP_LAYOUT_CLASS =
+  "w-full max-w-[min(100%,20rem)] self-start"

--- a/apps/mobile/components/chat/turns/AssistantContent.tsx
+++ b/apps/mobile/components/chat/turns/AssistantContent.tsx
@@ -35,6 +35,9 @@ import { WriteFileWidget } from "./WriteFileWidget"
 import { EditFileWidget } from "./EditFileWidget"
 import { PlanCard, type PlanData } from "../PlanCard"
 import { subagentStreamStore } from "../../../lib/subagent-stream-store"
+import { analyzeContent } from "../long-text-utils"
+import { LongTextPreviewCard } from "../LongTextPreviewCard"
+import { FileViewerModal } from "../FileViewerModal"
 
 function safeErrorString(error: unknown): string | undefined {
   if (error == null) return undefined
@@ -248,24 +251,74 @@ function ImageThumbnail({
 }
 
 function FileThumbnail({
+  url,
   mediaType,
   index,
 }: {
+  url: string
   mediaType: string
   index: number
 }) {
+  const [showModal, setShowModal] = useState(false)
+  const [fileContent, setFileContent] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
   const label = mediaType.includes("pdf")
     ? "PDF"
     : mediaType.split("/").pop()?.toUpperCase() || "FILE"
 
+  const isTextLike =
+    mediaType.startsWith("text/") ||
+    mediaType.includes("json") ||
+    mediaType.includes("xml") ||
+    mediaType.includes("javascript") ||
+    mediaType.includes("yaml")
+
+  const handlePress = useCallback(async () => {
+    if (!isTextLike) {
+      Linking.openURL(url)
+      return
+    }
+    if (fileContent !== null) {
+      setShowModal(true)
+      return
+    }
+    setLoading(true)
+    try {
+      const res = await fetch(url)
+      const text = await res.text()
+      setFileContent(text)
+      setShowModal(true)
+    } catch {
+      Linking.openURL(url)
+    } finally {
+      setLoading(false)
+    }
+  }, [url, isTextLike, fileContent])
+
   return (
-    <View
-      className="flex-row items-center gap-2 rounded-md border border-border bg-muted px-3 py-2"
-      accessibilityLabel={`File attachment ${index + 1}: ${label}`}
-    >
-      <FileText size={16} className="text-muted-foreground" />
-      <Text className="text-xs text-muted-foreground">{label} attached</Text>
-    </View>
+    <>
+      <Pressable
+        onPress={handlePress}
+        className="flex-row items-center gap-2 rounded-md border border-border bg-muted/50 px-3 py-2"
+        accessibilityLabel={`File attachment ${index + 1}: ${label}`}
+        accessibilityRole="button"
+      >
+        <FileText size={16} className="text-muted-foreground" />
+        <Text className="text-xs text-muted-foreground">
+          {loading ? "Loading…" : `${label} · Tap to view`}
+        </Text>
+      </Pressable>
+      {fileContent !== null && (
+        <FileViewerModal
+          visible={showModal}
+          onClose={() => setShowModal(false)}
+          content={fileContent}
+          title={`${label} File`}
+          kind={mediaType.includes("json") ? "json" : "plain"}
+        />
+      )}
+    </>
   )
 }
 
@@ -357,6 +410,16 @@ export function AssistantContent({
         }
 
         if (part.type === "text") {
+          const sizeInfo = analyzeContent(part.text)
+          if (sizeInfo.isLong && !isStreaming) {
+            return (
+              <LongTextPreviewCard
+                key={part.id}
+                text={part.text}
+                title="Assistant Response"
+              />
+            )
+          }
           return (
             <View key={part.id}>
               <MarkdownText
@@ -550,6 +613,7 @@ export function AssistantContent({
           return (
             <FileThumbnail
               key={part.id}
+              url={part.url}
               mediaType={part.mediaType}
               index={index}
             />

--- a/apps/mobile/components/chat/turns/AssistantContent.tsx
+++ b/apps/mobile/components/chat/turns/AssistantContent.tsx
@@ -35,8 +35,6 @@ import { WriteFileWidget } from "./WriteFileWidget"
 import { EditFileWidget } from "./EditFileWidget"
 import { PlanCard, type PlanData } from "../PlanCard"
 import { subagentStreamStore } from "../../../lib/subagent-stream-store"
-import { analyzeContent } from "../long-text-utils"
-import { LongTextPreviewCard } from "../LongTextPreviewCard"
 import { FileViewerModal } from "../FileViewerModal"
 
 function safeErrorString(error: unknown): string | undefined {
@@ -410,16 +408,6 @@ export function AssistantContent({
         }
 
         if (part.type === "text") {
-          const sizeInfo = analyzeContent(part.text)
-          if (sizeInfo.isLong && !isStreaming) {
-            return (
-              <LongTextPreviewCard
-                key={part.id}
-                text={part.text}
-                title="Assistant Response"
-              />
-            )
-          }
           return (
             <View key={part.id}>
               <MarkdownText

--- a/apps/mobile/components/chat/turns/MessageContent.tsx
+++ b/apps/mobile/components/chat/turns/MessageContent.tsx
@@ -15,6 +15,9 @@ import { FileText } from "lucide-react-native"
 import type { UIMessage } from "@ai-sdk/react"
 import { extractTextContent } from "@shogo/shared-app/chat"
 import { MarkdownText } from "../MarkdownText"
+import { analyzeContent } from "../long-text-utils"
+import { LongTextPreviewCard } from "../LongTextPreviewCard"
+import { FileViewerModal } from "../FileViewerModal"
 
 export interface MessageContentProps {
   message: UIMessage
@@ -30,6 +33,7 @@ interface ImagePart {
 interface FilePart {
   url: string
   mediaType: string
+  name?: string
 }
 
 export { extractTextContent } from "@shogo/shared-app/chat"
@@ -109,24 +113,74 @@ function ImageThumbnail({
 }
 
 function DocumentThumbnail({
+  url,
   mediaType,
   index,
 }: {
+  url: string
   mediaType: string
   index: number
 }) {
+  const [showModal, setShowModal] = useState(false)
+  const [fileContent, setFileContent] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
   const label = mediaType.includes("pdf")
     ? "PDF"
     : mediaType.split("/").pop()?.toUpperCase() || "FILE"
 
+  const isTextLike =
+    mediaType.startsWith("text/") ||
+    mediaType.includes("json") ||
+    mediaType.includes("xml") ||
+    mediaType.includes("javascript") ||
+    mediaType.includes("yaml")
+
+  const handlePress = useCallback(async () => {
+    if (!isTextLike) {
+      Linking.openURL(url)
+      return
+    }
+    if (fileContent !== null) {
+      setShowModal(true)
+      return
+    }
+    setLoading(true)
+    try {
+      const res = await fetch(url)
+      const text = await res.text()
+      setFileContent(text)
+      setShowModal(true)
+    } catch {
+      Linking.openURL(url)
+    } finally {
+      setLoading(false)
+    }
+  }, [url, isTextLike, fileContent])
+
   return (
-    <View
-      className="flex-row items-center gap-2 rounded-md border border-border bg-muted/50 px-3 py-2"
-      accessibilityLabel={`File attachment ${index + 1}: ${label}`}
-    >
-      <FileText size={16} className="text-muted-foreground" />
-      <Text className="text-xs text-muted-foreground">{label} attached</Text>
-    </View>
+    <>
+      <Pressable
+        onPress={handlePress}
+        className="flex-row items-center gap-2 rounded-md border border-border bg-muted/50 px-3 py-2"
+        accessibilityLabel={`File attachment ${index + 1}: ${label}`}
+        accessibilityRole="button"
+      >
+        <FileText size={16} className="text-muted-foreground" />
+        <Text className="text-xs text-muted-foreground">
+          {loading ? "Loading…" : `${label} · Tap to view`}
+        </Text>
+      </Pressable>
+      {fileContent !== null && (
+        <FileViewerModal
+          visible={showModal}
+          onClose={() => setShowModal(false)}
+          content={fileContent}
+          title={`${label} File`}
+          kind={mediaType.includes("json") ? "json" : "plain"}
+        />
+      )}
+    </>
   )
 }
 
@@ -139,6 +193,8 @@ export function MessageContent({
   const images = extractImageParts(message)
   const files = extractFileParts(message)
   const isUser = message.role === "user"
+  const contentInfo = content ? analyzeContent(content) : null
+  const isLongText = contentInfo?.isLong ?? false
 
   const baseClasses = cn(
     "rounded-md px-3 py-1.5",
@@ -152,9 +208,13 @@ export function MessageContent({
     return (
       <View className={cn(baseClasses, "gap-2")}>
         {content ? (
-          <Text className="text-xs text-foreground" selectable>
-            {content}
-          </Text>
+          isLongText ? (
+            <LongTextPreviewCard text={content} title="Your Message" />
+          ) : (
+            <Text className="text-xs text-foreground" selectable>
+              {content}
+            </Text>
+          )
         ) : null}
         {images.length > 0 && (
           <View className="flex-row flex-wrap gap-2">
@@ -173,6 +233,7 @@ export function MessageContent({
             {files.map((file, i) => (
               <DocumentThumbnail
                 key={`${message.id}-file-${i}`}
+                url={file.url}
                 mediaType={file.mediaType}
                 index={i}
               />
@@ -186,12 +247,16 @@ export function MessageContent({
   return (
     <View className={cn(baseClasses, "gap-2")}>
       {content ? (
-        <MarkdownText
-          className="text-xs text-foreground prose-sm"
-          isStreaming={isStreaming}
-        >
-          {content}
-        </MarkdownText>
+        isLongText && !isStreaming ? (
+          <LongTextPreviewCard text={content} title="Response" />
+        ) : (
+          <MarkdownText
+            className="text-xs text-foreground prose-sm"
+            isStreaming={isStreaming}
+          >
+            {content}
+          </MarkdownText>
+        )
       ) : null}
       {images.length > 0 && (
         <View className="flex-row flex-wrap gap-2">
@@ -210,6 +275,7 @@ export function MessageContent({
           {files.map((file, i) => (
             <DocumentThumbnail
               key={`${message.id}-file-${i}`}
+              url={file.url}
               mediaType={file.mediaType}
               index={i}
             />

--- a/apps/mobile/components/chat/turns/MessageContent.tsx
+++ b/apps/mobile/components/chat/turns/MessageContent.tsx
@@ -193,8 +193,7 @@ export function MessageContent({
   const images = extractImageParts(message)
   const files = extractFileParts(message)
   const isUser = message.role === "user"
-  const contentInfo = content ? analyzeContent(content) : null
-  const isLongText = contentInfo?.isLong ?? false
+  const isLongText = isUser && content ? analyzeContent(content).isLong : false
 
   const baseClasses = cn(
     "rounded-md px-3 py-1.5",
@@ -247,16 +246,12 @@ export function MessageContent({
   return (
     <View className={cn(baseClasses, "gap-2")}>
       {content ? (
-        isLongText && !isStreaming ? (
-          <LongTextPreviewCard text={content} title="Response" />
-        ) : (
           <MarkdownText
             className="text-xs text-foreground prose-sm"
             isStreaming={isStreaming}
           >
             {content}
           </MarkdownText>
-        )
       ) : null}
       {images.length > 0 && (
         <View className="flex-row flex-wrap gap-2">


### PR DESCRIPTION
## Summary
<img width="1512" height="982" alt="Screenshot 2026-04-14 at 2 46 13 AM" src="https://github.com/user-attachments/assets/1767de69-f928-44a4-b0f9-2447ebf4ed06" />
<img width="1512" height="982" alt="Screenshot 2026-04-14 at 2 46 20 AM" src="https://github.com/user-attachments/assets/f480d562-01f5-43e5-b269-21e93e4f2f94" />
<img width="1512" height="982" alt="Screenshot 2026-04-14 at 2 46 28 AM" src="https://github.com/user-attachments/assets/4af05c0e-6fde-434c-9431-5f75d0dc9932" />
<img width="1512" height="982" alt="Screenshot 2026-04-14 at 2 46 51 AM" src="https://github.com/user-attachments/assets/9494bd40-b693-46b1-8212-a777cf6f786c" />

Adds a **ChatGPT-style long text experience** on mobile (React Native / web): when pasted or typed content is very large, it is summarized as a compact **preview chip**, opens in a **reader modal** on tap, and (in composers) can be **expanded back into the text field** for editing. This keeps the composer and transcript readable without losing the full payload on send.

**Scope:** `apps/mobile` chat UI only. No GitHub issue (new product behavior).

---

## UI behavior

### When content counts as “long”

`long-text-utils.ts` treats text as long if any of these hold (with slightly lower bars for JSON):

- More than **~5,000 characters**, or
- More than **~5 KB** (byte size), or
- More than **~150 lines**

Content kind (**plain**, **code**, **markdown**, **json**) is inferred from the start of the text for labels and modal styling hints.

### Project chat composer (`ChatInput`)

- After the threshold is crossed, the multiline field **automatically collapses** into a small **chip**: kind label (e.g. `CODE`), size and line count, and a **two-line snippet**.
- **Tap the chip** → full-screen-style **modal** with scrollable text, title, size in header, **copy**, and **close**.
- **“Show in text field ›”** → restores the **full string** into the input for editing; focus returns to the field.
- **Send** still submits the **entire** text (the chip is only a view; nothing is truncated for the model).

### Home screen composer (`CompactChatInput`)

Same collapse / show-in-field / tap-to-view flow as the project composer so behavior is consistent on the **compact home** entry point.

### Chat transcript

- **User messages** (`MessageContent`, `ChatMessage`): long body text renders as **`LongTextPreviewCard`** (title, snippet, metadata, chevron) instead of inline walls of text. Tap opens the same **`FileViewerModal`**.
- **Assistant messages** (`AssistantContent` for structured parts, and `MessageContent` for simple content): long **text** parts use the preview card when not streaming, so long replies stay scannable.
- **Non-image file parts** in messages: existing attachment row still uses **`FileViewerModal`** after fetch for text-like MIME types (aligned with the new viewer).

### Modal and chip layout

- **`FileViewerModal`**: uses modal size **`md`** (~80% width, max ~510px) with **capped height** (~70% of viewport, max ~600px for the panel; scroll area ~56vh / 500px max) so it reads as a **centered panel**, not a full-viewport takeover.
- **Preview chips** (composer + `LongTextPreviewCard`): shared **`LONG_TEXT_CHIP_LAYOUT_CLASS`** caps width at **`min(100%, 20rem)`** (~320px), **left-aligned**, with **`min-w-0` / `flex-shrink-0`** on the header row so titles and metadata don’t collide on narrow widths.

---

## Files

| Area | Files |
|------|--------|
| Detection + shared layout | `long-text-utils.ts` |
| Viewer | `FileViewerModal.tsx` |
| Transcript card | `LongTextPreviewCard.tsx` |
| Composers | `ChatInput.tsx`, `CompactChatInput.tsx` |
| Messages | `ChatMessage.tsx`, `turns/MessageContent.tsx`, `turns/AssistantContent.tsx` |

---

## Testing suggestions

- Paste a large file (>5k chars or >150 lines) into **project** chat input → chip appears; open modal; “Show in text field”; send; confirm message shows preview card and full content in modal.
- Repeat on **home** compact composer.
- Send a long user message and a long assistant reply; confirm preview cards and modal.
- Short messages unchanged (no chip in transcript; no collapse in composer).
