### PR TITLE
fix(chat): keep user message visible during streaming (multi-tab)

### DIFF
--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -788,6 +788,7 @@ export const ChatPanel = observer(function ChatPanel({
   const hasInjectedInitialMessageRef = useRef(false)
   const isSendingMessageRef = useRef(false)
   const lastUserInputRef = useRef<{ content: string; files?: FileAttachment[] } | null>(null)
+  const lastNonEmptyMessagesRef = useRef<UIMessage[]>([])
 
   type QueuedMessage = {
     id: string
@@ -1451,6 +1452,9 @@ export const ChatPanel = observer(function ChatPanel({
   if (isActive && messages.length > 0) {
     cachedMessagesRef.current = messages
   }
+  if (messages.length > 0) {
+    lastNonEmptyMessagesRef.current = messages
+  }
 
   const isStreaming = (status === "streaming" || status === "submitted") && stoppedMessages === null
   const filesChangedFiredRef = useRef(false)
@@ -1516,6 +1520,32 @@ export const ChatPanel = observer(function ChatPanel({
   const displayMessages = useMemo((): UIMessage[] => {
     const effectiveMessages = stoppedMessages ?? messages
     if (effectiveMessages.length > 0) return effectiveMessages
+
+    // While streaming/sending, show the last known messages (plus an optimistic
+    // user bubble) so the conversation doesn't vanish during the brief gap
+    // before the AI SDK populates its internal state.
+    if (isStreaming || isSendingMessageRef.current) {
+      const fallback = lastNonEmptyMessagesRef.current
+      const lastInput = lastUserInputRef.current
+      const lastFallbackMsg = fallback[fallback.length - 1]
+      const needsOptimisticUser =
+        lastInput?.content && (!lastFallbackMsg || lastFallbackMsg.role !== "user")
+
+      if (fallback.length > 0 || needsOptimisticUser) {
+        if (needsOptimisticUser) {
+          return [
+            ...fallback,
+            {
+              id: "optimistic-user-pending",
+              role: "user",
+              parts: [{ type: "text", text: lastInput!.content }],
+            } as unknown as UIMessage,
+          ]
+        }
+        return fallback
+      }
+    }
+
     const text = (pendingInitialMessage ?? initialMessage ?? initialMessageRef.current ?? "").trim()
     if (text !== "") {
       return [
@@ -1527,7 +1557,7 @@ export const ChatPanel = observer(function ChatPanel({
       ]
     }
     return []
-  }, [messages, stoppedMessages, pendingInitialMessage, initialMessage])
+  }, [messages, stoppedMessages, pendingInitialMessage, initialMessage, isStreaming])
 
   const isStreamingRef = useRef(false)
   isStreamingRef.current = isStreaming
@@ -2284,6 +2314,7 @@ export const ChatPanel = observer(function ChatPanel({
       setMessageQueue([])
       isProcessingQueueRef.current = false
     }
+    lastNonEmptyMessagesRef.current = []
   }, [currentSessionId])
 
   const handleRemoveQueuedMessage = useCallback((messageId: string) => {


### PR DESCRIPTION
## Summary
Fixes a UI bug where the user message disappeared while the agent was responding, especially in secondary chat tabs or on the first message in a session. After the stream completed, the message reappeared.

## Cause
The AI SDK can briefly clear `messages` during send/stream. The previous fallback only worked when `lastNonEmptyMessagesRef` already had history, so fresh tabs with no prior in-memory messages showed an empty transcript.

## Changes
- Track `lastNonEmptyMessagesRef` when `messages` is non-empty; clear on session change.
- When streaming/sending and `messages` is empty, fall back to prior messages and/or an optimistic user bubble from `lastUserInputRef` (covers first message in a new tab).

AFTER
<img width="640" height="666" alt="image" src="https://github.com/user-attachments/assets/bf3d04b7-3142-44ff-ad75-c43d8615090c" />

BEFORE
<img width="631" height="585" alt="image" src="https://github.com/user-attachments/assets/3636dfc4-5353-4ac8-b1d1-63781b4e9eb1" />

