### PR TITLE
ci(android): submit production builds to Google Play production track

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,9 +11,11 @@
 #   - If fingerprint changed → full native build (expo prebuild + Gradle)
 #
 # Manual (workflow_dispatch):
-#   mode=full → fingerprint check, then build or OTA, optional Play Store submit
+#   mode=full → fingerprint check, then build or OTA, with Play Store submit
 #   mode=ota  → fingerprint check, OTA update only (skips build)
 #   environment=staging|production → controls OTA branch + build channel
+#   Production builds always auto-submit to production track on Google Play.
+#   Staging builds submit to internal track (can be toggled off with submit=false).
 #
 # Both build and OTA run on the same GitHub runner environment, so the
 # fingerprint hash is always consistent (no EAS server mismatch).
@@ -62,7 +64,7 @@ on:
           - staging
           - production
       submit:
-        description: 'Submit to Play Store (internal track) — full mode only'
+        description: 'Submit to Play Store — full mode only (staging→internal, production→production track)'
         required: false
         default: true
         type: boolean
@@ -417,14 +419,34 @@ jobs:
           path: .fingerprint-android
           key: android-fingerprint-${{ needs.check-fingerprint.outputs.environment }}-${{ needs.check-fingerprint.outputs.runtime_version || 'manual' }}
 
+      - name: Resolve submit decision
+        id: submit-decision
+        run: |
+          ENV="${{ needs.check-fingerprint.outputs.environment }}"
+          SUBMIT_INPUT="${{ github.event.inputs.submit }}"
+          if [ "$ENV" = "production" ]; then
+            echo "should_submit=true" >> $GITHUB_OUTPUT
+            echo "track=production" >> $GITHUB_OUTPUT
+            echo "Production build → always submitting to production track"
+          elif [ "$SUBMIT_INPUT" != "false" ]; then
+            echo "should_submit=true" >> $GITHUB_OUTPUT
+            echo "track=internal" >> $GITHUB_OUTPUT
+            echo "Staging build → submitting to internal track"
+          else
+            echo "should_submit=false" >> $GITHUB_OUTPUT
+            echo "track=none" >> $GITHUB_OUTPUT
+            echo "Submit skipped by user"
+          fi
+
       - name: Decode Google service account key
-        if: github.event.inputs.submit != 'false'
+        if: steps.submit-decision.outputs.should_submit == 'true'
         run: echo "${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}" | base64 -d > apps/mobile/google-services.json
 
-      - name: Submit to Play Store (internal track)
-        if: github.event.inputs.submit != 'false'
+      - name: Submit to Play Store
+        if: steps.submit-decision.outputs.should_submit == 'true'
         working-directory: apps/mobile
         run: |
+          echo "Submitting to ${{ steps.submit-decision.outputs.track }} track via profile ${{ needs.check-fingerprint.outputs.environment }}"
           eas submit \
             --platform android \
             --profile ${{ needs.check-fingerprint.outputs.environment }} \
@@ -439,7 +461,7 @@ jobs:
           echo "- **Channel:** ${{ needs.check-fingerprint.outputs.environment }}" >> $GITHUB_STEP_SUMMARY
           echo "- **versionCode:** ${{ github.run_number }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Submit:** ${{ github.event.inputs.submit != 'false' && 'Play Store (internal track)' || 'Skipped' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Submit:** ${{ steps.submit-decision.outputs.should_submit == 'true' && format('Play Store ({0} track)', steps.submit-decision.outputs.track) || 'Skipped' }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "AAB is available as a workflow artifact." >> $GITHUB_STEP_SUMMARY
 

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -54,7 +54,7 @@
     "production": {
       "android": {
         "serviceAccountKeyPath": "./google-services.json",
-        "track": "internal"
+        "track": "production"
       }
     }
   }


### PR DESCRIPTION
## Summary
Closes #353.

- **`apps/mobile/eas.json`**: production submit profile uses Play `production` track (was `internal`).
- **`.github/workflows/android.yml`**: resolve submit explicitly — production builds always submit to production; staging submits to internal unless `submit=false`; summary shows track or skipped.

## Testing
- [x] Merge, then tag `android-v*` from main and confirm workflow submits to production (or verify `eas submit` profile in a dry run if applicable).

No other files or themes are included in this branch.

Made with [Cursor](https://cursor.com)