### PR TITLE
feat(project): Restore Files tab and full workspace file tree

### DIFF
--- a/apps/mobile/components/project/ProjectTopBar.tsx
+++ b/apps/mobile/components/project/ProjectTopBar.tsx
@@ -84,7 +84,7 @@ const AGENT_TABS: { id: string; label: string; icon: React.ElementType }[] = [
   { id: 'chat-fullscreen', label: 'Chat', icon: MessageSquare },
   { id: 'dynamic-app', label: 'Canvas', icon: LayoutDashboard },
   // APP_MODE_DISABLED: { id: 'app-preview', label: 'App', icon: AppWindow },
-  // HIDDEN: { id: 'files', label: 'Files', icon: FolderOpen },
+  { id: 'files', label: 'Files', icon: FolderOpen },
   // { id: 'terminal', label: 'Terminal', icon: Terminal },
   { id: 'capabilities', label: 'Capabilities', icon: Sliders },
   { id: 'channels', label: 'Channels', icon: Radio },

--- a/apps/mobile/components/project/panels/FilesBrowserPanel.tsx
+++ b/apps/mobile/components/project/panels/FilesBrowserPanel.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import {
   View,
   Text,
@@ -288,6 +288,7 @@ export function FilesBrowserPanel({ projectId, agentUrl, visible }: FilesBrowser
   const [nativeKeyboardHeight, setNativeKeyboardHeight] = useState(0)
 
   const hasChanges = content !== savedContent
+  const treeJsonRef = useRef('')
 
   useEffect(() => {
     if (Platform.OS === 'web' || !visible) {
@@ -310,16 +311,21 @@ export function FilesBrowserPanel({ projectId, agentUrl, visible }: FilesBrowser
   // Data Loading
   // -------------------------------------------------------------------------
 
-  const loadTree = useCallback(async () => {
+  const loadTree = useCallback(async (showLoading = true) => {
     if (!client) return
-    setIsLoadingTree(true)
+    if (showLoading) setIsLoadingTree(true)
     setError(null)
     try {
-      setTree(await client.getWorkspaceTree())
+      const newTree = await client.getWorkspaceTree()
+      const json = JSON.stringify(newTree)
+      if (json !== treeJsonRef.current) {
+        treeJsonRef.current = json
+        setTree(newTree)
+      }
     } catch (err: any) {
       setError(err.message)
     } finally {
-      setIsLoadingTree(false)
+      if (showLoading) setIsLoadingTree(false)
     }
   }, [client])
 
@@ -365,7 +371,7 @@ export function FilesBrowserPanel({ projectId, agentUrl, visible }: FilesBrowser
 
   useEffect(() => {
     if (!visible || !client) return
-    const id = setInterval(loadTree, 5000)
+    const id = setInterval(() => loadTree(false), 5000)
     return () => clearInterval(id)
   }, [visible, client, loadTree])
 
@@ -792,7 +798,7 @@ export function FilesBrowserPanel({ projectId, agentUrl, visible }: FilesBrowser
 
               {/* General file tree */}
               <Text className="text-[10px] font-medium text-muted-foreground px-2 py-1 mt-2">
-                FILES
+                PROJECT FILES
               </Text>
               {tree.length === 0 ? (
                 <Text className="text-xs text-muted-foreground px-2 py-2 italic">

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -1526,7 +1526,27 @@ function mimeToExtension(mimeType: string): string {
   return MIME_EXTENSIONS[mimeType] || `.${mimeType.split('/').pop() || 'bin'}`
 }
 
-function walkFilesTree(dir: string, rootDir: string): any[] {
+const WORKSPACE_TREE_EXCLUDE_DIRS = new Set([
+  'node_modules', 'dist', '.next', '.cache', '.turbo', '.parcel-cache',
+  'coverage', '.nyc_output', '__pycache__', '.venv', 'venv',
+  'memory', 'scripts',
+])
+
+const WORKSPACE_TREE_EXCLUDE_FILES = new Set([
+  'bun.lock', '.virtfs_metadata',
+  'AGENTS.md', 'HEARTBEAT.md', 'MEMORY.md', 'TOOLS.md',
+  'package.json', 'tsconfig.json', 'vite.config.ts', 'tailwind.config.ts',
+  'postcss.config.js', 'postcss.config.mjs', 'components.json',
+  'pyrightconfig.json', 'LICENSE', 'README.md',
+  '.app-template',
+])
+
+function walkFilesTree(
+  dir: string,
+  rootDir: string,
+  excludeDirs?: Set<string>,
+  excludeFiles?: Set<string>,
+): any[] {
   if (!existsSync(dir)) return []
   const results: any[] = []
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -1535,14 +1555,16 @@ function walkFilesTree(dir: string, rootDir: string): any[] {
     const relPath = absPath.slice(rootDir.length + 1)
     const stat = statSync(absPath)
     if (entry.isDirectory()) {
+      if (excludeDirs?.has(entry.name)) continue
       results.push({
         name: entry.name,
         path: relPath,
         type: 'directory',
         modified: stat.mtimeMs,
-        children: walkFilesTree(absPath, rootDir),
+        children: walkFilesTree(absPath, rootDir, excludeDirs, excludeFiles),
       })
     } else {
+      if (excludeFiles?.has(entry.name)) continue
       results.push({
         name: entry.name,
         path: relPath,
@@ -1555,33 +1577,45 @@ function walkFilesTree(dir: string, rootDir: string): any[] {
   return results
 }
 
+function resolveWorkspacePath(subPath: string): string | null {
+  const resolved = resolve(WORKSPACE_DIR, subPath)
+  if (!resolved.startsWith(resolve(WORKSPACE_DIR))) return null
+  return resolved
+}
+
 // Recursive file tree for the file browser UI
 app.get('/agent/workspace/tree', (c) => {
-  mkdirSync(FILES_DIR, { recursive: true })
-  const tree = walkFilesTree(FILES_DIR, resolve(FILES_DIR))
+  const tree = walkFilesTree(WORKSPACE_DIR, resolve(WORKSPACE_DIR), WORKSPACE_TREE_EXCLUDE_DIRS, WORKSPACE_TREE_EXCLUDE_FILES)
   return c.json({ tree })
 })
 
-// Read a file from files/
+// Read a file from the workspace
 app.get('/agent/workspace/files/*', (c) => {
   const subPath = c.req.path.replace('/agent/workspace/files/', '')
   if (!subPath) return c.json({ error: 'Path required' }, 400)
 
-  const resolved = resolveFilesPath(subPath)
-  if (!resolved) return c.json({ error: 'Path outside files directory' }, 400)
-  if (!existsSync(resolved)) return c.json({ error: 'File not found' }, 404)
+  const resolved = resolveWorkspacePath(subPath)
+  if (!resolved) return c.json({ error: 'Path outside workspace' }, 400)
+  if (!existsSync(resolved)) {
+    const fallback = resolveFilesPath(subPath)
+    if (fallback && existsSync(fallback)) {
+      const content = readFileSync(fallback, 'utf-8')
+      return c.json({ path: subPath, content, bytes: content.length })
+    }
+    return c.json({ error: 'File not found' }, 404)
+  }
 
   const content = readFileSync(resolved, 'utf-8')
   return c.json({ path: subPath, content, bytes: content.length })
 })
 
-// Write/create a file in files/
+// Write/create a file in the workspace
 app.put('/agent/workspace/files/*', async (c) => {
   const subPath = c.req.path.replace('/agent/workspace/files/', '')
   if (!subPath) return c.json({ error: 'Path required' }, 400)
 
-  const resolved = resolveFilesPath(subPath)
-  if (!resolved) return c.json({ error: 'Path outside files directory' }, 400)
+  const resolved = resolveWorkspacePath(subPath)
+  if (!resolved) return c.json({ error: 'Path outside workspace' }, 400)
 
   const { content } = await c.req.json()
   const dir = dirname(resolved)
@@ -1591,13 +1625,13 @@ app.put('/agent/workspace/files/*', async (c) => {
   return c.json({ ok: true, path: subPath, bytes: content.length })
 })
 
-// Delete a file from files/
+// Delete a file from the workspace
 app.delete('/agent/workspace/files/*', (c) => {
   const subPath = c.req.path.replace('/agent/workspace/files/', '')
   if (!subPath) return c.json({ error: 'Path required' }, 400)
 
-  const resolved = resolveFilesPath(subPath)
-  if (!resolved) return c.json({ error: 'Path outside files directory' }, 400)
+  const resolved = resolveWorkspacePath(subPath)
+  if (!resolved) return c.json({ error: 'Path outside workspace' }, 400)
   if (!existsSync(resolved)) return c.json({ error: 'File not found' }, 404)
 
   unlinkSync(resolved)
@@ -1668,13 +1702,13 @@ app.get('/agent/workspace/download/*', (c) => {
   const subPath = c.req.path.replace('/agent/workspace/download/', '')
   if (!subPath) return c.json({ error: 'Path required' }, 400)
 
-  let resolved = resolveFilesPath(subPath)
-  if (!resolved) return c.json({ error: 'Path outside files directory' }, 400)
+  let resolved = resolveWorkspacePath(subPath)
+  if (!resolved) return c.json({ error: 'Path outside workspace' }, 400)
 
   if (!existsSync(resolved)) {
-    const wsRoot = resolve(WORKSPACE_DIR, subPath)
-    if (wsRoot.startsWith(resolve(WORKSPACE_DIR)) && existsSync(wsRoot) && /\.(png|jpe?g|gif|webp|svg|pdf)$/i.test(subPath)) {
-      resolved = wsRoot
+    const fallback = resolveFilesPath(subPath)
+    if (fallback && existsSync(fallback)) {
+      resolved = fallback
     } else {
       return c.json({ error: 'File not found' }, 404)
     }


### PR DESCRIPTION
## Summary
Restores the project **Files** tab in the top bar and makes the file browser show the real project workspace (source, prisma, etc.), not only the `files/` upload folder.

## Changes
- **ProjectTopBar:** Re-enable the Files tab (previously commented as HIDDEN).
- **agent-runtime:** `/agent/workspace/tree` walks `WORKSPACE_DIR` with excludes for `node_modules`, `dist`, build/tooling configs, and the four workspace MD files already shown under WORKSPACE. Read/write/delete/download for `/agent/workspace/files/*` resolve against the full workspace; read keeps a fallback for legacy paths under `files/`.
- **FilesBrowserPanel:** Section label **PROJECT FILES**; avoid unnecessary tree updates and loading flicker on the 5s poll (JSON compare, no spinner on background refresh).
<img width="1919" height="909" alt="image" src="https://github.com/user-attachments/assets/27fd6823-849a-4451-a37b-3c6434af8d05" />