### PR TITLE
fix: project export icon, K8s workspace bundle, SDK getWorkspaceBundle

### DIFF
--- a/apps/api/src/routes/project-export-import.ts
+++ b/apps/api/src/routes/project-export-import.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
+import { AgentClient, type WorkspaceBundle } from '@shogo-ai/sdk/agent'
 import { Hono } from 'hono'
 import {
   existsSync,
@@ -16,6 +17,7 @@ import type { AuthContext } from '../middleware/auth'
 
 const PROJECT_ROOT = resolve(import.meta.dir, '../../../..')
 const WORKSPACES_DIR = process.env.WORKSPACES_DIR || resolve(PROJECT_ROOT, 'workspaces')
+const isKubernetes = () => !!process.env.KUBERNETES_SERVICE_HOST
 
 const EXCLUDED_DIRS = new Set([
   'node_modules',
@@ -136,10 +138,26 @@ export function projectExportImportRoutes() {
 
     zipContents['project.json'] = strToU8(JSON.stringify(projectJson, null, 2))
 
-    const workspaceDir = join(WORKSPACES_DIR, projectId)
-    const workspaceFiles = collectWorkspaceFiles(workspaceDir, workspaceDir)
-    for (const [relPath, data] of Object.entries(workspaceFiles)) {
-      zipContents[`workspace/${relPath}`] = data
+    if (isKubernetes()) {
+      try {
+        const { getProjectPodUrl } = await import('../lib/knative-project-manager')
+        const podUrl = await getProjectPodUrl(projectId)
+        const agent = new AgentClient({ baseUrl: podUrl })
+        const bundle: WorkspaceBundle = await agent.getWorkspaceBundle()
+        for (const [relPath, base64Data] of Object.entries(bundle.files)) {
+          zipContents[`workspace/${relPath}`] = new Uint8Array(
+            Buffer.from(base64Data, 'base64'),
+          )
+        }
+      } catch (err: any) {
+        console.warn(`[Export] Could not reach agent pod for workspace files: ${err.message}`)
+      }
+    } else {
+      const workspaceDir = join(WORKSPACES_DIR, projectId)
+      const workspaceFiles = collectWorkspaceFiles(workspaceDir, workspaceDir)
+      for (const [relPath, data] of Object.entries(workspaceFiles)) {
+        zipContents[`workspace/${relPath}`] = data
+      }
     }
 
     for (const session of chatSessions) {

--- a/apps/mobile/components/project/ProjectTopBar.tsx
+++ b/apps/mobile/components/project/ProjectTopBar.tsx
@@ -62,7 +62,7 @@ import {
   ClipboardList,
   RefreshCw,
   GitCommit,
-  Download,
+  Upload,
 } from 'lucide-react-native'
 import { cn, Badge, Progress } from '@shogo/shared-ui/primitives'
 import { useTheme, type ThemePreference } from '../../contexts/theme'
@@ -1070,7 +1070,7 @@ function ProjectMenuView({
       onPress: () => { setShowDetailsModal(true) },
     },
     {
-      icon: Download,
+      icon: Upload,
       label: isExporting ? 'Exporting...' : 'Export project',
       onPress: handleExportProject,
     },

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -1555,6 +1555,45 @@ function walkFilesTree(dir: string, rootDir: string): any[] {
   return results
 }
 
+// Bundle all workspace files for project export (called by the API server in K8s mode)
+const BUNDLE_EXCLUDED_DIRS = new Set([
+  'node_modules', '.git', 'dist', '.cache', '.next', 'build', '.turbo', '.expo',
+])
+const BUNDLE_MAX_FILE_SIZE = 10 * 1024 * 1024
+
+function collectBundleFiles(dir: string, baseDir: string): Record<string, string> {
+  const files: Record<string, string> = {}
+  if (!existsSync(dir)) return files
+
+  const entries = readdirSync(dir, { withFileTypes: true })
+  for (const entry of entries) {
+    if (BUNDLE_EXCLUDED_DIRS.has(entry.name)) continue
+    if (entry.name.startsWith('.install-ok')) continue
+
+    const fullPath = join(dir, entry.name)
+    const relPath = require('path').relative(baseDir, fullPath).replace(/\\/g, '/')
+
+    if (entry.isDirectory()) {
+      Object.assign(files, collectBundleFiles(fullPath, baseDir))
+    } else if (entry.isFile()) {
+      try {
+        const stat = statSync(fullPath)
+        if (stat.size > BUNDLE_MAX_FILE_SIZE) continue
+        const buf = readFileSync(fullPath)
+        files[relPath] = Buffer.from(buf).toString('base64')
+      } catch {
+        // skip unreadable files
+      }
+    }
+  }
+  return files
+}
+
+app.get('/agent/workspace/bundle', (c) => {
+  const files = collectBundleFiles(WORKSPACE_DIR, WORKSPACE_DIR)
+  return c.json({ files })
+})
+
 // Recursive file tree for the file browser UI
 app.get('/agent/workspace/tree', (c) => {
   mkdirSync(FILES_DIR, { recursive: true })
@@ -2223,6 +2262,24 @@ app.delete('/agent/tools/:id', async (c) => {
 })
 
 // Agent export/import — bundle workspace into a shareable .shogo config
+function collectExportDir(dir: string, prefix: string, out: Record<string, string>): void {
+  if (!existsSync(dir)) return
+  const entries = readdirSync(dir, { withFileTypes: true })
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name)
+    const relPath = prefix ? `${prefix}/${entry.name}` : entry.name
+    if (entry.isDirectory()) {
+      collectExportDir(fullPath, relPath, out)
+    } else if (entry.isFile()) {
+      try {
+        const stat = statSync(fullPath)
+        if (stat.size > 5 * 1024 * 1024) continue
+        out[relPath] = readFileSync(fullPath, 'utf-8')
+      } catch { /* skip unreadable */ }
+    }
+  }
+}
+
 app.get('/agent/export', async (c) => {
   const exportFiles: Record<string, string> = {}
   const exportableFiles = [
@@ -2236,15 +2293,25 @@ app.get('/agent/export', async (c) => {
     }
   }
 
-  const skillsDir = join(WORKSPACE_DIR, 'skills')
-  if (existsSync(skillsDir)) {
-    const { readdirSync } = require('fs')
-    const skillFiles = readdirSync(skillsDir) as string[]
-    for (const file of skillFiles) {
-      if (file.endsWith('.md')) {
-        exportFiles[`skills/${file}`] = readFileSync(join(skillsDir, file), 'utf-8')
+  // Collect all .md files at workspace root (agent may create custom ones)
+  if (existsSync(WORKSPACE_DIR)) {
+    const rootEntries = readdirSync(WORKSPACE_DIR, { withFileTypes: true })
+    for (const entry of rootEntries) {
+      if (entry.isFile() && entry.name.endsWith('.md') && !exportFiles[entry.name]) {
+        exportFiles[entry.name] = readFileSync(join(WORKSPACE_DIR, entry.name), 'utf-8')
       }
     }
+  }
+
+  collectExportDir(join(WORKSPACE_DIR, 'skills'), 'skills', exportFiles)
+  collectExportDir(join(WORKSPACE_DIR, 'files'), 'files', exportFiles)
+  collectExportDir(join(WORKSPACE_DIR, 'memory'), 'memory', exportFiles)
+  collectExportDir(join(WORKSPACE_DIR, '.shogo', 'skills'), '.shogo/skills', exportFiles)
+  collectExportDir(join(WORKSPACE_DIR, '.shogo', 'plans'), '.shogo/plans', exportFiles)
+
+  const quickActionsPath = join(WORKSPACE_DIR, '.shogo', 'quick-actions.json')
+  if (existsSync(quickActionsPath)) {
+    exportFiles['.shogo/quick-actions.json'] = readFileSync(quickActionsPath, 'utf-8')
   }
 
   const bundle = {

--- a/packages/sdk/src/agent/client.ts
+++ b/packages/sdk/src/agent/client.ts
@@ -13,6 +13,7 @@ import type {
   FileNode,
   SearchResult,
   VisualMode,
+  WorkspaceBundle,
 } from './types.js'
 
 /** Per-request bodies set Content-Type; shared headers must not force a single type (e.g. multipart). */
@@ -151,6 +152,14 @@ export class AgentClient {
   async getWorkspaceTree(): Promise<FileNode[]> {
     const data = await this.fetchJson<{ tree: FileNode[] }>('/agent/workspace/tree')
     return data.tree ?? []
+  }
+
+  /**
+   * Full workspace snapshot for project export (K8s / server-side).
+   * Paths are relative to workspace root; values are base64-encoded file bytes.
+   */
+  async getWorkspaceBundle(): Promise<WorkspaceBundle> {
+    return this.fetchJson<WorkspaceBundle>('/agent/workspace/bundle')
   }
 
   async readFile(path: string): Promise<string> {

--- a/packages/sdk/src/agent/index.ts
+++ b/packages/sdk/src/agent/index.ts
@@ -60,6 +60,7 @@ export type {
   FileNode,
   SearchResult,
   VisualMode,
+  WorkspaceBundle,
 } from './types.js'
 
 // Hook result types

--- a/packages/sdk/src/agent/types.ts
+++ b/packages/sdk/src/agent/types.ts
@@ -87,6 +87,14 @@ export interface SearchResult {
   highlights?: string[]
 }
 
+/**
+ * Response body from `GET /agent/workspace/bundle`.
+ * Keys are paths relative to the workspace; values are base64-encoded raw file bytes.
+ */
+export interface WorkspaceBundle {
+  files: Record<string, string>
+}
+
 /** Response body from `GET /agent/export`. */
 export interface AgentExportBundle {
   version: string


### PR DESCRIPTION
Fixes #356
<img width="311" height="48" alt="Screenshot 2026-04-15 at 5 04 41 AM" src="https://github.com/user-attachments/assets/405fc53d-3023-4ad7-9fef-f4286a6cd835" />

## Summary

- **UI:** `Export project` now uses the `Upload` icon from lucide-react-native instead of `Download`, matching the export action.
- **K8s export:** The API builds the workspace section of the `.shogo-project` ZIP by calling the agent runtime’s full-workspace bundle via **`AgentClient.getWorkspaceBundle()`** (`@shogo-ai/sdk`), not raw `fetch` to the pod URL.
- **Agent runtime:** Adds `GET /agent/workspace/bundle` (base64 file map) and expands `GET /agent/export` to include skills, `files/`, `memory/`, `.shogo/skills`, `.shogo/plans`, and quick-actions where applicable.

## Local / non-K8s

Unchanged: workspace files are still collected from `WORKSPACES_DIR/<projectId>` on the API host.
