### PR TITLE
fix(mobile): restore project Files tab in top bar

### DIFF
--- a/apps/mobile/components/project/ProjectTopBar.tsx
+++ b/apps/mobile/components/project/ProjectTopBar.tsx
@@ -84,7 +84,7 @@ const AGENT_TABS: { id: string; label: string; icon: React.ElementType }[] = [
   { id: 'chat-fullscreen', label: 'Chat', icon: MessageSquare },
   { id: 'dynamic-app', label: 'Canvas', icon: LayoutDashboard },
   // APP_MODE_DISABLED: { id: 'app-preview', label: 'App', icon: AppWindow },
-  // HIDDEN: { id: 'files', label: 'Files', icon: FolderOpen },
+  { id: 'files', label: 'Files', icon: FolderOpen },
   // { id: 'terminal', label: 'Terminal', icon: Terminal },
   { id: 'capabilities', label: 'Capabilities', icon: Sliders },
   { id: 'channels', label: 'Channels', icon: Radio },


### PR DESCRIPTION
## What
Re-enables the **Files** tab in the project workspace top bar (`AGENT_TABS` in `ProjectTopBar.tsx`).
<img width="1512" height="982" alt="Screenshot 2026-04-15 at 5 06 48 AM" src="https://github.com/user-attachments/assets/dd2dd1ec-0212-40a6-8840-afd64f293d2b" />
## Why
The tab was previously hidden (`// HIDDEN`) while `FilesBrowserPanel` and layout wiring for `previewTab === 'files'` remained. Users had no entry point from the icon strip.

## How
Single-line change: restore `{ id: 'files', label: 'Files', icon: FolderOpen }`.

Closes #358

Made with [Cursor](https://cursor.com)