### PR TITLE
fix(mobile): align Import/Export Lucide icons (Projects + Files panel)

### DIFF
--- a/apps/mobile/app/(app)/projects/index.tsx
+++ b/apps/mobile/app/(app)/projects/index.tsx
@@ -58,7 +58,7 @@ import {
   Trash2,
   ArrowRightLeft,
   Pencil,
-  Upload,
+  Download,
 } from 'lucide-react-native'
 import {
   useSDKDomain,
@@ -1466,7 +1466,7 @@ export default observer(function AllProjectsPage() {
             disabled={isImporting}
             className="flex-row items-center gap-1 px-2.5 py-1.5 rounded-lg border border-input active:bg-muted"
           >
-            <Upload size={14} className="text-muted-foreground" />
+            <Download size={14} className="text-muted-foreground" />
             <Text className="text-xs text-foreground">{isImporting ? 'Importing...' : 'Import'}</Text>
           </Pressable>
 

--- a/apps/mobile/components/project/panels/FilesBrowserPanel.tsx
+++ b/apps/mobile/components/project/panels/FilesBrowserPanel.tsx
@@ -867,7 +867,7 @@ export function FilesBrowserPanel({ projectId, agentUrl, visible }: FilesBrowser
               disabled={isExporting}
               className="flex-row items-center gap-1.5 px-2 py-1.5 rounded-md active:bg-muted"
             >
-              <Download size={12} className="text-muted-foreground" />
+              <Upload size={12} className="text-muted-foreground" />
               <Text className="text-xs text-muted-foreground">
                 {isExporting ? 'Exporting...' : 'Export Agent'}
               </Text>
@@ -876,7 +876,7 @@ export function FilesBrowserPanel({ projectId, agentUrl, visible }: FilesBrowser
               onPress={handleImport}
               className="flex-row items-center gap-1.5 px-2 py-1.5 rounded-md active:bg-muted"
             >
-              <Upload size={12} className="text-muted-foreground" />
+              <Download size={12} className="text-muted-foreground" />
               <Text className="text-xs text-muted-foreground">Import Agent</Text>
             </Pressable>
           </View>


### PR DESCRIPTION
Closes #360
<img width="318" height="135" alt="Screenshot 2026-04-15 at 5 21 25 AM" src="https://github.com/user-attachments/assets/ed1aa168-e00c-4952-81af-c815a61a5290" />
## Summary

- **All Projects** toolbar: use `Download` for **Import** instead of `Upload` so the glyph matches “bring project into workspace” semantics.
- **Files browser** (`FilesBrowserPanel`): swap icons so **Export Agent** uses `Upload` and **Import Agent** uses `Download`.

Single-theme change; no other refactors.

Made with [Cursor](https://cursor.com)