### PR TITLE
fix(billing): stable credit totals and progress bars

### DIFF
--- a/apps/api/src/services/billing.service.ts
+++ b/apps/api/src/services/billing.service.ts
@@ -82,6 +82,7 @@ export async function allocateMonthlyCredits(
     create: {
       workspaceId,
       monthlyCredits,
+      monthlyAllocation: monthlyCredits,
       dailyCredits: DAILY_CREDITS,
       anniversaryDay: now.getDate(),
       lastDailyReset: now,
@@ -89,6 +90,7 @@ export async function allocateMonthlyCredits(
     },
     update: {
       monthlyCredits,
+      monthlyAllocation: monthlyCredits,
       lastMonthlyReset: now,
     },
   });

--- a/apps/desktop/prisma/schema.prisma
+++ b/apps/desktop/prisma/schema.prisma
@@ -388,6 +388,7 @@ model CreditLedger {
   workspaceId      String   @unique
   monthlyCredits   Float    @default(0)
   dailyCredits     Float    @default(0)
+  monthlyAllocation Float   @default(0)
   dailyCreditsDispensedThisMonth Float @default(0)
   anniversaryDay   Int
   lastDailyReset   DateTime

--- a/apps/mobile/app/(app)/billing.tsx
+++ b/apps/mobile/app/(app)/billing.tsx
@@ -131,6 +131,7 @@ export default observer(function BillingPage() {
   const creditsTotal = getCreditsCapacityForDisplay(
     subscription?.planId,
     effectiveBalance?.total,
+    effectiveBalance?.monthlyAllocation,
   )
 
   const planName = subscription

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -191,6 +191,7 @@ export default observer(function ProjectLayout() {
   const creditsTotal = getCreditsCapacityForDisplay(
     billingData.subscription?.planId,
     billingData.effectiveBalance?.total,
+    billingData.effectiveBalance?.monthlyAllocation,
   )
 
   const isStarred = useMemo(() => {

--- a/apps/mobile/app/(app)/settings.tsx
+++ b/apps/mobile/app/(app)/settings.tsx
@@ -2164,8 +2164,10 @@ function BillingTab() {
   const totalCredits = getCreditsCapacityForDisplay(
     hasActiveSubscription ? subscription?.planId : undefined,
     effectiveBalance?.total,
+    effectiveBalance?.monthlyAllocation,
   )
-  const creditsUsed = totalCredits - (effectiveBalance?.total ?? 0)
+  const creditsRemaining = effectiveBalance?.total ?? 0
+  const creditsUsed = Math.max(0, totalCredits - creditsRemaining)
   const usagePct = totalCredits > 0 ? Math.min(100, Math.round((creditsUsed / totalCredits) * 100)) : 0
 
   if (!workspace?.id) {

--- a/apps/mobile/components/layout/AppSidebar.tsx
+++ b/apps/mobile/components/layout/AppSidebar.tsx
@@ -631,7 +631,7 @@ function WorkspaceSwitcher({
   const creditsRemaining =
     effectiveBalance?.total ?? getTotalCreditsForPlan(planIdForCredits)
   const creditsTotal = Math.max(
-    getCreditsCapacityForDisplay(planIdForCredits, effectiveBalance?.total),
+    getCreditsCapacityForDisplay(planIdForCredits, effectiveBalance?.total, effectiveBalance?.monthlyAllocation),
     1,
   )
 

--- a/apps/mobile/lib/billing-config.ts
+++ b/apps/mobile/lib/billing-config.ts
@@ -94,11 +94,13 @@ export const MONTHLY_DAILY_CAP = 30
 export function getTotalCreditsForPlan(planId: string | undefined): number {
   if (!planId) return (PLAN_CREDITS['free'] || 0) + DAILY_CREDITS
 
-  if (PLAN_CREDITS[planId] !== undefined) {
-    return PLAN_CREDITS[planId] + DAILY_CREDITS
+  const normalizedId = planId.toLowerCase()
+
+  if (PLAN_CREDITS[normalizedId] !== undefined) {
+    return PLAN_CREDITS[normalizedId] + DAILY_CREDITS
   }
 
-  const match = planId.match(/^(free|basic|pro|business|enterprise)_(\d+)$/)
+  const match = normalizedId.match(/^(free|basic|pro|business|enterprise)_(\d+)$/)
   if (match) {
     return parseInt(match[2], 10) * 2 + DAILY_CREDITS
   }
@@ -107,15 +109,27 @@ export function getTotalCreditsForPlan(planId: string | undefined): number {
 }
 
 /**
- * Capacity shown as "remaining / total" when the ledger can exceed the plan baseline
- * (e.g. credit packs). Denominator must not stay at the plan floor while balance is higher.
+ * Compute the "total capacity" for display in "remaining / total" credit indicators.
+ *
+ * Uses monthlyAllocation from the CreditLedger (the original allocation that does
+ * not decrease with usage) when available. Falls back to deriving from planId.
  */
 export function getCreditsCapacityForDisplay(
   planId: string | undefined,
   remainingTotal: number | undefined,
+  monthlyAllocation?: number,
 ): number {
+  if (monthlyAllocation && monthlyAllocation > 0) {
+    return monthlyAllocation + DAILY_CREDITS
+  }
+
   const baseline = getTotalCreditsForPlan(planId)
+
   if (remainingTotal === undefined) return baseline
+
+  // For backward compat (before monthlyAllocation is populated), if remaining
+  // exceeds the plan baseline, use remaining as a conservative estimate of the
+  // initial allocation so the display doesn't show remaining > total.
   return Math.max(baseline, remainingTotal)
 }
 

--- a/packages/domain-stores/src/credit-ledger.model.ts
+++ b/packages/domain-stores/src/credit-ledger.model.ts
@@ -22,6 +22,7 @@ export const CreditLedgerModel = types
     workspaceId: types.string,
     monthlyCredits: types.optional(types.number, 0),
     dailyCredits: types.optional(types.number, 0),
+    monthlyAllocation: types.optional(types.number, 0),
     anniversaryDay: types.number,
     lastDailyReset: types.optional(types.number, 0),
     lastMonthlyReset: types.optional(types.number, 0),

--- a/packages/shared-app/src/hooks/useBillingData.ts
+++ b/packages/shared-app/src/hooks/useBillingData.ts
@@ -16,6 +16,7 @@ export interface BillingDataState {
   effectiveBalance: {
     dailyCredits: number
     monthlyCredits: number
+    monthlyAllocation: number
     total: number
   } | undefined
   usageEvents: any[]
@@ -99,7 +100,8 @@ export function useBillingData(workspaceId: string | undefined): BillingDataStat
       const needsReset = lastReset !== new Date().toDateString()
       const daily = needsReset ? 5 : (creditLedger.dailyCredits ?? 0)
       const monthly = creditLedger.monthlyCredits ?? 0
-      return { dailyCredits: daily, monthlyCredits: monthly, total: daily + monthly }
+      const monthlyAllocation = creditLedger.monthlyAllocation ?? 0
+      return { dailyCredits: daily, monthlyCredits: monthly, monthlyAllocation, total: daily + monthly }
     } catch { return undefined }
   }, [creditLedger])
 

--- a/prisma/migrations/20260415060000_add_monthly_allocation_to_credit_ledger/migration.sql
+++ b/prisma/migrations/20260415060000_add_monthly_allocation_to_credit_ledger/migration.sql
@@ -1,0 +1,24 @@
+-- AlterTable: Add monthlyAllocation to credit_ledgers
+-- Stores the original monthly credit allocation so the UI can display
+-- a stable "remaining / total" without the denominator decreasing with usage.
+ALTER TABLE "credit_ledgers" ADD COLUMN "monthlyAllocation" DOUBLE PRECISION NOT NULL DEFAULT 0;
+
+-- Backfill: set monthlyAllocation from the subscription's planId for existing ledgers.
+-- For workspaces with an active subscription, derive the allocation from the planId.
+-- Tiered plans (e.g. "business_1200") store half the credit amount as the suffix;
+-- base plans ("pro", "business") use 200 credits.
+UPDATE "credit_ledgers" cl
+SET "monthlyAllocation" = CASE
+  WHEN s."planId" ~ '^(pro|business)_[0-9]+$'
+    THEN CAST(SPLIT_PART(s."planId", '_', 2) AS DOUBLE PRECISION) * 2
+  WHEN s."planId" IN ('pro', 'business')
+    THEN 200
+  WHEN s."planId" = 'basic'
+    THEN 50
+  WHEN s."planId" LIKE 'enterprise%'
+    THEN 20000
+  ELSE 0
+END
+FROM "subscriptions" s
+WHERE s."workspaceId" = cl."workspaceId"
+  AND s."status" IN ('active', 'trialing');

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -501,6 +501,7 @@ model CreditLedger {
   workspaceId      String   @unique
   monthlyCredits   Float    @default(0)
   dailyCredits     Float    @default(0)
+  monthlyAllocation Float   @default(0)
   dailyCreditsDispensedThisMonth Float @default(0)
   anniversaryDay   Int
   lastDailyReset   DateTime


### PR DESCRIPTION
## Summary

Fixes credit UI where **remaining** and **total** could match (bar always full) and the **denominator** dropped as credits were used.

## Changes

- **Schema:** `CreditLedger.monthlyAllocation` — original monthly pool (does not decrease with usage).
- **API:** Set `monthlyAllocation` in `allocateMonthlyCredits` (create + update on renewal).
- **Migration:** Add column, backfill from active subscription `planId` for existing rows.
- **Client:** `useBillingData` exposes `monthlyAllocation`; `getCreditsCapacityForDisplay` prefers `monthlyAllocation + DAILY_CREDITS`; case-insensitive `planId` parsing.
- **UI:** Settings Billing tab, Billing page, workspace switcher, project layout — pass `monthlyAllocation` into capacity helper.

## Issue

Closes #362

## Deploy notes

Run `prisma migrate deploy` in environments that use migrations. Regenerate Prisma client in CI as usual.

Made with [Cursor](https://cursor.com)