### PR TITLE
fix(mobile): correct Image icon import in CompactChatInput

### DIFF
--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -34,7 +34,7 @@ import {
   X,
   File,
   FileText,
-  ImageIcon,
+  Image as ImageIcon,
   ChevronDown,
   Lock,
   Check,


### PR DESCRIPTION
Imports `Image as ImageIcon` from `lucide-react-native` instead of the non-existent `ImageIcon` export, matching `ChatInput.tsx` and preventing a runtime crash when rendering image file attachment icons.

Made with [Cursor](https://cursor.com)