### PR TITLE
fix(mobile): clear CompactChatInput after submit

### DIFF
--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -342,8 +342,13 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
           : undefined
 
       onSubmit(trimmedContent, fileData)
+      setValue("")
+      setPendingFiles([])
       setFileError(null)
-    }, [value, disabled, isLoading, onSubmit, pendingFiles, voiceInput.isBusy])
+      setLongTextCollapsed(false)
+      setLongTextViewerOpen(false)
+      textInputRef.current?.focus()
+    }, [value, disabled, isLoading, onSubmit, pendingFiles, voiceInput.isBusy, setValue])
 
     const getFileIcon = useCallback((fileType: string) => {
       if (fileType.startsWith("image/")) {


### PR DESCRIPTION
Clears the composer after a successful send: text (`setValue("")}` for controlled and internal state), pending file attachments, long-text collapsed/viewer state, and refocuses the input—matching `ChatInput` and preventing accidental double submission on the home composer.

Made with [Cursor](https://cursor.com)