### PR TITLE
fix(mobile): add size guard when fetching file content in DocumentThumbnail

### DIFF
--- a/apps/mobile/components/chat/turns/MessageContent.tsx
+++ b/apps/mobile/components/chat/turns/MessageContent.tsx
@@ -148,8 +148,14 @@ function DocumentThumbnail({
     setLoading(true)
     try {
       const res = await fetch(url)
+      const contentLength = parseInt(res.headers.get("content-length") || "0", 10)
+      const MAX_FILE_BYTES = 1 * 1024 * 1024 // 1 MB
+      if (contentLength > MAX_FILE_BYTES) {
+        Linking.openURL(url)
+        return
+      }
       const text = await res.text()
-      setFileContent(text)
+      setFileContent(text.length > MAX_FILE_BYTES ? text.slice(0, MAX_FILE_BYTES) + "\n\n…[truncated]" : text)
       setShowModal(true)
     } catch {
       Linking.openURL(url)


### PR DESCRIPTION
## Summary
- When a user taps a text-like file thumbnail in chat, the app fetched the entire file into memory with no size limit, risking OOM on mobile.
- Now checks the `Content-Length` header and falls back to `Linking.openURL` for files over 1 MB.
- Also truncates the response body to 1 MB as a safety net (header may be absent/wrong).

## Test plan
1. Open a chat that has a **text/JSON/YAML file attachment** in an assistant or user message.
2. Tap the file thumbnail — small files should open in the in-app `FileViewerModal` as before.
3. For files >1 MB the browser/system file viewer should open instead (via `Linking.openURL`).

Made with [Cursor](https://cursor.com)