### PR TITLE
fix(mobile): show publish dropdown when canvas is active

### DIFF
--- a/apps/mobile/components/project/ProjectTopBar.tsx
+++ b/apps/mobile/components/project/ProjectTopBar.tsx
@@ -770,6 +770,9 @@ export function ProjectTopBar({
 
         {/* Right actions */}
         <View className="flex-row items-center gap-0.5">
+          {isCanvasActive && (
+            <PublishDropdown projectId={projectId} projectName={projectName} />
+          )}
           {!hasActiveSubscription && (
             <Pressable
               onPress={() => router.push('/(app)/billing' as any)}


### PR DESCRIPTION
Closes #373
<img width="1512" height="982" alt="Screenshot 2026-04-16 at 1 17 25 PM" src="https://github.com/user-attachments/assets/91837ca8-37e1-4c7d-b854-9fc7a882a1ee" />
## Summary
Shows `PublishDropdown` in the project top bar right actions while the canvas is active so users can publish without leaving canvas view.

## Test plan
- Open a project on mobile, enter canvas mode, confirm the publish control appears in the top bar and opens the publish flow.

