### PR TITLE
fix(api): retry VM project URL in project-chat (desktop warm pool)

### DIFF
--- a/apps/api/src/routes/project-chat.ts
+++ b/apps/api/src/routes/project-chat.ts
@@ -479,7 +479,17 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
       // Do NOT fall back to local RuntimeManager — that creates a split-brain
       // where the preview renders from the host but the agent runs in the VM.
       const { getVMProjectUrl } = await import("../lib/vm-warm-pool-controller")
-      return await getVMProjectUrl(projectId)
+      const maxRetries = 5
+      const retryDelayMs = 3000
+      for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        try {
+          return await getVMProjectUrl(projectId)
+        } catch (err) {
+          if (attempt === maxRetries) throw err
+          console.log(`[ProjectChat] VM not ready (attempt ${attempt}/${maxRetries}), retrying in ${retryDelayMs}ms...`)
+          await new Promise(r => setTimeout(r, retryDelayMs))
+        }
+      }
     }
     if (runtimeManager) {
       // Local development: Use RuntimeManager


### PR DESCRIPTION
## Problem

With **VM isolation** (desktop), the first project chat request can fail while `getVMProjectUrl` is still racing warm-pool assignment. Users often recover by using **Retry** in the chat UI once the VM is ready.

## Change

Retry `getVMProjectUrl(projectId)` up to 5 times with a 3s delay between attempts when resolving the runtime URL for the project-chat proxy.

## Issue

Closes #375

Made with [Cursor](https://cursor.com)