### PR TITLE
fix(api): skip TunnelRedis in local mode, graceful fallback when Redis unavailable

### DIFF
--- a/apps/api/src/lib/tunnel-redis.ts
+++ b/apps/api/src/lib/tunnel-redis.ts
@@ -14,6 +14,7 @@
 
 import Redis from 'ioredis'
 
+const isLocalMode = process.env.SHOGO_LOCAL_MODE === 'true'
 const REDIS_URL = process.env.REDIS_URL || 'redis://redis-master:6379'
 const POD_ID = process.env.HOSTNAME || crypto.randomUUID()
 
@@ -36,41 +37,56 @@ export function getPodId(): string {
 export async function initTunnelRedis(): Promise<void> {
   if (initialized) return
 
-  pub = new Redis(REDIS_URL, {
-    maxRetriesPerRequest: 3,
-    connectTimeout: 5000,
-    lazyConnect: true,
-    retryStrategy(times) {
-      if (times > 5) return null
-      return Math.min(times * 500, 3000)
-    },
-  })
-  pub.on('error', (err) => {
-    console.error('[TunnelRedis] Publisher error:', err.message)
-  })
+  if (isLocalMode) {
+    initialized = true
+    console.log('[TunnelRedis] Skipped — local mode (single process, no cross-pod relay needed)')
+    return
+  }
 
-  sub = new Redis(REDIS_URL, {
-    maxRetriesPerRequest: 3,
-    connectTimeout: 5000,
-    lazyConnect: true,
-    retryStrategy(times) {
-      if (times > 5) return null
-      return Math.min(times * 500, 3000)
-    },
-  })
-  sub.on('error', (err) => {
-    console.error('[TunnelRedis] Subscriber error:', err.message)
-  })
+  try {
+    pub = new Redis(REDIS_URL, {
+      maxRetriesPerRequest: 3,
+      connectTimeout: 5000,
+      lazyConnect: true,
+      retryStrategy(times) {
+        if (times > 5) return null
+        return Math.min(times * 500, 3000)
+      },
+    })
+    pub.on('error', (err) => {
+      console.error('[TunnelRedis] Publisher error:', err.message)
+    })
 
-  await Promise.all([pub.connect(), sub.connect()])
+    sub = new Redis(REDIS_URL, {
+      maxRetriesPerRequest: 3,
+      connectTimeout: 5000,
+      lazyConnect: true,
+      retryStrategy(times) {
+        if (times > 5) return null
+        return Math.min(times * 500, 3000)
+      },
+    })
+    sub.on('error', (err) => {
+      console.error('[TunnelRedis] Subscriber error:', err.message)
+    })
 
-  await sub.subscribe(`tunnel:pod:${POD_ID}:request`)
-  await sub.subscribe(`tunnel:pod:${POD_ID}:stream-request`)
+    await Promise.all([pub.connect(), sub.connect()])
 
-  sub.on('message', handleSubMessage)
+    await sub.subscribe(`tunnel:pod:${POD_ID}:request`)
+    await sub.subscribe(`tunnel:pod:${POD_ID}:stream-request`)
+
+    sub.on('message', handleSubMessage)
+
+    console.log(`[TunnelRedis] Initialized (pod=${POD_ID})`)
+  } catch (err) {
+    console.error('[TunnelRedis] Failed to connect — falling back to in-memory only:', (err as Error).message)
+    try { pub?.disconnect() } catch {}
+    try { sub?.disconnect() } catch {}
+    pub = null
+    sub = null
+  }
 
   initialized = true
-  console.log(`[TunnelRedis] Initialized (pod=${POD_ID})`)
 }
 
 export async function shutdownTunnelRedis(): Promise<void> {


### PR DESCRIPTION
## Summary

- Skip Redis connection entirely when `SHOGO_LOCAL_MODE=true` (desktop app) — no connection attempt, no error spam
- Wrap cloud-mode Redis connection in try/catch so a missing Redis falls back to in-memory only instead of crashing or spamming errors
- All existing Redis-backed functions already handle `null` publisher gracefully (return null/empty/false), so in-memory fallbacks in `instances.ts` take over seamlessly

## Context

Redis is only needed for cross-pod tunnel routing in multi-pod K8s. In desktop/local mode the WebSocket tunnel and HTTP requests land on the same process, so the in-memory `tunnels` Map handles everything. This was always the intended behavior, but the init function was missing the guard.

Closes #377

## Test plan

- [ ] Run `SHOGO_LOCAL_MODE=true bun run api:dev` — confirm log shows `[TunnelRedis] Skipped — local mode` and no Redis errors
- [ ] Run `bun run api:dev` without Redis running — confirm log shows `[TunnelRedis] Failed to connect — falling back to in-memory only` once, then no further errors
- [ ] Run `bun run api:dev` with Redis running — confirm log shows `[TunnelRedis] Initialized (pod=...)` and remote control proxy works

Made with [Cursor](https://cursor.com)