### PR TITLE
fix(warm-pool): prevent GC from killing pods with active streams

### DIFF
--- a/apps/api/src/lib/warm-pool-controller.ts
+++ b/apps/api/src/lib/warm-pool-controller.ts
@@ -1113,7 +1113,13 @@ export class WarmPoolController {
             headers: { 'x-runtime-token': deriveRuntimeToken(pod.projectId) },
           })
           if (resp.ok) {
-            const activity = await resp.json() as { idleSeconds: number }
+            const activity = await resp.json() as { idleSeconds: number; activeStreams?: number }
+            if ((activity.activeStreams ?? 0) > 0) {
+              console.log(
+                `[WarmPool GC] Skipping pod ${pod.serviceName} for project ${pod.projectId} — ${activity.activeStreams} active stream(s)`
+              )
+              continue
+            }
             if (activity.idleSeconds * 1000 < this._idleTimeoutMs) continue
             console.log(
               `[WarmPool GC] Evicting idle promoted pod ${pod.serviceName} for project ${pod.projectId} (idle ${activity.idleSeconds}s, timeout ${this._idleTimeoutMs / 1000}s)`

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -198,7 +198,7 @@ const { app, state, logTiming } = await createRuntimeApp({
       (max: number, s: any) => Math.max(max, now - (s.idleSeconds ?? 0) * 1000),
       state.poolAssignedAt ?? state.serverStartTime
     )
-    return { activeSessions: stats.length, lastActivityAt: lastSessionActivity }
+    return { activeSessions: stats.length, lastActivityAt: lastSessionActivity, activeStreams }
   },
   getHealthExtra: () => ({
     gateway: agentGateway?.getStatus() ?? null,

--- a/packages/shared-runtime/src/server-framework.ts
+++ b/packages/shared-runtime/src/server-framework.ts
@@ -50,7 +50,7 @@ export interface RuntimeAppConfig {
    * Returns activity stats for the /pool/activity endpoint.
    * If not provided, only HTTP request tracking is used.
    */
-  getActivityStats?: () => { activeSessions: number; lastActivityAt: number | null }
+  getActivityStats?: () => { activeSessions: number; lastActivityAt: number | null; activeStreams?: number }
   /**
    * Extra data to include in the /health response.
    */
@@ -402,10 +402,12 @@ export async function createRuntimeApp(config: RuntimeAppConfig): Promise<Runtim
     const now = Date.now()
     const lastSessionActivity = activityStats.lastActivityAt ?? (state.poolAssignedAt ?? SERVER_START_TIME)
     const lastActivity = Math.max(state.lastRequestAt, lastSessionActivity)
+    const streams = activityStats.activeStreams ?? 0
     return c.json({
       projectId: state.currentProjectId,
       lastActivityAt: lastActivity,
-      idleSeconds: Math.floor((now - lastActivity) / 1000),
+      idleSeconds: streams > 0 ? 0 : Math.floor((now - lastActivity) / 1000),
+      activeStreams: streams,
       activeSessions: activityStats.activeSessions,
       lastRequestAt: state.lastRequestAt,
       lastSessionActivityAt: lastSessionActivity,


### PR DESCRIPTION
## Summary

- **Root cause:** The warm pool GC was killing pods mid-stream because the `activeStreams` counter (used only for graceful shutdown) was never exposed to the `/pool/activity` endpoint that the GC checks before eviction. Long-running agent turns (PR reviews, multi-tool calls) appeared "idle" to the GC even while actively streaming a response.
- **Effect:** `ERR_HTTP2_PROTOCOL_ERROR` / "Connection interrupted. Please tap Retry to continue." on staging when agent turns exceeded the idle timeout.
- **Fix:** Expose `activeStreams` in `/pool/activity` and skip GC eviction when streams are active.

## Changes

| File | Change |
|------|--------|
| `packages/shared-runtime/src/server-framework.ts` | Add `activeStreams` to `/pool/activity` response; report `idleSeconds: 0` when streams are active |
| `packages/agent-runtime/src/server.ts` | Pass `activeStreams` counter to `getActivityStats()` |
| `apps/api/src/lib/warm-pool-controller.ts` | Skip idle eviction when `activeStreams > 0` |

## How it works

```
Before:
  GC calls GET /pool/activity → { idleSeconds: 65 }
  GC sees idle > timeout → evicts pod → stream dies → ERR_HTTP2_PROTOCOL_ERROR

After:
  GC calls GET /pool/activity → { idleSeconds: 0, activeStreams: 1 }
  GC sees activeStreams > 0 → skips eviction → stream completes normally
```

## Test plan

- [ ] Deploy to staging and trigger a long-running agent turn (e.g. PR review with multiple tool calls)
- [ ] Verify in SigNoz logs that `[WarmPool GC] Skipping pod ... — N active stream(s)` appears during active turns
- [ ] Verify no more `ERR_HTTP2_PROTOCOL_ERROR` during active streaming
- [ ] Verify idle pods (no active streams) are still properly evicted after timeout


Made with [Cursor](https://cursor.com)