### PR TITLE
fix(api-keys): clear loading state when workspace is not yet available

### DIFF
--- a/apps/mobile/app/(app)/api-keys.tsx
+++ b/apps/mobile/app/(app)/api-keys.tsx
@@ -72,7 +72,10 @@ export default observer(function ApiKeysPage() {
   const [isRevoking, setIsRevoking] = useState(false)
 
   const loadKeys = useCallback(async () => {
-    if (!workspace?.id) return
+    if (!workspace?.id) {
+      setIsLoading(false)
+      return
+    }
     setIsLoading(true)
     try {
       setKeys(await platform.listApiKeys(workspace.id))


### PR DESCRIPTION
## Summary

- Fixes infinite spinner on the API Keys page when workspace hasn't loaded on first paint
- `loadKeys` returned early when `workspace?.id` was undefined but never cleared `isLoading` (which starts as `true`), leaving users stuck on a spinner forever
- Now calls `setIsLoading(false)` before the early return — shows the empty state until the workspace becomes available, then auto-fetches keys

## Test plan

- [ ] Navigate to API Keys with a valid workspace — verify keys load normally
- [ ] Open API Keys via direct URL before workspace loads — verify spinner clears and shows empty state, then loads keys once workspace is ready
- [ ] Switch workspaces while on API Keys — verify keys refresh for the new workspace
- [ ] Disconnect network, open API Keys — verify spinner clears (doesn't hang forever)


Made with [Cursor](https://cursor.com)