### PR TITLE
fix(api): Remote Control without Redis — Postgres tunnel registry + pod HTTP relay

### DIFF
--- a/apps/api/src/lib/tunnel-db.ts
+++ b/apps/api/src/lib/tunnel-db.ts
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Tunnel DB Layer — Redis-less Cross-Pod Coordination
+ *
+ * When Redis is not available (e.g. staging without a Redis deployment),
+ * these helpers provide equivalent functionality via Postgres + direct
+ * pod-to-pod HTTP relay:
+ *
+ *   • Viewer presence  → `active_viewers` table (replaces Redis `viewer:*`)
+ *   • Tunnel ownership → `tunnel_ownership` table (replaces `tunnel:*:pod`)
+ *   • Request relay    → HTTP POST to owning pod IP (replaces pub/sub)
+ *
+ * `tunnel-redis.ts` detects the Redis-unavailable condition and forwards
+ * every helper to this module, so callers (`routes/instances.ts`) never
+ * need to know which backend is in use.
+ */
+import { prisma } from './prisma'
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const VIEWER_TTL_MS = 2 * 60 * 1000
+const OWNERSHIP_STALE_MS = 90_000 // refreshed every 25 s by startTunnelHeartbeat
+const RELAY_TIMEOUT_MS = 30_000
+const STREAM_RELAY_TIMEOUT_MS = 600_000
+const POD_ALIVE_TIMEOUT_MS = 3_000
+
+// ─── Pod identity (matches tunnel-redis.ts) ──────────────────────────────────
+
+const POD_ID = process.env.HOSTNAME || crypto.randomUUID()
+const POD_IP = process.env.POD_IP || '127.0.0.1'
+const INTERNAL_RELAY_PORT = parseInt(process.env.API_PORT || process.env.PORT || '8002', 10)
+const INTERNAL_RELAY_SECRET = process.env.INTERNAL_RELAY_SECRET || ''
+
+export function getLocalPodIp(): string {
+  return POD_IP
+}
+
+function podBaseUrl(podIp: string): string {
+  return `http://${podIp}:${INTERNAL_RELAY_PORT}`
+}
+
+function relayAuthHeaders(): Record<string, string> {
+  // When no shared secret is configured (single-pod dev) we still emit a
+  // header so the internal endpoint can detect the "local, trust me" case.
+  // In a real multi-pod deployment, set INTERNAL_RELAY_SECRET so pods can
+  // reject unauthenticated traffic that somehow makes it through NetworkPolicy.
+  return INTERNAL_RELAY_SECRET
+    ? { 'x-internal-relay-secret': INTERNAL_RELAY_SECRET }
+    : {}
+}
+
+export function verifyInternalRelaySecret(header: string | null | undefined): boolean {
+  if (!INTERNAL_RELAY_SECRET) return true // single-pod dev (no shared secret configured)
+  return header === INTERNAL_RELAY_SECRET
+}
+
+// ─── Viewer presence ─────────────────────────────────────────────────────────
+
+export async function markViewerActiveDb(workspaceId: string): Promise<void> {
+  try {
+    await prisma.activeViewer.upsert({
+      where: { workspaceId },
+      update: { lastSeenAt: new Date() },
+      create: { workspaceId, lastSeenAt: new Date() },
+    })
+  } catch (err) {
+    console.warn('[TunnelDb] markViewerActiveDb failed:', (err as Error).message)
+  }
+}
+
+export async function isViewerActiveDb(workspaceId: string): Promise<boolean> {
+  try {
+    const row = await prisma.activeViewer.findUnique({ where: { workspaceId } })
+    if (!row) return false
+    return Date.now() - row.lastSeenAt.getTime() < VIEWER_TTL_MS
+  } catch (err) {
+    console.warn('[TunnelDb] isViewerActiveDb failed:', (err as Error).message)
+    return false
+  }
+}
+
+// ─── Tunnel ownership ────────────────────────────────────────────────────────
+
+export async function registerTunnelOwnershipDb(instanceId: string): Promise<void> {
+  try {
+    await prisma.tunnelOwnership.upsert({
+      where: { instanceId },
+      update: { podId: POD_ID, podIp: POD_IP, refreshedAt: new Date() },
+      create: {
+        instanceId,
+        podId: POD_ID,
+        podIp: POD_IP,
+        acquiredAt: new Date(),
+        refreshedAt: new Date(),
+      },
+    })
+  } catch (err) {
+    console.warn('[TunnelDb] registerTunnelOwnershipDb failed:', (err as Error).message)
+  }
+}
+
+export async function unregisterTunnelOwnershipDb(instanceId: string): Promise<void> {
+  try {
+    await prisma.tunnelOwnership.deleteMany({
+      where: { instanceId, podId: POD_ID },
+    })
+  } catch (err) {
+    console.warn('[TunnelDb] unregisterTunnelOwnershipDb failed:', (err as Error).message)
+  }
+}
+
+export async function evictTunnelOwnershipDb(instanceId: string): Promise<void> {
+  try {
+    await prisma.tunnelOwnership.delete({ where: { instanceId } }).catch(() => {})
+  } catch (err) {
+    console.warn('[TunnelDb] evictTunnelOwnershipDb failed:', (err as Error).message)
+  }
+}
+
+export async function refreshTunnelOwnershipDb(instanceId: string): Promise<void> {
+  try {
+    await prisma.tunnelOwnership.updateMany({
+      where: { instanceId, podId: POD_ID },
+      data: { refreshedAt: new Date() },
+    })
+  } catch (err) {
+    console.warn('[TunnelDb] refreshTunnelOwnershipDb failed:', (err as Error).message)
+  }
+}
+
+export interface TunnelOwnerRef {
+  podId: string
+  podIp: string
+}
+
+export async function getTunnelOwnerDb(instanceId: string): Promise<TunnelOwnerRef | null> {
+  try {
+    const row = await prisma.tunnelOwnership.findUnique({ where: { instanceId } })
+    if (!row) return null
+    if (Date.now() - row.refreshedAt.getTime() > OWNERSHIP_STALE_MS) {
+      // Stale row — treat as no owner. Cleanup happens separately to avoid
+      // doing a DELETE in the read path.
+      return null
+    }
+    return { podId: row.podId, podIp: row.podIp }
+  } catch (err) {
+    console.warn('[TunnelDb] getTunnelOwnerDb failed:', (err as Error).message)
+    return null
+  }
+}
+
+export async function isTunnelConnectedAnywhereDb(instanceId: string): Promise<boolean> {
+  return (await getTunnelOwnerDb(instanceId)) !== null
+}
+
+// Background janitor — run this from a single pod periodically. Currently
+// invoked from `tunnel-redis.ts` in the same interval as the ping heartbeat.
+export async function cleanupStaleTunnelOwnershipsDb(): Promise<number> {
+  try {
+    const cutoff = new Date(Date.now() - OWNERSHIP_STALE_MS)
+    const res = await prisma.tunnelOwnership.deleteMany({
+      where: { refreshedAt: { lt: cutoff } },
+    })
+    return res.count
+  } catch (err) {
+    console.warn('[TunnelDb] cleanupStaleTunnelOwnershipsDb failed:', (err as Error).message)
+    return 0
+  }
+}
+
+// ─── Pod liveness probe (HTTP) ──────────────────────────────────────────────
+
+export async function verifyPodAliveDb(podIp: string): Promise<boolean> {
+  if (podIp === POD_IP) return true
+  try {
+    const resp = await fetch(`${podBaseUrl(podIp)}/api/internal/tunnel-alive`, {
+      method: 'GET',
+      headers: relayAuthHeaders(),
+      signal: AbortSignal.timeout(POD_ALIVE_TIMEOUT_MS),
+    })
+    return resp.ok
+  } catch {
+    return false
+  }
+}
+
+// ─── Cross-pod relay over HTTP ──────────────────────────────────────────────
+
+export interface RelayRequestBody {
+  instanceId: string
+  request: {
+    type: 'request'
+    requestId: string
+    method: string
+    path: string
+    headers?: Record<string, string>
+    body?: string
+    projectId?: string
+  }
+}
+
+export interface RelayResponseShape {
+  type: 'response'
+  requestId: string
+  status: number
+  headers?: Record<string, string>
+  body?: string
+}
+
+export async function relayTunnelRequestDb(
+  owner: TunnelOwnerRef,
+  instanceId: string,
+  request: RelayRequestBody['request'],
+): Promise<RelayResponseShape> {
+  const resp = await fetch(`${podBaseUrl(owner.podIp)}/api/internal/tunnel-relay`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...relayAuthHeaders(),
+    },
+    body: JSON.stringify({ instanceId, request } satisfies RelayRequestBody),
+    signal: AbortSignal.timeout(RELAY_TIMEOUT_MS),
+  })
+
+  if (!resp.ok) {
+    if (resp.status === 404 || resp.status === 503) {
+      throw new Error('Instance is offline')
+    }
+    throw new Error(`Relay returned HTTP ${resp.status}`)
+  }
+
+  return (await resp.json()) as RelayResponseShape
+}
+
+export interface StreamRelayChunkShape {
+  type: 'stream-chunk' | 'stream-end' | 'stream-error'
+  requestId: string
+  data?: string
+  error?: string
+}
+
+export function relayTunnelStreamRequestDb(
+  owner: TunnelOwnerRef,
+  instanceId: string,
+  request: RelayRequestBody['request'],
+  onChunk: (chunk: StreamRelayChunkShape) => void,
+): { cancel: () => void } {
+  const controller = new AbortController()
+  let finished = false
+
+  const timeoutTimer = setTimeout(() => {
+    if (finished) return
+    finished = true
+    controller.abort()
+    onChunk({
+      type: 'stream-error',
+      requestId: request.requestId,
+      error: 'Cross-pod stream relay timed out',
+    })
+  }, STREAM_RELAY_TIMEOUT_MS)
+
+  ;(async () => {
+    let resp: Response
+    try {
+      resp = await fetch(
+        `${podBaseUrl(owner.podIp)}/api/internal/tunnel-relay/stream`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...relayAuthHeaders(),
+          },
+          body: JSON.stringify({ instanceId, request } satisfies RelayRequestBody),
+          signal: controller.signal,
+        },
+      )
+    } catch (err: any) {
+      if (finished) return
+      finished = true
+      clearTimeout(timeoutTimer)
+      if (err?.name === 'AbortError') return
+      onChunk({
+        type: 'stream-error',
+        requestId: request.requestId,
+        error: err?.message ?? 'Relay fetch failed',
+      })
+      return
+    }
+
+    if (!resp.ok || !resp.body) {
+      if (finished) return
+      finished = true
+      clearTimeout(timeoutTimer)
+      onChunk({
+        type: 'stream-error',
+        requestId: request.requestId,
+        error: `Relay returned HTTP ${resp.status}`,
+      })
+      return
+    }
+
+    const reader = resp.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        // Newline-delimited JSON framing (one chunk per line).
+        let newlineIdx: number
+        while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
+          const line = buffer.slice(0, newlineIdx)
+          buffer = buffer.slice(newlineIdx + 1)
+          if (!line) continue
+          try {
+            const chunk = JSON.parse(line) as StreamRelayChunkShape
+            onChunk(chunk)
+            if (chunk.type === 'stream-end' || chunk.type === 'stream-error') {
+              finished = true
+              clearTimeout(timeoutTimer)
+              try { reader.cancel() } catch {}
+              return
+            }
+          } catch {
+            // Malformed line — ignore.
+          }
+        }
+      }
+      if (!finished) {
+        finished = true
+        clearTimeout(timeoutTimer)
+        onChunk({ type: 'stream-end', requestId: request.requestId })
+      }
+    } catch (err: any) {
+      if (finished) return
+      finished = true
+      clearTimeout(timeoutTimer)
+      if (err?.name === 'AbortError') return
+      onChunk({
+        type: 'stream-error',
+        requestId: request.requestId,
+        error: err?.message ?? 'Relay stream read failed',
+      })
+    }
+  })()
+
+  return {
+    cancel: () => {
+      if (finished) return
+      finished = true
+      clearTimeout(timeoutTimer)
+      controller.abort()
+    },
+  }
+}

--- a/apps/api/src/lib/tunnel-redis.ts
+++ b/apps/api/src/lib/tunnel-redis.ts
@@ -13,10 +13,33 @@
  */
 
 import Redis from 'ioredis'
+import {
+  markViewerActiveDb,
+  isViewerActiveDb,
+  registerTunnelOwnershipDb,
+  unregisterTunnelOwnershipDb,
+  evictTunnelOwnershipDb,
+  refreshTunnelOwnershipDb,
+  getTunnelOwnerDb,
+  verifyPodAliveDb,
+  relayTunnelRequestDb,
+  relayTunnelStreamRequestDb,
+  type TunnelOwnerRef,
+} from './tunnel-db'
 
 const isLocalMode = process.env.SHOGO_LOCAL_MODE === 'true'
 const REDIS_URL = process.env.REDIS_URL || 'redis://redis-master:6379'
 const POD_ID = process.env.HOSTNAME || crypto.randomUUID()
+
+/**
+ * When Redis is available we use it for low-latency pub/sub relays and
+ * TTL-backed tracking. When it's not (e.g. staging deployment with no
+ * Redis), we transparently fall back to the Postgres + HTTP implementation
+ * in `tunnel-db.ts`. Routers call the same helpers either way.
+ */
+function redisAvailable(): boolean {
+  return pub !== null
+}
 
 const TUNNEL_OWNERSHIP_TTL = 600 // 10 min, refreshed by heartbeat
 const VIEWER_TTL = 120 // 2 min
@@ -124,12 +147,18 @@ export async function checkRedisHealth(): Promise<{ healthy: boolean; latencyMs?
 // ─── Tunnel Ownership ───────────────────────────────────────────────────────
 
 export async function registerTunnelOwnership(instanceId: string): Promise<void> {
+  // Always write to Postgres — it's the durable/cross-pod source of truth
+  // used for HTTP relay (it carries the pod IP) and survives a Redis outage.
+  await registerTunnelOwnershipDb(instanceId)
+
   const r = getPublisher()
   if (!r) return
   await r.set(`tunnel:${instanceId}:pod`, POD_ID, 'EX', TUNNEL_OWNERSHIP_TTL)
 }
 
 export async function unregisterTunnelOwnership(instanceId: string): Promise<void> {
+  await unregisterTunnelOwnershipDb(instanceId)
+
   const r = getPublisher()
   if (!r) return
   const owner = await r.get(`tunnel:${instanceId}:pod`)
@@ -143,37 +172,51 @@ export async function unregisterTunnelOwnership(instanceId: string): Promise<voi
  * Used when a relay to the owning pod times out, indicating the owner is dead.
  */
 export async function evictTunnelOwnership(instanceId: string): Promise<void> {
+  await evictTunnelOwnershipDb(instanceId)
+
   const r = getPublisher()
   if (!r) return
   await r.del(`tunnel:${instanceId}:pod`)
 }
 
 export async function refreshTunnelOwnership(instanceId: string): Promise<void> {
+  await refreshTunnelOwnershipDb(instanceId)
+
   const r = getPublisher()
   if (!r) return
   await r.expire(`tunnel:${instanceId}:pod`, TUNNEL_OWNERSHIP_TTL)
 }
 
-export async function getTunnelOwner(instanceId: string): Promise<string | null> {
-  const r = getPublisher()
-  if (!r) return null
-  try {
-    return await r.get(`tunnel:${instanceId}:pod`)
-  } catch (err) {
-    console.warn(`[TunnelRedis] getTunnelOwner failed for ${instanceId}:`, (err as Error).message)
-    return null
-  }
+export interface TunnelOwnerInfo {
+  podId: string
+  podIp: string
 }
 
 /**
- * Verify that a tunnel-owning pod is actually alive by publishing a ping
- * and waiting for a pong response within a short timeout. Returns true if
- * the pod responds, false otherwise.
+ * Returns the pod currently owning the tunnel for `instanceId`, or null.
+ * We always read from Postgres because that's what carries the pod IP we
+ * need for HTTP relay. The Redis `tunnel:*:pod` key is kept only as a
+ * warm cache / cross-check when Redis is available.
  */
-export async function verifyPodAlive(podId: string, timeoutMs = 3000): Promise<boolean> {
+export async function getTunnelOwner(instanceId: string): Promise<TunnelOwnerInfo | null> {
+  return await getTunnelOwnerDb(instanceId)
+}
+
+/**
+ * Verify that a tunnel-owning pod is actually alive.
+ *
+ * Redis mode → pub/sub ping/pong (same pod used for relay).
+ * DB mode   → HTTP GET to the pod's `/api/internal/tunnel-alive` endpoint.
+ */
+export async function verifyPodAlive(owner: TunnelOwnerInfo, timeoutMs = 3000): Promise<boolean> {
+  if (owner.podId === POD_ID) return true
+
+  if (!redisAvailable()) {
+    return await verifyPodAliveDb(owner.podIp)
+  }
+
   const r = getPublisher()
   if (!r) return false
-  if (podId === POD_ID) return true
 
   const probeId = `probe_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
 
@@ -203,7 +246,7 @@ export async function verifyPodAlive(podId: string, timeoutMs = 3000): Promise<b
       replyPod: POD_ID,
       request: { type: 'request', requestId: probeId, method: 'GET', path: '/__probe__' },
     }
-    r.publish(`tunnel:pod:${podId}:request`, JSON.stringify(msg)).catch(() => {
+    r.publish(`tunnel:pod:${owner.podId}:request`, JSON.stringify(msg)).catch(() => {
       clearTimeout(timer)
       pendingRelayResponses.delete(probeId)
       resolve(false)
@@ -283,6 +326,17 @@ export function setLocalTunnelHandlers(
 ): void {
   localSendFn = send
   localStreamFn = stream
+}
+
+/**
+ * Expose the local (this-pod) tunnel handlers to the internal HTTP relay
+ * route so another pod can forward proxy traffic to us.
+ */
+export function getLocalTunnelHandlers(): {
+  send: LocalTunnelSendFn | null
+  stream: LocalTunnelStreamFn | null
+} {
+  return { send: localSendFn, stream: localStreamFn }
 }
 
 const pendingRelayResponses = new Map<string, {
@@ -388,10 +442,14 @@ function handleIncomingStreamRelayChunk(msg: StreamRelayChunk) {
 }
 
 export async function relayTunnelRequest(
-  ownerPod: string,
+  owner: TunnelOwnerInfo,
   instanceId: string,
   request: RelayRequest['request'],
 ): Promise<RelayResponse['response']> {
+  if (!redisAvailable()) {
+    return await relayTunnelRequestDb(owner as TunnelOwnerRef, instanceId, request)
+  }
+
   const r = getPublisher()
   if (!r) throw new Error('Redis not initialized')
 
@@ -406,7 +464,7 @@ export async function relayTunnelRequest(
     pendingRelayResponses.set(relayId, { resolve, reject, timeout })
 
     const msg: RelayRequest = { relayId, instanceId, replyPod: POD_ID, request }
-    r.publish(`tunnel:pod:${ownerPod}:request`, JSON.stringify(msg)).catch((err) => {
+    r.publish(`tunnel:pod:${owner.podId}:request`, JSON.stringify(msg)).catch((err) => {
       clearTimeout(timeout)
       pendingRelayResponses.delete(relayId)
       reject(err)
@@ -415,11 +473,15 @@ export async function relayTunnelRequest(
 }
 
 export function relayTunnelStreamRequest(
-  ownerPod: string,
+  owner: TunnelOwnerInfo,
   instanceId: string,
   request: StreamRelayRequest['request'],
   onChunk: (chunk: StreamRelayChunk['chunk']) => void,
 ): { cancel: () => void } {
+  if (!redisAvailable()) {
+    return relayTunnelStreamRequestDb(owner as TunnelOwnerRef, instanceId, request, onChunk)
+  }
+
   const r = getPublisher()
   if (!r) {
     onChunk({ type: 'stream-error', requestId: request.requestId, error: 'Redis not initialized' })
@@ -436,7 +498,7 @@ export function relayTunnelStreamRequest(
   pendingStreamRelays.set(relayId, { onChunk, timeout })
 
   const msg: StreamRelayRequest = { relayId, instanceId, replyPod: POD_ID, request }
-  r.publish(`tunnel:pod:${ownerPod}:stream-request`, JSON.stringify(msg)).catch(() => {
+  r.publish(`tunnel:pod:${owner.podId}:stream-request`, JSON.stringify(msg)).catch(() => {
     clearTimeout(timeout)
     pendingStreamRelays.delete(relayId)
     onChunk({ type: 'stream-error', requestId: request.requestId, error: 'Failed to publish relay request' })
@@ -450,23 +512,32 @@ export function relayTunnelStreamRequest(
   }
 }
 
-// ─── Viewer Tracking (Redis-backed) ─────────────────────────────────────────
+// ─── Viewer Tracking (Redis-preferred, DB fallback) ─────────────────────────
 
 export async function markViewerActiveRedis(workspaceId: string): Promise<void> {
   const r = getPublisher()
-  if (!r) return
+  if (!r) {
+    await markViewerActiveDb(workspaceId)
+    return
+  }
   await r.set(`viewer:${workspaceId}`, Date.now().toString(), 'EX', VIEWER_TTL)
+  // Also mirror to Postgres so an out-of-order heartbeat hitting a pod that
+  // briefly lost Redis still sees the viewer as active.
+  markViewerActiveDb(workspaceId).catch(() => {})
 }
 
 export async function isViewerActiveRedis(workspaceId: string): Promise<boolean> {
   const r = getPublisher()
-  if (!r) return false
+  if (!r) return await isViewerActiveDb(workspaceId)
   try {
     const ts = await r.get(`viewer:${workspaceId}`)
-    return ts !== null
+    if (ts !== null) return true
+    // Redis may have expired but DB still has a fresh viewer (e.g. keepalive
+    // landed on a different pod that wrote Postgres only).
+    return await isViewerActiveDb(workspaceId)
   } catch (err) {
     console.warn('[TunnelRedis] isViewerActiveRedis failed:', (err as Error).message)
-    return false
+    return await isViewerActiveDb(workspaceId)
   }
 }
 

--- a/apps/api/src/routes/instances.ts
+++ b/apps/api/src/routes/instances.ts
@@ -46,7 +46,11 @@ import { sendPushToInstance } from '../lib/push-notifications'
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
-const POLL_INTERVAL_IDLE_S = 60
+// Idle poll was 60s which made the heartbeat-click race (see RCA) fatal on
+// staging — a click at t=+2s had to wait up to 58s for the desktop to learn
+// wsRequestedAt. 15s keeps desktop awareness tight even if `viewer-active`
+// never fires (e.g. ancient web build open in a tab).
+const POLL_INTERVAL_IDLE_S = 15
 const POLL_INTERVAL_VIEWER_S = 5
 const POLL_INTERVAL_WS_REQUESTED_S = 3
 const WS_REQUEST_TTL_MS = 2 * 60 * 1000
@@ -411,29 +415,30 @@ async function sendTunnelRequest(instanceId: string, req: TunnelRequest): Promis
   const conn = tunnels.get(instanceId)
   if (conn) return sendLocalTunnelRequest(instanceId, req)
 
-  const ownerPod = await getTunnelOwner(instanceId)
-  if (!ownerPod) throw new Error('Instance is offline')
+  const owner = await getTunnelOwner(instanceId)
+  if (!owner) throw new Error('Instance is offline')
 
-  if (ownerPod === getPodId()) {
+  if (owner.podId === getPodId()) {
     await evictTunnelOwnership(instanceId).catch(() => {})
     throw new Error('Instance is offline')
   }
 
-  const alive = await verifyPodAlive(ownerPod)
+  const alive = await verifyPodAlive(owner)
   if (!alive) {
     await evictTunnelOwnership(instanceId).catch(() => {})
-    console.warn(`[RemoteControl] Proactively evicted dead pod ${ownerPod} for instance ${instanceId} (sendTunnelRequest)`)
+    console.warn(`[RemoteControl] Proactively evicted dead pod ${owner.podId} for instance ${instanceId} (sendTunnelRequest)`)
     throw new Error('Instance is offline')
   }
 
   try {
-    const response = await relayTunnelRequest(ownerPod, instanceId, req)
+    const response = await relayTunnelRequest(owner, instanceId, req)
     if (!response) throw new Error('Empty relay response')
     return response as TunnelResponse
   } catch (err: any) {
-    if (err.message === 'Cross-pod relay timed out') {
+    const msg = err?.message ?? ''
+    if (msg === 'Cross-pod relay timed out' || msg === 'Instance is offline') {
       await evictTunnelOwnership(instanceId).catch(() => {})
-      console.warn(`[RemoteControl] Evicted stale tunnel owner ${ownerPod} for instance ${instanceId} after relay timeout`)
+      console.warn(`[RemoteControl] Evicted stale tunnel owner ${owner.podId} for instance ${instanceId} after relay failure: ${msg}`)
     }
     throw err
   }
@@ -503,25 +508,25 @@ function sendTunnelStreamRequest(
   let cancelled = false
   const cancelRef = { cancel: () => { cancelled = true } }
 
-  getTunnelOwner(instanceId).then(async (ownerPod) => {
+  getTunnelOwner(instanceId).then(async (owner) => {
     if (cancelled) return
-    if (!ownerPod) {
+    if (!owner) {
       onChunk({ type: 'stream-error', requestId: req.requestId, error: 'Instance is offline' })
       return
     }
-    if (ownerPod === getPodId()) {
+    if (owner.podId === getPodId()) {
       evictTunnelOwnership(instanceId).catch(() => {})
       onChunk({ type: 'stream-error', requestId: req.requestId, error: 'Instance is offline' })
       return
     }
-    const alive = await verifyPodAlive(ownerPod)
+    const alive = await verifyPodAlive(owner)
     if (!alive) {
       await evictTunnelOwnership(instanceId).catch(() => {})
-      console.warn(`[RemoteControl] Proactively evicted dead pod ${ownerPod} for instance ${instanceId} (sendTunnelStreamRequest)`)
+      console.warn(`[RemoteControl] Proactively evicted dead pod ${owner.podId} for instance ${instanceId} (sendTunnelStreamRequest)`)
       onChunk({ type: 'stream-error', requestId: req.requestId, error: 'Instance is offline' })
       return
     }
-    const relay = relayTunnelStreamRequest(ownerPod, instanceId, req, onChunk)
+    const relay = relayTunnelStreamRequest(owner, instanceId, req, onChunk)
     cancelRef.cancel = relay.cancel
   }).catch((err) => {
     onChunk({ type: 'stream-error', requestId: req.requestId, error: (err as Error).message })
@@ -1005,28 +1010,28 @@ export function instanceRoutes() {
     }
 
     const localTunnel = tunnels.has(instanceId)
-    let remoteTunnelPod = localTunnel ? null : await getTunnelOwner(instanceId)
+    let remoteTunnelOwner = localTunnel ? null : await getTunnelOwner(instanceId)
 
-    // If Redis says a remote pod owns this tunnel but that pod is actually us
+    // If the registry says a remote pod owns this tunnel but that pod is actually us
     // and we don't have a local connection, the ownership is stale. Evict it.
-    if (!localTunnel && remoteTunnelPod === getPodId()) {
+    if (!localTunnel && remoteTunnelOwner && remoteTunnelOwner.podId === getPodId()) {
       await evictTunnelOwnership(instanceId).catch(() => {})
-      remoteTunnelPod = null
+      remoteTunnelOwner = null
     }
 
-    // If Redis points to a different pod, verify it's actually alive before
+    // If the registry points to a different pod, verify it's actually alive before
     // committing to a 30s relay timeout. Dead pods (e.g. from a dev server
     // restart) will never respond. Evict and fall through to the wake-up path.
-    if (!localTunnel && remoteTunnelPod && remoteTunnelPod !== getPodId()) {
-      const alive = await verifyPodAlive(remoteTunnelPod)
+    if (!localTunnel && remoteTunnelOwner && remoteTunnelOwner.podId !== getPodId()) {
+      const alive = await verifyPodAlive(remoteTunnelOwner)
       if (!alive) {
-        console.warn(`[RemoteControl] Proactively evicting dead pod ${remoteTunnelPod} for instance ${instanceId}`)
+        console.warn(`[RemoteControl] Proactively evicting dead pod ${remoteTunnelOwner.podId} for instance ${instanceId}`)
         await evictTunnelOwnership(instanceId).catch(() => {})
-        remoteTunnelPod = null
+        remoteTunnelOwner = null
       }
     }
 
-    if (!localTunnel && !remoteTunnelPod) {
+    if (!localTunnel && !remoteTunnelOwner) {
       await prisma.instance.update({
         where: { id: instanceId },
         data: { wsRequestedAt: new Date() },
@@ -1037,11 +1042,11 @@ export function instanceRoutes() {
       while (Date.now() < deadline) {
         await new Promise((r) => setTimeout(r, TUNNEL_WAIT_POLL_MS))
         if (tunnels.has(instanceId)) break
-        remoteTunnelPod = await getTunnelOwner(instanceId)
-        if (remoteTunnelPod) break
+        remoteTunnelOwner = await getTunnelOwner(instanceId)
+        if (remoteTunnelOwner) break
       }
 
-      if (!tunnels.has(instanceId) && !remoteTunnelPod) {
+      if (!tunnels.has(instanceId) && !remoteTunnelOwner) {
         return c.json({ error: { code: 'offline', message: 'Instance is offline' } }, 503)
       }
     }
@@ -1233,9 +1238,15 @@ export function instanceRoutes() {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
+// An instance is considered "recently seen" if we got a heartbeat within
+// ~2.5× the idle poll interval. Using a fixed floor so that lowering
+// POLL_INTERVAL_IDLE_S doesn't accidentally make us mark live desktops as
+// offline during transient network hiccups.
+const HEARTBEAT_RECENCY_MS = Math.max(POLL_INTERVAL_IDLE_S * 1000 * 2 + 15_000, 45_000)
+
 function isRecentlySeenViaHeartbeat(lastSeenAt: Date | null): boolean {
   if (!lastSeenAt) return false
-  return Date.now() - lastSeenAt.getTime() < POLL_INTERVAL_IDLE_S * 2 * 1000
+  return Date.now() - lastSeenAt.getTime() < HEARTBEAT_RECENCY_MS
 }
 
 // ─── Heartbeat ping for all connected tunnels ───────────────────────────────
@@ -1244,6 +1255,8 @@ let heartbeatTimer: ReturnType<typeof setInterval> | null = null
 
 export function startTunnelHeartbeat() {
   if (heartbeatTimer) return
+
+  let cleanupTickCounter = 0
   heartbeatTimer = setInterval(() => {
     for (const [instanceId, conn] of tunnels) {
       try {
@@ -1257,6 +1270,17 @@ export function startTunnelHeartbeat() {
           console.warn('[RemoteControl] unregisterTunnelOwnership failed:', (err as Error).message)
         })
       }
+    }
+
+    // Every ~5 ticks (~2 min at 25s interval) sweep DB-backed ownership rows
+    // whose owning pod died without running unregisterTunnelOwnership. This
+    // is the Postgres equivalent of Redis TTL expiry.
+    cleanupTickCounter++
+    if (cleanupTickCounter >= 5) {
+      cleanupTickCounter = 0
+      import('../lib/tunnel-db').then(({ cleanupStaleTunnelOwnershipsDb }) =>
+        cleanupStaleTunnelOwnershipsDb(),
+      ).catch(() => {})
     }
   }, HEARTBEAT_INTERVAL_MS)
 }

--- a/apps/api/src/routes/internal-tunnel-relay.ts
+++ b/apps/api/src/routes/internal-tunnel-relay.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Internal Tunnel Relay — Pod-to-Pod HTTP bridge
+ *
+ * Mounted under `/api/internal/*`. Not exposed through the external ingress.
+ * Peer API pods hit these endpoints directly via pod IP (Downward API) to
+ * relay Remote Control proxy traffic to whichever pod currently owns the
+ * desktop WebSocket tunnel — this is the Redis-less replacement for the
+ * `tunnel:pod:*:request` pub/sub channel in `tunnel-redis.ts`.
+ *
+ * Endpoints
+ *   GET  /api/internal/tunnel-alive           — liveness probe (pod reachable?)
+ *   POST /api/internal/tunnel-relay           — unary request → response
+ *   POST /api/internal/tunnel-relay/stream    — NDJSON streaming response
+ */
+import { Hono } from 'hono'
+import { verifyInternalRelaySecret } from '../lib/tunnel-db'
+import { getLocalTunnelHandlers } from '../lib/tunnel-redis'
+
+interface RelayBody {
+  instanceId: string
+  request: {
+    type: 'request'
+    requestId: string
+    method: string
+    path: string
+    headers?: Record<string, string>
+    body?: string
+    projectId?: string
+  }
+}
+
+export function internalTunnelRelayRoutes() {
+  const app = new Hono()
+
+  app.use('*', async (c, next) => {
+    if (!verifyInternalRelaySecret(c.req.header('x-internal-relay-secret'))) {
+      return c.json({ error: 'forbidden' }, 403)
+    }
+    return next()
+  })
+
+  app.get('/tunnel-alive', (c) => c.json({ ok: true, podId: process.env.HOSTNAME || 'unknown' }))
+
+  app.post('/tunnel-relay', async (c) => {
+    const { send } = getLocalTunnelHandlers()
+    if (!send) {
+      return c.json({ error: 'no-local-handler' }, 503)
+    }
+
+    let body: RelayBody
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'invalid-json' }, 400)
+    }
+
+    try {
+      const response = await send(body.instanceId, body.request)
+      if (!response) {
+        return c.json({ error: 'empty-response' }, 502)
+      }
+      return c.json(response)
+    } catch (err: any) {
+      const msg = err?.message ?? 'relay-failed'
+      // The owning pod should have held the WebSocket but the in-memory map
+      // says otherwise → ownership is stale on this pod. 404 is the signal
+      // the caller uses to evict the stale `tunnel_ownership` row.
+      if (msg.includes('Instance is offline')) {
+        return c.json({ error: msg }, 404)
+      }
+      return c.json({ error: msg }, 502)
+    }
+  })
+
+  app.post('/tunnel-relay/stream', async (c) => {
+    const { stream } = getLocalTunnelHandlers()
+    if (!stream) {
+      return c.json({ error: 'no-local-handler' }, 503)
+    }
+
+    let body: RelayBody
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'invalid-json' }, 400)
+    }
+
+    const encoder = new TextEncoder()
+
+    const readable = new ReadableStream<Uint8Array>({
+      start(controller) {
+        let closed = false
+        function safeClose() {
+          if (closed) return
+          closed = true
+          try { controller.close() } catch {}
+        }
+
+        const { cancel } = stream!(body.instanceId, body.request, (chunk) => {
+          if (closed) return
+          try {
+            // NDJSON framing — one JSON object per line.
+            controller.enqueue(encoder.encode(JSON.stringify(chunk) + '\n'))
+          } catch {
+            closed = true
+          }
+          if (chunk.type === 'stream-end' || chunk.type === 'stream-error') {
+            safeClose()
+          }
+        })
+
+        const signal = c.req.raw.signal
+        if (signal) {
+          signal.addEventListener(
+            'abort',
+            () => {
+              try { cancel() } catch {}
+              safeClose()
+            },
+            { once: true },
+          )
+        }
+      },
+    })
+
+    return new Response(readable, {
+      headers: {
+        'Content-Type': 'application/x-ndjson',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      },
+    })
+  })
+
+  return app
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -60,6 +60,7 @@ import { checkRedisHealth } from './lib/tunnel-redis'
 import { remoteAuditRoutes } from './routes/remote-audit'
 import { syncRoutes } from './routes/sync'
 import internalRoutes from './routes/internal'
+import { internalTunnelRelayRoutes } from './routes/internal-tunnel-relay'
 import { vmRoutes, triggerVMImageDownload } from './routes/vm'
 import { requireSuperAdmin } from './middleware/super-admin'
 // Generated admin CRUD routes (unrestricted, middleware-protected)
@@ -5011,6 +5012,11 @@ app.route('/api', integrationRoutes())
 
 // Internal routes for cluster-internal pod communication (not exposed externally)
 app.route('/api/internal', internalRoutes)
+
+// Cross-pod HTTP relay for Remote Control tunnels (Redis-less fallback).
+// Mounted here so peer pods can reach it directly via pod IP without the
+// external ingress or session auth layer — secured by x-internal-relay-secret.
+app.route('/api/internal', internalTunnelRelayRoutes())
 
 // =============================================================================
 // Current User Route (/api/me) - Returns user profile with role

--- a/apps/mobile/app/(app)/remote-control.tsx
+++ b/apps/mobile/app/(app)/remote-control.tsx
@@ -90,6 +90,34 @@ export default observer(function RemoteControlPage() {
     refresh()
   }, [workspace?.id, refresh])
 
+  // Keepalive: tell the API a user is viewing Remote Control so desktop
+  // heartbeats switch from the idle cadence (15 s) to the viewer cadence
+  // (5 s). This makes the heartbeat → wsRequested pickup near-instant,
+  // which is the primary fix for the "silent no-connect" on staging.
+  useEffect(() => {
+    if (!workspace?.id || !API_URL) return
+    let cancelled = false
+
+    const ping = () => {
+      if (cancelled) return
+      fetch(`${API_URL}/api/instances/viewer-active`, {
+        method: 'POST',
+        credentials: Platform.OS === 'web' ? 'include' : 'omit',
+        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+        body: JSON.stringify({ workspaceId: workspace.id }),
+      }).catch(() => {}) // best-effort — failures just revert to idle cadence
+    }
+
+    ping()
+    // Viewer TTL is 2 min on the server; refresh every 45 s so we stay live
+    // through brief network blips without spamming.
+    const interval = setInterval(ping, 45_000)
+    return () => {
+      cancelled = true
+      clearInterval(interval)
+    }
+  }, [workspace?.id])
+
   const connectedCount = instances.filter(i => i.status === 'online').length
   const standbyCount = instances.filter(i => i.status === 'heartbeat').length
   const totalCount = instances.length

--- a/k8s/overlays/staging/api-service.yaml
+++ b/k8s/overlays/staging/api-service.yaml
@@ -126,6 +126,24 @@ spec:
               value: "https://studio.staging.shogo.ai"
             - name: REDIS_URL
               value: "redis://redis-master.shogo-staging-system:6379"
+            # Downward API — pod IP is needed for the cross-pod HTTP relay
+            # used by Remote Control tunnels when Redis is unavailable.
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            # Shared secret validated by /api/internal/tunnel-* endpoints.
+            # Pods use this header when relaying proxy traffic to each other.
+            - name: INTERNAL_RELAY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: INTERNAL_RELAY_SECRET
+                  optional: true
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/packages/shared-app/src/hooks/useInstancePicker.ts
+++ b/packages/shared-app/src/hooks/useInstancePicker.ts
@@ -63,7 +63,10 @@ export function useInstancePicker({
   clearInstance,
   fetchFn = fetch,
   fetchOptions,
-  connectPollCount = 35,
+  // 45 × 2s = 90s. Needs to comfortably exceed the worst-case path:
+  //   desktop idle-poll (15s) + heartbeat→WS hop through Knative (~5s) +
+  //   owner detection across pods (~1s) + safety margin.
+  connectPollCount = 45,
   connectPollIntervalMs = 2000,
 }: UseInstancePickerOptions): UseInstancePickerResult {
   const [isOpen, setIsOpen] = useState(false)

--- a/prisma/migrations/20260417100000_add_tunnel_registry_tables/migration.sql
+++ b/prisma/migrations/20260417100000_add_tunnel_registry_tables/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "active_viewers" (
+    "workspaceId" TEXT NOT NULL,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "active_viewers_pkey" PRIMARY KEY ("workspaceId")
+);
+
+-- CreateIndex
+CREATE INDEX "active_viewers_lastSeenAt_idx" ON "active_viewers"("lastSeenAt");
+
+-- CreateTable
+CREATE TABLE "tunnel_ownership" (
+    "instanceId" TEXT NOT NULL,
+    "podId" TEXT NOT NULL,
+    "podIp" TEXT NOT NULL,
+    "acquiredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "refreshedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "tunnel_ownership_pkey" PRIMARY KEY ("instanceId")
+);
+
+-- CreateIndex
+CREATE INDEX "tunnel_ownership_podId_idx" ON "tunnel_ownership"("podId");
+
+-- CreateIndex
+CREATE INDEX "tunnel_ownership_refreshedAt_idx" ON "tunnel_ownership"("refreshedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1343,6 +1343,37 @@ model PushSubscription {
   @@map("push_subscriptions")
 }
 
+// ─── Cross-pod coordination (Redis-less fallback) ────────────────────────────
+// These tables let the Remote Control tunnel layer coordinate across multiple
+// API pods without requiring Redis. They are used whenever the Redis publisher
+// is unavailable (see apps/api/src/lib/tunnel-redis.ts + tunnel-db.ts).
+
+/// Records "a user is viewing Remote Control for this workspace right now"
+/// so that desktop heartbeats can switch to the fast (5 s) poll cadence
+/// regardless of which API pod receives the heartbeat.
+model ActiveViewer {
+  workspaceId String   @id
+  lastSeenAt  DateTime @default(now())
+
+  @@index([lastSeenAt])
+  @@map("active_viewers")
+}
+
+/// Records which API pod currently owns the on-demand WebSocket tunnel for
+/// a given instance. Other pods use `podIp` to HTTP-relay proxy requests to
+/// the owning pod when Redis pub/sub is unavailable.
+model TunnelOwnership {
+  instanceId  String   @id
+  podId       String
+  podIp       String
+  acquiredAt  DateTime @default(now())
+  refreshedAt DateTime @default(now()) @updatedAt
+
+  @@index([podId])
+  @@index([refreshedAt])
+  @@map("tunnel_ownership")
+}
+
 // =============================================================================
 // EVAL RUNS (Agent eval tracking — local + K8s Job support)
 // =============================================================================


### PR DESCRIPTION
## Summary

Fixes Remote Control on **multi-pod API** deployments when **Redis is not available** (e.g. staging), and addresses the **heartbeat / connect** timing race that caused silent timeouts.

**Root causes addressed**

1. Desktop idle poll was 60s while the web UI gave up after ~70s of polling — too narrow once `wsRequestedAt` was set just after a heartbeat.
2. Without Redis, `getTunnelOwner` / cross-pod relay did not work; tunnels were invisible off the pod that held the WebSocket.

**Approach**

- **Postgres** tables `active_viewers` and `tunnel_ownership` for durable, cross-pod state.
- **HTTP relay** (`/api/internal/tunnel-*`) between pods when Redis pub/sub is unavailable; owning pod IP stored in `tunnel_ownership`.
- **Faster idle poll** (15s server-side), **viewer-active keepalive** from Remote Control UI, **longer connect poll** (90s) on the client.

Fixes #384

---

## File-by-file changes

### `prisma/schema.prisma`

- Adds **`ActiveViewer`** (`workspaceId`, `lastSeenAt`) — mirrors viewer presence when Redis is down so any pod can mark/check “user is viewing Remote Control.”
- Adds **`TunnelOwnership`** (`instanceId`, `podId`, `podIp`, `acquiredAt`, `refreshedAt`) — durable record of which API pod owns the instance WebSocket; `podIp` is used for HTTP relay targets.

### `prisma/migrations/20260417100000_add_tunnel_registry_tables/migration.sql`

- Creates `active_viewers` and `tunnel_ownership` tables with indexes on `lastSeenAt`, `podId`, and `refreshedAt`.

### `apps/api/src/lib/tunnel-db.ts` (new)

- DB helpers: upsert/delete **`ActiveViewer`**, upsert/delete/query **`TunnelOwnership`** (with stale-row handling).
- **`verifyPodAliveDb`**: HTTP GET to peer pod `/api/internal/tunnel-alive`.
- **`relayTunnelRequestDb` / `relayTunnelStreamRequestDb`**: HTTP POST to peer for unary and NDJSON-stream relay; shared-secret headers.
- **`cleanupStaleTunnelOwnershipsDb`**: removes rows whose refresh is too old (zombie pods).
- **`verifyInternalRelaySecret`**: validates `x-internal-relay-secret` when configured.

### `apps/api/src/lib/tunnel-redis.ts`

- Imports DB layer; when **`pub === null`** (Redis unavailable), uses **HTTP + Postgres** paths instead of pub/sub.
- **`registerTunnelOwnership` / unregister / evict / refresh`**: always update Postgres; Redis keys updated when publisher exists.
- **`getTunnelOwner`**: returns **`{ podId, podIp }`** from Postgres (not Redis-only string).
- **`verifyPodAlive`**: Redis ping path vs HTTP liveness when Redis down.
- **`relayTunnelRequest` / `relayTunnelStreamRequest`**: Redis publish path vs **`relayTunnelRequestDb` / `relayTunnelStreamRequestDb`** when Redis down.
- **`markViewerActiveRedis` / `isViewerActiveRedis`**: write/read Postgres when Redis missing; dual-write when Redis present.
- Exposes **`getLocalTunnelHandlers()`** for the internal relay route to invoke the same in-memory tunnel send/stream as this pod.

### `apps/api/src/routes/internal-tunnel-relay.ts` (new)

- Hono sub-app: **`GET /tunnel-alive`**, **`POST /tunnel-relay`**, **`POST /tunnel-relay/stream`** (mounted under `/api/internal`).
- Auth: **`x-internal-relay-secret`** (optional in dev; required when secret env set).
- Unary/stream handlers delegate to **`getLocalTunnelHandlers()`** from `tunnel-redis.ts`.

### `apps/api/src/routes/instances.ts`

- **`sendTunnelRequest` / `sendTunnelStreamRequest` / proxy wait path**: use **`TunnelOwnerInfo`** (`podId` + `podIp`) instead of pod id string only; **`verifyPodAlive` / relay** updated accordingly.
- **`POLL_INTERVAL_IDLE_S`**: `60` → **`15`** to shrink worst-case delay before desktop sees `wsRequestedAt`.
- **`isRecentlySeenViaHeartbeat`**: uses **`HEARTBEAT_RECENCY_MS`** floor so lowering idle poll does not falsely mark instances offline.
- **`startTunnelHeartbeat`**: periodic **`cleanupStaleTunnelOwnershipsDb`** (~every ~2 min) for Postgres ownership GC.

### `apps/api/src/server.ts`

- Mounts **`internalTunnelRelayRoutes()`** at **`/api/internal`** alongside existing internal routes.

### `apps/mobile/app/(app)/remote-control.tsx`

- **`useEffect`**: on workspace mount, **`POST /api/instances/viewer-active`** immediately and every **45s** so server marks viewer active and desktop uses **5s** poll cadence while this screen is open.

### `packages/shared-app/src/hooks/useInstancePicker.ts`

- Default **`connectPollCount`**: **`35` → `45`** (90s total at 2s interval) to cover idle poll + WS establishment through Knative/edge.

### `k8s/overlays/staging/api-service.yaml`

- **`POD_IP`**: Downward API `status.podIP` for relay target URLs.
- **`POD_NAME`**: optional visibility (`metadata.name`).
- **`INTERNAL_RELAY_SECRET`**: optional from **`api-secrets`** key `INTERNAL_RELAY_SECRET` — should be set for authenticated pod-to-pod relay in cluster.

---

## Deploy / ops checklist

1. Run **`prisma migrate deploy`** (or equivalent) so new tables exist.
2. CI/CD runs **`prisma generate`** — generated client is not committed (`**/src/generated/` gitignored).
3. Staging: add **`INTERNAL_RELAY_SECRET`** to **`api-secrets`** if you require non-empty relay auth (recommended for multi-pod).
4. Confirm **NetworkPolicy / mesh** allows pod → **`POD_IP:8002`** (user container) for internal relay; adjust if your cluster only exposes queue-proxy.

---

## Testing suggestions

- Local: `SHOGO_LOCAL_MODE=true` — tunnel Redis skipped; single process unchanged.
- Staging: connect Remote Control with desktop app running; verify instance goes **online** within poll window; proxy/chat works when requests hit a non-owning pod.
