### PR TITLE
fix(remote-control): tighten heartbeat/connect timing race

### DIFF
--- a/apps/api/src/routes/instances.ts
+++ b/apps/api/src/routes/instances.ts
@@ -46,7 +46,11 @@ import { sendPushToInstance } from '../lib/push-notifications'
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
-const POLL_INTERVAL_IDLE_S = 60
+// Idle poll was 60s which made the heartbeat/click race fatal: a click
+// seconds after a heartbeat had to wait ~58s before the desktop polled
+// again and saw wsRequestedAt. 15s keeps desktop awareness tight even
+// if `viewer-active` never fires (ancient web build open in a tab).
+const POLL_INTERVAL_IDLE_S = 15
 const POLL_INTERVAL_VIEWER_S = 5
 const POLL_INTERVAL_WS_REQUESTED_S = 3
 const WS_REQUEST_TTL_MS = 2 * 60 * 1000
@@ -1233,9 +1237,13 @@ export function instanceRoutes() {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
+// ~2.5x the idle poll, floored so lowering POLL_INTERVAL_IDLE_S does
+// not make a single missed poll flip a live desktop to offline.
+const HEARTBEAT_RECENCY_MS = Math.max(POLL_INTERVAL_IDLE_S * 1000 * 2 + 15_000, 45_000)
+
 function isRecentlySeenViaHeartbeat(lastSeenAt: Date | null): boolean {
   if (!lastSeenAt) return false
-  return Date.now() - lastSeenAt.getTime() < POLL_INTERVAL_IDLE_S * 2 * 1000
+  return Date.now() - lastSeenAt.getTime() < HEARTBEAT_RECENCY_MS
 }
 
 // ─── Heartbeat ping for all connected tunnels ───────────────────────────────

--- a/apps/mobile/app/(app)/remote-control.tsx
+++ b/apps/mobile/app/(app)/remote-control.tsx
@@ -90,6 +90,32 @@ export default observer(function RemoteControlPage() {
     refresh()
   }, [workspace?.id, refresh])
 
+  // Keepalive: tell the API a user is viewing Remote Control so desktop
+  // heartbeats switch from the idle cadence (15s) to the viewer cadence
+  // (5s). Makes the heartbeat → wsRequested pickup near-instant.
+  useEffect(() => {
+    if (!workspace?.id || !API_URL) return
+    let cancelled = false
+
+    const ping = () => {
+      if (cancelled) return
+      fetch(`${API_URL}/api/instances/viewer-active`, {
+        method: 'POST',
+        credentials: Platform.OS === 'web' ? 'include' : 'omit',
+        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+        body: JSON.stringify({ workspaceId: workspace.id }),
+      }).catch(() => {})
+    }
+
+    ping()
+    // Server TTL is 2 min; refresh every 45s to stay live through blips.
+    const interval = setInterval(ping, 45_000)
+    return () => {
+      cancelled = true
+      clearInterval(interval)
+    }
+  }, [workspace?.id])
+
   const connectedCount = instances.filter(i => i.status === 'online').length
   const standbyCount = instances.filter(i => i.status === 'heartbeat').length
   const totalCount = instances.length

--- a/packages/shared-app/src/hooks/useInstancePicker.ts
+++ b/packages/shared-app/src/hooks/useInstancePicker.ts
@@ -33,7 +33,7 @@ export interface UseInstancePickerOptions {
   fetchFn?: typeof fetch
   /** Extra options merged into every fetch (e.g. credentials). */
   fetchOptions?: RequestInit
-  /** Max number of polls when waiting for a connect. Default 35 (70s — survives a full desktop idle poll cycle). */
+  /** Max number of polls when waiting for a connect. Default 45 (90s — covers desktop idle-poll + WS-open through Knative/edge). */
   connectPollCount?: number
   /** Milliseconds between connect polls. Default 2000. */
   connectPollIntervalMs?: number
@@ -63,7 +63,7 @@ export function useInstancePicker({
   clearInstance,
   fetchFn = fetch,
   fetchOptions,
-  connectPollCount = 35,
+  connectPollCount = 45,
   connectPollIntervalMs = 2000,
 }: UseInstancePickerOptions): UseInstancePickerResult {
   const [isOpen, setIsOpen] = useState(false)


### PR DESCRIPTION
## Summary

Narrow replacement for #385 (which was closed because its premises were wrong — staging already has Redis via `REDIS_URL` in `k8s/overlays/staging/api-service.yaml`, and local mode uses SQLite via `prisma/schema.local.prisma`, so a Postgres registry + HTTP relay was both unnecessary on staging and broken on local).

This PR keeps only the small timing-race fix that actually addresses the user-visible symptom in #384: clicking Connect seconds after a heartbeat left almost no time for the desktop to pick up `wsRequestedAt` before the web/mobile client gave up polling.

## Changes

- **`apps/api/src/routes/instances.ts`**
  - `POLL_INTERVAL_IDLE_S` 60s → 15s. Shrinks the worst-case delay between `wsRequestedAt` being set and the desktop's next poll seeing it.
  - New `HEARTBEAT_RECENCY_MS = max(POLL_INTERVAL_IDLE_S * 2s + 15s, 45s)`. Floored so halving the idle poll cannot flip a live desktop to `offline` on a single missed heartbeat.
- **`packages/shared-app/src/hooks/useInstancePicker.ts`**
  - Default `connectPollCount` 35 → 45 (~70s → ~90s). Covers one full desktop idle-poll + WS-open round trip through Knative / edge.
- **`apps/mobile/app/(app)/remote-control.tsx`**
  - New `useEffect` that posts `/api/instances/viewer-active` on mount and every 45s while the screen is open, matching the existing web behavior. Server switches the desktop from 15s idle cadence to 5s viewer cadence while a user is actually looking at Remote Control.

## What this does NOT touch

- No schema / migration changes.
- No edits to `apps/api/src/lib/tunnel-redis.ts`; cross-pod routing continues to work via the existing Redis pub/sub path.
- No new k8s env vars (`POD_IP` / `INTERNAL_RELAY_SECRET`).
- No new `/api/internal/tunnel-*` relay surface.

## Test plan

- [ ] Local (`SHOGO_LOCAL_MODE=true`): Remote Control pairs and proxies as before — SQLite schema unchanged.
- [ ] Staging: click Connect within 1–2 s of a heartbeat; instance should go `online` within the 90s connect-poll budget.
- [ ] Staging multi-pod: chat/proxy requests that hit a non-owning pod still route via the existing Redis pub/sub path.
- [ ] Open Remote Control on mobile, confirm desktop reports the 5s viewer cadence (via existing logs).
- [ ] Leave Remote Control screen, confirm desktop returns to the 15s idle cadence within one TTL.

Supersedes #385.
Fixes #384

Made with [Cursor](https://cursor.com)