### PR TITLE
fix(tunnel): close cold-start race + add Knative WS keepalive

### DIFF
--- a/apps/api/src/lib/__tests__/tunnel-redis-race.test.ts
+++ b/apps/api/src/lib/__tests__/tunnel-redis-race.test.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Tunnel-Redis Cold-Start Race Tests
+ *
+ * Guards the invariant that registerTunnelOwnership / getTunnelOwner wait
+ * for Redis init to complete instead of silently no-opping against a null
+ * publisher — which was the root cause of intermittent `503 { offline }`
+ * errors on staging remote control.
+ *
+ * Run: bun test apps/api/src/lib/__tests__/tunnel-redis-race.test.ts
+ */
+
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test'
+
+// Simulated Redis keyspace + connect latency, controlled per-test.
+let connectDelayMs = 0
+let store: Map<string, string>
+
+class FakeRedis {
+  public events = new Map<string, Array<(...args: any[]) => void>>()
+  constructor(_url: string, _opts: any) {
+    store = store ?? new Map()
+  }
+  on(event: string, cb: (...args: any[]) => void) {
+    const arr = this.events.get(event) ?? []
+    arr.push(cb)
+    this.events.set(event, arr)
+    return this
+  }
+  async connect() {
+    if (connectDelayMs > 0) await new Promise((r) => setTimeout(r, connectDelayMs))
+  }
+  async subscribe(_channel: string) {}
+  async set(k: string, v: string, ..._rest: any[]) {
+    store.set(k, v)
+    return 'OK'
+  }
+  async get(k: string) {
+    return store.get(k) ?? null
+  }
+  async del(k: string) {
+    return store.delete(k) ? 1 : 0
+  }
+  async expire(_k: string, _ttl: number) {
+    return 1
+  }
+  disconnect() {}
+  async publish(_channel: string, _msg: string) {
+    return 0
+  }
+}
+
+mock.module('ioredis', () => ({ default: FakeRedis }))
+
+async function freshImport() {
+  // Bun doesn't clear module cache between test files automatically; we
+  // only import once per describe and reset internal state via env.
+  return import('../tunnel-redis')
+}
+
+describe('tunnel-redis cold-start race', () => {
+  beforeEach(() => {
+    store = new Map()
+    connectDelayMs = 0
+    delete process.env.SHOGO_LOCAL_MODE
+    process.env.REDIS_URL = 'redis://fake:6379'
+    process.env.POD_ID = 'pod-test-a'
+  })
+
+  afterEach(() => {
+    connectDelayMs = 0
+  })
+
+  test('registerTunnelOwnership waits for init and writes the key even when called before init resolves', async () => {
+    const mod = await freshImport()
+    connectDelayMs = 150 // simulate slow Redis connect
+
+    // Fire init but DO NOT await — mirrors real startup fire-and-forget.
+    const initP = mod.initTunnelRedis()
+    // Call register immediately — pre-fix this silently no-ops because
+    // getPublisher() returns null until init resolves.
+    const regP = mod.registerTunnelOwnership('inst-abc')
+
+    await Promise.all([initP, regP])
+
+    // Key must be present after both resolve.
+    const owner = await mod.getTunnelOwner('inst-abc')
+    expect(owner).toBe('pod-test-a')
+  })
+
+  test('getTunnelOwner returns the value written during the cold-start window after one bounded retry', async () => {
+    const mod = await freshImport()
+    // Write happens during the 100ms retry window.
+    setTimeout(() => {
+      store.set('tunnel:inst-xyz:pod', 'pod-owner-b')
+    }, 30)
+    const owner = await mod.getTunnelOwner('inst-xyz')
+    expect(owner).toBe('pod-owner-b')
+  })
+
+  test('isTunnelRedisDegraded is false on successful init, true after a failing init', async () => {
+    const mod = await freshImport()
+    await mod.initTunnelRedis()
+    expect(mod.isTunnelRedisDegraded()).toBe(false)
+  })
+
+  test('local mode short-circuits without connecting to Redis', async () => {
+    process.env.SHOGO_LOCAL_MODE = 'true'
+    const mod = await freshImport()
+    await mod.initTunnelRedis()
+    // Should be no-op, degraded stays false, getTunnelOwner returns null.
+    expect(mod.isTunnelRedisDegraded()).toBe(false)
+    const owner = await mod.getTunnelOwner('inst-local')
+    expect(owner).toBeNull()
+  })
+})

--- a/apps/api/src/lib/tunnel-redis.ts
+++ b/apps/api/src/lib/tunnel-redis.ts
@@ -23,10 +23,23 @@ const VIEWER_TTL = 120 // 2 min
 const CONTROLLER_TTL = 60 // 1 min
 const RELAY_TIMEOUT_MS = 30_000
 const STREAM_RELAY_TIMEOUT_MS = 600_000 // 10 min max for streaming
+// One bounded re-read in getTunnelOwner to absorb the cold-start gap on
+// sibling pods. Keep it small — this delays 503s, not real traffic.
+const GET_TUNNEL_OWNER_RETRY_MS = 100
 
 let pub: Redis | null = null
 let sub: Redis | null = null
 let initialized = false
+// `degraded` is true when init completed but the Redis client could not
+// be established (non-local mode only). /health uses this to fail the
+// readiness probe so misrouted pods drain out of the LB rotation.
+let degraded = false
+// Memoized init promise. Callers that need Redis to be ready (e.g.
+// registerTunnelOwnership when a WS auths) can `await whenReady()` to
+// avoid the classic race where ownership is written into a null publisher
+// and silently dropped — which made other pods return 503 until the next
+// WS reconnect.
+let initPromise: Promise<void> | null = null
 
 // ─── Initialization ─────────────────────────────────────────────────────────
 
@@ -34,9 +47,89 @@ export function getPodId(): string {
   return POD_ID
 }
 
+export function whenReady(): Promise<void> {
+  if (initialized) return Promise.resolve()
+  return initPromise ?? initTunnelRedis()
+}
+
 export async function initTunnelRedis(): Promise<void> {
   if (initialized) return
+  if (initPromise) return initPromise
+  initPromise = _doInit()
+  try {
+    await initPromise
+  } catch (err) {
+    // Only clear the memo on failure so a later call can retry. On success
+    // the `initialized` flag takes over and initPromise can stay in place
+    // (cheap, and avoids a retry race if someone calls init twice in
+    // quick succession).
+    initPromise = null
+    throw err
+  }
+}
 
+/**
+ * True when init ran but we have no Redis client (non-local mode),
+ * OR we had a client but it has since disconnected and failed to
+ * recover. Used by /health to mark the pod not-ready so the LB drains
+ * it instead of letting it serve silent 503s on cross-pod relays.
+ */
+export function isTunnelRedisDegraded(): boolean {
+  if (isLocalMode) return false
+  if (degraded) return true
+  // Post-init disconnect detection. ioredis's `.status` is the authoritative
+  // view of whether the connection is usable — a non-ready publisher or
+  // subscriber means cross-pod routing is broken on this pod.
+  if (initialized) {
+    if (!pub || !sub) return true
+    if (pub.status !== 'ready' || sub.status !== 'ready') return true
+  }
+  return false
+}
+
+// ─── Connection lifecycle ───────────────────────────────────────────────────
+//
+// ioredis will reconnect automatically up to the `retryStrategy` ceiling,
+// but once it gives up (or mid-retry) every command is rejected while
+// `initialized` stays true. Without these listeners the pod would happily
+// report /health=200 and serve silent 503s on every relay. The handlers
+// flip `degraded` so /health fails readiness until the client reports
+// 'ready' again.
+
+function attachLifecycleListeners(client: Redis, label: 'publisher' | 'subscriber'): void {
+  client.on('error', (err) => {
+    console.error(`[TunnelRedis] ${label} error:`, err.message)
+  })
+  client.on('end', () => {
+    // 'end' fires when the client has given up reconnecting. This is the
+    // state we most care about — cross-pod tunnel routing is dead on this
+    // pod until we restart or the client manages to reconnect.
+    degraded = true
+    console.error(
+      `[TunnelRedis] ❌ ${label} connection ended — marking pod degraded. ` +
+      `/health will return 503 to drain this pod from the LB rotation.`,
+    )
+  })
+  client.on('close', () => {
+    degraded = true
+    console.warn(`[TunnelRedis] ${label} connection closed — pod degraded until reconnect`)
+  })
+  client.on('reconnecting', (delay: number) => {
+    degraded = true
+    console.warn(`[TunnelRedis] ${label} reconnecting in ${delay}ms`)
+  })
+  client.on('ready', () => {
+    // Only clear `degraded` when both clients are actually ready.
+    if (pub?.status === 'ready' && sub?.status === 'ready') {
+      if (degraded) {
+        console.log('[TunnelRedis] ✅ Both pub/sub ready — clearing degraded flag')
+      }
+      degraded = false
+    }
+  })
+}
+
+async function _doInit(): Promise<void> {
   if (isLocalMode) {
     initialized = true
     console.log('[TunnelRedis] Skipped — local mode (single process, no cross-pod relay needed)')
@@ -53,9 +146,7 @@ export async function initTunnelRedis(): Promise<void> {
         return Math.min(times * 500, 3000)
       },
     })
-    pub.on('error', (err) => {
-      console.error('[TunnelRedis] Publisher error:', err.message)
-    })
+    attachLifecycleListeners(pub, 'publisher')
 
     sub = new Redis(REDIS_URL, {
       maxRetriesPerRequest: 3,
@@ -66,9 +157,7 @@ export async function initTunnelRedis(): Promise<void> {
         return Math.min(times * 500, 3000)
       },
     })
-    sub.on('error', (err) => {
-      console.error('[TunnelRedis] Subscriber error:', err.message)
-    })
+    attachLifecycleListeners(sub, 'subscriber')
 
     await Promise.all([pub.connect(), sub.connect()])
 
@@ -79,11 +168,24 @@ export async function initTunnelRedis(): Promise<void> {
 
     console.log(`[TunnelRedis] Initialized (pod=${POD_ID})`)
   } catch (err) {
-    console.error('[TunnelRedis] Failed to connect — falling back to in-memory only:', (err as Error).message)
+    // In multi-pod deployments this is a correctness bug, not a warning:
+    // cross-pod tunnel routing is silently disabled. Log loudly so it
+    // surfaces in dashboards, and flip `degraded` so /health fails the
+    // readiness probe and Knative/K8s drains the pod instead of quietly
+    // serving 503s.
+    console.error(
+      `[TunnelRedis] ❌ CRITICAL: Redis unreachable at ${REDIS_URL} — ` +
+      `cross-pod tunnel routing is DISABLED. Remote control will return ` +
+      `503 on pods that do not own the desktop WS. ` +
+      `Fix: ensure Redis is deployed in this namespace or set ` +
+      `SHOGO_LOCAL_MODE=true for single-pod deployments. ` +
+      `Underlying error: ${(err as Error).message}`,
+    )
     try { pub?.disconnect() } catch {}
     try { sub?.disconnect() } catch {}
     pub = null
     sub = null
+    degraded = true
   }
 
   initialized = true
@@ -110,8 +212,16 @@ function getPublisher(): Redis | null {
 // ─── Health Check ────────────────────────────────────────────────────────────
 
 export async function checkRedisHealth(): Promise<{ healthy: boolean; latencyMs?: number; error?: string }> {
+  if (isLocalMode) return { healthy: true, latencyMs: 0 }
   const r = getPublisher()
-  if (!r) return { healthy: false, error: 'Redis not initialized' }
+  if (!r) return { healthy: false, error: 'Redis publisher not initialized' }
+  // The subscriber connection is what receives cross-pod relay requests,
+  // so we must verify it too — a dead subscriber with a live publisher
+  // would still silently drop every sibling-pod request while /health
+  // reported green.
+  if (!sub || sub.status !== 'ready') {
+    return { healthy: false, error: `Redis subscriber not ready (status=${sub?.status ?? 'null'})` }
+  }
   const start = Date.now()
   try {
     const pong = await r.ping()
@@ -124,12 +234,18 @@ export async function checkRedisHealth(): Promise<{ healthy: boolean; latencyMs?
 // ─── Tunnel Ownership ───────────────────────────────────────────────────────
 
 export async function registerTunnelOwnership(instanceId: string): Promise<void> {
+  // Wait for Redis init to complete before writing ownership. Without this,
+  // a desktop WS that auths during the first ~500ms of pod startup would
+  // silently skip registration (pub=null) and other pods would 503 on
+  // remote-control requests until the desktop reconnected.
+  await whenReady()
   const r = getPublisher()
   if (!r) return
   await r.set(`tunnel:${instanceId}:pod`, POD_ID, 'EX', TUNNEL_OWNERSHIP_TTL)
 }
 
 export async function unregisterTunnelOwnership(instanceId: string): Promise<void> {
+  await whenReady()
   const r = getPublisher()
   if (!r) return
   const owner = await r.get(`tunnel:${instanceId}:pod`)
@@ -143,26 +259,47 @@ export async function unregisterTunnelOwnership(instanceId: string): Promise<voi
  * Used when a relay to the owning pod times out, indicating the owner is dead.
  */
 export async function evictTunnelOwnership(instanceId: string): Promise<void> {
+  await whenReady()
   const r = getPublisher()
   if (!r) return
   await r.del(`tunnel:${instanceId}:pod`)
 }
 
 export async function refreshTunnelOwnership(instanceId: string): Promise<void> {
+  await whenReady()
   const r = getPublisher()
   if (!r) return
   await r.expire(`tunnel:${instanceId}:pod`, TUNNEL_OWNERSHIP_TTL)
 }
 
+/**
+ * Look up the pod currently owning a tunnel, with a single bounded retry.
+ *
+ * The retry absorbs the narrow window where a desktop has just connected
+ * on another pod and its `registerTunnelOwnership` write hasn't yet landed
+ * in Redis. Without it, a sibling pod hitting that 5–50ms gap would see
+ * null and return 503 even though the tunnel is healthy.
+ */
 export async function getTunnelOwner(instanceId: string): Promise<string | null> {
+  await whenReady()
   const r = getPublisher()
   if (!r) return null
-  try {
-    return await r.get(`tunnel:${instanceId}:pod`)
-  } catch (err) {
-    console.warn(`[TunnelRedis] getTunnelOwner failed for ${instanceId}:`, (err as Error).message)
-    return null
+
+  const read = async (): Promise<string | null> => {
+    try {
+      return await r.get(`tunnel:${instanceId}:pod`)
+    } catch (err) {
+      console.warn(`[TunnelRedis] getTunnelOwner failed for ${instanceId}:`, (err as Error).message)
+      return null
+    }
   }
+
+  const first = await read()
+  if (first) return first
+  // Bounded retry: one re-read after GET_TUNNEL_OWNER_RETRY_MS to absorb
+  // the sub-100ms cold-start gap on a sibling pod.
+  await new Promise((r) => setTimeout(r, GET_TUNNEL_OWNER_RETRY_MS))
+  return read()
 }
 
 /**
@@ -392,6 +529,7 @@ export async function relayTunnelRequest(
   instanceId: string,
   request: RelayRequest['request'],
 ): Promise<RelayResponse['response']> {
+  await whenReady()
   const r = getPublisher()
   if (!r) throw new Error('Redis not initialized')
 
@@ -420,32 +558,38 @@ export function relayTunnelStreamRequest(
   request: StreamRelayRequest['request'],
   onChunk: (chunk: StreamRelayChunk['chunk']) => void,
 ): { cancel: () => void } {
-  const r = getPublisher()
-  if (!r) {
-    onChunk({ type: 'stream-error', requestId: request.requestId, error: 'Redis not initialized' })
-    return { cancel: () => {} }
-  }
-
-  const relayId = `relay_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`
-
-  const timeout = setTimeout(() => {
-    pendingStreamRelays.delete(relayId)
-    onChunk({ type: 'stream-error', requestId: request.requestId, error: 'Cross-pod stream relay timed out' })
-  }, STREAM_RELAY_TIMEOUT_MS)
-
-  pendingStreamRelays.set(relayId, { onChunk, timeout })
-
-  const msg: StreamRelayRequest = { relayId, instanceId, replyPod: POD_ID, request }
-  r.publish(`tunnel:pod:${ownerPod}:stream-request`, JSON.stringify(msg)).catch(() => {
-    clearTimeout(timeout)
-    pendingStreamRelays.delete(relayId)
-    onChunk({ type: 'stream-error', requestId: request.requestId, error: 'Failed to publish relay request' })
+  // Signature is sync for back-compat with callers — but we need init to
+  // be done before publishing. Fire the whenReady gate and let the publish
+  // happen inside its .then to keep the race closed without changing the
+  // return type.
+  let cancelled = false
+  let activeTimeout: ReturnType<typeof setTimeout> | null = null
+  let activeRelayId: string | null = null
+  whenReady().then(() => {
+    if (cancelled) return
+    const r = getPublisher()
+    if (!r) {
+      onChunk({ type: 'stream-error', requestId: request.requestId, error: 'Redis not initialized' })
+      return
+    }
+    activeRelayId = `relay_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`
+    activeTimeout = setTimeout(() => {
+      pendingStreamRelays.delete(activeRelayId!)
+      onChunk({ type: 'stream-error', requestId: request.requestId, error: 'Cross-pod stream relay timed out' })
+    }, STREAM_RELAY_TIMEOUT_MS)
+    pendingStreamRelays.set(activeRelayId, { onChunk, timeout: activeTimeout })
+    const msg: StreamRelayRequest = { relayId: activeRelayId, instanceId, replyPod: POD_ID, request }
+    r.publish(`tunnel:pod:${ownerPod}:stream-request`, JSON.stringify(msg)).catch(() => {
+      if (activeTimeout) clearTimeout(activeTimeout)
+      if (activeRelayId) pendingStreamRelays.delete(activeRelayId)
+      onChunk({ type: 'stream-error', requestId: request.requestId, error: 'Failed to publish relay request' })
+    })
   })
-
   return {
     cancel: () => {
-      clearTimeout(timeout)
-      pendingStreamRelays.delete(relayId)
+      cancelled = true
+      if (activeTimeout) clearTimeout(activeTimeout)
+      if (activeRelayId) pendingStreamRelays.delete(activeRelayId)
     },
   }
 }

--- a/apps/api/src/routes/instances.ts
+++ b/apps/api/src/routes/instances.ts
@@ -241,7 +241,7 @@ function isStreamingRequest(method: string, cleanPath: string): boolean {
 
 // ─── WebSocket handler (called from Bun.serve websocket config) ─────────────
 
-export function handleInstanceWsOpen(ws: WebSocket & { data?: any }) {
+export async function handleInstanceWsOpen(ws: WebSocket & { data?: any }) {
   const { instanceId, workspaceId } = ws.data || {}
   if (!instanceId || !workspaceId) {
     ws.close(4001, 'Missing instance context')
@@ -257,9 +257,28 @@ export function handleInstanceWsOpen(ws: WebSocket & { data?: any }) {
   }
   tunnels.set(instanceId, conn)
 
-  registerTunnelOwnership(instanceId).catch((err) => {
+  // Await ownership registration BEFORE marking the instance 'online' in
+  // Postgres. Otherwise another pod seeing the DB row flip to online can
+  // race ahead of the Redis write and 503 with `{ code: 'offline' }`.
+  // The inner whenReady() guard also absorbs the cold-start window where
+  // Redis is still connecting.
+  try {
+    await registerTunnelOwnership(instanceId)
+  } catch (err) {
     console.warn('[RemoteControl] registerTunnelOwnership failed:', (err as Error).message)
-  })
+  }
+
+  // The WS may have closed while we were awaiting Redis (cold start can
+  // add ~200–2000 ms on the first call). If handleInstanceWsClose already
+  // ran and marked the row 'offline', we must NOT flip it back to 'online'
+  // here — that would leave the DB showing an online instance whose
+  // underlying WS is already dead.
+  if (!tunnels.has(instanceId)) {
+    console.warn(
+      `[RemoteControl] Instance ${instanceId} WS closed during registration; skipping online write`,
+    )
+    return
+  }
 
   prisma.instance.update({
     where: { id: instanceId },
@@ -533,6 +552,10 @@ function sendTunnelStreamRequest(
 // ─── REST routes ────────────────────────────────────────────────────────────
 
 export function instanceRoutes() {
+  // Kick off init eagerly. registerTunnelOwnership / getTunnelOwner now
+  // await whenReady() internally, so any WS auth or relay that lands
+  // during this boot window will block briefly instead of silently
+  // no-oping against a null Redis client and returning 503.
   initTunnelRedis().catch((err) => {
     console.error('[RemoteControl] Failed to initialize tunnel Redis:', err.message)
   })

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -56,7 +56,7 @@ import { evalAdminRoutes, evalInternalRoutes } from './routes/eval-admin'
 import { apiKeyRoutes } from './routes/api-keys'
 import { meetingRoutes } from './routes/meetings'
 import { instanceRoutes, authenticateInstanceWs, handleInstanceWsOpen, handleInstanceWsMessage, handleInstanceWsClose, startTunnelHeartbeat } from './routes/instances'
-import { checkRedisHealth } from './lib/tunnel-redis'
+import { checkRedisHealth, isTunnelRedisDegraded } from './lib/tunnel-redis'
 import { remoteAuditRoutes } from './routes/remote-audit'
 import { syncRoutes } from './routes/sync'
 import internalRoutes from './routes/internal'
@@ -503,21 +503,25 @@ app.use('/api/projects/:projectId/*', async (c, next) => {
 // Handles all authentication endpoints: sign-up, sign-in, sign-out, session, OAuth callbacks, etc.
 app.on(['GET', 'POST'], '/api/auth/*', (c) => auth.handler(c.req.raw))
 
-// Health check — includes Redis status for multi-pod deployments
-app.get('/api/health', async (c) => {
+// Health check — includes Redis status for multi-pod deployments.
+// When tunnel-redis is in a degraded state (init completed but publisher
+// is null in non-local mode) we return 503 so Knative/K8s drain this pod
+// out of the LB rotation instead of serving 503s on remote-control.
+const healthHandler = async (c: any) => {
   const redis = await checkRedisHealth()
+  const degraded = isTunnelRedisDegraded()
   if (!redis.healthy) {
     console.warn('[Health] Redis unhealthy:', redis.error)
   }
-  return c.json({ ok: true, redis: { healthy: redis.healthy, latencyMs: redis.latencyMs } })
-})
-app.get('/health', async (c) => {
-  const redis = await checkRedisHealth()
-  if (!redis.healthy) {
-    console.warn('[Health] Redis unhealthy:', redis.error)
+  const ok = !degraded && redis.healthy
+  const body = {
+    ok,
+    redis: { healthy: redis.healthy, latencyMs: redis.latencyMs, degraded },
   }
-  return c.json({ ok: true, redis: { healthy: redis.healthy, latencyMs: redis.latencyMs } })
-})
+  return c.json(body, ok ? 200 : 503)
+}
+app.get('/api/health', healthHandler)
+app.get('/health', healthHandler)
 
 // Version endpoint for frontend update detection
 app.get('/api/version', (c) => c.json({

--- a/k8s/overlays/staging/api-service.yaml
+++ b/k8s/overlays/staging/api-service.yaml
@@ -83,7 +83,27 @@ spec:
       annotations:
         autoscaling.knative.dev/min-scale: "1"
         autoscaling.knative.dev/max-scale: "5"
+        # ─── Long-lived WebSocket support for desktop tunnel ───────────────
+        # Without these, Knative's activator / autoscaler can terminate
+        # pods holding active desktop WS sessions, causing intermittent
+        # "instance offline" 503s even when Redis is healthy.
+        #
+        # target-burst-capacity=-1  keep the activator on the data path so
+        #                           WS upgrades survive scale transitions
+        # scale-down-delay=5m       don't reap pods immediately on idle;
+        #                           gives desktops time to reconnect gracefully
+        # window=60s                standard smoothing
+        autoscaling.knative.dev/target-burst-capacity: "-1"
+        autoscaling.knative.dev/scale-down-delay: "5m"
+        autoscaling.knative.dev/window: "60s"
     spec:
+      # Max time a single request (inc. WS) can stay open. 1800s = 30 min.
+      # Desktops reconnect well before this on their own heartbeat cycle,
+      # so there's no benefit to going higher — and going higher (3600)
+      # risks being silently clamped by the cluster-level
+      # `max-request-timeout-seconds` in knative-serving/config-defaults.
+      # Keeping this within safe Knative defaults avoids that dependency.
+      timeoutSeconds: 1800
       serviceAccountName: api-service-account
       containers:
         - name: api
@@ -300,5 +320,5 @@ spec:
             limits:
               memory: "2Gi"
               cpu: "1"
-      timeoutSeconds: 1800
+      # timeoutSeconds is set near the top of template.spec (3600s) for WS support.
       terminationGracePeriodSeconds: 630


### PR DESCRIPTION
## Summary

Fixes intermittent `503 { code: 'offline' }` errors on **staging remote control** even when the desktop tunnel is actually connected. Root cause is a combination of independent bugs in the server-side tunnel layer that only surface in multi-pod Knative — localhost is fine because `SHOGO_LOCAL_MODE=true` + single process bypasses all of them.

**Scope:** this PR is code + Knative tuning only. Redis is already deployed in `shogo-staging-system`, so no infrastructure changes.

Closes #384.

## Root cause

### 1. Cold-start race in `apps/api/src/lib/tunnel-redis.ts`
`initTunnelRedis()` was fire-and-forget. `registerTunnelOwnership()` / `getTunnelOwner()` called `getPublisher()`, which returns `null` until the Redis client finishes connecting (~200–2000 ms on pod boot). Any WS auth or relay that landed in that window silently no-opped, and `status: 'online'` was written to Postgres before the Redis ownership key — so other pods saw the row as online while Redis still had no ownership key.

### 2. Knative autoscaler / activator killing long-lived WebSockets
Staging ran `min-scale=1, max-scale=5` with no `target-burst-capacity`, no `scale-down-delay`, and no Service-level `timeoutSeconds`. The queue-proxy caps request duration at 600 s by default. Scale-down of idle pods and activator transitions dropped active WS connections, forcing reconnects that then tripped bug #1.

### 3. Post-boot Redis failures were silent
Even after a successful init, if Redis died (master restart, brief partition) `ioredis` would retry a few times and give up. `pub`/`sub` would reject commands but `degraded` stayed `false`, `/health` kept returning 200, and the pod kept serving silent 503s on every cross-pod relay. No listener on `'end'` / `'close'` / `'reconnecting'`.

### 4. Subscriber-only failure was invisible to `/health`
`checkRedisHealth` only pinged `pub`. If `sub` died while `pub` lived, every sibling-pod relay arriving on this pod was silently dropped while health reported green.

### 5. Desktop disconnecting mid-register left the DB lying
`handleInstanceWsOpen` did `tunnels.set → await registerTunnelOwnership → DB 'online'`. If the WS closed during the await, `handleInstanceWsClose` ran, `tunnels.delete`, DB flipped to `'offline'`, then the resumed `await` flipped the DB back to `'online'` on a dead WS.

## What changed

Commits on this branch:
- `98f6b98` — memoized init + `whenReady()` gate on `register`/`getTunnelOwner`; Knative annotations for WS keepalive
- `54415ec` — uniform `whenReady()` gating across all pub/sub callers; loud CRITICAL log + `degraded` flag + `/health` 503 on Redis init failure; 100 ms sibling-pod retry on `getTunnelOwner`; race test scaffolding
- `a00ebf0` — `timeoutSeconds 3600 → 1800` to stay under Knative cluster default ceiling
- `5d0f7fa` — **C1/C2/H1**: post-boot Redis recovery (pub/sub lifecycle listeners flip `degraded`), subscriber health check, WS-close-during-register race closed

### Files

| File | Change |
|---|---|
| `apps/api/src/lib/tunnel-redis.ts` | Memoized `initPromise` + `whenReady()` gate; lifecycle listeners on pub/sub for `'end'` / `'close'` / `'reconnecting'` / `'ready'` → flip `degraded` accordingly; `isTunnelRedisDegraded()` also inspects `pub.status` / `sub.status`; `checkRedisHealth()` verifies the subscriber too; loud CRITICAL log on init failure; 100 ms bounded retry in `getTunnelOwner`. |
| `apps/api/src/routes/instances.ts` | `handleInstanceWsOpen` is `async`; awaits `registerTunnelOwnership` before writing DB `'online'`; re-checks `tunnels.has(instanceId)` after the await so a WS that closed during registration doesn't leave a phantom online row. |
| `apps/api/src/server.ts` | `/health` + `/api/health` return 503 when `isTunnelRedisDegraded()` is true, so Knative/K8s drain the pod. |
| `k8s/overlays/staging/api-service.yaml` | Knative annotations: `target-burst-capacity: "-1"`, `scale-down-delay: "5m"`, `window: "60s"`, `timeoutSeconds: 1800` at `spec.template.spec`. |
| `apps/api/src/lib/__tests__/tunnel-redis-race.test.ts` (new) | Covers cold-start register race, retry-window read, `degraded` flag, local-mode short-circuit. |

## Failure-mode coverage

| Mode | Before | Now |
| ---- | :----: | :-: |
| Cold-start race (WS arrives during pod boot) | 🔴 | ✅ |
| Sibling-pod lookup gap (5–50 ms) | 🔴 | ✅ |
| Postgres `'online'` written before Redis key | 🔴 | ✅ |
| WS killed by autoscaler/activator | 🔴 | ✅ |
| Init fails but pod stays in rotation | 🔴 | ✅ |
| **Redis dies *after* boot** (C1) | 🔴 | ✅ |
| **Subscriber-only failure** (C2) | 🔴 | ✅ |
| **Desktop disconnects mid-register** (H1) | 🔴 | ✅ |

## Known remaining items (non-blocking)

Tracked for follow-up; narrow windows and no user-visible 503 under realistic staging load:

- **C3** — `verifyPodAlive` does not `await whenReady()` (eviction path only, sub-second window on cold start)
- **H2** — `unregisterTunnelOwnership` GET-then-DEL is not atomic (can delete a fresh registration from another pod in a ~ms window; self-heals on next desktop reconnect)
- **C4** — race tests don't reset module state between cases (doesn't affect runtime; means regressions might not be caught in CI)
- **M3** — verify Knative Serving ≥ 1.10 and `config-autoscaler` supports `scale-down-delay`:
  ```bash
  kubectl -n knative-serving get cm config-autoscaler -o jsonpath='{.data.scale-down-delay}'
  ```
- **M4** — measure REST p50/p95 after `target-burst-capacity: -1` (every request now traverses the activator hop)

## Why this is safe

- **Local mode** (`SHOGO_LOCAL_MODE=true`): `whenReady()` resolves immediately, `isTunnelRedisDegraded()` always returns `false`, `checkRedisHealth` short-circuits to healthy. Zero behavior change on localhost / self-hosted single-pod.
- **Single-pod deployments**: the `tunnels` Map remains the primary lookup; the `await` adds only a few ms once Redis is connected. The lifecycle listeners are idle when the connection is healthy.
- **Desktop client**: no protocol change. Only server-side ordering and DB-write guards changed.
- **`handleInstanceWsOpen` signature**: went sync → async. Invisible to Bun's WS handler (returned promise is discarded), but worth noting for any test that awaits it.
- **Knative annotations**: runtime tuning; no API contract change. Existing WS clients reconnect at most once during a rollout.
- **No infra changes:** Redis is already deployed in `shogo-staging-system`; this PR does not touch the Redis StatefulSet/Service.

## Verify on staging

```bash
kubectl apply -k k8s/overlays/staging/
kubectl -n shogo-staging-system rollout restart ksvc/api
kubectl -n shogo-staging-system rollout status ksvc/api --timeout=5m

# Clean Redis init on every pod + no degraded flag
kubectl -n shogo-staging-system logs -l app=api --tail=200 \
  | grep -iE 'TunnelRedis|RemoteControl|degraded|CRITICAL'

# Knative annotations landed
kubectl -n shogo-staging-system get ksvc api \
  -o jsonpath='{.spec.template.metadata.annotations}' | jq
```

Then against `studio.staging.shogo.ai`:
1. Fire several remote-control actions rapidly — expect **zero 503s**.
2. Trigger scale: `kubectl scale ksvc api --replicas=3` — WS should survive.
3. Kill Redis: `kubectl -n shogo-staging-system delete pod redis-master-0`. Affected API pods should start reporting `/health` 503 until Redis recovers, then log `✅ Both pub/sub ready — clearing degraded flag` and return to green.