### PR TITLE
Align Auto model picker with Cursor-style uniform list

### DIFF
--- a/apps/mobile/components/chat/AutoModelOption.tsx
+++ b/apps/mobile/components/chat/AutoModelOption.tsx
@@ -4,31 +4,31 @@
 import { View, Text, Pressable } from "react-native"
 import { cn } from "@shogo/shared-ui/primitives"
 import { AUTO_MODEL_ID } from "@shogo/model-catalog"
-import { Zap, Check } from "lucide-react-native"
+import { Check } from "lucide-react-native"
 
 interface AutoModelOptionProps {
   currentModelId: string
   onSelect: () => void
-  compact?: boolean
 }
 
-export function AutoModelOption({ currentModelId, onSelect, compact }: AutoModelOptionProps) {
+export function AutoModelOption({ currentModelId, onSelect }: AutoModelOptionProps) {
   const isSelected = currentModelId === AUTO_MODEL_ID
   return (
     <Pressable
       onPress={onSelect}
       className={cn(
-        "flex-row items-center gap-2.5 px-3",
-        compact ? "py-2" : "py-2.5",
+        "flex-row items-center gap-2.5 px-3 py-2",
         isSelected && "bg-accent",
       )}
     >
-      <Zap size={14} className="text-primary" />
       <View className="flex-1">
-        <Text className="text-sm font-medium text-foreground">Auto</Text>
-        <Text className="text-[10px] text-muted-foreground">Best model per turn</Text>
+        <Text className="text-sm text-foreground">Auto</Text>
       </View>
-      {isSelected && <Check className="h-3.5 w-3.5 text-primary" size={14} />}
+      {isSelected ? (
+        <Check className="h-3.5 w-3.5 text-primary" size={14} />
+      ) : (
+        <Text className="text-[10px] text-muted-foreground">Efficiency</Text>
+      )}
     </Pressable>
   )
 }

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -1019,7 +1019,6 @@ export function ChatInput({
                       handleModelChange(AUTO_MODEL_ID)
                       setModelPickerOpen(false)
                     }}
-                    compact
                   />
                   <View className="h-px bg-border/50 mx-2" />
                   {MODEL_GROUPS.map((group) => (


### PR DESCRIPTION
This PR updates the model picker `Auto` row so it matches the rest of the menu instead of using a distinct header-style layout (icon, stacked subtitle, different spacing).

**Changes**
- `AutoModelOption`: single-line row with the same padding and typography as other model rows; muted `Efficiency` label on the right when not selected; checkmark when selected.
- `ChatInput`: remove the obsolete `compact` prop on `AutoModelOption` so behavior is consistent with `CompactChatInput`.
**after**
<img width="468" height="469" alt="image" src="https://github.com/user-attachments/assets/0ae9a479-2e10-4990-adb9-013573b7927e" />

**before**
<img width="632" height="460" alt="image" src="https://github.com/user-attachments/assets/d1827386-c3da-4fc2-9769-48027a04defd" />
