### PR TITLE
feat(mobile-chat): render long pastes as per-paste file chips

### DIFF
--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -62,8 +62,16 @@ import {
 import { AutoModelOption } from "./AutoModelOption"
 import { useVoiceInput } from "./useVoiceInput"
 import { VoiceWaveform } from "./VoiceWaveform"
-import { analyzeContent, kindLabel, LONG_TEXT_CHIP_LAYOUT_CLASS } from "./long-text-utils"
+import {
+  analyzeContent,
+  extractLongPaste,
+  kindLabel,
+  LONG_PASTE_MIN_CHARS,
+  pastedEntryToAttachment,
+  type PastedTextEntry,
+} from "./long-text-utils"
 import { FileViewerModal } from "./FileViewerModal"
+import { PastedTextChip } from "./PastedTextChip"
 
 export const DEFAULT_MODEL_PRO = "claude-sonnet-4-6"
 export const DEFAULT_MODEL_FREE = "claude-haiku-4-5-20251001"
@@ -244,39 +252,36 @@ export function ChatInput({
 
   const [quickActionsOpen, setQuickActionsOpen] = useState(false)
 
-  // Long-text collapse state: when the user types/pastes a large block of text,
-  // we collapse the input into a compact file-like card (ChatGPT style).
-  const [longTextCollapsed, setLongTextCollapsed] = useState(false)
-  const [longTextViewerOpen, setLongTextViewerOpen] = useState(false)
+  // Long-text pastes are extracted out of the TextInput and rendered as
+  // compact ChatGPT-style file chips. The input stays editable so the user
+  // can keep typing and paste additional long blocks (each becomes its own
+  // chip).
+  const [pastedTexts, setPastedTexts] = useState<PastedTextEntry[]>([])
+  const [viewingPastedId, setViewingPastedId] = useState<string | null>(null)
 
-  const longTextInfo = useMemo(() => {
-    if (!inputValue || inputValue.length < 2000) return null
-    const info = analyzeContent(inputValue)
-    return info.isLong ? info : null
-  }, [inputValue])
-
-  // Auto-collapse when text becomes long
-  const prevWasLongRef = useRef(false)
-  useEffect(() => {
-    const isLong = longTextInfo !== null
-    if (isLong && !prevWasLongRef.current) {
-      setLongTextCollapsed(true)
-    } else if (!isLong) {
-      setLongTextCollapsed(false)
-    }
-    prevWasLongRef.current = isLong
-  }, [longTextInfo])
-
-  const handleShowInTextField = useCallback(() => {
-    setLongTextCollapsed(false)
-    setTimeout(() => textInputRef.current?.focus(), 0)
+  const addPastedText = useCallback((content: string) => {
+    const info = analyzeContent(content)
+    if (!info.isLong) return false
+    setPastedTexts((prev) => [
+      ...prev,
+      {
+        id: `paste-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        content,
+        info,
+      },
+    ])
+    return true
   }, [])
 
-  const handleRemoveLongText = useCallback(() => {
-    setInputValue("")
-    setLongTextCollapsed(false)
-    setLongTextViewerOpen(false)
+  const handleRemovePastedText = useCallback((id: string) => {
+    setPastedTexts((prev) => prev.filter((p) => p.id !== id))
+    setViewingPastedId((curr) => (curr === id ? null : curr))
   }, [])
+
+  const viewingPasted = useMemo(
+    () => pastedTexts.find((p) => p.id === viewingPastedId) ?? null,
+    [pastedTexts, viewingPastedId]
+  )
 
   // Skill picker state
   const [showSkillPicker, setShowSkillPicker] = useState(false)
@@ -412,18 +417,31 @@ export function ChatInput({
     if (!node) return
 
     const handlePaste = (e: ClipboardEvent) => {
-      const items = e.clipboardData?.items
-      if (!items) return
+      const cd = e.clipboardData
+      if (!cd) return
+      const items = cd.items
       const imageFiles: File[] = []
-      for (let i = 0; i < items.length; i++) {
-        if (items[i].type.startsWith("image/")) {
-          const file = items[i].getAsFile()
-          if (file) imageFiles.push(file)
+      if (items) {
+        for (let i = 0; i < items.length; i++) {
+          if (items[i].type.startsWith("image/")) {
+            const file = items[i].getAsFile()
+            if (file) imageFiles.push(file)
+          }
         }
       }
       if (imageFiles.length > 0) {
         e.preventDefault()
         processFiles(imageFiles)
+        return
+      }
+
+      const text = cd.getData("text")
+      if (text && text.length >= LONG_PASTE_MIN_CHARS) {
+        const info = analyzeContent(text)
+        if (info.isLong) {
+          e.preventDefault()
+          addPastedText(text)
+        }
       }
     }
 
@@ -431,7 +449,7 @@ export function ChatInput({
     return () => {
       node.removeEventListener("paste", handlePaste as EventListener)
     }
-  }, [processFiles])
+  }, [processFiles, addPastedText])
 
   const appendTranscriptToInput = useCallback((transcript: string) => {
     const normalized = transcript.trim()
@@ -465,7 +483,7 @@ export function ChatInput({
   const handleSubmit = useCallback(() => {
     const trimmedContent = inputValue.trim()
     if (
-      (!trimmedContent && pendingFiles.length === 0) ||
+      (!trimmedContent && pendingFiles.length === 0 && pastedTexts.length === 0) ||
       disabled ||
       isProcessingFiles ||
       voiceInput.isBusy
@@ -473,21 +491,42 @@ export function ChatInput({
       return
     }
 
-    const fileData: FileAttachment[] | undefined =
-      pendingFiles.length > 0
-        ? pendingFiles.map((f) => ({ dataUrl: f.dataUrl, name: f.name, type: f.type }))
-        : undefined
+    // Each pasted long-text block is shipped as its own file attachment so
+    // the chat renders them as discrete chips (ChatGPT-style) rather than
+    // merging everything into one giant preview card.
+    const pastedAttachments: FileAttachment[] = pastedTexts.map((entry, i) =>
+      pastedEntryToAttachment(entry, i)
+    )
+    const combinedFiles: FileAttachment[] = [
+      ...pendingFiles.map((f) => ({ dataUrl: f.dataUrl, name: f.name, type: f.type })),
+      ...pastedAttachments,
+    ]
+    const fileData = combinedFiles.length > 0 ? combinedFiles : undefined
 
     onSubmit(trimmedContent, fileData, currentModelId)
     setInputValue("")
     setPendingFiles([])
+    setPastedTexts([])
+    setViewingPastedId(null)
     setFileError(null)
 
     textInputRef.current?.focus()
-  }, [disabled, onSubmit, pendingFiles, isProcessingFiles, currentModelId, inputValue, voiceInput.isBusy])
+  }, [disabled, onSubmit, pendingFiles, isProcessingFiles, currentModelId, inputValue, pastedTexts, voiceInput.isBusy])
 
   const handleChangeText = useCallback(
     (text: string) => {
+      // Fallback paste detection for platforms where we can't intercept
+      // the clipboard event (native, and any web path that bypasses the
+      // DOM paste listener). If a large chunk was just inserted, pull it
+      // out into a chip instead of keeping it in the TextInput.
+      const paste = extractLongPaste(inputValue, text)
+      if (paste) {
+        addPastedText(paste.inserted)
+        setInputValue(paste.restored)
+        setShowSkillPicker(false)
+        return
+      }
+
       setInputValue(text)
 
       if (text.startsWith("/") && !text.includes(" ")) {
@@ -498,7 +537,7 @@ export function ChatInput({
         setShowSkillPicker(false)
       }
     },
-    []
+    [inputValue, addPastedText]
   )
 
   const getFileIcon = useCallback((fileType: string) => {
@@ -718,78 +757,46 @@ export function ChatInput({
           />
         )}
 
-        {/* TextInput or collapsed long-text card */}
-        {longTextCollapsed && longTextInfo ? (
-          <View className="px-3 pt-3 pb-1 gap-2">
-            <View className={cn("relative", LONG_TEXT_CHIP_LAYOUT_CLASS)}>
-              <Pressable
-                onPress={() => setLongTextViewerOpen(true)}
-                className={cn(
-                  "w-full rounded-lg border border-border bg-muted/50 p-3 pr-10 gap-1.5"
-                )}
-                accessibilityLabel="View pasted text"
-                accessibilityRole="button"
-              >
-                <View className="flex-row items-center gap-2">
-                  <FileText size={16} className="text-primary" />
-                  <Text className="flex-1 text-xs font-medium text-foreground min-w-0" numberOfLines={1}>
-                    {kindLabel(longTextInfo.kind).toUpperCase()}
-                  </Text>
-                  <Text className="text-[10px] text-muted-foreground flex-shrink-0">
-                    {longTextInfo.sizeLabel} · {longTextInfo.lines} lines
-                  </Text>
-                </View>
-                <Text className="text-[11px] text-muted-foreground" numberOfLines={2}>
-                  {inputValue.slice(0, 200).replace(/\n/g, " ")}
-                </Text>
-              </Pressable>
-              <Pressable
-                onPress={handleRemoveLongText}
-                className="absolute top-1.5 right-1.5 z-10 rounded-full bg-background/90 p-1 border border-border/60"
-                accessibilityLabel="Remove pasted text"
-                accessibilityRole="button"
-                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-              >
-                <X size={14} className="text-muted-foreground" />
-              </Pressable>
-            </View>
-            <Pressable
-              onPress={handleShowInTextField}
-              className="self-start"
-            >
-              <Text className="text-[11px] text-primary font-medium">
-                Show in text field ›
-              </Text>
-            </Pressable>
+        {/* Pasted long-text chips (ChatGPT-style). Multiple allowed. */}
+        {pastedTexts.length > 0 && (
+          <View className="flex-row flex-wrap gap-2 px-3 pt-3">
+            {pastedTexts.map((entry) => (
+              <PastedTextChip
+                key={entry.id}
+                entry={entry}
+                onOpen={() => setViewingPastedId(entry.id)}
+                onRemove={() => handleRemovePastedText(entry.id)}
+              />
+            ))}
           </View>
-        ) : (
-          <TextInput
-            ref={textInputRef}
-            value={voiceInput.isRecording && voiceInput.liveTranscript ? voiceInput.liveTranscript : inputValue}
-            onChangeText={handleChangeText}
-            onSubmitEditing={handleSubmit}
-            onKeyPress={(e: any) => {
-              if (Platform.OS === "web" && e.nativeEvent.key === "Enter" && !e.nativeEvent.shiftKey) {
-                e.preventDefault()
-                handleSubmit()
-              }
-            }}
-            placeholder={placeholder}
-            placeholderTextColor="#9ca3af"
-            accessibilityLabel="Chat message input"
-            editable={!disabled && !voiceInput.isRecording}
-            multiline
-            blurOnSubmit={false}
-            className={cn(
-              "min-h-[60px] max-h-[200px] w-full",
-              "bg-transparent",
-              "px-4 pt-4 text-xs text-foreground",
-              disabled && "opacity-50",
-              Platform.OS === "web" && "outline-none"
-            )}
-            textAlignVertical="top"
-          />
         )}
+
+        <TextInput
+          ref={textInputRef}
+          value={voiceInput.isRecording && voiceInput.liveTranscript ? voiceInput.liveTranscript : inputValue}
+          onChangeText={handleChangeText}
+          onSubmitEditing={handleSubmit}
+          onKeyPress={(e: any) => {
+            if (Platform.OS === "web" && e.nativeEvent.key === "Enter" && !e.nativeEvent.shiftKey) {
+              e.preventDefault()
+              handleSubmit()
+            }
+          }}
+          placeholder={placeholder}
+          placeholderTextColor="#9ca3af"
+          accessibilityLabel="Chat message input"
+          editable={!disabled && !voiceInput.isRecording}
+          multiline
+          blurOnSubmit={false}
+          className={cn(
+            "min-h-[60px] max-h-[200px] w-full",
+            "bg-transparent",
+            "px-4 pt-4 text-xs text-foreground",
+            disabled && "opacity-50",
+            Platform.OS === "web" && "outline-none no-focus-ring"
+          )}
+          textAlignVertical="top"
+        />
 
         {/* Bottom toolbar */}
         <View className="flex-row items-center justify-between p-1.5">
@@ -1183,14 +1190,14 @@ export function ChatInput({
         </View>
       </View>
 
-      {longTextInfo && (
+      {viewingPasted && (
         <FileViewerModal
-          visible={longTextViewerOpen}
-          onClose={() => setLongTextViewerOpen(false)}
-          content={inputValue}
-          title={`${kindLabel(longTextInfo.kind)} content`}
-          kind={longTextInfo.kind}
-          sizeLabel={longTextInfo.sizeLabel}
+          visible={viewingPastedId !== null}
+          onClose={() => setViewingPastedId(null)}
+          content={viewingPasted.content}
+          title={`${kindLabel(viewingPasted.info.kind)} content`}
+          kind={viewingPasted.info.kind}
+          sizeLabel={viewingPasted.info.sizeLabel}
         />
       )}
 

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -67,7 +67,8 @@ import {
   extractLongPaste,
   kindLabel,
   LONG_PASTE_MIN_CHARS,
-  pastedEntryToAttachment,
+  MAX_PASTED_TEXTS,
+  buildPastedAttachments,
   type PastedTextEntry,
 } from "./long-text-utils"
 import { FileViewerModal } from "./FileViewerModal"
@@ -198,6 +199,10 @@ export function ChatInput({
   const textInputRef = useRef<TextInput>(null)
   const dropZoneRef = useRef<View>(null)
   const dragCounterRef = useRef(0)
+  const inputValueRef = useRef("")
+  // Guards against the DOM paste listener AND onChangeText both firing for
+  // the same clipboard event, which would create duplicate chips.
+  const pasteHandledRef = useRef(false)
 
   const [inputValue, setInputValue] = useState("")
   const [pendingFiles, setPendingFiles] = useState<AttachedFile[]>([])
@@ -208,6 +213,10 @@ export function ChatInput({
   const [modelPickerOpen, setModelPickerOpen] = useState(false)
   const [interactionModeOpen, setInteractionModeOpen] = useState(false)
   const [attachSheetOpen, setAttachSheetOpen] = useState(false)
+
+  useEffect(() => {
+    inputValueRef.current = inputValue
+  }, [inputValue])
 
   const [internalModel, setInternalModel] = useState<string>(
     effectiveIsPro ? DEFAULT_MODEL_PRO : DEFAULT_MODEL_FREE
@@ -262,14 +271,17 @@ export function ChatInput({
   const addPastedText = useCallback((content: string) => {
     const info = analyzeContent(content)
     if (!info.isLong) return false
-    setPastedTexts((prev) => [
-      ...prev,
-      {
-        id: `paste-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-        content,
-        info,
-      },
-    ])
+    setPastedTexts((prev) => {
+      if (prev.length >= MAX_PASTED_TEXTS) return prev
+      return [
+        ...prev,
+        {
+          id: `paste-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+          content,
+          info,
+        },
+      ]
+    })
     return true
   }, [])
 
@@ -440,7 +452,9 @@ export function ChatInput({
         const info = analyzeContent(text)
         if (info.isLong) {
           e.preventDefault()
+          pasteHandledRef.current = true
           addPastedText(text)
+          setTimeout(() => { pasteHandledRef.current = false }, 0)
         }
       }
     }
@@ -491,12 +505,10 @@ export function ChatInput({
       return
     }
 
-    // Each pasted long-text block is shipped as its own file attachment so
-    // the chat renders them as discrete chips (ChatGPT-style) rather than
-    // merging everything into one giant preview card.
-    const pastedAttachments: FileAttachment[] = pastedTexts.map((entry, i) =>
-      pastedEntryToAttachment(entry, i)
-    )
+    // Pasted long-text blocks are shipped as file attachments (ChatGPT-style).
+    // The typed text is sent as the message body; the model receives both the
+    // text part and the file parts so it sees everything.
+    const pastedAttachments: FileAttachment[] = buildPastedAttachments(pastedTexts)
     const combinedFiles: FileAttachment[] = [
       ...pendingFiles.map((f) => ({ dataUrl: f.dataUrl, name: f.name, type: f.type })),
       ...pastedAttachments,
@@ -515,11 +527,18 @@ export function ChatInput({
 
   const handleChangeText = useCallback(
     (text: string) => {
+      // If the DOM paste listener already handled this event, skip the
+      // fallback detection to avoid creating duplicate chips.
+      if (pasteHandledRef.current) {
+        pasteHandledRef.current = false
+        return
+      }
+
       // Fallback paste detection for platforms where we can't intercept
       // the clipboard event (native, and any web path that bypasses the
       // DOM paste listener). If a large chunk was just inserted, pull it
       // out into a chip instead of keeping it in the TextInput.
-      const paste = extractLongPaste(inputValue, text)
+      const paste = extractLongPaste(inputValueRef.current, text)
       if (paste) {
         addPastedText(paste.inserted)
         setInputValue(paste.restored)
@@ -537,7 +556,7 @@ export function ChatInput({
         setShowSkillPicker(false)
       }
     },
-    [inputValue, addPastedText]
+    [addPastedText]
   )
 
   const getFileIcon = useCallback((fileType: string) => {
@@ -1138,7 +1157,7 @@ export function ChatInput({
                     size={10}
                   />
                 </Pressable>
-                {(inputValue.trim() || pendingFiles.length > 0) && (
+                {(inputValue.trim() || pendingFiles.length > 0 || pastedTexts.length > 0) && (
                   <Pressable
                     onPress={handleSubmit}
                     disabled={disabled || isProcessingFiles}
@@ -1150,7 +1169,7 @@ export function ChatInput({
                   </Pressable>
                 )}
               </>
-            ) : (inputValue.trim() || pendingFiles.length > 0) ? (
+            ) : (inputValue.trim() || pendingFiles.length > 0 || pastedTexts.length > 0) ? (
               <Pressable
                 onPress={handleSubmit}
                 disabled={disabled || isProcessingFiles}

--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -53,8 +53,16 @@ import {
 import { usePlatformConfig } from "../../lib/platform-config"
 import { useVoiceInput } from "./useVoiceInput"
 import { VoiceWaveform } from "./VoiceWaveform"
-import { analyzeContent, kindLabel, LONG_TEXT_CHIP_LAYOUT_CLASS } from "./long-text-utils"
+import {
+  analyzeContent,
+  extractLongPaste,
+  kindLabel,
+  LONG_PASTE_MIN_CHARS,
+  pastedEntryToAttachment,
+  type PastedTextEntry,
+} from "./long-text-utils"
 import { FileViewerModal } from "./FileViewerModal"
+import { PastedTextChip } from "./PastedTextChip"
 
 const MODEL_GROUPS = getModelsByProvider().map((g) => ({
   label: g.label,
@@ -250,6 +258,36 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
       [processFiles]
     )
 
+    // Long-text pastes get extracted out of the TextInput and rendered as
+    // compact file-style chips. The input remains editable so users can
+    // keep typing and paste multiple long blocks (each becomes a chip).
+    const [pastedTexts, setPastedTexts] = useState<PastedTextEntry[]>([])
+    const [viewingPastedId, setViewingPastedId] = useState<string | null>(null)
+
+    const addPastedText = useCallback((content: string) => {
+      const info = analyzeContent(content)
+      if (!info.isLong) return false
+      setPastedTexts((prev) => [
+        ...prev,
+        {
+          id: `paste-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+          content,
+          info,
+        },
+      ])
+      return true
+    }, [])
+
+    const handleRemovePastedText = useCallback((id: string) => {
+      setPastedTexts((prev) => prev.filter((p) => p.id !== id))
+      setViewingPastedId((curr) => (curr === id ? null : curr))
+    }, [])
+
+    const viewingPasted = useMemo(
+      () => pastedTexts.find((p) => p.id === viewingPastedId) ?? null,
+      [pastedTexts, viewingPastedId]
+    )
+
     useEffect(() => {
       if (Platform.OS !== "web") return
       const node = dropZoneRef.current as unknown as HTMLElement | null
@@ -266,14 +304,43 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
           processFiles(Array.from(e.dataTransfer.files) as any)
         }
       }
+      const handlePaste = (e: ClipboardEvent) => {
+        const cd = e.clipboardData
+        if (!cd) return
+        const items = cd.items
+        const imageFiles: File[] = []
+        if (items) {
+          for (let i = 0; i < items.length; i++) {
+            if (items[i].type.startsWith("image/")) {
+              const file = items[i].getAsFile()
+              if (file) imageFiles.push(file)
+            }
+          }
+        }
+        if (imageFiles.length > 0) {
+          e.preventDefault()
+          processFiles(imageFiles as any)
+          return
+        }
+        const text = cd.getData("text")
+        if (text && text.length >= LONG_PASTE_MIN_CHARS) {
+          const info = analyzeContent(text)
+          if (info.isLong) {
+            e.preventDefault()
+            addPastedText(text)
+          }
+        }
+      }
 
       node.addEventListener("dragover", handleDragOver)
       node.addEventListener("drop", handleDrop)
+      node.addEventListener("paste", handlePaste as EventListener)
       return () => {
         node.removeEventListener("dragover", handleDragOver)
         node.removeEventListener("drop", handleDrop)
+        node.removeEventListener("paste", handlePaste as EventListener)
       }
-    }, [processFiles])
+    }, [processFiles, addPastedText])
 
     const appendTranscriptToInput = useCallback(
       (transcript: string) => {
@@ -296,41 +363,10 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
       onTranscript: appendTranscriptToInput,
     })
 
-    const [longTextCollapsed, setLongTextCollapsed] = useState(false)
-    const [longTextViewerOpen, setLongTextViewerOpen] = useState(false)
-
-    const longTextInfo = useMemo(() => {
-      if (!value || value.length < 2000) return null
-      const info = analyzeContent(value)
-      return info.isLong ? info : null
-    }, [value])
-
-    const prevWasLongRef = useRef(false)
-    useEffect(() => {
-      const isLong = longTextInfo !== null
-      if (isLong && !prevWasLongRef.current) {
-        setLongTextCollapsed(true)
-      } else if (!isLong) {
-        setLongTextCollapsed(false)
-      }
-      prevWasLongRef.current = isLong
-    }, [longTextInfo])
-
-    const handleShowInTextField = useCallback(() => {
-      setLongTextCollapsed(false)
-      setTimeout(() => textInputRef.current?.focus(), 0)
-    }, [])
-
-    const handleRemoveLongText = useCallback(() => {
-      setValue("")
-      setLongTextCollapsed(false)
-      setLongTextViewerOpen(false)
-    }, [setValue])
-
     const handleSubmit = useCallback(() => {
       const trimmedContent = value.trim()
       if (
-        (!trimmedContent && pendingFiles.length === 0) ||
+        (!trimmedContent && pendingFiles.length === 0 && pastedTexts.length === 0) ||
         disabled ||
         isLoading ||
         voiceInput.isBusy
@@ -338,19 +374,42 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
         return
       }
 
-      const fileData: FileAttachment[] | undefined =
-        pendingFiles.length > 0
-          ? pendingFiles.map((f) => ({ dataUrl: f.dataUrl, name: f.name, type: f.type }))
-          : undefined
+      // Each pasted long-text block is shipped as its own file attachment
+      // so the chat renders them as discrete chips (ChatGPT-style) instead
+      // of merging everything into one giant preview card.
+      const pastedAttachments: FileAttachment[] = pastedTexts.map((entry, i) =>
+        pastedEntryToAttachment(entry, i)
+      )
+      const combinedFiles: FileAttachment[] = [
+        ...pendingFiles.map((f) => ({ dataUrl: f.dataUrl, name: f.name, type: f.type })),
+        ...pastedAttachments,
+      ]
+      const fileData = combinedFiles.length > 0 ? combinedFiles : undefined
 
       onSubmit(trimmedContent, fileData)
       setValue("")
       setPendingFiles([])
       setFileError(null)
-      setLongTextCollapsed(false)
-      setLongTextViewerOpen(false)
+      setPastedTexts([])
+      setViewingPastedId(null)
       textInputRef.current?.focus()
-    }, [value, disabled, isLoading, onSubmit, pendingFiles, voiceInput.isBusy, setValue])
+    }, [value, disabled, isLoading, onSubmit, pendingFiles, pastedTexts, voiceInput.isBusy, setValue])
+
+    // Fallback paste detection for platforms where the DOM paste listener
+    // doesn't fire (native). If a large chunk was just inserted, pull it
+    // out into a chip instead of keeping it in the TextInput.
+    const handleChangeText = useCallback(
+      (next: string) => {
+        const paste = extractLongPaste(valueRef.current, next)
+        if (paste) {
+          addPastedText(paste.inserted)
+          setValue(paste.restored)
+          return
+        }
+        setValue(next)
+      },
+      [setValue, addPastedText]
+    )
 
     const getFileIcon = useCallback((fileType: string) => {
       if (fileType.startsWith("image/")) {
@@ -447,77 +506,45 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
             <Text className="text-sm text-destructive px-4 pb-2">{voiceInput.error}</Text>
           )}
 
-          {/* TextInput or collapsed long-text card */}
-          {longTextCollapsed && longTextInfo ? (
-            <View className="px-3 pt-3 pb-1 gap-2">
-              <View className={cn("relative", LONG_TEXT_CHIP_LAYOUT_CLASS)}>
-                <Pressable
-                  onPress={() => setLongTextViewerOpen(true)}
-                  className={cn(
-                    "w-full rounded-lg border border-border bg-muted/50 p-3 pr-10 gap-1.5"
-                  )}
-                  accessibilityLabel="View pasted text"
-                  accessibilityRole="button"
-                >
-                  <View className="flex-row items-center gap-2">
-                    <FileText size={16} className="text-primary" />
-                    <Text className="flex-1 text-xs font-medium text-foreground min-w-0" numberOfLines={1}>
-                      {kindLabel(longTextInfo.kind).toUpperCase()}
-                    </Text>
-                    <Text className="text-[10px] text-muted-foreground flex-shrink-0">
-                      {longTextInfo.sizeLabel} · {longTextInfo.lines} lines
-                    </Text>
-                  </View>
-                  <Text className="text-[11px] text-muted-foreground" numberOfLines={2}>
-                    {value.slice(0, 200).replace(/\n/g, " ")}
-                  </Text>
-                </Pressable>
-                <Pressable
-                  onPress={handleRemoveLongText}
-                  className="absolute top-1.5 right-1.5 z-10 rounded-full bg-background/90 p-1 border border-border/60"
-                  accessibilityLabel="Remove pasted text"
-                  accessibilityRole="button"
-                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                >
-                  <X size={14} className="text-muted-foreground" />
-                </Pressable>
-              </View>
-              <Pressable
-                onPress={handleShowInTextField}
-                className="self-start"
-              >
-                <Text className="text-[11px] text-primary font-medium">
-                  Show in text field ›
-                </Text>
-              </Pressable>
+          {/* Pasted long-text chips (ChatGPT-style). Multiple allowed. */}
+          {pastedTexts.length > 0 && (
+            <View className="flex-row flex-wrap gap-2 px-4 pt-3">
+              {pastedTexts.map((entry) => (
+                <PastedTextChip
+                  key={entry.id}
+                  entry={entry}
+                  onOpen={() => setViewingPastedId(entry.id)}
+                  onRemove={() => handleRemovePastedText(entry.id)}
+                />
+              ))}
             </View>
-          ) : (
-            <TextInput
-              ref={textInputRef}
-              placeholder={placeholderText}
-              placeholderTextColor="#9ca3af"
-              accessibilityLabel="Describe the agent you want to build"
-              value={voiceInput.isRecording && voiceInput.liveTranscript ? voiceInput.liveTranscript : value}
-              onChangeText={setValue}
-              onSubmitEditing={handleSubmit}
-              onKeyPress={(e: any) => {
-                if (Platform.OS === "web" && e.nativeEvent.key === "Enter" && !e.nativeEvent.shiftKey) {
-                  e.preventDefault()
-                  handleSubmit()
-                }
-              }}
-              editable={!disabled && !isLoading && !voiceInput.isRecording}
-              multiline
-              blurOnSubmit={false}
-              className={cn(
-                "min-h-[80px] max-h-[200px] w-full",
-                "px-4 pt-4 text-xs text-foreground",
-                disabled && "opacity-50",
-                Platform.OS === "web" && "outline-none"
-              )}
-              textAlignVertical="top"
-            />
           )}
+
+          <TextInput
+            ref={textInputRef}
+            placeholder={placeholderText}
+            placeholderTextColor="#9ca3af"
+            accessibilityLabel="Describe the agent you want to build"
+            value={voiceInput.isRecording && voiceInput.liveTranscript ? voiceInput.liveTranscript : value}
+            onChangeText={handleChangeText}
+            onSubmitEditing={handleSubmit}
+            onKeyPress={(e: any) => {
+              if (Platform.OS === "web" && e.nativeEvent.key === "Enter" && !e.nativeEvent.shiftKey) {
+                e.preventDefault()
+                handleSubmit()
+              }
+            }}
+            editable={!disabled && !isLoading && !voiceInput.isRecording}
+            multiline
+            blurOnSubmit={false}
+            className={cn(
+              "min-h-[80px] max-h-[200px] w-full",
+              "px-4 pt-4 text-xs text-foreground",
+              disabled && "opacity-50",
+              Platform.OS === "web" && "outline-none no-focus-ring"
+            )}
+            textAlignVertical="top"
+          />
 
           {/* Bottom toolbar */}
           <View className="flex-row items-center justify-between p-1.5">
@@ -806,14 +833,14 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
           </View>
         </View>
 
-        {longTextInfo && (
+        {viewingPasted && (
           <FileViewerModal
-            visible={longTextViewerOpen}
-            onClose={() => setLongTextViewerOpen(false)}
-            content={value}
-            title={`${kindLabel(longTextInfo.kind)} content`}
-            kind={longTextInfo.kind}
-            sizeLabel={longTextInfo.sizeLabel}
+            visible={viewingPastedId !== null}
+            onClose={() => setViewingPastedId(null)}
+            content={viewingPasted.content}
+            title={`${kindLabel(viewingPasted.info.kind)} content`}
+            kind={viewingPasted.info.kind}
+            sizeLabel={viewingPasted.info.sizeLabel}
           />
         )}
 

--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -58,7 +58,8 @@ import {
   extractLongPaste,
   kindLabel,
   LONG_PASTE_MIN_CHARS,
-  pastedEntryToAttachment,
+  MAX_PASTED_TEXTS,
+  buildPastedAttachments,
   type PastedTextEntry,
 } from "./long-text-utils"
 import { FileViewerModal } from "./FileViewerModal"
@@ -131,6 +132,7 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
 
     const [internalValue, setInternalValue] = useState("")
     const textInputRef = useRef<TextInput>(null)
+    const pasteHandledRef = useRef(false)
 
     const [pendingFiles, setPendingFiles] = useState<AttachedFile[]>([])
     const [fileError, setFileError] = useState<string | null>(null)
@@ -267,14 +269,17 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
     const addPastedText = useCallback((content: string) => {
       const info = analyzeContent(content)
       if (!info.isLong) return false
-      setPastedTexts((prev) => [
-        ...prev,
-        {
-          id: `paste-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-          content,
-          info,
-        },
-      ])
+      setPastedTexts((prev) => {
+        if (prev.length >= MAX_PASTED_TEXTS) return prev
+        return [
+          ...prev,
+          {
+            id: `paste-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+            content,
+            info,
+          },
+        ]
+      })
       return true
     }, [])
 
@@ -327,7 +332,9 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
           const info = analyzeContent(text)
           if (info.isLong) {
             e.preventDefault()
+            pasteHandledRef.current = true
             addPastedText(text)
+            setTimeout(() => { pasteHandledRef.current = false }, 0)
           }
         }
       }
@@ -374,12 +381,10 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
         return
       }
 
-      // Each pasted long-text block is shipped as its own file attachment
-      // so the chat renders them as discrete chips (ChatGPT-style) instead
-      // of merging everything into one giant preview card.
-      const pastedAttachments: FileAttachment[] = pastedTexts.map((entry, i) =>
-        pastedEntryToAttachment(entry, i)
-      )
+      // Pasted long-text blocks are shipped as file attachments (ChatGPT-style).
+      // The typed text is sent as the message body; the model receives both the
+      // text part and the file parts so it sees everything.
+      const pastedAttachments: FileAttachment[] = buildPastedAttachments(pastedTexts)
       const combinedFiles: FileAttachment[] = [
         ...pendingFiles.map((f) => ({ dataUrl: f.dataUrl, name: f.name, type: f.type })),
         ...pastedAttachments,
@@ -400,6 +405,11 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
     // out into a chip instead of keeping it in the TextInput.
     const handleChangeText = useCallback(
       (next: string) => {
+        if (pasteHandledRef.current) {
+          pasteHandledRef.current = false
+          return
+        }
+
         const paste = extractLongPaste(valueRef.current, next)
         if (paste) {
           addPastedText(paste.inserted)
@@ -793,7 +803,7 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
                   <View className="h-5 w-5 rounded-full items-center justify-center bg-primary opacity-50">
                     <Loader2 className="h-3 w-3 text-primary-foreground" size={12} />
                   </View>
-                ) : (value.trim() || pendingFiles.length > 0) ? (
+                ) : (value.trim() || pendingFiles.length > 0 || pastedTexts.length > 0) ? (
                   <Pressable
                     onPress={handleSubmit}
                     disabled={disabled}

--- a/apps/mobile/components/chat/PastedTextChip.tsx
+++ b/apps/mobile/components/chat/PastedTextChip.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * PastedTextChip — compact file-style chip for a pasted long-text block.
+ *
+ * Used by ChatInput and CompactChatInput. Visually mirrors the non-image
+ * file chip (ChatGPT-style): small card with icon, kind label, size/line
+ * count, and a close button. Tapping the chip opens a FileViewerModal
+ * showing the full contents.
+ */
+
+import { View, Text, Pressable } from "react-native"
+import { FileText, X } from "lucide-react-native"
+import { cn } from "@shogo/shared-ui/primitives"
+import { kindLabel, type PastedTextEntry } from "./long-text-utils"
+
+export interface PastedTextChipProps {
+  entry: PastedTextEntry
+  onOpen: () => void
+  onRemove: () => void
+  /** Optional extra className for the outer wrapper. */
+  className?: string
+}
+
+export function PastedTextChip({
+  entry,
+  onOpen,
+  onRemove,
+  className,
+}: PastedTextChipProps) {
+  return (
+    <View className={cn("relative w-[180px]", className)}>
+      <Pressable
+        onPress={onOpen}
+        className="rounded-lg border border-border bg-muted/50 p-2"
+        accessibilityLabel="View pasted text"
+        accessibilityRole="button"
+      >
+        <View className="flex-row items-center gap-2">
+          <View className="h-7 w-7 items-center justify-center rounded-md bg-primary/15">
+            <FileText size={14} className="text-primary" />
+          </View>
+          <View className="flex-1 min-w-0">
+            <Text
+              className="text-xs font-medium text-foreground"
+              numberOfLines={1}
+            >
+              {kindLabel(entry.info.kind)} paste
+            </Text>
+            <Text
+              className="text-[10px] text-muted-foreground"
+              numberOfLines={1}
+            >
+              {entry.info.sizeLabel} · {entry.info.lines} lines
+            </Text>
+          </View>
+        </View>
+      </Pressable>
+      <Pressable
+        onPress={onRemove}
+        className="absolute -right-1 -top-1 h-5 w-5 rounded-full bg-destructive items-center justify-center"
+        accessibilityLabel="Remove pasted text"
+        accessibilityRole="button"
+        hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+      >
+        <X className="h-3 w-3 text-destructive-foreground" size={10} />
+      </Pressable>
+    </View>
+  )
+}
+
+export default PastedTextChip

--- a/apps/mobile/components/chat/long-text-utils.ts
+++ b/apps/mobile/components/chat/long-text-utils.ts
@@ -12,6 +12,7 @@
 const CHAR_THRESHOLD = 5_000
 const BYTE_THRESHOLD = 5 * 1024 // 5 KB
 const LINE_THRESHOLD = 150
+export const MAX_PASTED_TEXTS = 10
 
 /**
  * Detected content type used for display hints (icon, label, syntax).
@@ -51,18 +52,22 @@ function detectKind(text: string): ContentKind {
   const sample = text.length > 2048 ? text.slice(0, 2048) : text
   const trimmed = sample.trimStart()
 
-  const startsObj = trimmed.startsWith("{") || trimmed.startsWith("[")
-  if (startsObj) {
-    // Quick heuristic: looks like JSON but don't parse the full string
-    const endChar = text.trimEnd().slice(-1)
-    if ((trimmed[0] === "{" && endChar === "}") || (trimmed[0] === "[" && endChar === "]")) {
-      return "json"
-    }
-  }
-
   const codePatterns =
     /^(import |export |const |let |var |function |class |def |fn |pub |package |#include|<\?php|from .+ import)/m
   if (codePatterns.test(trimmed)) return "code"
+
+  const startsObj = trimmed.startsWith("{") || trimmed.startsWith("[")
+  if (startsObj) {
+    const endChar = text.trimEnd().slice(-1)
+    if ((trimmed[0] === "{" && endChar === "}") || (trimmed[0] === "[" && endChar === "]")) {
+      // Disambiguate: only call it JSON if the first line looks like a JSON
+      // key/value or array element, not a code block (CSS, Go, Rust, etc.)
+      const nlIdx = trimmed.indexOf("\n")
+      const firstLine = trimmed.slice(0, nlIdx >= 0 ? nlIdx : 200)
+      const looksLikeJson = /^\s*[\[{]\s*$/.test(firstLine) || /"[^"]*"\s*:/.test(firstLine)
+      if (looksLikeJson) return "json"
+    }
+  }
 
   const mdPatterns = /^(#{1,6} |\* |- |\d+\. |\[.*\]\(.*\))/m
   if (mdPatterns.test(trimmed)) return "markdown"
@@ -169,7 +174,8 @@ export function extractLongPaste(
   prev: string,
   next: string
 ): { inserted: string; restored: string; info: ContentSizeInfo } | null {
-  if (next.length - prev.length < LONG_PASTE_MIN_CHARS) return null
+  // Quick exit: if next is shorter or barely longer, no large paste happened.
+  if (next.length <= prev.length) return null
 
   let prefixLen = 0
   const minLen = Math.min(prev.length, next.length)
@@ -191,6 +197,9 @@ export function extractLongPaste(
   }
 
   const inserted = next.slice(prefixLen, next.length - suffixLen)
+  // Threshold is on the *inserted* content, not the delta — this ensures
+  // select-all-then-paste of a large block is still detected even when the
+  // replaced selection shrinks the net delta below the threshold.
   if (inserted.length < LONG_PASTE_MIN_CHARS) return null
 
   const info = analyzeContent(inserted)
@@ -199,22 +208,6 @@ export function extractLongPaste(
   const restored =
     prev.slice(0, prefixLen) + prev.slice(prev.length - suffixLen)
   return { inserted, restored, info }
-}
-
-/**
- * Build the final message content by appending pasted text blocks to the
- * user's typed content. Keeps typed text first, then each pasted block
- * separated by a blank line.
- */
-export function composePastedContent(
-  typed: string,
-  pasted: PastedTextEntry[]
-): string {
-  const trimmed = typed.trim()
-  if (pasted.length === 0) return trimmed
-  const blocks = pasted.map((p) => p.content.trim()).filter(Boolean)
-  if (blocks.length === 0) return trimmed
-  return trimmed ? `${trimmed}\n\n${blocks.join("\n\n")}` : blocks.join("\n\n")
 }
 
 /**
@@ -227,11 +220,12 @@ function encodeTextAsDataUrl(content: string, mediaType: string): string {
   try {
     const bytes = new TextEncoder().encode(content)
     let binary = ""
-    const chunkSize = 0x8000
-    for (let i = 0; i < bytes.length; i += chunkSize) {
-      binary += String.fromCharCode(
-        ...Array.from(bytes.subarray(i, i + chunkSize))
-      )
+    // Process in chunks to avoid call-stack overflow with Function.apply
+    for (let i = 0; i < bytes.length; i += 0x8000) {
+      const chunk = bytes.subarray(i, i + 0x8000)
+      for (let j = 0; j < chunk.length; j++) {
+        binary += String.fromCharCode(chunk[j])
+      }
     }
     // eslint-disable-next-line no-restricted-globals
     const b64 = (globalThis as any).btoa?.(binary)
@@ -263,22 +257,37 @@ const EXT_BY_KIND: Record<ContentKind, string> = {
  * render it as a discrete chip (one chip per paste) instead of merging
  * everything into a single blob.
  *
- * `index` is used to disambiguate names when the user pastes multiple
- * blocks of the same kind in one turn (e.g. "Pasted code.txt",
- * "Pasted code (2).txt").
+ * `kindIndex` is the 0-based occurrence of this kind within the current
+ * batch (e.g. the second JSON paste has kindIndex=1). Use
+ * `buildPastedAttachments` to compute these automatically.
  */
 export function pastedEntryToAttachment(
   entry: PastedTextEntry,
-  index = 0
+  kindIndex = 0
 ): { dataUrl: string; name: string; type: string } {
   const { content, info } = entry
   const mediaType = MEDIA_TYPE_BY_KIND[info.kind]
   const ext = EXT_BY_KIND[info.kind]
   const base = `Pasted ${kindLabel(info.kind).toLowerCase()}`
-  const name = index === 0 ? `${base}.${ext}` : `${base} (${index + 1}).${ext}`
+  const name = kindIndex === 0 ? `${base}.${ext}` : `${base} (${kindIndex + 1}).${ext}`
   return {
     dataUrl: encodeTextAsDataUrl(content, mediaType),
     name,
     type: mediaType,
   }
+}
+
+/**
+ * Convert all pasted entries to file attachments with per-kind numbering.
+ */
+export function buildPastedAttachments(
+  entries: PastedTextEntry[]
+): { dataUrl: string; name: string; type: string }[] {
+  const kindCounts: Record<string, number> = {}
+  return entries.map((entry) => {
+    const k = entry.info.kind
+    const idx = kindCounts[k] ?? 0
+    kindCounts[k] = idx + 1
+    return pastedEntryToAttachment(entry, idx)
+  })
 }

--- a/apps/mobile/components/chat/long-text-utils.ts
+++ b/apps/mobile/components/chat/long-text-utils.ts
@@ -138,3 +138,147 @@ export function kindLabel(kind: ContentKind): string {
  */
 export const LONG_TEXT_CHIP_LAYOUT_CLASS =
   "w-full max-w-[min(100%,20rem)] self-start"
+
+/**
+ * Minimum size (in characters) for a newly-inserted chunk to be treated
+ * as a "paste large block" action. Below this, we leave the text in the
+ * TextInput so short pastes (URLs, sentences) behave normally.
+ */
+export const LONG_PASTE_MIN_CHARS = 2_000
+
+/**
+ * A single pasted-text block that has been extracted from the TextInput
+ * and is now rendered as a compact file-like chip.
+ */
+export interface PastedTextEntry {
+  id: string
+  content: string
+  info: ContentSizeInfo
+}
+
+/**
+ * Compare a previous and next value from an onChangeText event and, if a
+ * single large chunk was inserted, return the inserted chunk along with
+ * the text that should be restored to the input (i.e. prev minus any
+ * selection that was replaced by the paste).
+ *
+ * Returns null if the insertion isn't large enough to qualify as a long
+ * paste — in that case the caller should let the change through normally.
+ */
+export function extractLongPaste(
+  prev: string,
+  next: string
+): { inserted: string; restored: string; info: ContentSizeInfo } | null {
+  if (next.length - prev.length < LONG_PASTE_MIN_CHARS) return null
+
+  let prefixLen = 0
+  const minLen = Math.min(prev.length, next.length)
+  while (
+    prefixLen < minLen &&
+    prev.charCodeAt(prefixLen) === next.charCodeAt(prefixLen)
+  ) {
+    prefixLen++
+  }
+
+  let suffixLen = 0
+  const maxSuffix = minLen - prefixLen
+  while (
+    suffixLen < maxSuffix &&
+    prev.charCodeAt(prev.length - 1 - suffixLen) ===
+      next.charCodeAt(next.length - 1 - suffixLen)
+  ) {
+    suffixLen++
+  }
+
+  const inserted = next.slice(prefixLen, next.length - suffixLen)
+  if (inserted.length < LONG_PASTE_MIN_CHARS) return null
+
+  const info = analyzeContent(inserted)
+  if (!info.isLong) return null
+
+  const restored =
+    prev.slice(0, prefixLen) + prev.slice(prev.length - suffixLen)
+  return { inserted, restored, info }
+}
+
+/**
+ * Build the final message content by appending pasted text blocks to the
+ * user's typed content. Keeps typed text first, then each pasted block
+ * separated by a blank line.
+ */
+export function composePastedContent(
+  typed: string,
+  pasted: PastedTextEntry[]
+): string {
+  const trimmed = typed.trim()
+  if (pasted.length === 0) return trimmed
+  const blocks = pasted.map((p) => p.content.trim()).filter(Boolean)
+  if (blocks.length === 0) return trimmed
+  return trimmed ? `${trimmed}\n\n${blocks.join("\n\n")}` : blocks.join("\n\n")
+}
+
+/**
+ * Encode a text blob as a base64 data URL. Used to ship pasted long-text
+ * blocks as file attachments so they render as separate file chips in the
+ * chat transcript (ChatGPT-style) instead of being inlined as a single
+ * long-text preview card.
+ */
+function encodeTextAsDataUrl(content: string, mediaType: string): string {
+  try {
+    const bytes = new TextEncoder().encode(content)
+    let binary = ""
+    const chunkSize = 0x8000
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+      binary += String.fromCharCode(
+        ...Array.from(bytes.subarray(i, i + chunkSize))
+      )
+    }
+    // eslint-disable-next-line no-restricted-globals
+    const b64 = (globalThis as any).btoa?.(binary)
+    if (typeof b64 === "string") {
+      return `data:${mediaType};base64,${b64}`
+    }
+  } catch {
+    // fall through to the percent-encoded form
+  }
+  return `data:${mediaType};charset=utf-8,${encodeURIComponent(content)}`
+}
+
+const MEDIA_TYPE_BY_KIND: Record<ContentKind, string> = {
+  json: "application/json",
+  code: "text/plain",
+  markdown: "text/markdown",
+  plain: "text/plain",
+}
+
+const EXT_BY_KIND: Record<ContentKind, string> = {
+  json: "json",
+  code: "txt",
+  markdown: "md",
+  plain: "txt",
+}
+
+/**
+ * Convert a pasted long-text entry to a file attachment so the chat can
+ * render it as a discrete chip (one chip per paste) instead of merging
+ * everything into a single blob.
+ *
+ * `index` is used to disambiguate names when the user pastes multiple
+ * blocks of the same kind in one turn (e.g. "Pasted code.txt",
+ * "Pasted code (2).txt").
+ */
+export function pastedEntryToAttachment(
+  entry: PastedTextEntry,
+  index = 0
+): { dataUrl: string; name: string; type: string } {
+  const { content, info } = entry
+  const mediaType = MEDIA_TYPE_BY_KIND[info.kind]
+  const ext = EXT_BY_KIND[info.kind]
+  const base = `Pasted ${kindLabel(info.kind).toLowerCase()}`
+  const name = index === 0 ? `${base}.${ext}` : `${base} (${index + 1}).${ext}`
+  return {
+    dataUrl: encodeTextAsDataUrl(content, mediaType),
+    name,
+    type: mediaType,
+  }
+}

--- a/apps/mobile/components/chat/turns/MessageContent.tsx
+++ b/apps/mobile/components/chat/turns/MessageContent.tsx
@@ -175,15 +175,17 @@ function DocumentThumbnail({
     }
     setLoading(true)
     try {
-      const res = await fetch(url)
-      const contentLength = parseInt(res.headers.get("content-length") || "0", 10)
       const MAX_FILE_BYTES = 1 * 1024 * 1024 // 1 MB
+      const res = await fetch(url)
+      // content-length may be absent for data: URLs — fall through to text check
+      const contentLength = parseInt(res.headers.get("content-length") || "0", 10)
       if (contentLength > MAX_FILE_BYTES) {
         Linking.openURL(url)
         return
       }
       const text = await res.text()
-      setFileContent(text.length > MAX_FILE_BYTES ? text.slice(0, MAX_FILE_BYTES) + "\n\n…[truncated]" : text)
+      const byteSize = new Blob([text]).size
+      setFileContent(byteSize > MAX_FILE_BYTES ? text.slice(0, MAX_FILE_BYTES) + "\n\n…[truncated]" : text)
       setShowModal(true)
     } catch {
       Linking.openURL(url)
@@ -196,12 +198,12 @@ function DocumentThumbnail({
     <>
       <Pressable
         onPress={handlePress}
-        className="flex-row items-center gap-2 rounded-lg border border-border bg-muted/50 px-2.5 py-2 w-[220px] max-w-full"
+        className="flex-row items-center gap-2.5 rounded-xl border border-border bg-muted/40 px-3 py-2.5 min-w-[200px] max-w-full"
         accessibilityLabel={`File attachment ${index + 1}: ${title}`}
         accessibilityRole="button"
       >
-        <View className="h-8 w-8 items-center justify-center rounded-md bg-primary/15 flex-shrink-0">
-          <FileText size={16} className="text-primary" />
+        <View className="h-9 w-9 items-center justify-center rounded-lg bg-primary/15 flex-shrink-0">
+          <FileText size={18} className="text-primary" />
         </View>
         <View className="flex-1 min-w-0">
           <Text
@@ -210,7 +212,7 @@ function DocumentThumbnail({
           >
             {title}
           </Text>
-          <Text className="text-[10px] text-muted-foreground" numberOfLines={1}>
+          <Text className="text-[11px] text-muted-foreground" numberOfLines={1}>
             {loading ? "Loading…" : typeLabel}
           </Text>
         </View>
@@ -237,7 +239,13 @@ export function MessageContent({
   const images = extractImageParts(message)
   const files = extractFileParts(message)
   const isUser = message.role === "user"
-  const isLongText = isUser && content ? analyzeContent(content).isLong : false
+  // Only show the preview card when there's genuinely long typed text and no
+  // file attachments. When file chips are present the text body is just the
+  // typed portion (short) so we always render it inline — matching ChatGPT.
+  const hasAttachments = files.length > 0 || images.length > 0
+  const isLongText = isUser && content && !hasAttachments
+    ? analyzeContent(content).isLong
+    : false
 
   const baseClasses = cn(
     "rounded-md px-3 py-1.5",

--- a/apps/mobile/components/chat/turns/MessageContent.tsx
+++ b/apps/mobile/components/chat/turns/MessageContent.tsx
@@ -36,6 +36,33 @@ interface FilePart {
   name?: string
 }
 
+function deriveFileLabel(mediaType: string, name?: string): {
+  title: string
+  kindLabel: string
+} {
+  if (name) {
+    const ext = name.includes(".") ? name.split(".").pop()!.toUpperCase() : ""
+    const kindFromMedia = mediaType.includes("json")
+      ? "JSON"
+      : mediaType.includes("markdown")
+      ? "Markdown"
+      : mediaType.includes("pdf")
+      ? "PDF"
+      : mediaType.startsWith("text/")
+      ? "Text"
+      : ext || (mediaType.split("/").pop() || "FILE").toUpperCase()
+    return { title: name, kindLabel: kindFromMedia }
+  }
+  if (mediaType.includes("pdf")) return { title: "PDF document", kindLabel: "PDF" }
+  if (mediaType.includes("json")) return { title: "JSON file", kindLabel: "JSON" }
+  if (mediaType.includes("markdown")) return { title: "Markdown", kindLabel: "Markdown" }
+  if (mediaType.startsWith("text/")) return { title: "Text file", kindLabel: "Text" }
+  return {
+    title: "Attachment",
+    kindLabel: (mediaType.split("/").pop() || "FILE").toUpperCase(),
+  }
+}
+
 export { extractTextContent } from "@shogo/shared-app/chat"
 
 function extractImageParts(message: UIMessage): ImagePart[] {
@@ -71,6 +98,7 @@ function extractFileParts(message: UIMessage): FilePart[] {
     .map((part) => ({
       url: part.url,
       mediaType: part.mediaType || "application/octet-stream",
+      ...(part.name ? { name: part.name } : {}),
     }))
 }
 
@@ -115,19 +143,19 @@ function ImageThumbnail({
 function DocumentThumbnail({
   url,
   mediaType,
+  name,
   index,
 }: {
   url: string
   mediaType: string
+  name?: string
   index: number
 }) {
   const [showModal, setShowModal] = useState(false)
   const [fileContent, setFileContent] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
-  const label = mediaType.includes("pdf")
-    ? "PDF"
-    : mediaType.split("/").pop()?.toUpperCase() || "FILE"
+  const { title, kindLabel: typeLabel } = deriveFileLabel(mediaType, name)
 
   const isTextLike =
     mediaType.startsWith("text/") ||
@@ -168,22 +196,32 @@ function DocumentThumbnail({
     <>
       <Pressable
         onPress={handlePress}
-        className="flex-row items-center gap-2 rounded-md border border-border bg-muted/50 px-3 py-2"
-        accessibilityLabel={`File attachment ${index + 1}: ${label}`}
+        className="flex-row items-center gap-2 rounded-lg border border-border bg-muted/50 px-2.5 py-2 w-[220px] max-w-full"
+        accessibilityLabel={`File attachment ${index + 1}: ${title}`}
         accessibilityRole="button"
       >
-        <FileText size={16} className="text-muted-foreground" />
-        <Text className="text-xs text-muted-foreground">
-          {loading ? "Loading…" : `${label} · Tap to view`}
-        </Text>
+        <View className="h-8 w-8 items-center justify-center rounded-md bg-primary/15 flex-shrink-0">
+          <FileText size={16} className="text-primary" />
+        </View>
+        <View className="flex-1 min-w-0">
+          <Text
+            className="text-xs font-medium text-foreground"
+            numberOfLines={1}
+          >
+            {title}
+          </Text>
+          <Text className="text-[10px] text-muted-foreground" numberOfLines={1}>
+            {loading ? "Loading…" : typeLabel}
+          </Text>
+        </View>
       </Pressable>
       {fileContent !== null && (
         <FileViewerModal
           visible={showModal}
           onClose={() => setShowModal(false)}
           content={fileContent}
-          title={`${label} File`}
-          kind={mediaType.includes("json") ? "json" : "plain"}
+          title={title}
+          kind={mediaType.includes("json") ? "json" : mediaType.includes("markdown") ? "markdown" : "plain"}
         />
       )}
     </>
@@ -212,15 +250,6 @@ export function MessageContent({
   if (isUser) {
     return (
       <View className={cn(baseClasses, "gap-2")}>
-        {content ? (
-          isLongText ? (
-            <LongTextPreviewCard text={content} title="Your Message" />
-          ) : (
-            <Text className="text-xs text-foreground" selectable>
-              {content}
-            </Text>
-          )
-        ) : null}
         {images.length > 0 && (
           <View className="flex-row flex-wrap gap-2">
             {images.map((img, i) => (
@@ -234,17 +263,27 @@ export function MessageContent({
           </View>
         )}
         {files.length > 0 && (
-          <View className="flex-row flex-wrap gap-2">
+          <View className="flex-col gap-1.5">
             {files.map((file, i) => (
               <DocumentThumbnail
                 key={`${message.id}-file-${i}`}
                 url={file.url}
                 mediaType={file.mediaType}
+                name={file.name}
                 index={i}
               />
             ))}
           </View>
         )}
+        {content ? (
+          isLongText ? (
+            <LongTextPreviewCard text={content} title="Your Message" />
+          ) : (
+            <Text className="text-xs text-foreground" selectable>
+              {content}
+            </Text>
+          )
+        ) : null}
       </View>
     )
   }
@@ -272,12 +311,13 @@ export function MessageContent({
         </View>
       )}
       {files.length > 0 && (
-        <View className="flex-row flex-wrap gap-2">
+        <View className="flex-col gap-1.5">
           {files.map((file, i) => (
             <DocumentThumbnail
               key={`${message.id}-file-${i}`}
               url={file.url}
               mediaType={file.mediaType}
+              name={file.name}
               index={i}
             />
           ))}

--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -205,6 +205,16 @@ textarea:focus {
   outline-color: rgb(var(--color-ring)) !important;
 }
 
+/* Chat-style inputs opt out of the orange focus ring. The textarea sits
+   inside an `overflow-hidden` rounded container with sibling chips above
+   it; a 2px outline bleeds upward through the clip and shows as a stray
+   orange horizontal line between the chip row and the text field. */
+input.no-focus-ring:focus,
+textarea.no-focus-ring:focus {
+  outline: none !important;
+  box-shadow: none !important;
+}
+
 /* Expo web: full-height chain so auth hero (flex + CSS background) fills the viewport */
 html,
 body {


### PR DESCRIPTION
Closes #390

## Summary

Reworks the long-text paste UX in the mobile chat input (`ChatInput` and `CompactChatInput`) so big pastes no longer collapse the whole input and block further typing. Pastes now behave like ChatGPT: each large paste becomes its own compact file-style chip rendered above the textarea, the input stays editable, and multiple pastes per message are supported.

## Changes

### `long-text-utils.ts`
- Add `LONG_PASTE_MIN_CHARS`, `PastedTextEntry`, `extractLongPaste`, `buildPastedAttachments`, and helpers to encode a paste as a base64 data URL and pick a sensible filename/ext (`Pasted code.txt`, `Pasted JSON.json`, `Pasted markdown.md`, ...).
- `extractLongPaste` qualifies on the **inserted chunk length** (not net delta), so select-and-replace pastes are correctly detected.
- JSON detection runs **after** code-pattern check and requires the first line to look like a JSON key/value, avoiding false positives on CSS, Go, Rust, and Python dicts.
- `MAX_PASTED_TEXTS = 10` cap prevents unbounded memory growth.
- `buildPastedAttachments` uses per-kind numbering (two code pastes → `Pasted code.txt`, `Pasted code (2).txt`) regardless of interleaved JSON pastes.
- `encodeTextAsDataUrl` uses a per-byte loop instead of spread to avoid call-stack overflow on large chunks.
- Removed dead `composePastedContent` export.

### `PastedTextChip.tsx` (new)
- Compact chip with file icon, kind label, size + line count, remove button. Tapping opens the existing `FileViewerModal`.

### `ChatInput.tsx` / `CompactChatInput.tsx`
- Replace the old "collapse the whole input into one card" flow with a list of `PastedTextEntry` chips.
- Detect pastes on web via a DOM `paste` listener (alongside existing image paste handling) and on native via a diff of `onChangeText` transitions, so both platforms route through the same chip extraction.
- **Double-interception guard**: `pasteHandledRef` prevents the DOM paste listener and `onChangeText` fallback from both firing for the same event, avoiding duplicate chips.
- **Stale closure fix**: `ChatInput.handleChangeText` reads from `inputValueRef` (a ref) instead of captured state, matching `CompactChatInput`.
- **Send button visibility**: includes `pastedTexts.length > 0` so chip-only messages (no typed text) can still be sent.
- **ChatGPT-style submit**: typed text is sent as the message body; pasted content travels exclusively as file attachments. The model receives both text and file parts. No giant "Your Message 65 KB" preview card — just compact file chips above plain typed text.

### `turns/MessageContent.tsx`
- `LongTextPreviewCard` only activates when there are no file/image attachments, so messages with file chips always show typed text inline.
- `DocumentThumbnail` shows the real filename (from `part.name`) + type label, uses ChatGPT-style card layout with responsive width.
- File truncation guard uses `Blob` byte-size instead of `text.length` (char count) for accurate multibyte handling.
- Attachments stack vertically (`flex-col`) instead of wrapping as tight pills.

### `global.css`
- Add `.no-focus-ring` opt-out for the chat textarea; the global focus outline was bleeding upward through the rounded `overflow-hidden` container.

No API / backend / schema changes. Mobile app only.

## Edge cases addressed

| Issue | Fix |
|-------|-----|
| Send button invisible with chips-only (no typed text) | Added `pastedTexts.length > 0` to visibility gates |
| Duplicate chips on web (paste + onChangeText both fire) | `pasteHandledRef` guard suppresses the fallback |
| Stale `inputValue` in `ChatInput.handleChangeText` | Uses `inputValueRef` (ref) instead of captured state |
| Select-and-replace paste not detected (delta too small) | Threshold checks inserted length, not net delta |
| Giant "Your Message 65 KB" preview card in transcript | Typed text only in message body; pasted content as file attachments |
| JSON false positives (CSS, Go, Python dicts) | Code patterns checked first; stricter JSON first-line heuristic |
| No limit on pasted text count (memory explosion) | `MAX_PASTED_TEXTS = 10` cap |
| `DocumentThumbnail` content-length unreliable for data URLs | Uses `Blob` byte-size for truncation check |
| File naming collision across kinds | Per-kind numbering via `buildPastedAttachments` |
| `encodeTextAsDataUrl` stack overflow on large chunks | Per-byte loop instead of `String.fromCharCode(...spread)` |

## Test plan

- [x] Web: paste ~5 KB of plain text — a chip appears, input stays editable, can keep typing after.
- [x] Web: paste a large JSON blob — chip labelled "JSON paste", opens in viewer modal as JSON.
- [x] Web: paste twice — two independent chips, remove one leaves the other + typed content intact.
- [x] Web: short paste (URL, a sentence) still goes inline into the textarea.
- [x] Native (iOS/Android): paste a large block — chip appears via `onChangeText` fallback, input keeps the pre-paste text (if any).
- [x] Submit with typed text + one paste — message renders typed text plus a discrete file chip showing the paste filename.
- [x] Submit with typed text + multiple pastes — each paste renders as its own chip in the transcript.
- [x] Submit with only pasted chips (no typed text) — send button is visible, message sends correctly.
- [x] Tap a sent file chip — opens in `FileViewerModal` with the correct kind and size label.
- [x] Web: no orange horizontal line between the chip row and the textarea when focused.
- [x] Select all text then paste — large paste is still detected and extracted into a chip.
- [x] Paste CSS/Go/Rust code starting with `{` — classified as "code", not "JSON".