### PR TITLE
feat(mobile): user message copy on hover

### DIFF
--- a/apps/mobile/components/chat/turns/TurnGroup.tsx
+++ b/apps/mobile/components/chat/turns/TurnGroup.tsx
@@ -121,7 +121,17 @@ export const TurnGroup = memo(
     >
       {/* User message */}
       {turn.userMessage && (
-        <View className="w-full flex-row items-end justify-end gap-2">
+        <View className="group w-full flex-row items-end justify-end gap-1">
+          <View
+            className={cn(
+              "items-center justify-center",
+              "opacity-100 web:opacity-0 web:pointer-events-none web:transition-opacity",
+              "web:group-hover:opacity-100 web:group-hover:pointer-events-auto",
+              "web:group-focus-within:opacity-100 web:group-focus-within:pointer-events-auto"
+            )}
+          >
+            <CopyButton text={extractTextContent(turn.userMessage)} />
+          </View>
           <MessageContent message={turn.userMessage} className="ml-0" />
         </View>
       )}


### PR DESCRIPTION
## Summary
- Adds a **Copy** control next to user chat bubbles (same pattern as assistant copy), visible on hover/focus on web and always on native.
- Keeps user bubble layout unchanged: copy sits as a flex sibling with `ml-0` on `MessageContent` so short prompts stay on one line.


https://github.com/user-attachments/assets/3effa3d7-93ab-4b0b-b734-95e55be2f8f6




