### PR TITLE
fix(agent-runtime): graceful error handling for read_file image path

### DIFF
--- a/packages/agent-runtime/src/gateway-tools.ts
+++ b/packages/agent-runtime/src/gateway-tools.ts
@@ -352,29 +352,36 @@ function createReadFileTool(ctx: ToolContext): AgentTool {
       const imageExt = extname(resolved).toLowerCase()
       const imageMime = IMAGE_READ_MIME[imageExt]
       if (imageMime) {
-        const imgStat = statSync(resolved)
-        if (imgStat.size > MAX_IMAGE_READ_BYTES) {
+        try {
+          const imgStat = statSync(resolved)
+          if (imgStat.size > MAX_IMAGE_READ_BYTES) {
+            return textResult({
+              error: `Image too large to read: ${filePath} (${imgStat.size} bytes, max ${MAX_IMAGE_READ_BYTES}). ` +
+                'Downscale the image before reading.',
+            })
+          }
+          const buf = readFileSync(resolved)
+          const base64 = buf.toString('base64')
+          const details = {
+            path: filePath,
+            bytes: buf.length,
+            mimeType: imageMime,
+            ...(offset !== undefined || limit !== undefined
+              ? { note: 'offset/limit are ignored for image files.' }
+              : {}),
+          }
+          return {
+            content: [
+              { type: 'image' as const, data: base64, mimeType: imageMime },
+              { type: 'text' as const, text: JSON.stringify(details) },
+            ],
+            details,
+          }
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err)
           return textResult({
-            error: `Image too large to read: ${filePath} (${imgStat.size} bytes, max ${MAX_IMAGE_READ_BYTES}). ` +
-              'Downscale the image before reading.',
+            error: `Failed to read image file: ${filePath} — ${msg}`,
           })
-        }
-        const buf = readFileSync(resolved)
-        const base64 = buf.toString('base64')
-        const details = {
-          path: filePath,
-          bytes: buf.length,
-          mimeType: imageMime,
-          ...(offset !== undefined || limit !== undefined
-            ? { note: 'offset/limit are ignored for image files.' }
-            : {}),
-        }
-        return {
-          content: [
-            { type: 'image' as const, data: base64, mimeType: imageMime },
-            { type: 'text' as const, text: JSON.stringify(details) },
-          ],
-          details,
         }
       }
 


### PR DESCRIPTION
## Summary

- Wraps `statSync` and `readFileSync` in the image branch of the `read_file` tool with `try/catch`
- On failure (permissions, disk I/O, race conditions), returns a clean `textResult({ error })` to the model instead of throwing an uncaught exception through the tool layer
- Matches the existing error pattern used by the oversize-image check

## Motivation

Commit `0c7f90e` added multimodal image reading to `read_file` but left `statSync`/`readFileSync` unguarded. If the file is unreadable (e.g. permission denied, removed between `existsSync` and `readFileSync`, or disk error), the tool throws an uncaught exception that bubbles up as an internal runtime error rather than a graceful message the model can reason about and recover from.

## What changed

**`packages/agent-runtime/src/gateway-tools.ts`** — the image read path (lines ~354–385):
- Added `try/catch` around `statSync` + `readFileSync`
- The `catch` block extracts the error message and returns `textResult({ error: "Failed to read image file: <path> — <reason>" })`
- No behavioral change for the happy path or the existing oversize check

## Test plan

- [ ] Verify existing `gateway-tools.test.ts` image tests still pass
- [ ] Manually test with a permission-denied file (e.g. `chmod 000 test.png`) and confirm the model receives a clean error
- [ ] Verify large image (>20 MB) still returns the existing "too large" error unchanged


Made with [Cursor](https://cursor.com)