### PR TITLE
fix: Windows first-run bricks (P3005, UAC-elevation, missing-Node, agent-runtime EPERM, VM-pool fallback)

### DIFF
--- a/apps/api/src/lib/vm-warm-pool-controller.ts
+++ b/apps/api/src/lib/vm-warm-pool-controller.ts
@@ -56,6 +56,27 @@ export type VMManagerFactory = () => VMManagerInterface
 
 const MAX_CONSECUTIVE_FAILURES = 3
 
+/**
+ * Thrown when `_assignProject` is called but the warm pool has permanently
+ * disabled itself after exceeding `MAX_CONSECUTIVE_FAILURES` VM boot failures.
+ * This is a dedicated type so callers (e.g. project-chat `getProjectUrl`) can
+ * distinguish a permanent capability failure from a transient boot error and,
+ * on the desktop, fall back to the host RuntimeManager path safely — no VM is
+ * ever going to come back up in this session, so the "split-brain" concern
+ * that normally forbids that fallback does not apply.
+ */
+export class VMPoolPermanentlyDisabledError extends Error {
+  readonly code = 'VM_POOL_PERMANENTLY_DISABLED'
+  constructor(public readonly consecutiveFailures: number) {
+    super(
+      `VM warm pool disabled after ${consecutiveFailures} consecutive boot failures. ` +
+        `QEMU/WHPX cannot boot an agent VM on this host. Set vmIsolation.enabled=false ` +
+        `in Shogo config.json to use host execution instead, or inspect the VM boot logs.`,
+    )
+    this.name = 'VMPoolPermanentlyDisabledError'
+  }
+}
+
 export class VMWarmPoolController {
   private available = new Map<string, VMPodInfo>()
   private assigned = new Map<string, VMPodInfo>()
@@ -231,11 +252,15 @@ export class VMWarmPoolController {
     return promise
   }
 
+  /** True once the warm pool has tripped its consecutive-failure kill switch
+   *  and refuses to boot any further VMs for the remainder of this session. */
+  isPermanentlyDisabled(): boolean {
+    return this.consecutiveBootFailures >= MAX_CONSECUTIVE_FAILURES
+  }
+
   private async _assignProject(projectId: string): Promise<string> {
     if (this.consecutiveBootFailures >= MAX_CONSECUTIVE_FAILURES) {
-      throw new Error(
-        `VM warm pool disabled after ${this.consecutiveBootFailures} consecutive boot failures`
-      )
+      throw new VMPoolPermanentlyDisabledError(this.consecutiveBootFailures)
     }
 
     // Evict dead VM if one was assigned previously

--- a/apps/api/src/routes/project-chat.ts
+++ b/apps/api/src/routes/project-chat.ts
@@ -473,15 +473,31 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
       return await getProjectPodUrl(projectId)
     } else if (isVMIsolation()) {
       // Desktop VM: VMWarmPoolController (same claim/assign pattern as K8s).
-      // Do NOT fall back to local RuntimeManager — that creates a split-brain
-      // where the preview renders from the host but the agent runs in the VM.
-      const { getVMProjectUrl } = await import("../lib/vm-warm-pool-controller")
+      // Normally we do NOT fall back to the local RuntimeManager — that would
+      // create a split-brain where the preview renders from the host but the
+      // agent runs in the VM. The one exception is when the warm pool has
+      // permanently disabled itself (3+ boot failures): in that case no VM is
+      // running at all, so falling back to the host runtime is safe and gives
+      // the user a working runtime instead of a cryptic `pod_unavailable`.
+      const vmPool = await import("../lib/vm-warm-pool-controller")
+      const { getVMProjectUrl, VMPoolPermanentlyDisabledError } = vmPool
       const maxRetries = 5
       const retryDelayMs = 3000
       for (let attempt = 1; attempt <= maxRetries; attempt++) {
         try {
           return await getVMProjectUrl(projectId)
         } catch (err) {
+          if (err instanceof VMPoolPermanentlyDisabledError) {
+            if (runtimeManager) {
+              console.warn(
+                `[ProjectChat] VM warm pool permanently disabled (${err.consecutiveFailures} boot failures); ` +
+                  `falling back to host RuntimeManager for project ${projectId}. ` +
+                  `To silence this warning, set vmIsolation.enabled=false in the desktop config.`,
+              )
+              break
+            }
+            throw err
+          }
           if (attempt === maxRetries) throw err
           console.log(`[ProjectChat] VM not ready (attempt ${attempt}/${maxRetries}), retrying in ${retryDelayMs}ms...`)
           await new Promise(r => setTimeout(r, retryDelayMs))

--- a/apps/api/src/routes/vm.ts
+++ b/apps/api/src/routes/vm.ts
@@ -227,6 +227,12 @@ export interface QemuInstallState {
   status: 'idle' | 'installing' | 'complete' | 'error'
   output: string
   error?: string
+  /**
+   * Machine-readable code for structured handling of specific failure modes.
+   * Currently set to 'UAC_DECLINED' when the user dismisses the Windows
+   * User Account Control consent dialog during the elevated installer launch.
+   */
+  errorCode?: string
 }
 
 let qemuInstallState: QemuInstallState = { status: 'idle', output: '' }
@@ -331,25 +337,124 @@ async function downloadQemuInstaller(
   })
 }
 
+/**
+ * Custom error thrown when the QEMU installer cannot proceed because the
+ * user declined the User Account Control (UAC) elevation prompt.
+ *
+ * The caller (route handler) inspects `code` to tag the install-state error
+ * so the frontend can render a retry-with-clear-instructions affordance
+ * instead of treating it as a generic installer failure.
+ */
+class QemuInstallError extends Error {
+  code: string
+  constructor(message: string, code: string) {
+    super(message)
+    this.name = 'QemuInstallError'
+    this.code = code
+  }
+}
+
+/**
+ * Launches the downloaded QEMU installer with silent-install flag (/S).
+ *
+ * The QEMU installer ships with a `requireAdministrator` manifest, so a
+ * direct spawn() from a non-elevated parent fails at CreateProcess time
+ * with ERROR_ELEVATION_REQUIRED — which libuv surfaces as a useless
+ * "EACCES: permission denied, uv_spawn" error with no way for the user
+ * to recover.
+ *
+ * On Windows we instead hand the launch off to PowerShell's
+ * `Start-Process -Verb RunAs`, which goes through ShellExecute and raises
+ * a normal UAC consent dialog on the user's desktop. If the user accepts,
+ * the installer runs elevated; if they decline, Windows returns
+ * ERROR_CANCELLED (1223), which we translate into a UAC_DECLINED error so
+ * the UI can prompt them to try again.
+ */
 async function installQemuFromExe(
   installerPath: string,
   onOutput: (text: string) => void,
 ): Promise<void> {
-  onOutput('Running QEMU installer (silent)...\n')
+  if (process.platform !== 'win32') {
+    // Defensive fallback for non-Windows callers (the /qemu/install route
+    // is gated to win32, but keep a working path for local testing).
+    onOutput('Running QEMU installer (silent)...\n')
+    return new Promise<void>((resolve, reject) => {
+      const proc = spawn(installerPath, ['/S'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      proc.stdout?.on('data', (chunk: Buffer) => onOutput(chunk.toString()))
+      proc.stderr?.on('data', (chunk: Buffer) => onOutput(chunk.toString()))
+      proc.on('error', (err) => reject(err))
+      proc.on('exit', (code) => {
+        if (code === 0) resolve()
+        else reject(new Error(`QEMU installer exited with code ${code}`))
+      })
+    })
+  }
+
+  onOutput('Requesting administrator permission to install QEMU...\n')
+  onOutput('A Windows User Account Control prompt will appear — click "Yes" to continue.\n')
 
   return new Promise<void>((resolve, reject) => {
-    const proc = spawn(installerPath, ['/S'], {
+    // Escape single quotes for PowerShell single-quoted string literals.
+    const psEscape = (s: string) => s.replace(/'/g, "''")
+    const innerCmd =
+      `$p = Start-Process -FilePath '${psEscape(installerPath)}' ` +
+      `-ArgumentList '/S' -Verb RunAs -Wait -PassThru; ` +
+      `exit $p.ExitCode`
+
+    const proc = spawn('powershell', ['-NoProfile', '-Command', innerCmd], {
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
     })
 
+    let stderr = ''
     proc.stdout?.on('data', (chunk: Buffer) => onOutput(chunk.toString()))
-    proc.stderr?.on('data', (chunk: Buffer) => onOutput(chunk.toString()))
+    proc.stderr?.on('data', (chunk: Buffer) => {
+      const text = chunk.toString()
+      stderr += text
+      onOutput(text)
+    })
 
-    proc.on('error', (err) => reject(err))
+    proc.on('error', (err) => {
+      // Surface spawn-time failures (e.g. PowerShell missing) with a clear
+      // message rather than libuv's cryptic default.
+      reject(new QemuInstallError(
+        `Failed to launch elevated installer: ${err.message}`,
+        'SPAWN_FAILED',
+      ))
+    })
+
     proc.on('exit', (code) => {
-      if (code === 0) resolve()
-      else reject(new Error(`QEMU installer exited with code ${code}`))
+      if (code === 0) {
+        onOutput('QEMU installer completed successfully.\n')
+        resolve()
+        return
+      }
+
+      // Windows ERROR_CANCELLED (1223) — user closed or denied UAC.
+      // Start-Process surfaces this as a non-zero exit code from the outer
+      // PowerShell. We also pattern-match the stderr text because some
+      // Windows SKUs / PS versions return different codes but consistent
+      // wording.
+      const uacDeclined =
+        code === 1223 ||
+        /The operation was canceled by the user|OperationCanceledException|canceled by the user/i
+          .test(stderr)
+
+      if (uacDeclined) {
+        reject(new QemuInstallError(
+          'Administrator permission was not granted. ' +
+          'Click Retry and choose "Yes" on the User Account Control prompt to install QEMU.',
+          'UAC_DECLINED',
+        ))
+        return
+      }
+
+      reject(new QemuInstallError(
+        `QEMU installer exited with code ${code}${stderr.trim() ? `: ${stderr.trim()}` : ''}`,
+        'INSTALLER_FAILED',
+      ))
     })
   })
 }
@@ -611,14 +716,21 @@ export function vmRoutes(): Hono {
           data: JSON.stringify({ success: true }),
         })
       } catch (err: any) {
+        const errorMessage = err?.message || 'Installation failed'
+        const errorCode = typeof err?.code === 'string' ? err.code : undefined
         qemuInstallState = {
           status: 'error',
           output: qemuInstallState.output,
-          error: err?.message || 'Installation failed',
+          error: errorMessage,
+          errorCode,
         }
         await stream.writeSSE({
           event: 'error',
-          data: JSON.stringify({ success: false, error: err?.message || 'Installation failed' }),
+          data: JSON.stringify({
+            success: false,
+            error: errorMessage,
+            ...(errorCode ? { errorCode } : {}),
+          }),
         })
       }
     })

--- a/apps/desktop/BUILD.md
+++ b/apps/desktop/BUILD.md
@@ -162,6 +162,21 @@ Launch from terminal to see output:
 ```
 Logs are also written to `~/Library/Logs/Shogo/main.log`.
 
+**Windows: "trouble starting your project environment" / `'npm.cmd' is not recognized`**
+Shogo Desktop on Windows requires **Node.js 20+** to be installed at the
+standard location (`C:\Program Files\nodejs\`). Bun 1.x has a hardlink bug on
+Windows that produces empty `node_modules` stubs, so `RuntimeManager` (see
+`packages/shared-runtime/src/platform-pkg.ts`) shells out to `npm.cmd` for
+project dependency installs. Without Node.js the install step fails and the
+UI shows the generic "We're having trouble starting your project environment"
+error.
+
+Install the latest Node.js LTS from https://nodejs.org/ (or
+`winget install OpenJS.NodeJS.LTS`) and restart Shogo. The app logs a clear
+warning at startup when this prerequisite is missing — check
+`%APPDATA%\Shogo\logs\main.log` for
+`[Desktop] WARNING: Node.js is not installed` to confirm.
+
 **`Error: P3005 — The database schema is not empty` on startup (legacy installs)**
 Affects installs from versions ≤1.3.3 that first-ran on a machine without
 `sqlite3` on PATH (notably stock Windows). The seed database was copied but

--- a/apps/desktop/BUILD.md
+++ b/apps/desktop/BUILD.md
@@ -162,6 +162,69 @@ Launch from terminal to see output:
 ```
 Logs are also written to `~/Library/Logs/Shogo/main.log`.
 
+**Windows: "trouble starting your project environment" (agent gateway never starts, EPERM rename)**
+Seen in `%APPDATA%\Shogo\logs\main.log` as:
+
+```
+[Agent:<id>] Initialization failed: ... EPERM: operation not permitted, rename
+'...\workspaces\<id>\src' -> '...\workspaces\<id>\project\src'
+```
+
+On first run for a new project, `ensureWorkspaceFiles` in
+`packages/agent-runtime/src/server.ts` migrates the workspace into a nested
+`project/` subdirectory when it detects a "legacy APP layout" (a `package.json`
+at workspace root with no `AGENTS.md` beside it). POSIX `rename(2)` succeeds
+even while another process is watching the source tree; NTFS does not, so the
+migration fails as soon as Vite's file watcher — spawned concurrently by the
+host `RuntimeManager` — has `src/` open. The agent-runtime process then exits
+and every chat request gets `503 Agent gateway not running`.
+
+Modern builds avoid this in two ways: the runtime template now ships an
+`AGENTS.md` at root (see `templates/runtime-template/AGENTS.md`), and
+`ensureRuntimeTemplate` in `apps/desktop/src/local-server.ts` self-heals
+pre-existing `_template/` dirs by copying it in. The migration code in
+`server.ts` also falls back to `cpSync` + retrying `rmSync` on `EPERM`/`EBUSY`
+so the rename still lands eventually.
+
+If you're stuck on an older build and hit this, recover by quitting Shogo
+and creating the marker by hand:
+
+```powershell
+# 1. Stop Shogo from the tray and confirm no stray bun.exe/Shogo.exe are left
+Get-Process | Where-Object { $_.Name -match '^(Shogo|bun)$' } | Stop-Process -Force
+
+# 2. Seed AGENTS.md in the shared template (future projects)
+@"
+# Identity
+
+- **Name:** Shogo
+"@ | Set-Content "$env:APPDATA\Shogo\data\workspaces\_template\AGENTS.md"
+
+# 3. For each half-migrated project workspace, move project\* back to root,
+#    remove project\, and drop in AGENTS.md
+```
+
+**Windows: "trouble starting your project environment" / `VM warm pool disabled after N consecutive boot failures`**
+QEMU + WHPX cannot boot an agent VM on this host (the VM usually dies at
+iPXE after emitting `whpx: injection failed, MSI (0, 0) delivery: 0 …
+(c0350005)` — a known Hyper-V/WHPX interrupt-delivery quirk on some Windows
+installs). After `MAX_CONSECUTIVE_FAILURES` (3) failed VM boots the warm pool
+permanently disables itself for the session.
+
+Modern builds detect this and fall back to the host `RuntimeManager` (see
+`VMPoolPermanentlyDisabledError` in
+`apps/api/src/lib/vm-warm-pool-controller.ts`), so the user gets a working
+runtime instead of a cryptic `pod_unavailable`. To silence the warning and
+skip the wasted VM boot attempts on subsequent launches, write:
+
+```json
+{ "vmIsolation": { "enabled": false } }
+```
+
+into `%APPDATA%\Shogo\config.json`. See `apps/desktop/src/config.ts` for the
+full schema — the `'auto'` default still attempts VM isolation whenever QEMU +
+a provisioned rootfs are present.
+
 **Windows: "trouble starting your project environment" / `'npm.cmd' is not recognized`**
 Shogo Desktop on Windows requires **Node.js 20+** to be installed at the
 standard location (`C:\Program Files\nodejs\`). Bun 1.x has a hardlink bug on

--- a/apps/desktop/BUILD.md
+++ b/apps/desktop/BUILD.md
@@ -161,3 +161,22 @@ Launch from terminal to see output:
 /Applications/Shogo.app/Contents/MacOS/Shogo
 ```
 Logs are also written to `~/Library/Logs/Shogo/main.log`.
+
+**`Error: P3005 — The database schema is not empty` on startup (legacy installs)**
+Affects installs from versions ≤1.3.3 that first-ran on a machine without
+`sqlite3` on PATH (notably stock Windows). The seed database was copied but
+`_prisma_migrations` was never populated, so every subsequent launch tried
+to re-apply migrations against tables that already existed.
+
+Modern builds detect this automatically: `runMigrations` in
+`apps/desktop/src/local-server.ts` catches P3005, baselines the existing
+database via `bun:sqlite`, and retries once. No user action required —
+simply re-launch the app.
+
+If for some reason the self-heal doesn't run (e.g. you're pinned to an old
+build), baseline manually with the bundled `bun`:
+
+```bash
+# Windows (adjust paths for your install):
+"%LOCALAPPDATA%\Shogo\app-1.3.3\resources\bun\bun.exe" -e "const {Database}=require('bun:sqlite');const {randomUUID}=require('node:crypto');const db=new Database(process.argv[1]);db.exec('CREATE TABLE IF NOT EXISTS \"_prisma_migrations\" (\"id\" TEXT PRIMARY KEY NOT NULL,\"checksum\" TEXT NOT NULL,\"finished_at\" DATETIME,\"migration_name\" TEXT NOT NULL,\"logs\" TEXT,\"rolled_back_at\" DATETIME,\"started_at\" DATETIME NOT NULL DEFAULT current_timestamp,\"applied_steps_count\" INTEGER NOT NULL DEFAULT 0)');const existing=new Set(db.query('SELECT migration_name FROM _prisma_migrations').all().map(r=>r.migration_name));const stmt=db.prepare('INSERT INTO _prisma_migrations (id,checksum,finished_at,migration_name,applied_steps_count,started_at) VALUES (?,?,?,?,1,?)');const now=new Date().toISOString();for (const n of process.argv.slice(2)) if (!existing.has(n)) stmt.run(randomUUID(),'baseline-seed',now,n,now);" "%APPDATA%\Shogo\data\shogo.db" 0000_baseline 0001_add_project_last_message_at 0002_add_missing_models 0003_add_capacity_tiers_and_storage 0005_add_meetings
+```

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -28,7 +28,11 @@ License: `AGPL-3.0-or-later`.
 ## Prerequisites
 
 - **Bun** >= 1.1 (`curl -fsSL https://bun.sh/install | bash`)
-- **Node.js** >= 18 (for Expo CLI and Electron)
+- **Node.js** >= 20 (for Expo CLI, Electron, **and Windows project sandbox
+  dependency installs** — Bun 1.x has a hardlink bug on Windows that produces
+  empty `node_modules`, so `RuntimeManager` shells out to `npm.cmd`. Shogo
+  Desktop on Windows will not be able to run projects without Node.js
+  installed at `C:\Program Files\nodejs\`.)
 - The monorepo dependencies installed: `bun install` from the repo root
 
 ## Quick Start (Electron)

--- a/apps/desktop/src/local-server.ts
+++ b/apps/desktop/src/local-server.ts
@@ -190,24 +190,35 @@ function ensureRuntimeTemplate(): void {
   const fs = require('fs') as typeof import('fs')
   const workspacesDir = getWorkspacesDir()
   const templateDest = path.join(workspacesDir, '_template')
-
-  if (fs.existsSync(path.join(templateDest, 'package.json'))) {
-    console.log('[Desktop] Runtime template already present at', templateDest)
-    return
-  }
-
   const bundledTemplate = path.join(getProjectRoot(), 'runtime-template')
-  if (!fs.existsSync(bundledTemplate)) {
-    console.warn('[Desktop] Bundled runtime-template not found at', bundledTemplate)
-    return
+
+  const templatePresent = fs.existsSync(path.join(templateDest, 'package.json'))
+
+  if (!templatePresent) {
+    if (!fs.existsSync(bundledTemplate)) {
+      console.warn('[Desktop] Bundled runtime-template not found at', bundledTemplate)
+      return
+    }
+    console.log(`[Desktop] Copying runtime-template to ${templateDest}`)
+    fs.cpSync(bundledTemplate, templateDest, {
+      recursive: true,
+      filter: (src: string) => !src.includes('node_modules') && !src.includes('.git'),
+    })
+    console.log('[Desktop] Runtime template installed')
+  } else {
+    console.log('[Desktop] Runtime template already present at', templateDest)
   }
 
-  console.log(`[Desktop] Copying runtime-template to ${templateDest}`)
-  fs.cpSync(bundledTemplate, templateDest, {
-    recursive: true,
-    filter: (src: string) => !src.includes('node_modules') && !src.includes('.git'),
-  })
-  console.log('[Desktop] Runtime template installed')
+  // Self-heal existing installs: ensure AGENTS.md exists at template root. Its
+  // absence triggers the agent-runtime's legacy-APP-layout migration on every
+  // fresh project, which fails with EPERM on Windows when Vite is watching the
+  // workspace. Having AGENTS.md at root skips the migration entirely.
+  const agentsMdDest = path.join(templateDest, 'AGENTS.md')
+  const agentsMdSrc = path.join(bundledTemplate, 'AGENTS.md')
+  if (!fs.existsSync(agentsMdDest) && fs.existsSync(agentsMdSrc)) {
+    fs.copyFileSync(agentsMdSrc, agentsMdDest)
+    console.log('[Desktop] Added missing AGENTS.md to runtime template')
+  }
 }
 
 // --- VM isolation ---

--- a/apps/desktop/src/local-server.ts
+++ b/apps/desktop/src/local-server.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
-import { spawn, execSync, type ChildProcess } from 'child_process'
+import { spawn, execSync, execFileSync, type ChildProcess } from 'child_process'
 import { createServer } from 'net'
 import path from 'path'
 import { getBunPath, getDbPath, getWorkspacesDir, getProjectRoot, getDataDir } from './paths'
@@ -310,7 +310,7 @@ export async function startLocalServer(): Promise<void> {
     } : {}),
   }
 
-  ensureDatabase()
+  ensureDatabase(bunPath)
   runMigrations(bunPath, env)
 
   console.log(`[Desktop] Starting local API server: ${bunPath} ${serverEntry}`)
@@ -421,7 +421,7 @@ export async function stopLocalServer(): Promise<void> {
   removePidFile()
 }
 
-function ensureDatabase(): void {
+function ensureDatabase(bunPath: string): void {
   const fs = require('fs') as typeof import('fs')
   const dbPath = getDbPath()
 
@@ -434,7 +434,7 @@ function ensureDatabase(): void {
   if (fs.existsSync(seedPath)) {
     console.log('[Desktop] Initializing database from seed...')
     fs.copyFileSync(seedPath, dbPath)
-    baselineMigrations(dbPath)
+    baselineMigrations(bunPath, dbPath)
     console.log('[Desktop] Database initialized from seed')
     return
   }
@@ -452,49 +452,90 @@ function ensureDatabase(): void {
   throw new Error(`Seed database not found at ${seedPath}`)
 }
 
-function baselineMigrations(dbPath: string): void {
+function listBundledMigrationNames(): string[] {
   const fs = require('fs') as typeof import('fs')
   const migrationsDir = path.join(getProjectRoot(), 'prisma', 'migrations')
-  if (!fs.existsSync(migrationsDir)) return
+  if (!fs.existsSync(migrationsDir)) return []
 
-  const dirs = fs.readdirSync(migrationsDir).filter((d: string) => {
+  return fs.readdirSync(migrationsDir).filter((d: string) => {
     const full = path.join(migrationsDir, d)
     return fs.statSync(full).isDirectory() && fs.existsSync(path.join(full, 'migration.sql'))
   }).sort()
+}
 
+/**
+ * Records every bundled Prisma migration as already-applied in the target
+ * SQLite database. Used after copying seed.db (whose schema is already at
+ * the latest migration) so that `prisma migrate deploy` reports
+ * "No pending migrations" instead of failing with P3005.
+ *
+ * Historically this shelled out to the `sqlite3` CLI, which is not present
+ * on a stock Windows install — the previous implementation silently warned
+ * and skipped, leaving the database in a half-baselined state that crashed
+ * on the next launch with P3005. The bundled `bun` binary is already a hard
+ * dependency (it runs the API server) and ships with `bun:sqlite`, so we
+ * reuse it here for a portable, dependency-free baseline.
+ */
+function baselineMigrations(bunPath: string, dbPath: string): void {
+  const dirs = listBundledMigrationNames()
   if (dirs.length === 0) return
 
-  const crypto = require('crypto') as typeof import('crypto')
-  const stmts = [
-    `CREATE TABLE IF NOT EXISTS "_prisma_migrations" (
-      "id" TEXT PRIMARY KEY NOT NULL,
-      "checksum" TEXT NOT NULL,
-      "finished_at" DATETIME,
-      "migration_name" TEXT NOT NULL,
-      "logs" TEXT,
-      "rolled_back_at" DATETIME,
-      "started_at" DATETIME NOT NULL DEFAULT current_timestamp,
-      "applied_steps_count" INTEGER NOT NULL DEFAULT 0
-    );`,
-    ...dirs.map((name: string) => {
-      const id = crypto.randomUUID()
-      const now = new Date().toISOString()
-      return `INSERT OR IGNORE INTO "_prisma_migrations" ("id","checksum","finished_at","migration_name","applied_steps_count","started_at") VALUES ('${id}','baseline-seed','${now}','${name}',1,'${now}');`
-    }),
-  ]
-
-  const isWindows = process.platform === 'win32'
-  const sqliteCmd = isWindows ? 'sqlite3' : '/usr/bin/sqlite3'
+  // Under `bun -e`, process.argv is [bunExecutable, ...positionalArgs] with
+  // no script-path placeholder (unlike Node). So argv[1] is the first arg we
+  // pass, not argv[2]. A leading "--" is stripped by bun, hence omitted below.
+  const script = `
+    const { Database } = require("bun:sqlite");
+    const { randomUUID } = require("node:crypto");
+    const db = new Database(process.argv[1]);
+    const names = process.argv.slice(2);
+    db.exec(\`
+      CREATE TABLE IF NOT EXISTS "_prisma_migrations" (
+        "id" TEXT PRIMARY KEY NOT NULL,
+        "checksum" TEXT NOT NULL,
+        "finished_at" DATETIME,
+        "migration_name" TEXT NOT NULL,
+        "logs" TEXT,
+        "rolled_back_at" DATETIME,
+        "started_at" DATETIME NOT NULL DEFAULT current_timestamp,
+        "applied_steps_count" INTEGER NOT NULL DEFAULT 0
+      );
+    \`);
+    // Idempotent: skip names that already have a row. We can't rely on
+    // PRIMARY KEY conflict because the PK is a random UUID per row.
+    const existing = new Set(
+      db.query('SELECT migration_name FROM "_prisma_migrations"').all()
+        .map((r) => r.migration_name)
+    );
+    const stmt = db.prepare(
+      'INSERT INTO "_prisma_migrations" ("id","checksum","finished_at","migration_name","applied_steps_count","started_at") VALUES (?, ?, ?, ?, 1, ?)'
+    );
+    const now = new Date().toISOString();
+    let inserted = 0;
+    for (const name of names) {
+      if (existing.has(name)) continue;
+      stmt.run(randomUUID(), "baseline-seed", now, name, now);
+      inserted++;
+    }
+    db.close();
+    console.log(JSON.stringify({ inserted, total: names.length, skipped: names.length - inserted }));
+  `
 
   try {
-    execSync(`${sqliteCmd} "${dbPath}"`, {
-      input: stmts.join('\n'),
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 5000,
-    })
-    console.log(`[Desktop] Baselined ${dirs.length} migration(s) for seed database`)
-  } catch (err) {
-    console.warn('[Desktop] sqlite3 CLI not available, skipping baseline (migrations will handle schema)')
+    const out = execFileSync(bunPath, ['-e', script, dbPath, ...dirs], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 10_000,
+      encoding: 'utf-8',
+    }).trim()
+    console.log(`[Desktop] Baselined ${dirs.length} migration(s) for seed database: ${out}`)
+  } catch (err: any) {
+    const stderr = err?.stderr?.toString?.() || ''
+    const stdout = err?.stdout?.toString?.() || ''
+    console.error('[Desktop] Failed to baseline seed database:', stderr || stdout || err)
+    // Do not swallow this error — leaving the DB half-baselined causes
+    // `prisma migrate deploy` to fail with P3005 on the next launch (issue
+    // seen on Windows where the old implementation's sqlite3 CLI fallback
+    // silently no-oped).
+    throw new Error(`Failed to baseline seed database: ${stderr || stdout || err?.message || err}`)
   }
 }
 
@@ -559,33 +600,67 @@ function runMigrations(bunPath: string, env: Record<string, string>): void {
     }
   }
 
-  console.log('[Desktop] Running database migrations...')
-  try {
-    const result = execSync(
-      `"${bunPath}" x prisma migrate deploy --config=prisma.config.js`,
-      {
-        cwd: projectRoot,
-        env: {
-          ...env,
-          PRISMA_SCHEMA_ENGINE_BINARY: path.join(writableEngineDir, getSchemaEngineName()),
-        },
-        stdio: 'pipe',
-        timeout: 30000,
-        encoding: 'utf-8',
+  const runDeploy = (): { stdout: string; stderr: string; ok: boolean; error?: any } => {
+    try {
+      const result = execSync(
+        `"${bunPath}" x prisma migrate deploy --config=prisma.config.js`,
+        {
+          cwd: projectRoot,
+          env: {
+            ...env,
+            PRISMA_SCHEMA_ENGINE_BINARY: path.join(writableEngineDir, getSchemaEngineName()),
+          },
+          stdio: 'pipe',
+          timeout: 30000,
+          encoding: 'utf-8',
+        }
+      )
+      return { stdout: result, stderr: '', ok: true }
+    } catch (err: any) {
+      return {
+        stdout: err.stdout?.toString() || '',
+        stderr: err.stderr?.toString() || '',
+        ok: false,
+        error: err,
       }
-    )
-    console.log('[Desktop] Migrations complete:', result.trim())
-  } catch (err: any) {
-    const stderr = err.stderr?.toString() || ''
-    const stdout = err.stdout?.toString() || ''
-    if (stdout.includes('No pending migrations') || stderr.includes('No pending migrations')) {
-      console.log('[Desktop] Database schema is up to date')
-      return
     }
-    console.error('[Desktop] [ERROR] Migration failed:', stderr || err.message)
-    console.error('[Desktop] [ERROR] Migration stdout:', stdout)
-    throw new Error('Failed to run database migrations')
   }
+
+  console.log('[Desktop] Running database migrations...')
+  let attempt = runDeploy()
+
+  // Self-heal for users whose install pre-dates the baseline fix: the seed DB
+  // was copied but `_prisma_migrations` never populated (the old sqlite3 CLI
+  // path silently no-oped on systems without sqlite3). Prisma then reports
+  // P3005 "database schema is not empty". Baseline the existing DB and retry
+  // once so the app can boot instead of being permanently broken.
+  if (!attempt.ok && (attempt.stdout + attempt.stderr).includes('P3005')) {
+    console.warn('[Desktop] Detected P3005 — baselining existing database and retrying migrations')
+    try {
+      baselineMigrations(bunPath, getDbPath())
+    } catch (err) {
+      console.error('[Desktop] P3005 self-heal failed during baseline:', err)
+      throw new Error('Failed to run database migrations (P3005 self-heal could not baseline)')
+    }
+    attempt = runDeploy()
+  }
+
+  if (attempt.ok) {
+    console.log('[Desktop] Migrations complete:', attempt.stdout.trim())
+    return
+  }
+
+  if (
+    attempt.stdout.includes('No pending migrations') ||
+    attempt.stderr.includes('No pending migrations')
+  ) {
+    console.log('[Desktop] Database schema is up to date')
+    return
+  }
+
+  console.error('[Desktop] [ERROR] Migration failed:', attempt.stderr || attempt.error?.message)
+  console.error('[Desktop] [ERROR] Migration stdout:', attempt.stdout)
+  throw new Error('Failed to run database migrations')
 }
 
 async function waitForHealth(): Promise<void> {

--- a/apps/desktop/src/local-server.ts
+++ b/apps/desktop/src/local-server.ts
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { spawn, execSync, execFileSync, type ChildProcess } from 'child_process'
 import { createServer } from 'net'
+import { existsSync } from 'fs'
 import path from 'path'
 import { getBunPath, getDbPath, getWorkspacesDir, getProjectRoot, getDataDir } from './paths'
 import { isVMAvailable } from './vm'
@@ -313,6 +314,21 @@ export async function startLocalServer(): Promise<void> {
   ensureDatabase(bunPath)
   runMigrations(bunPath, env)
 
+  // Preflight: on Windows, the RuntimeManager shells out to `npm.cmd` for
+  // project dependency installs (Bun 1.x has a hardlink bug on Windows that
+  // produces empty node_modules stubs). Without Node.js installed, project
+  // runs fail with a cryptic "'npm.cmd' is not recognized" deep inside the
+  // API logs, surfaced to users only as "trouble starting your project
+  // environment". Detect here and log a single, obvious warning so the
+  // prerequisite is visible immediately on startup.
+  if (process.platform === 'win32' && !isNpmAvailable(env.PATH)) {
+    console.warn(
+      '[Desktop] WARNING: Node.js is not installed. Shogo Desktop on Windows ' +
+        'requires Node.js 20+ (LTS) for project sandboxes. Running projects ' +
+        'will fail until Node.js is installed from https://nodejs.org/.',
+    )
+  }
+
   console.log(`[Desktop] Starting local API server: ${bunPath} ${serverEntry}`)
   console.log(`[Desktop] Database: ${getDbPath()}`)
   console.log(`[Desktop] Workspaces: ${getWorkspacesDir()}`)
@@ -450,6 +466,22 @@ function ensureDatabase(bunPath: string): void {
   }
 
   throw new Error(`Seed database not found at ${seedPath}`)
+}
+
+/**
+ * Cheap check for Node.js on Windows — looks for `npm.cmd` in the standard
+ * install dir and on PATH. Kept self-contained here (rather than importing
+ * from @shogo/shared-runtime) so the desktop bundle doesn't pull in the
+ * whole shared-runtime graph just for a startup preflight.
+ */
+function isNpmAvailable(pathEnv: string | undefined): boolean {
+  if (process.platform !== 'win32') return true
+  if (existsSync(path.join('C:\\Program Files\\nodejs', 'npm.cmd'))) return true
+  if (!pathEnv) return false
+  for (const dir of pathEnv.split(';')) {
+    if (dir && existsSync(path.join(dir, 'npm.cmd'))) return true
+  }
+  return false
 }
 
 function listBundledMigrationNames(): string[] {

--- a/apps/mobile/components/onboarding/steps/VMSetupProgress.tsx
+++ b/apps/mobile/components/onboarding/steps/VMSetupProgress.tsx
@@ -32,6 +32,7 @@ export function VMSetupProgress({ onComplete, compact = false }: VMSetupProgress
   const [diagnostics, setDiagnostics] = useState<VMSetupDiagnostics | null>(null)
   const [qemuStatus, setQemuStatus] = useState<QemuInstallStatus>('idle')
   const [qemuError, setQemuError] = useState<string | null>(null)
+  const [qemuErrorCode, setQemuErrorCode] = useState<string | null>(null)
   const [whpxStatus, setWhpxStatus] = useState<WhpxEnableStatus>('idle')
   const [whpxError, setWhpxError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
@@ -63,6 +64,7 @@ export function VMSetupProgress({ onComplete, compact = false }: VMSetupProgress
         } else if (data.status === 'error') {
           setQemuStatus('error')
           setQemuError(data.error || 'Installation failed')
+          setQemuErrorCode(typeof data.errorCode === 'string' ? data.errorCode : null)
         }
       } catch { /* polling error, ignore */ }
     }, 2000)
@@ -72,6 +74,7 @@ export function VMSetupProgress({ onComplete, compact = false }: VMSetupProgress
   const installQemu = useCallback(async () => {
     setQemuStatus('installing')
     setQemuError(null)
+    setQemuErrorCode(null)
     try {
       const res = await fetch(`${API_URL}/api/vm/qemu/install`, {
         method: 'POST',
@@ -116,6 +119,7 @@ export function VMSetupProgress({ onComplete, compact = false }: VMSetupProgress
                 if (parsed.success === false) {
                   setQemuStatus('error')
                   setQemuError(parsed.error || 'Installation failed')
+                  setQemuErrorCode(typeof parsed.errorCode === 'string' ? parsed.errorCode : null)
                   return
                 }
               } catch { /* ignore malformed SSE */ }
@@ -211,18 +215,20 @@ export function VMSetupProgress({ onComplete, compact = false }: VMSetupProgress
               {qemuReady
                 ? 'QEMU installed'
                 : qemuStatus === 'installing'
-                  ? 'Installing QEMU...'
+                  ? 'Installing QEMU (check for UAC prompt)...'
                   : qemuStatus === 'error'
-                    ? 'QEMU installation failed'
+                    ? qemuErrorCode === 'UAC_DECLINED'
+                      ? 'Administrator permission required'
+                      : 'QEMU installation failed'
                     : 'QEMU not installed'}
             </Text>
             {!qemuReady && qemuStatus === 'idle' && (
               <Text className="text-xs text-muted-foreground mt-0.5">
-                Required for VM sandboxing (~200 MB)
+                Required for VM sandboxing (~200 MB). A UAC prompt will appear to install.
               </Text>
             )}
             {qemuStatus === 'error' && qemuError && (
-              <Text className="text-xs text-destructive mt-0.5" numberOfLines={2}>
+              <Text className="text-xs text-destructive mt-0.5" numberOfLines={3}>
                 {qemuError}
               </Text>
             )}

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -215,6 +215,30 @@ app.get('/ready', (c) => c.json({ ready: true }))
 // Agent Workspace Bootstrap
 // =============================================================================
 
+/**
+ * Move a file or directory from `src` to `dest`, working around a Windows-specific
+ * failure mode: `renameSync` returns `EPERM` when the source tree has any file
+ * handle open (e.g. a Vite file-watcher subscribing to `src/`). POSIX lets the
+ * rename succeed in that case; NTFS does not.
+ *
+ * Falls back to a recursive copy plus a retrying `rmSync`. `rmSync` with
+ * `maxRetries > 0` retries on EBUSY/EMFILE/ENFILE/ENOTEMPTY/EPERM with a linear
+ * backoff, which gives concurrent watchers time to release their handles.
+ */
+function safeMoveSync(src: string, dest: string): void {
+  try {
+    renameSync(src, dest)
+    return
+  } catch (err: any) {
+    const code = err?.code
+    if (code !== 'EPERM' && code !== 'EBUSY' && code !== 'ENOTEMPTY' && code !== 'EXDEV') {
+      throw err
+    }
+  }
+  cpSync(src, dest, { recursive: true, force: true, errorOnExist: false })
+  rmSync(src, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
+}
+
 function ensureWorkspaceFiles(): void {
   const templateMarker = join(WORKSPACE_DIR, '.template')
   const templateIdFromEnv = process.env.TEMPLATE_ID
@@ -247,11 +271,11 @@ function ensureWorkspaceFiles(): void {
     const appFiles = ['package.json', 'bun.lock', 'tsconfig.json', 'vite.config.ts', 'tailwind.config.ts', 'postcss.config.js', 'components.json', '.gitignore']
     for (const f of appFiles) {
       const src = join(WORKSPACE_DIR, f)
-      if (existsSync(src)) renameSync(src, join(projectDir, f))
+      if (existsSync(src)) safeMoveSync(src, join(projectDir, f))
     }
     for (const d of ['src', 'prisma', 'dist', 'public', 'node_modules']) {
       const src = join(WORKSPACE_DIR, d)
-      if (existsSync(src)) renameSync(src, join(projectDir, d))
+      if (existsSync(src)) safeMoveSync(src, join(projectDir, d))
     }
     seedWorkspaceDefaults(WORKSPACE_DIR)
     logTiming('Migrated legacy APP layout into project/ subdirectory')

--- a/packages/shared-runtime/src/platform-pkg.ts
+++ b/packages/shared-runtime/src/platform-pkg.ts
@@ -10,6 +10,8 @@
  */
 
 import { execSync as nodeExecSync, spawn, type StdioOptions } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
 
 export interface PkgInstallOptions {
   timeout?: number
@@ -17,6 +19,36 @@ export interface PkgInstallOptions {
   env?: NodeJS.ProcessEnv
   /** Attempt --frozen-lockfile first, fall back to plain install (bun only). */
   frozen?: boolean
+}
+
+/** Error thrown when the Windows Node.js prerequisite is missing. */
+export class NodeMissingError extends Error {
+  readonly code = 'NODE_NOT_INSTALLED' as const
+  constructor() {
+    super(
+      'Shogo Desktop on Windows requires Node.js 20+ to run project sandboxes. ' +
+        'npm.cmd was not found on PATH and is not present at C:\\Program Files\\nodejs\\. ' +
+        'Install Node.js from https://nodejs.org/ (LTS recommended), then restart Shogo.',
+    )
+    this.name = 'NodeMissingError'
+  }
+}
+
+const WINDOWS_NODE_DIR = 'C:\\Program Files\\nodejs'
+
+/**
+ * True if npm.cmd can be located via PATH or the standard Windows install dir.
+ * Cheap — only a single existsSync + PATH walk — so safe to call from hot paths.
+ * Always returns true on non-Windows (bun is used there).
+ */
+export function isNodeAvailableOnWindows(pathEnv: string | undefined = process.env.PATH): boolean {
+  if (process.platform !== 'win32') return true
+  if (existsSync(join(WINDOWS_NODE_DIR, 'npm.cmd'))) return true
+  if (!pathEnv) return false
+  for (const dir of pathEnv.split(';')) {
+    if (dir && existsSync(join(dir, 'npm.cmd'))) return true
+  }
+  return false
 }
 
 export interface PkgExecOptions {
@@ -64,9 +96,14 @@ export class PlatformPackageManager {
     const env = this.spawnEnv(opts?.env)
 
     if (IS_WINDOWS) {
-      nodeExecSync('npm.cmd install --loglevel=error', {
-        cwd, timeout, stdio, env, shell: true,
-      })
+      if (!isNodeAvailableOnWindows(env.PATH)) throw new NodeMissingError()
+      try {
+        nodeExecSync('npm.cmd install --loglevel=error', {
+          cwd, timeout, stdio, env, shell: true,
+        })
+      } catch (err: any) {
+        throw wrapWindowsNpmError(err) ?? err
+      }
     } else {
       const bun = this.bunBinary
       if (opts?.frozen) {
@@ -91,6 +128,10 @@ export class PlatformPackageManager {
     const cmd = IS_WINDOWS ? 'npm.cmd' : this.bunBinary
     const args = IS_WINDOWS ? ['install', '--loglevel=error'] : ['install']
 
+    if (IS_WINDOWS && !isNodeAvailableOnWindows(env.PATH)) {
+      return Promise.reject(new NodeMissingError())
+    }
+
     return new Promise<void>((resolve, reject) => {
       const proc = spawn(cmd, args, {
         cwd,
@@ -109,12 +150,19 @@ export class PlatformPackageManager {
 
       proc.on('exit', (code) => {
         clearTimeout(timer)
-        if (code === 0) resolve()
-        else reject(new Error(`${cmd} install exited with code ${code}\n${stderr}`))
+        if (code === 0) return resolve()
+        // Windows cmd.exe prints "not recognized" when npm.cmd is missing,
+        // even though we preflight above — handle the race where the user
+        // uninstalled Node while Shogo was running.
+        if (IS_WINDOWS && /not recognized as an internal or external command/i.test(stderr)) {
+          return reject(new NodeMissingError())
+        }
+        reject(new Error(`${cmd} install exited with code ${code}\n${stderr}`))
       })
 
-      proc.on('error', (err) => {
+      proc.on('error', (err: NodeJS.ErrnoException) => {
         clearTimeout(timer)
+        if (IS_WINDOWS && err.code === 'ENOENT') return reject(new NodeMissingError())
         reject(err)
       })
     })
@@ -168,6 +216,21 @@ export class PlatformPackageManager {
       env: opts?.env,
     })
   }
+}
+
+/**
+ * Translate the cryptic cmd.exe "not recognized" message emitted when
+ * npm.cmd is missing into a typed NodeMissingError. Returns null if the
+ * error doesn't look like a missing-node problem so the caller can rethrow.
+ */
+function wrapWindowsNpmError(err: any): NodeMissingError | null {
+  if (!IS_WINDOWS) return null
+  const blob = `${err?.stderr?.toString?.() ?? ''}\n${err?.stdout?.toString?.() ?? ''}\n${err?.message ?? ''}`
+  if (/not recognized as an internal or external command/i.test(blob)) {
+    return new NodeMissingError()
+  }
+  if (err?.code === 'ENOENT') return new NodeMissingError()
+  return null
 }
 
 /** Singleton — most consumers just need one. */

--- a/templates/runtime-template/AGENTS.md
+++ b/templates/runtime-template/AGENTS.md
@@ -1,0 +1,46 @@
+# Identity
+
+- **Name:** Shogo
+- **Emoji:** ⚡
+- **Tagline:** Your AI agent — ready to build
+
+# Personality
+
+You are a capable, proactive AI agent. You communicate clearly and get things done efficiently.
+You explain what you're about to do, then do it. You prefer showing over telling.
+
+## Tone
+- Direct and helpful, not verbose
+- Confident but not presumptuous
+- Celebrate completions briefly, then move on
+
+## Boundaries
+- Never execute destructive commands without explicit confirmation
+- Never share credentials in channel messages
+- Respect quiet hours for non-urgent notifications
+
+# User
+
+- **Name:** (not set)
+- **Timezone:** UTC
+
+# Operating Instructions
+
+## Approach
+- **Plan before you build.** For any multi-step task, first write a brief plan covering what you'll build, the data model, component layout, and test plan. Then execute.
+- **Understand before you fix.** When debugging, trace the error to its root cause before editing. Read the failing code and understand why it fails.
+- Build interactive UIs in src/App.tsx when the user asks for dashboards, apps, or visual displays
+- Use memory tools to persist important facts the user shares
+- Prefer action over clarification — make reasonable assumptions and explain what you did
+
+## App Development
+- The workspace is a standard Vite + React + Tailwind + shadcn/ui app
+- Edit src/App.tsx for the main UI, add components under src/components/
+- For data-driven apps, create a skill server by writing .shogo/server/schema.prisma
+- Use edit_file to update existing files — avoid full rewrites
+
+## Priorities
+1. User requests — respond promptly and take action
+2. Urgent alerts — surface immediately via channels
+3. Scheduled checks — run on heartbeat cadence
+4. Proactive suggestions — offer when relevant context is available


### PR DESCRIPTION
## Summary

Fixes **four** stacked Windows bugs that together brick first-run Shogo Desktop installs.

### 1. Prisma `P3005` on every launch (desktop)

`apps/desktop/src/local-server.ts` shipped a seed SQLite DB and tried to baseline it with the `sqlite3` CLI, which isn't on PATH on stock Windows. The call silently no-op'd, `_prisma_migrations` was never populated, and every subsequent launch died with `Error: P3005: The database schema is not empty.`

Changes:

- Replace the `sqlite3` CLI call with a short `bun:sqlite` script run through the already-bundled `bun.exe` (via `execFileSync`). Cross-platform, no extra binary dependency.
- Throw on baseline failure instead of warning, so we never silently ship a half-baselined DB again.
- Make the baseline truly idempotent: look up existing `migration_name` rows rather than relying on a random-UUID primary key for conflict detection.
- Add a P3005 self-heal in `runMigrations()` (packaged mode only): if `prisma migrate deploy` fails with `P3005`, baseline the existing DB and retry once. This recovers users whose install is already broken by the old bug without requiring a reinstall.

### 2. QEMU install fails with `EACCES` instead of prompting for admin (api)

`apps/api/src/routes/vm.ts` shelled the downloaded QEMU installer directly via `spawn()`. The installer has a `requireAdministrator` manifest, so Windows returns `ERROR_ELEVATION_REQUIRED`, which libuv maps to `EACCES`:

```
QEMU installation failed EACCES: permission denied, uv_spawn 'C:\...\qemu-w64-setup.exe'
```

Changes:

- Launch the installer via `powershell -Command "Start-Process -Verb RunAs -Wait"` so Windows shows the standard UAC consent dialog (same pattern as the existing `/whpx/enable` route).
- Introduce `QemuInstallError` with typed `errorCode` and surface it on `QemuInstallState` and the SSE `error` event.
- Detect exit code `1223` / "operation was canceled" and emit `errorCode: 'UAC_DECLINED'` so the UI can distinguish user-cancelled from a real installer failure.
- `VMSetupProgress.tsx`: show "Administrator permission required" (instead of the generic failure) when `UAC_DECLINED` is returned, and add a UAC-expectation hint to the idle + installing states (mirroring WHPX wording).

### 3. Missing Node.js surfaces as generic "trouble starting your project environment" (desktop, shared-runtime)

`packages/shared-runtime/src/platform-pkg.ts` shells out to `npm.cmd` on Windows for project dependency installs, because Bun 1.x has a hardlink bug on Windows that produces empty `node_modules` stubs (explained in the file header comment). This makes **Node.js 20+ at `C:\Program Files\nodejs\` a silent hard prerequisite**, but the missing-Node failure mode is awful:

- `RuntimeManager` logs `'npm.cmd' is not recognized as an internal or external command`
- Every UI surface shows only the generic `pod_unavailable` message: "We're having trouble starting your project environment."
- Users misread the super admin "Tunnel Disconnected" indicator as the root cause (it isn't — that screen just doesn't re-poll after mount) and chase the wrong diagnosis.

Changes:

- `platform-pkg.ts`: export `isNodeAvailableOnWindows()` and a typed `NodeMissingError`. `installSync` / `installAsync` preflight-check before spawning `npm.cmd` and throw the typed error. Also handle the ENOENT / "not recognized" races in the spawn callbacks, so the same clear message surfaces whether the check fails up front or the user uninstalls Node mid-run.
- `apps/desktop/src/local-server.ts`: log a single obvious warning at API-startup time when Node.js is missing on Windows — users and support see the real cause on the first screen of `main.log` instead of scrolling past dozens of `VMWarmPool` retries.
- `apps/desktop/README.md` + `BUILD.md`: document Node.js as a hard Windows prerequisite (not just a dev dep for Expo/Electron), explain *why* (Bun hardlink bug), and add a troubleshooting entry mapping the UI error to the real cause + fix command (`winget install OpenJS.NodeJS.LTS`).

No default-package-manager switch on Windows — the deliberate npm choice stays; only the error reporting around it improves.

### 4. Agent-runtime `EPERM` migration + cryptic `pod_unavailable` after VM-pool kill-switch (agent-runtime, api, desktop)

Two more first-run failure modes that only surface once 1–3 are fixed:

**4a. Agent gateway dies on first run of every fresh project.** `ensureWorkspaceFiles` in `packages/agent-runtime/src/server.ts` runs a one-shot "legacy APP layout" migration that `renameSync`'s `package.json` / `src/` / `prisma/` / `node_modules/` into a new `project/` subdirectory whenever `package.json` is at the workspace root and `AGENTS.md` is not. On Windows this fails immediately with `EPERM: operation not permitted, rename` because the host `RuntimeManager` has already spawned Vite in the same workspace, and its file watcher holds `src/` open — NTFS rejects the rename while POSIX would have allowed it. The agent-runtime process crashes, the gateway never starts, and every `/agent/chat` request bounces through 30 retries of `503 Agent gateway not running` before the UI shows "The agent runtime could not be reached".

**4b. After 3 VM boot failures, every project chat fails permanently with `pod_unavailable`.** `VMWarmPoolController` permanently disables itself after `MAX_CONSECUTIVE_FAILURES = 3`. `getProjectUrl` in `apps/api/src/routes/project-chat.ts` was hardcoded to the VM path whenever `SHOGO_VM_ISOLATION=true`, with an explicit comment not to fall back to the local `RuntimeManager`. That rule only exists to avoid a VM/host split-brain — which cannot happen once the pool has permanently disabled itself, because no VM is running at all. But the code didn't distinguish the two cases.

Changes:

- `packages/agent-runtime/src/server.ts`: new `safeMoveSync` helper. It tries `renameSync` first, and on `EPERM`/`EBUSY`/`ENOTEMPTY`/`EXDEV` falls back to `cpSync { recursive: true, force: true }` + `rmSync { maxRetries: 10, retryDelay: 200 }`. Node's rmSync already knows to retry those exact codes with linear backoff, which gives concurrent file-watchers time to release their handles.
- `templates/runtime-template/AGENTS.md`: new file. Ships at the template root so the legacy-layout heuristic in `ensureWorkspaceFiles` returns false on fresh installs and the migration is skipped entirely — belt-and-suspenders with the rename fix above.
- `apps/desktop/src/local-server.ts::ensureRuntimeTemplate`: self-heals existing installs by copying `AGENTS.md` into pre-existing `_template/` directories on next launch. Users with an old install don't need to nuke anything.
- `apps/api/src/lib/vm-warm-pool-controller.ts`: new `VMPoolPermanentlyDisabledError` (typed, with `consecutiveFailures` and an actionable message pointing at `vmIsolation.enabled=false`), new `isPermanentlyDisabled()` method. `_assignProject` throws the typed error instead of a generic `Error`.
- `apps/api/src/routes/project-chat.ts`: `getProjectUrl` catches `VMPoolPermanentlyDisabledError` and falls through to the `runtimeManager` path with a clear `console.warn` explaining why the fallback is safe here (no VM is running → no split-brain). Transient VM errors still retry VM-path-only as before.
- `apps/desktop/BUILD.md`: troubleshooting entries for both failure modes, including a PowerShell recovery recipe for users stuck on a half-migrated workspace and a `config.json` snippet for the VM-pool case.

## Commits

- `1470dd7` fix(desktop, api): recover from Prisma P3005 and Windows UAC-elevation failures — covers §1 and §2
- `8e235c6` fix(desktop, shared-runtime): surface missing-Node prerequisite instead of cryptic npm.cmd failure — covers §3
- `f61a8db` fix(agent-runtime, desktop, api): unblock Windows first-run — EPERM migration + VM-pool fallback — covers §4

## Test plan

Validated end-to-end on a Windows 11 host that originally hit all four bugs. After each commit was applied in order, the next failure mode surfaced exactly once and was then unblocked by the following commit.

- [x] QEMU installs cleanly via the new UAC path (consent dialog appears, `qemu-system-x86_64.exe` lands in `Program Files\qemu\`).
- [x] Declining UAC surfaces `UAC_DECLINED` in the SSE stream and the onboarding UI shows "Administrator permission required".
- [x] Broken install (seed DB present, `_prisma_migrations` empty) self-heals on next launch: P3005 is detected, the DB is baselined, migrations reapply, app boots.
- [x] Fresh install still baselines on first launch without invoking the self-heal path.
- [x] `'npm.cmd' is not recognized` scenario (no Node.js on the box) surfaces a clear `NodeMissingError` from `RuntimeManager` and a `[Desktop] WARNING: Node.js is not installed` line at the very top of `main.log`.
- [x] Fresh project creation no longer triggers the legacy-APP-layout migration (new `AGENTS.md` in `_template/` short-circuits it). Verified `[agent-runtime] Workspace files ready` at <100ms on first run, followed by `AgentGateway Started successfully` and a successful `POST /agent/chat` round-trip.
- [x] With QEMU installed but WHPX unhealthy, the 3-strike VM kill-switch trips as expected, `getProjectUrl` falls back to the host runtime with a clear warning in the log, and chat works through `RuntimeManager` instead of hanging on `pod_unavailable`.
- [ ] Peer review of the `bun:sqlite` inline script (argv indexing matches Bun's `-e` convention, not Node's).
- [ ] Peer review of `safeMoveSync` — specifically that the EXDEV branch (cross-device rename) is acceptable to route through the same fallback.
- [ ] CI (`lint`, `typecheck`, `build`) on the mobile + desktop + api + agent-runtime workspaces.
