### PR TITLE
fix: prevent warm pool pod churn and duplicate claims in production

### DIFF
--- a/apps/api/src/lib/knative-project-manager.ts
+++ b/apps/api/src/lib/knative-project-manager.ts
@@ -49,6 +49,17 @@ const IS_PRODUCTION = PREVIEW_ENVIRONMENT === "production" || PREVIEW_ENVIRONMEN
 // Log preview configuration on module load
 console.log(`[knative-project-manager] Preview config: PREVIEW_BASE_DOMAIN=${PREVIEW_BASE_DOMAIN}, PREVIEW_ENVIRONMENT=${PREVIEW_ENVIRONMENT}, IS_PRODUCTION=${IS_PRODUCTION}`)
 
+// Hash a project UUID to a stable 32-bit integer for use as a PostgreSQL
+// advisory lock key. Uses a simple FNV-1a hash to distribute evenly.
+function hashProjectIdToLockKey(projectId: string): number {
+  let hash = 0x811c9dc5 // FNV offset basis
+  for (let i = 0; i < projectId.length; i++) {
+    hash ^= projectId.charCodeAt(i)
+    hash = (hash * 0x01000193) | 0 // FNV prime, force 32-bit
+  }
+  return hash
+}
+
 // Environment detection
 const isKubernetes = () => !!process.env.KUBERNETES_SERVICE_HOST
 
@@ -1764,6 +1775,11 @@ export async function getProjectPodUrl(projectId: string): Promise<string> {
  * background creation of the real Knative Service.
  * Returns the warm pod URL on success, null on failure/unavailability.
  * Retries with different pods from the pool if the first claim fails.
+ *
+ * Uses a DB-level row lock (SELECT ... FOR UPDATE) on the project row
+ * to prevent multiple API replicas from claiming different pods for the
+ * same project simultaneously. The second replica will see the
+ * knativeServiceName written by the first and reuse it.
  */
 async function tryClaimWarmPod(
   projectId: string,
@@ -1781,37 +1797,95 @@ async function tryClaimWarmPod(
       return null
     }
 
-    const envVars = await warmPool.buildProjectEnv(projectId)
-    const envTime = Date.now()
-    console.log(`[KnativeProjectManager] buildProjectEnv for ${projectId}: ${envTime - t0}ms`)
+    // Acquire a PostgreSQL advisory lock keyed on the project ID to prevent
+    // multiple API replicas from claiming different warm pods for the same
+    // project simultaneously. Advisory locks are session-scoped and don't
+    // require holding a transaction open during the long /pool/assign call.
+    const { prisma } = await import('./prisma')
+    const lockKey = hashProjectIdToLockKey(projectId)
 
-    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-      const pod = warmPool.claim()
-      if (!pod) {
-        console.log(`[KnativeProjectManager] No warm pod available for ${projectId} (attempt ${attempt}/${MAX_ATTEMPTS})`)
-        break
+    // pg_try_advisory_lock returns true if we acquired it, false if another
+    // session already holds it. If contended, re-check the DB — the winning
+    // replica may have already written knativeServiceName.
+    const [{ acquired }] = await prisma.$queryRawUnsafe<{ acquired: boolean }[]>(
+      `SELECT pg_try_advisory_lock($1) AS acquired`, lockKey,
+    )
+
+    if (!acquired) {
+      // Another replica is actively claiming for this project. Wait briefly
+      // for it to finish, then check if it wrote a service name.
+      console.log(`[KnativeProjectManager] Warm pool claim lock contended for ${projectId} — waiting for other replica`)
+      await new Promise((r) => setTimeout(r, 5000))
+
+      const project = await prisma.project.findUnique({
+        where: { id: projectId },
+        select: { knativeServiceName: true },
+      })
+      if (project?.knativeServiceName) {
+        const url = `http://${project.knativeServiceName}.${NAMESPACE}.svc.cluster.local`
+        console.log(
+          `[KnativeProjectManager] Warm pool claim for ${projectId} resolved by another replica: ${project.knativeServiceName} (elapsed: ${Date.now() - t0}ms)`
+        )
+        return url
       }
 
-      console.log(`[KnativeProjectManager] Claimed warm pod ${pod.serviceName} for ${projectId} (attempt ${attempt}/${MAX_ATTEMPTS})`)
+      // Other replica may have failed — proceed with our own claim.
+      // Try to acquire the lock now (blocking).
+      await prisma.$queryRawUnsafe(`SELECT pg_advisory_lock($1)`, lockKey)
+      console.log(`[KnativeProjectManager] Acquired warm pool claim lock for ${projectId} after contention`)
 
-      try {
-        const assignStart = Date.now()
-        await warmPool.assign(pod, projectId, envVars)
-        const assignEnd = Date.now()
-        console.log(`[KnativeProjectManager] assign for ${projectId}: ${assignEnd - assignStart}ms (total warm pipeline: ${assignEnd - t0}ms)`)
-
-        manager.createPreviewDomainMapping(projectId, pod.serviceName).catch((err: any) => {
-          console.error(`[KnativeProjectManager] Failed to create preview DomainMapping for warm pod ${pod.serviceName}:`, err.message)
-        })
-
-        return pod.url
-      } catch (assignErr: any) {
-        console.warn(`[KnativeProjectManager] Warm pod ${pod.serviceName} unreachable for ${projectId} (attempt ${attempt}/${MAX_ATTEMPTS}): ${assignErr.message}`)
+      // Re-check after acquiring — other replica may have finished between our wait and lock
+      const recheck = await prisma.project.findUnique({
+        where: { id: projectId },
+        select: { knativeServiceName: true },
+      })
+      if (recheck?.knativeServiceName) {
+        await prisma.$queryRawUnsafe(`SELECT pg_advisory_unlock($1)`, lockKey)
+        const url = `http://${recheck.knativeServiceName}.${NAMESPACE}.svc.cluster.local`
+        console.log(
+          `[KnativeProjectManager] Warm pool claim for ${projectId} resolved after lock acquisition: ${recheck.knativeServiceName} (elapsed: ${Date.now() - t0}ms)`
+        )
+        return url
       }
     }
 
-    console.log(`[KnativeProjectManager] All warm pool attempts exhausted for ${projectId} after ${Date.now() - t0}ms — falling back to cold start`)
-    return null
+    // We hold the advisory lock — proceed with claim. Release in finally block.
+    try {
+      const envVars = await warmPool.buildProjectEnv(projectId)
+      const envTime = Date.now()
+      console.log(`[KnativeProjectManager] buildProjectEnv for ${projectId}: ${envTime - t0}ms`)
+
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        const pod = warmPool.claim()
+        if (!pod) {
+          console.log(`[KnativeProjectManager] No warm pod available for ${projectId} (attempt ${attempt}/${MAX_ATTEMPTS})`)
+          break
+        }
+
+        console.log(`[KnativeProjectManager] Claimed warm pod ${pod.serviceName} for ${projectId} (attempt ${attempt}/${MAX_ATTEMPTS})`)
+
+        try {
+          const assignStart = Date.now()
+          await warmPool.assign(pod, projectId, envVars)
+          const assignEnd = Date.now()
+          console.log(`[KnativeProjectManager] assign for ${projectId}: ${assignEnd - assignStart}ms (total warm pipeline: ${assignEnd - t0}ms)`)
+
+          manager.createPreviewDomainMapping(projectId, pod.serviceName).catch((err: any) => {
+            console.error(`[KnativeProjectManager] Failed to create preview DomainMapping for warm pod ${pod.serviceName}:`, err.message)
+          })
+
+          return pod.url
+        } catch (assignErr: any) {
+          console.warn(`[KnativeProjectManager] Warm pod ${pod.serviceName} unreachable for ${projectId} (attempt ${attempt}/${MAX_ATTEMPTS}): ${assignErr.message}`)
+        }
+      }
+
+      console.log(`[KnativeProjectManager] All warm pool attempts exhausted for ${projectId} after ${Date.now() - t0}ms — falling back to cold start`)
+      return null
+    } finally {
+      // Always release the advisory lock
+      await prisma.$queryRawUnsafe(`SELECT pg_advisory_unlock($1)`, lockKey).catch(() => {})
+    }
   } catch (err: any) {
     const elapsed = Date.now() - t0
     console.error(`[KnativeProjectManager] Warm pool claim failed for ${projectId} after ${elapsed}ms:`, err.message)

--- a/apps/api/src/lib/warm-pool-controller.ts
+++ b/apps/api/src/lib/warm-pool-controller.ts
@@ -95,6 +95,7 @@ const NAMESPACE_GC_CREATION_GRACE_MS = 5 * 60 * 1000 // skip services created wi
 const POOL_PROJECT_ID = '__POOL__'
 const POOL_LABEL_KEY = 'shogo.io/warm-pool'
 const POOL_STATUS_LABEL_KEY = 'shogo.io/warm-pool-status'
+const ACTIVE_LABEL_KEY = 'shogo.io/active'
 
 export interface WarmPodInfo {
   id: string
@@ -675,6 +676,7 @@ export class WarmPoolController {
         labels: {
           [POOL_STATUS_LABEL_KEY]: 'promoted',
           'shogo.io/project': projectId,
+          [ACTIVE_LABEL_KEY]: 'true',
         },
       },
     }
@@ -803,10 +805,24 @@ export class WarmPoolController {
       console.error(`[WarmPool] evictProject: DB cleanup failed for ${projectId}:`, err.message)
     }
 
-    // Delete the old Knative Service (best-effort, non-blocking)
+    // Clear the active label so namespace GC can reclaim the service if
+    // it scales to zero before we finish deleting it.
     const serviceToDelete = oldServiceName
     if (serviceToDelete) {
       (async () => {
+        try {
+          const { mergePatchKnativeService } = await import('./knative-project-manager')
+          await mergePatchKnativeService(this.namespace, serviceToDelete, {
+            metadata: { labels: { [ACTIVE_LABEL_KEY]: 'false' } },
+          })
+        } catch (err: any) {
+          if (err?.message?.includes('404') || err?.message?.includes('not found')) {
+            // Service already gone — nothing to clear
+          } else {
+            console.error(`[WarmPool] evictProject: failed to clear active label on ${serviceToDelete} (non-fatal):`, err.message)
+          }
+        }
+
         try {
           const api = getCustomApi()
           await api.deleteNamespacedCustomObject({
@@ -1191,6 +1207,7 @@ export class WarmPoolController {
         replicas: number
         createdAt: number
         isUnschedulable: boolean
+        isActive: boolean
       }[] = []
 
       for (const svc of allServices) {
@@ -1225,8 +1242,9 @@ export class WarmPoolController {
         const conditions = status.conditions || []
         const readyCondition = conditions.find((c: any) => c.type === 'Ready')
         const isUnschedulable = readyCondition?.reason === 'Unschedulable'
+        const isActive = labels[ACTIVE_LABEL_KEY] === 'true'
 
-        candidateServices.push({ name, projectId, replicas, createdAt, isUnschedulable })
+        candidateServices.push({ name, projectId, replicas, createdAt, isUnschedulable, isActive })
       }
 
       if (candidateServices.length === 0) return 0
@@ -1276,6 +1294,12 @@ export class WarmPoolController {
             dbMappingsToClear.push(svc.name)
           }
         } else if (isScaledToZero && !isRecentlyCreated) {
+          if (svc.isActive) {
+            console.log(
+              `[WarmPool GC:namespace] Skipping active scaled-to-zero service ${svc.name} (project ${svc.projectId || 'unknown'} — shogo.io/active=true, deferring to promoted-pod GC)`
+            )
+            continue
+          }
           console.log(
             `[WarmPool GC:namespace] Deleting scaled-to-zero service ${svc.name} (project ${svc.projectId || 'unknown'} — warm pool will handle next visit)`
           )


### PR DESCRIPTION
## Summary

- **GC active-label protection**: Adds a `shogo.io/active` label to Knative Services during warm pool assignment. The namespace GC now skips scaled-to-zero services that carry this label, deferring cleanup to the promoted-pod GC (which checks `/pool/activity` for live streams). This prevents the destructive cycle where GC deletes a pod, causing DomainMapping re-creation, TLS cert re-provisioning, and `ERR_CERT_AUTHORITY_INVALID` errors. One production project (`b59e096c`) was churned through **17 different pods in 1 hour** due to this.

- **Distributed claim lock**: Adds a PostgreSQL advisory lock (`pg_try_advisory_lock`) in `tryClaimWarmPod()` keyed on the project ID to prevent multiple API replicas from independently claiming different warm pool pods for the same project. Logs showed two replicas (`724nc` and `pwkwq`) both claiming pods for the same project within 200ms of each other, causing one to become orphaned.

## Root cause (from SigNoz production logs)

The namespace GC runs every ~5 min and deletes any scaled-to-zero Knative Service. But promoted pods scale to zero within ~60s of idle and get deleted before the user's next request. Each deletion triggers: evict → re-claim new pod → new DomainMapping → new TLS cert provisioning → GC deletes again before cert finishes → `ERR_CERT_AUTHORITY_INVALID` + `proxy_error` for the user.

Separately, without a distributed lock, concurrent requests hitting different API replicas each independently claim a warm pod, resulting in double assignments and orphaned services.

## Test plan

- [ ] Deploy to staging and verify `[WarmPool GC:namespace] Skipping active scaled-to-zero service` log appears for assigned pods
- [ ] Verify pods survive namespace GC cycles when `shogo.io/active=true` label is present
- [ ] Verify `shogo.io/active` label is cleared on eviction (`evictProject`)
- [ ] Verify advisory lock prevents double-claim: send two concurrent requests for the same project and confirm only one pod is assigned
- [ ] Verify lock is released on failure (kill the claiming process, confirm another replica can claim)
- [ ] Monitor pod assignment count per project — should drop from ~17/hour to ~1-2/hour

