### PR TITLE
Fix : Subagent LLM/Tool Executions Ignoring Cancellation

### DIFF
--- a/packages/agent-runtime/src/agent-manager.ts
+++ b/packages/agent-runtime/src/agent-manager.ts
@@ -274,7 +274,7 @@ export class AgentManager {
       },
     }
 
-    const promise = runSubagent(config, prompt, parentCtx, allTools, trackingCallbacks, { history: options?.history, instanceId })
+    const promise = runSubagent(config, prompt, parentCtx, allTools, trackingCallbacks, { history: options?.history, instanceId, signal: abortController.signal })
       .then((result) => {
         const inst = this.instances.get(instanceId)
         if (inst) {
@@ -298,14 +298,18 @@ export class AgentManager {
       })
       .catch((err) => {
         const inst = this.instances.get(instanceId)
+        const wasCancelled = inst?.status === 'cancelled' || abortController.signal.aborted
         if (inst) {
-          inst.status = 'failed'
-          inst.completedAt = Date.now()
-          inst.result = { responseText: err.message, toolCalls: 0, iterations: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 }
+          if (!wasCancelled) inst.status = 'failed'
+          inst.completedAt ??= Date.now()
+          inst.result = {
+            responseText: wasCancelled ? 'Subagent cancelled' : err.message,
+            toolCalls: 0, iterations: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0,
+          }
         }
         if (regEntry) {
           regEntry.metrics.totalRuns++
-          regEntry.metrics.failures++
+          if (!wasCancelled) regEntry.metrics.failures++
           regEntry.metrics.totalWallTimeMs += Date.now() - startTime
           this.flushMetrics(type, regEntry.metrics)
         }

--- a/packages/agent-runtime/src/subagent.ts
+++ b/packages/agent-runtime/src/subagent.ts
@@ -570,6 +570,9 @@ export interface SubagentRunOptions {
   /** AgentManager instance id for this run — plumbed into ToolContext.subagentInstanceId
    *  so tools (e.g. `browser`) can key per-instance resources like the CDP screencast. */
   instanceId?: string
+  /** AbortSignal for external cancellation. When aborted, the underlying
+   *  agent loop stops after the current LLM call / tool execution completes. */
+  signal?: AbortSignal
 }
 
 /**
@@ -753,6 +756,7 @@ export async function runSubagent(
       thinkingLevel,
       loopDetection: config.loopDetection,
       streamFn: options?.streamFn,
+      signal: options?.signal,
       onToolCall: callbacks?.onToolCall,
       onTextDelta: callbacks?.onTextDelta,
       onThinkingStart: callbacks?.onThinkingStart,


### PR DESCRIPTION
###  Summary

**The problem:** `AgentManager.cancel()` called `abortController.abort()` but the signal was never passed to `runSubagent` → `runAgentLoop`. The LLM call and tool execution kept running (and billing) after "cancellation."

**The fix — 3 precise edits:**

**1. `packages/agent-runtime/src/subagent.ts` — `SubagentRunOptions`**

Added `signal?: AbortSignal` to the options interface so callers can pass a cancellation signal.

**2. `packages/agent-runtime/src/subagent.ts` — `runOnce()`**

Threaded `signal: options?.signal` into the `runAgentLoop()` call. `runAgentLoop` already fully supports `AbortSignal` (checks `signal.aborted` on entry, wires an `abort` event listener, and cleans up on finally) — it just was never receiving one from subagent runs.

**3. `packages/agent-runtime/src/agent-manager.ts` — `spawn()` and `.catch()`**

- Passed `signal: abortController.signal` in the `runSubagent` options object
- Fixed the `.catch()` handler to **not overwrite** `cancelled` status with `failed` when the abort signal caused the rejection:
  - Checks `wasCancelled` via `inst.status === 'cancelled'` (set by `cancel()`) or `abortController.signal.aborted`
  - Preserves `cancelled` status and `completedAt` timestamp set by `cancel()`
  - Sets `responseText` to `'Subagent cancelled'` instead of the raw error message
  - Does **not** increment `failures` metric for cancellations (they're intentional, not errors)

### What happens now when a user cancels

1. `cancel(id)` is called → sets `status = 'cancelled'`, calls `abortController.abort()`
2. The signal reaches `runAgentLoop` → the loop stops after the current LLM call or tool execution completes
3. The promise rejects (or resolves with partial results) → `.catch()` sees `wasCancelled = true`, preserves the `cancelled` status, and doesn't count it as a failure in metrics
