### PR TITLE
fix(agent-runtime): GET /api/dist-files for publish pipeline (staging 404)

### DIFF
--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -2790,6 +2790,33 @@ function getDistDir(): string {
   return join(WORKSPACE_DIR, 'dist')
 }
 
+// Publish pipeline: returns all dist/ files base64-encoded so the API server
+// can upload them to S3 without needing direct filesystem access.
+app.get('/api/dist-files', (c) => {
+  const distDir = getDistDir()
+
+  if (!existsSync(distDir)) {
+    return c.json({ error: 'dist directory not found — run a build first' }, 404)
+  }
+
+  const results: { path: string; content: string }[] = []
+
+  function walk(dir: string, base: string) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name)
+      const rel = base ? `${base}/${entry.name}` : entry.name
+      if (entry.isDirectory()) {
+        walk(full, rel)
+      } else {
+        results.push({ path: rel, content: readFileSync(full).toString('base64') })
+      }
+    }
+  }
+
+  walk(distDir, '')
+  return c.json(results)
+})
+
 app.get('*', (c) => {
   const urlPath = new URL(c.req.url).pathname
 


### PR DESCRIPTION
## Problem
Fixes #401 — staging publish failed with `download_failed` / `Failed to get dist files: 404` because the runtime never served `GET /api/dist-files`; the `/api/*` branch in the static catch-all returned 404.

## Change
- Add `app.get('/api/dist-files', ...)` before `app.get('*', ...)` in `packages/agent-runtime/src/server.ts`.
- Walk `dist/`, return `[{ path, content }]` with base64 contents (same contract as `publish.ts`).

## Verification
- [ ] After deploy, trigger Publish on staging and confirm S3/Knative path succeeds.


