### PR TITLE
fix(api): Harden Anthropic streaming (retries, keepalive, typed errors, billing guard)

### DIFF
--- a/apps/api/src/routes/__tests__/ai-proxy-streaming.test.ts
+++ b/apps/api/src/routes/__tests__/ai-proxy-streaming.test.ts
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * AI Proxy — Streaming Resilience Tests
+ *
+ * Covers the three invariants that fix "Claude connection lost":
+ *
+ *   1. Transient 5xx / 429 / 529 / TCP reset before bytes flow is retried
+ *      with exponential backoff + jitter and `Retry-After[-Ms]` honored.
+ *   2. AbortError caused by the caller's signal NEVER retries — client
+ *      cancel must propagate immediately (so the UI's Stop button works).
+ *   3. Mid-stream / truncated-EOF Anthropic streams inject an explicit
+ *      `event: error` SSE frame so downstream SDKs see a typed error
+ *      instead of a silent end-of-stream.
+ *   4. A clean `message_stop` stream never injects a synthetic error.
+ *   5. SSE keepalive comments are emitted when upstream is idle (keeps
+ *      intermediate proxies from killing long Opus thinking windows).
+ *
+ * Run: bun test apps/api/src/routes/__tests__/ai-proxy-streaming.test.ts
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test'
+import {
+  fetchAnthropicWithRetry,
+  wrapSseForErrorVisibility,
+  scanForTerminalEvent,
+  parseRetryAfter,
+  isRetryableNetworkError,
+  type StreamErrorPayload,
+} from '../ai-proxy'
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+const TE = new TextEncoder()
+const TD = new TextDecoder()
+
+/** Build a ReadableStream<Uint8Array> from a sequence of string/events. */
+function sseStreamFrom(
+  chunks: string[],
+  opts: { errorAfter?: number; delayMsBetween?: number } = {},
+): ReadableStream<Uint8Array> {
+  let i = 0
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (opts.delayMsBetween) {
+        await new Promise((r) => setTimeout(r, opts.delayMsBetween))
+      }
+      if (opts.errorAfter !== undefined && i === opts.errorAfter) {
+        controller.error(new TypeError('fetch failed'))
+        return
+      }
+      if (i >= chunks.length) {
+        controller.close()
+        return
+      }
+      controller.enqueue(TE.encode(chunks[i]!))
+      i++
+    },
+  })
+}
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader()
+  let out = ''
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (value) out += TD.decode(value, { stream: true })
+  }
+  return out
+}
+
+/** Patch global fetch with a scriptable sequence of responses. */
+function scriptFetch(
+  script: Array<Response | Error | (() => Promise<Response> | Response | never)>,
+) {
+  let call = 0
+  const calls: Array<{ url: string; init: RequestInit | undefined }> = []
+  const fn = mock(async (url: string, init?: RequestInit) => {
+    calls.push({ url, init })
+    const step = script[call++]
+    if (step === undefined) {
+      throw new Error(`fetch called more than scripted (${call} calls)`)
+    }
+    if (step instanceof Error) throw step
+    if (typeof step === 'function') return await step()
+    return step
+  })
+  ;(globalThis as any).fetch = fn
+  return { fn, calls }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// parseRetryAfter / isRetryableNetworkError (pure helpers)
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('parseRetryAfter', () => {
+  test('parses integer seconds', () => {
+    expect(parseRetryAfter('3')).toBe(3000)
+  })
+  test('caps at 30s', () => {
+    expect(parseRetryAfter('600')).toBe(30_000)
+  })
+  test('parses HTTP-date', () => {
+    const future = new Date(Date.now() + 2000).toUTCString()
+    const ms = parseRetryAfter(future)
+    expect(ms).not.toBeNull()
+    expect(ms!).toBeGreaterThanOrEqual(0)
+    expect(ms!).toBeLessThanOrEqual(30_000)
+  })
+  test('returns null for garbage', () => {
+    expect(parseRetryAfter('not-a-date')).toBeNull()
+    expect(parseRetryAfter(null)).toBeNull()
+  })
+})
+
+describe('isRetryableNetworkError', () => {
+  test('detects undici error codes', () => {
+    expect(isRetryableNetworkError({ code: 'ECONNRESET' })).toBe(true)
+    expect(isRetryableNetworkError({ code: 'UND_ERR_SOCKET' })).toBe(true)
+    expect(isRetryableNetworkError({ cause: { code: 'ETIMEDOUT' } })).toBe(true)
+  })
+  test('detects "fetch failed" messages', () => {
+    expect(isRetryableNetworkError(new TypeError('fetch failed'))).toBe(true)
+  })
+  test('rejects non-network errors', () => {
+    expect(isRetryableNetworkError(new TypeError('bad arg'))).toBe(false)
+    expect(isRetryableNetworkError(null)).toBe(false)
+  })
+})
+
+describe('scanForTerminalEvent (split-frame safe)', () => {
+  test('finds message_stop', () => {
+    expect(
+      scanForTerminalEvent('event: message_stop\ndata: {"type":"message_stop"}\n\n'),
+    ).toBe(true)
+  })
+  test('finds error event', () => {
+    expect(
+      scanForTerminalEvent('data: {"type":"error","error":{"type":"overloaded_error"}}\n\n'),
+    ).toBe(true)
+  })
+  test('ignores text delta that quotes the string', () => {
+    expect(
+      scanForTerminalEvent(
+        'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"type:\\"message_stop\\""}}\n\n',
+      ),
+    ).toBe(false)
+  })
+  test('catches message_stop even if split across chunks when buffered', () => {
+    // Simulate buffering: previous chunk ended with partial data: line.
+    const buffered =
+      'data: {"type":"content_block_delta"}\n\ndata: {"type":"mess' +
+      'age_stop"}\n\n'
+    expect(scanForTerminalEvent(buffered)).toBe(true)
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────────────
+// fetchAnthropicWithRetry
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('fetchAnthropicWithRetry', () => {
+  const origFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = origFetch
+  })
+
+  test('returns immediately on 200', async () => {
+    const { fn } = scriptFetch([new Response('ok', { status: 200 })])
+    const res = await fetchAnthropicWithRetry('https://x', { method: 'POST' }, {
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      maxDelayMs: 1,
+    })
+    expect(res.status).toBe(200)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  test('retries on 529 overloaded_error and succeeds on attempt 2', async () => {
+    const { fn } = scriptFetch([
+      new Response('{"type":"error","error":{"type":"overloaded_error"}}', {
+        status: 529,
+      }),
+      new Response('ok', { status: 200 }),
+    ])
+    const res = await fetchAnthropicWithRetry('https://x', { method: 'POST' }, {
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      maxDelayMs: 2,
+    })
+    expect(res.status).toBe(200)
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  test('retries on ECONNRESET and succeeds on attempt 2', async () => {
+    const err: any = new Error('fetch failed')
+    err.code = 'ECONNRESET'
+    const { fn } = scriptFetch([err, new Response('ok', { status: 200 })])
+    const res = await fetchAnthropicWithRetry('https://x', { method: 'POST' }, {
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      maxDelayMs: 2,
+    })
+    expect(res.status).toBe(200)
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  test('returns final 5xx Response body after maxAttempts', async () => {
+    const { fn } = scriptFetch([
+      new Response('overloaded 1', { status: 529 }),
+      new Response('overloaded 2', { status: 529 }),
+    ])
+    const res = await fetchAnthropicWithRetry('https://x', { method: 'POST' }, {
+      maxAttempts: 2,
+      baseDelayMs: 1,
+      maxDelayMs: 2,
+    })
+    expect(res.status).toBe(529)
+    expect(await res.text()).toBe('overloaded 2')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  test('does NOT retry on 400 (client error)', async () => {
+    const { fn } = scriptFetch([new Response('bad request', { status: 400 })])
+    const res = await fetchAnthropicWithRetry('https://x', { method: 'POST' }, {
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      maxDelayMs: 2,
+    })
+    expect(res.status).toBe(400)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  test('does NOT retry on AbortError and bubbles up', async () => {
+    const abortErr = new DOMException('Aborted', 'AbortError')
+    const { fn } = scriptFetch([abortErr])
+    await expect(
+      fetchAnthropicWithRetry(
+        'https://x',
+        { method: 'POST' },
+        { maxAttempts: 3, baseDelayMs: 1, maxDelayMs: 1 },
+      ),
+    ).rejects.toThrow(/Aborted/)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  test('aborts during backoff sleep', async () => {
+    const { fn } = scriptFetch([
+      new Response('retry me', { status: 503 }),
+      new Response('should not reach', { status: 200 }),
+    ])
+    const ac = new AbortController()
+    const promise = fetchAnthropicWithRetry(
+      'https://x',
+      { method: 'POST' },
+      {
+        maxAttempts: 3,
+        baseDelayMs: 10_000, // long enough that we must abort during sleep
+        maxDelayMs: 10_000,
+        signal: ac.signal,
+      },
+    )
+    // Give the first fetch a tick to settle into the backoff sleep.
+    await new Promise((r) => setTimeout(r, 20))
+    ac.abort()
+    await expect(promise).rejects.toThrow(/Aborted/)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  test('honors Retry-After-Ms header (Anthropic-specific)', async () => {
+    const headers = new Headers({
+      'Content-Type': 'application/json',
+      'retry-after-ms': '25',
+    })
+    const { fn } = scriptFetch([
+      new Response('slow down', { status: 429, headers }),
+      new Response('ok', { status: 200 }),
+    ])
+    const t0 = Date.now()
+    const res = await fetchAnthropicWithRetry('https://x', { method: 'POST' }, {
+      maxAttempts: 3,
+      baseDelayMs: 10_000, // high base so if we fell back to exp we'd notice
+      maxDelayMs: 10_000,
+    })
+    const elapsed = Date.now() - t0
+    expect(res.status).toBe(200)
+    expect(fn).toHaveBeenCalledTimes(2)
+    // We waited ~25ms (retry-after-ms), not ~10s (would have been baseDelay).
+    expect(elapsed).toBeLessThan(500)
+  })
+
+  test('uses reduced maxAttempts=2 for shogo-cloud label by default', async () => {
+    const { fn } = scriptFetch([
+      new Response('overloaded 1', { status: 529 }),
+      new Response('overloaded 2', { status: 529 }),
+    ])
+    const res = await fetchAnthropicWithRetry(
+      'https://x',
+      { method: 'POST' },
+      { label: 'shogo-cloud', baseDelayMs: 1, maxDelayMs: 2 }, // no maxAttempts
+    )
+    expect(res.status).toBe(529)
+    expect(fn).toHaveBeenCalledTimes(2) // 2 attempts for cloud hop (not 3)
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────────────
+// wrapSseForErrorVisibility
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('wrapSseForErrorVisibility', () => {
+  test('clean message_stop stream is passed through untouched', async () => {
+    const clean =
+      'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":10}}}\n\n' +
+      'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"text_delta","text":"hi"}}\n\n' +
+      'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+    const wrapped = wrapSseForErrorVisibility(sseStreamFrom([clean]), 'anthropic')
+    const out = await collect(wrapped)
+    expect(out).toBe(clean)
+    expect(out).not.toContain('event: error')
+    expect(out).not.toContain('stream_error')
+  })
+
+  test('truncated-EOF (no message_stop) injects a typed error frame with code + retryable + meta', async () => {
+    const truncated =
+      'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":10}}}\n\n' +
+      'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"text_delta","text":"partial"}}\n\n'
+    const wrapped = wrapSseForErrorVisibility(sseStreamFrom([truncated]), 'anthropic')
+    const out = await collect(wrapped)
+    expect(out).toStartWith(truncated)
+    expect(out).toContain('event: error')
+
+    // Parse the injected error frame
+    const errLine = out.split('\n').find((l) => l.startsWith('data: ') && l.includes('stream_error'))!
+    const payload: StreamErrorPayload = JSON.parse(errLine.slice(6))
+    expect(payload.error.type).toBe('stream_error')
+    expect(payload.error.code).toBe('upstream_truncated')
+    expect(payload.error.retryable).toBe(true)
+    expect(payload.error.meta.chunks).toBe(1)
+    expect(payload.error.meta.bytes).toBeGreaterThan(0)
+    expect(payload.error.meta.durationMs).toBeGreaterThanOrEqual(0)
+    expect(payload.error.message).toContain('message_stop')
+  })
+
+  test('mid-stream upstream fault injects a typed error frame with code network_drop', async () => {
+    const wrapped = wrapSseForErrorVisibility(
+      sseStreamFrom(
+        [
+          'event: message_start\ndata: {"type":"message_start"}\n\n',
+          'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"text_delta","text":"half"}}\n\n',
+        ],
+        { errorAfter: 2 }, // throw after 2 chunks
+      ),
+      'anthropic',
+    )
+    const out = await collect(wrapped)
+    expect(out).toContain('event: error')
+
+    const errLine = out.split('\n').find((l) => l.startsWith('data: ') && l.includes('stream_error'))!
+    const payload: StreamErrorPayload = JSON.parse(errLine.slice(6))
+    expect(payload.error.code).toBe('network_drop')
+    expect(payload.error.retryable).toBe(true)
+    expect(payload.error.meta.chunks).toBe(2)
+    expect(payload.error.message).toContain('fetch failed')
+  })
+
+  test('does NOT inject error when message_stop is split across chunks', async () => {
+    const head =
+      'event: message_start\ndata: {"type":"message_start"}\n\n' +
+      'data: {"type":"mess'
+    const tail = 'age_stop"}\n\n'
+    const wrapped = wrapSseForErrorVisibility(sseStreamFrom([head, tail]), 'anthropic')
+    const out = await collect(wrapped)
+    expect(out).toBe(head + tail)
+    expect(out).not.toContain('event: error\ndata:')
+  })
+
+  test('emits a keepalive comment when upstream idles beyond keepaliveMs', async () => {
+    // 2 chunks with a 50ms gap; keepalive at 20ms should fire at least once.
+    const stream = sseStreamFrom(
+      [
+        'event: message_start\ndata: {"type":"message_start"}\n\n',
+        'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+      ],
+      { delayMsBetween: 50 },
+    )
+    const wrapped = wrapSseForErrorVisibility(stream, 'anthropic', {
+      keepaliveMs: 20,
+    })
+    const out = await collect(wrapped)
+    expect(out).toContain(': keepalive')
+    expect(out).toContain('message_stop')
+  })
+
+  test('client-initiated AbortError is propagated cleanly (no synthetic frame)', async () => {
+    const upstream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.error(new DOMException('Aborted', 'AbortError'))
+      },
+    })
+    const wrapped = wrapSseForErrorVisibility(upstream, 'anthropic')
+    const out = await collect(wrapped)
+    expect(out).not.toContain('event: error')
+    expect(out).not.toContain('stream_error')
+  })
+
+  test('idle watchdog fires when upstream is silent beyond maxIdleMs', async () => {
+    // Upstream sends one chunk then hangs forever.
+    let resolveHang: (() => void) | null = null
+    const upstream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        if (resolveHang) {
+          // Second pull — hang until cancelled or test ends.
+          await new Promise<void>((r) => { resolveHang = r })
+          controller.close()
+          return
+        }
+        controller.enqueue(TE.encode('event: message_start\ndata: {"type":"message_start"}\n\n'))
+        resolveHang = () => {}
+      },
+      cancel() { resolveHang?.() },
+    })
+    const wrapped = wrapSseForErrorVisibility(upstream, 'anthropic', {
+      keepaliveMs: 10,
+      maxIdleMs: 50,
+      watchdogIntervalMs: 20, // tight interval for testing
+    })
+    const out = await collect(wrapped)
+    expect(out).toContain('event: error')
+    const errLine = out.split('\n').find((l) => l.startsWith('data: ') && l.includes('stream_error'))!
+    const payload: StreamErrorPayload = JSON.parse(errLine.slice(6))
+    expect(payload.error.code).toBe('idle_timeout')
+    expect(payload.error.retryable).toBe(true)
+    expect(payload.error.message).toContain('No data from anthropic')
+  })
+})

--- a/apps/api/src/routes/ai-proxy.ts
+++ b/apps/api/src/routes/ai-proxy.ts
@@ -197,6 +197,482 @@ function resolveAgentModel(model: string): { resolvedModel: string; isLocal: boo
 }
 
 // =============================================================================
+// Streaming Resilience — retry + mid-stream error visibility + SSE keepalive
+// =============================================================================
+//
+// These helpers harden the upstream legs that hit Anthropic (or Shogo Cloud,
+// which fronts Anthropic). They are modelled on `@anthropic-ai/sdk` (the
+// library Claude Code CLI uses internally) and fix the failure modes that
+// surface to users as "Claude connection lost":
+//
+//  1. Transient 429 / 5xx / 529 "overloaded_error" / TCP reset on the initial
+//     POST — retried here instead of bubbling to the agent runtime.
+//  2. Mid-stream disconnect where Anthropic's response body aborts after
+//     `message_start` but before `message_stop`. Previously the SSE pipe
+//     closed silently at EOF and the downstream SDK threw an opaque error.
+//     We now inject an Anthropic-shaped `event: error` frame so the SDK
+//     surfaces a typed, actionable error.
+//  3. Opus-specific idle timeouts: Opus pauses tens of seconds during
+//     extended thinking. Intermediate proxies (Cloudflare ~100s, AWS ALB
+//     default 60s, Kubernetes Ingress often 60s) kill idle TCP in that
+//     window. We emit SSE keepalive comments (`: keepalive\n\n`) every
+//     KEEPALIVE_INTERVAL_MS when upstream is silent — parsers ignore
+//     comments but intermediaries see live traffic.
+//
+// Parity notes vs @anthropic-ai/sdk (>= v0.30):
+//   - SDK default `maxRetries`: 2. We use 2 for cloud hops (where upstream
+//     already retries) and 3 for direct Anthropic hops (slightly more
+//     aggressive since we are the only retry layer).
+//   - SDK retries 408/409/429 + all 5xx. We add 425 (Too Early) + 529
+//     (Anthropic Overloaded) which both Claude Code and the Python SDK
+//     treat as retryable.
+//   - SDK: exponential backoff with jitter honoring Retry-After /
+//     Retry-After-Ms. Matching us. Cap at 30s (guard against buggy
+//     upstream wedging a worker).
+//
+// We intentionally DO NOT retry mid-stream: Anthropic's Messages API has no
+// resume-by-event-id semantics, so a silent retry would duplicate tokens.
+// The agent runtime handles turn-level retries safely (same tool_use ids).
+
+/** HTTP status codes that are worth retrying against Anthropic / Shogo Cloud. */
+const ANTHROPIC_RETRYABLE_STATUS = new Set([408, 409, 425, 429, 500, 502, 503, 504, 529])
+
+/** Node/undici network error codes that indicate a retry-able transient fault. */
+const RETRYABLE_ERROR_CODES = new Set([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ECONNABORTED',
+  'ETIMEDOUT',
+  'EPIPE',
+  'EAI_AGAIN',
+  'UND_ERR_SOCKET',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+])
+
+/** How long upstream can be silent before we send a keepalive comment. */
+const KEEPALIVE_INTERVAL_MS = 15_000
+
+/**
+ * Env escape-hatch: set to disable retries in the cloud-forwarding path.
+ * Prevents 3x (local) * 3x (cloud) = 9 attempt amplification when both
+ * layers run this same code. When unset, we use a smaller attempt budget
+ * (2) for cloud hops as a safe default.
+ */
+const SHOGO_CLOUD_DISABLE_LOCAL_RETRY =
+  process.env.SHOGO_CLOUD_DISABLE_LOCAL_RETRY === 'true'
+
+export interface RetryOptions {
+  /**
+   * Max attempts (inclusive of the first try). Defaults: 3 for direct
+   * Anthropic hops, 2 for cloud hops (upstream has its own retries).
+   */
+  maxAttempts?: number
+  /** Base delay for exponential backoff, in ms. Default 500. */
+  baseDelayMs?: number
+  /** Upper bound on a single wait, in ms. Default 8000. */
+  maxDelayMs?: number
+  /** Label used in logs (e.g. "anthropic" or "shogo-cloud"). */
+  label?: string
+  /** AbortSignal — when aborted we stop retrying immediately. */
+  signal?: AbortSignal
+}
+
+export function isRetryableNetworkError(err: any): boolean {
+  if (!err) return false
+  const code = err.code || err.cause?.code
+  if (code && RETRYABLE_ERROR_CODES.has(code)) return true
+  // undici surfaces many network faults as { name: 'TypeError', message: 'fetch failed' }
+  const msg = String(err.message || '')
+  if (/fetch failed|socket hang up|network.*error|terminated/i.test(msg)) return true
+  return false
+}
+
+/**
+ * Parse a `Retry-After` header value (RFC 7231 §7.1.3): integer seconds or
+ * HTTP-date. Result is in milliseconds, capped at 30s.
+ */
+export function parseRetryAfter(header: string | null): number | null {
+  if (!header) return null
+  const asInt = Number(header)
+  if (Number.isFinite(asInt) && asInt >= 0) return Math.min(asInt * 1000, 30_000)
+  const asDate = Date.parse(header)
+  if (Number.isFinite(asDate)) return Math.max(0, Math.min(asDate - Date.now(), 30_000))
+  return null
+}
+
+/**
+ * Parse Anthropic's `Retry-After-Ms` header (milliseconds, integer).
+ * Capped at 30s to avoid wedging a worker on a buggy upstream.
+ */
+export function parseRetryAfterMs(header: string | null): number | null {
+  if (!header) return null
+  const ms = Number(header)
+  if (!Number.isFinite(ms) || ms < 0) return null
+  return Math.min(ms, 30_000)
+}
+
+async function sleepWithAbort(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(new DOMException('Aborted', 'AbortError'))
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+/**
+ * Split-frame-safe terminal-event detector.
+ *
+ * A TCP read can cleave `"type":"message_stop"` across two chunks, so the
+ * caller must scan a rolling tail buffer — not individual chunks. We line-
+ * match against `data:` lines so a value that coincidentally quotes the
+ * string in a text delta cannot false-positive us.
+ */
+export const TERMINAL_EVENT_RE =
+  /(?:^|\n)data:[^\n]*"type"\s*:\s*"(message_stop|error)"/
+
+export function scanForTerminalEvent(buffer: string): boolean {
+  return TERMINAL_EVENT_RE.test(buffer)
+}
+
+/**
+ * Fetch wrapper that retries transient failures before any stream bytes flow.
+ *
+ * Retries are confined to the *connection* phase — once `fetch()` resolves
+ * with a 2xx, we return the Response as-is and let the caller stream the
+ * body. This preserves idempotency: the upstream has not yet emitted any
+ * tokens when we retry, so duplicate-token risk is zero.
+ *
+ * Retries on:
+ *   - Network errors (ECONNRESET, ECONNREFUSED, ETIMEDOUT, EPIPE, "fetch failed")
+ *   - HTTP 408 / 409 / 425 / 429 / 500 / 502 / 503 / 504 / 529
+ *
+ * Does NOT retry on:
+ *   - AbortError caused by the caller's signal (client cancel → surface 499)
+ *   - 4xx responses other than the transient set above
+ *   - Cloud hops when SHOGO_CLOUD_DISABLE_LOCAL_RETRY=true (trust upstream)
+ *
+ * Honors `Retry-After-Ms` (Anthropic-specific) and `Retry-After` response
+ * headers, capped at 30s to avoid wedging a worker on a buggy upstream.
+ */
+export async function fetchAnthropicWithRetry(
+  url: string,
+  init: RequestInit,
+  opts: RetryOptions = {},
+): Promise<Response> {
+  const isCloudHop = opts.label === 'shogo-cloud'
+  const defaultAttempts = isCloudHop
+    ? SHOGO_CLOUD_DISABLE_LOCAL_RETRY ? 1 : 2
+    : 3
+  const maxAttempts = opts.maxAttempts ?? defaultAttempts
+  const baseDelayMs = opts.baseDelayMs ?? 500
+  const maxDelayMs = opts.maxDelayMs ?? 8000
+  const label = opts.label ?? 'anthropic'
+  const signal = opts.signal ?? (init.signal as AbortSignal | undefined)
+
+  let lastError: any = null
+  let lastStatus: number | null = null
+  let lastRetryAfterMs: number | null = null
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    if (signal?.aborted) {
+      throw new DOMException('Aborted', 'AbortError')
+    }
+
+    try {
+      const response = await fetch(url, { ...init, signal })
+
+      // Success or non-retryable client error — return to caller.
+      if (response.ok || !ANTHROPIC_RETRYABLE_STATUS.has(response.status)) {
+        return response
+      }
+
+      // Retryable HTTP status — drain body so we can reuse the connection.
+      lastStatus = response.status
+      // Anthropic returns `retry-after-ms` (integer ms) in addition to the
+      // standard `Retry-After` (seconds or HTTP-date). Prefer the ms one.
+      lastRetryAfterMs =
+        parseRetryAfterMs(response.headers.get('retry-after-ms')) ??
+        parseRetryAfter(response.headers.get('retry-after'))
+      try {
+        lastError = new Error(await response.text())
+      } catch {
+        lastError = new Error(`${label} HTTP ${response.status}`)
+      }
+
+      if (attempt >= maxAttempts) {
+        // Out of attempts — synthesize a Response so the caller can forward
+        // the last error body verbatim (preserves Anthropic's error shape).
+        return new Response(lastError.message, {
+          status: response.status,
+          headers: {
+            'Content-Type':
+              response.headers.get('Content-Type') || 'application/json',
+          },
+        })
+      }
+    } catch (err: any) {
+      // Client-initiated abort must bubble up; never retry it.
+      if (err?.name === 'AbortError' || err?.name === 'TimeoutError') {
+        throw err
+      }
+      if (!isRetryableNetworkError(err)) {
+        throw err
+      }
+      lastError = err
+      lastStatus = null
+      lastRetryAfterMs = null
+      if (attempt >= maxAttempts) break
+    }
+
+    // Compute backoff: Retry-After wins; otherwise exponential with full jitter.
+    const exp = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs)
+    const jittered = Math.floor(Math.random() * exp)
+    const delay = lastRetryAfterMs ?? jittered
+    console.warn(
+      `[AI Proxy] ${label} transient failure (attempt ${attempt}/${maxAttempts}, ` +
+        `status=${lastStatus ?? 'network'}): retrying in ${delay}ms — ${lastError?.message || lastError?.code || 'unknown'}`,
+    )
+    await sleepWithAbort(delay, signal)
+  }
+
+  // Network error path exhausted without a Response — rethrow the last error.
+  throw lastError ?? new Error(`${label} request failed after ${maxAttempts} attempts`)
+}
+
+/**
+ * Classify a stream error into a typed code for downstream consumers.
+ * The code lets the UI decide whether to auto-retry (retryable) or surface
+ * a fatal message (non-retryable).
+ */
+export type StreamErrorCode =
+  | 'upstream_truncated' // clean EOF without message_stop
+  | 'network_drop'       // ECONNRESET, socket hang up, etc.
+  | 'idle_timeout'       // MAX_IDLE_MS exceeded with no upstream data
+  | 'upstream_error'     // catch-all for other errors
+
+export interface StreamErrorPayload {
+  type: 'error'
+  error: {
+    type: 'stream_error'
+    code: StreamErrorCode
+    retryable: boolean
+    message: string
+    meta: {
+      chunks: number
+      bytes: number
+      durationMs: number
+      idleMs: number
+    }
+  }
+}
+
+function classifyStreamError(err: any): StreamErrorCode {
+  if (!err) return 'upstream_truncated'
+  const msg = String(err?.message ?? '')
+  if (err?.code === 'ETIMEDOUT' || /idle.?timeout/i.test(msg)) return 'idle_timeout'
+  if (/ECONNRESET|socket hang up|terminated|fetch failed/i.test(msg)) return 'network_drop'
+  if (err?.code && RETRYABLE_ERROR_CODES.has(err.code)) return 'network_drop'
+  return 'upstream_error'
+}
+
+/**
+ * Maximum time (ms) the upstream can be silent (no real chunks) before we
+ * abort and inject a retryable error. 120s is well below the 30min fetch
+ * timeout but long enough for Opus extended-thinking pauses (which are
+ * covered by keepalive comments, not this watchdog).
+ */
+const MAX_IDLE_MS = 120_000
+
+export interface StreamWrapOptions {
+  /** Idle ms before emitting a SSE keepalive comment. Default 15000. */
+  keepaliveMs?: number
+  /** Hard idle limit before injecting a retryable error. Default 120000. */
+  maxIdleMs?: number
+  /** How often to check the watchdog condition, in ms. Default 5000. */
+  watchdogIntervalMs?: number
+}
+
+/**
+ * Wrap an upstream SSE body so that (a) mid-stream disconnects surface as
+ * explicit `event: error` frames, and (b) an idle upstream does not cause
+ * intermediate proxies to drop the TCP connection.
+ *
+ * Without (a): when Anthropic's TCP connection drops after `message_start`
+ * but before `message_stop`, the downstream SDK sees a normal end-of-stream
+ * and throws an opaque "connection lost" error. We now inject a structured
+ * error event so the SDK surfaces a typed, actionable error.
+ *
+ * Without (b): Opus streams frequently pause 30–60s during extended
+ * thinking. Cloudflare / AWS ALB / Kubernetes Ingress can kill idle TCP in
+ * that window. A SSE comment line (`: keepalive\n\n`) is ignored by parsers
+ * (per https://html.spec.whatwg.org/multipage/server-sent-events.html) but
+ * keeps the socket hot.
+ *
+ * We track whether a terminal event (`message_stop` or `error`) was observed
+ * in a split-frame-safe rolling buffer, so we only inject synthetic errors
+ * on actual truncation.
+ */
+export function wrapSseForErrorVisibility(
+  upstream: ReadableStream<Uint8Array>,
+  providerLabel: string,
+  options: StreamWrapOptions = {},
+): ReadableStream<Uint8Array> {
+  const decoder = new TextDecoder()
+  const encoder = new TextEncoder()
+  const keepaliveMs = options.keepaliveMs ?? KEEPALIVE_INTERVAL_MS
+  const maxIdleMs = options.maxIdleMs ?? MAX_IDLE_MS
+  const watchdogIntervalMs = options.watchdogIntervalMs ?? 5_000
+  let tailBuffer = ''
+  let sawTerminalEvent = false
+  let chunkCount = 0
+  let totalBytes = 0
+  const startedAt = Date.now()
+  let lastChunkAt = startedAt
+
+  function buildErrorPayload(
+    code: StreamErrorCode,
+    message: string,
+  ): StreamErrorPayload {
+    return {
+      type: 'error',
+      error: {
+        type: 'stream_error',
+        code,
+        retryable: code !== 'upstream_error',
+        message,
+        meta: {
+          chunks: chunkCount,
+          bytes: totalBytes,
+          durationMs: Date.now() - startedAt,
+          idleMs: Date.now() - lastChunkAt,
+        },
+      },
+    }
+  }
+
+  function emitErrorFrame(
+    controller: ReadableStreamDefaultController<Uint8Array>,
+    payload: StreamErrorPayload,
+  ) {
+    try {
+      controller.enqueue(
+        encoder.encode(`event: error\ndata: ${JSON.stringify(payload)}\n\n`),
+      )
+    } catch { /* downstream gone */ }
+  }
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const reader = upstream.getReader()
+      let idleWatchdogFired = false
+
+      // Keepalive: emit a SSE comment when upstream is silent so intermediate
+      // proxies see live traffic and refresh their idle timer.
+      const keepaliveTimer = setInterval(() => {
+        const idleFor = Date.now() - lastChunkAt
+        if (idleFor < keepaliveMs) return
+        try {
+          controller.enqueue(encoder.encode(`: keepalive ${idleFor}ms\n\n`))
+        } catch {
+          // Downstream gone or controller closed — nothing to do.
+        }
+      }, keepaliveMs)
+
+      // Watchdog: if upstream produces zero real chunks for MAX_IDLE_MS,
+      // inject a retryable error and cancel. 120s is well beyond any
+      // Opus thinking pause (covered by keepalive), so this catches
+      // genuinely-stuck upstream connections.
+      const watchdogTimer = setInterval(() => {
+        const idle = Date.now() - lastChunkAt
+        if (idle <= maxIdleMs) return
+        idleWatchdogFired = true
+        const payload = buildErrorPayload(
+          'idle_timeout',
+          `No data from ${providerLabel} for ${idle}ms; giving up. Please retry.`,
+        )
+        emitErrorFrame(controller, payload)
+        console.warn(
+          `[AI Proxy] ${providerLabel} idle watchdog fired after ${idle}ms. ` +
+            `chunks=${chunkCount} bytes=${totalBytes} duration=${Date.now() - startedAt}ms.`,
+        )
+        try { reader.cancel('idle timeout') } catch { /* noop */ }
+        try { controller.close() } catch { /* noop */ }
+      }, watchdogIntervalMs)
+
+      try {
+        while (true) {
+          if (idleWatchdogFired) break
+          const { done, value } = await reader.read()
+          if (done) break
+          if (value && value.byteLength > 0) {
+            chunkCount++
+            totalBytes += value.byteLength
+            lastChunkAt = Date.now()
+            const text = decoder.decode(value, { stream: true })
+            tailBuffer = (tailBuffer + text).slice(-8192)
+            if (!sawTerminalEvent && scanForTerminalEvent(tailBuffer)) {
+              sawTerminalEvent = true
+            }
+            controller.enqueue(value)
+          }
+        }
+        // Clean EOF. If we never saw a terminal event (and watchdog didn't
+        // already handle this), synthesize a typed error frame.
+        if (!sawTerminalEvent && !idleWatchdogFired) {
+          const payload = buildErrorPayload(
+            'upstream_truncated',
+            `Upstream ${providerLabel} stream ended without message_stop after ${Date.now() - startedAt}ms (likely network drop; idle ${Date.now() - lastChunkAt}ms before close). The turn may be incomplete; please retry.`,
+          )
+          emitErrorFrame(controller, payload)
+          console.warn(
+            `[AI Proxy] ${providerLabel} stream truncated — injected error frame. ` +
+              `chunks=${chunkCount} bytes=${totalBytes} duration=${payload.error.meta.durationMs}ms idle=${payload.error.meta.idleMs}ms. ` +
+              `Last bytes: ${tailBuffer.slice(-200).replace(/\n/g, '\\n')}`,
+          )
+        }
+        if (!idleWatchdogFired) {
+          try { controller.close() } catch { /* noop */ }
+        }
+      } catch (err: any) {
+        if (idleWatchdogFired) return
+        if (err?.name === 'AbortError') {
+          try { controller.close() } catch { /* noop */ }
+          return
+        }
+        const code = classifyStreamError(err)
+        const payload = buildErrorPayload(
+          code,
+          `Upstream ${providerLabel} stream dropped after ${Date.now() - startedAt}ms (idle ${Date.now() - lastChunkAt}ms): ${err?.message || err?.code || 'unknown network error'}. Please retry.`,
+        )
+        emitErrorFrame(controller, payload)
+        console.warn(
+          `[AI Proxy] ${providerLabel} stream faulted mid-body [${code}]: ${err?.message || err?.code}. ` +
+            `chunks=${chunkCount} bytes=${totalBytes} duration=${payload.error.meta.durationMs}ms idle=${payload.error.meta.idleMs}ms. ` +
+            `Last bytes: ${tailBuffer.slice(-200).replace(/\n/g, '\\n')}`,
+        )
+        try { controller.close() } catch { /* noop */ }
+      } finally {
+        clearInterval(keepaliveTimer)
+        clearInterval(watchdogTimer)
+        try { reader.releaseLock() } catch { /* noop */ }
+      }
+    },
+    cancel(reason) {
+      upstream.cancel(reason).catch(() => { /* noop */ })
+    },
+  })
+}
+
+// =============================================================================
 // Anthropic Proxy
 // =============================================================================
 
@@ -500,16 +976,20 @@ async function proxyAnthropicStream(
     stream: true,
   })
 
-  const response = await fetch('https://api.anthropic.com/v1/messages', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': apiKey,
-      'anthropic-version': '2023-06-01',
+  const response = await fetchAnthropicWithRetry(
+    'https://api.anthropic.com/v1/messages',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify(body),
+      signal,
     },
-    body: JSON.stringify(body),
-    signal,
-  })
+    { label: 'anthropic', signal },
+  )
 
   if (!response.ok) {
     const errorText = await response.text()
@@ -562,19 +1042,11 @@ async function proxyAnthropicStream(
     },
   })
 
-  const reader = response.body!.getReader()
-  const readable = new ReadableStream<Uint8Array>({
-    async pull(controller) {
-      const { done, value } = await reader.read()
-      if (done) {
-        controller.close()
-        return
-      }
-      controller.enqueue(value)
-    },
-  })
-
-  const transformed = readable.pipeThrough(transformStream)
+  // Wrap upstream with keepalive + mid-stream error visibility before the
+  // OpenAI translator runs, so truncation-related `event: error` frames flow
+  // through `convertAnthropicStreamEvent` and surface as typed errors.
+  const wrapped = wrapSseForErrorVisibility(response.body!, 'anthropic')
+  const transformed = wrapped.pipeThrough(transformStream)
 
   return new Response(transformed, {
     headers: {
@@ -692,6 +1164,34 @@ function convertAnthropicStreamEvent(event: any, id: string, model: string): any
         ],
       }
 
+    // Synthetic `event: error` frames produced by `wrapSseForErrorVisibility`
+    // (or returned verbatim by Anthropic on hard errors). We surface the
+    // structured error payload at the chunk level while keeping
+    // `finish_reason: 'stop'` — strict OpenAI SDKs reject non-standard
+    // finish_reason values, and the `error` field on the chunk is what the
+    // Vercel AI SDK and `@anthropic-ai/sdk` consumers inspect.
+    case 'error': {
+      const msg =
+        event.error?.message ||
+        event.message ||
+        'Upstream stream dropped'
+      const errType = event.error?.type || 'stream_error'
+      return {
+        id,
+        object: 'chat.completion.chunk',
+        created: Math.floor(Date.now() / 1000),
+        model,
+        error: { type: errType, message: msg },
+        choices: [
+          {
+            index: 0,
+            delta: {},
+            finish_reason: 'stop',
+          },
+        ],
+      }
+    }
+
     default:
       return null
   }
@@ -712,16 +1212,20 @@ async function proxyAnthropicNonStream(
     stream: false,
   })
 
-  const response = await fetch('https://api.anthropic.com/v1/messages', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': apiKey,
-      'anthropic-version': '2023-06-01',
+  const response = await fetchAnthropicWithRetry(
+    'https://api.anthropic.com/v1/messages',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify(body),
+      signal,
     },
-    body: JSON.stringify(body),
-    signal,
-  })
+    { label: 'anthropic', signal },
+  )
 
   if (!response.ok) {
     const errorText = await response.text()
@@ -1314,25 +1818,32 @@ export function aiProxyRoutes() {
       }
     }
 
-    const response = await fetch(`${cloudUrl}/api/ai/anthropic/v1/messages`, {
-      method: 'POST',
-      headers: forwardHeaders,
-      body: JSON.stringify(parsed),
-      signal,
-    })
+    const response = await fetchAnthropicWithRetry(
+      `${cloudUrl}/api/ai/anthropic/v1/messages`,
+      {
+        method: 'POST',
+        headers: forwardHeaders,
+        body: JSON.stringify(parsed),
+        signal,
+      },
+      { label: 'shogo-cloud', signal },
+    )
 
     if (isStream) {
       if (!response.body) {
         return c.json({ type: 'error', error: { type: 'api_error', message: 'Cloud proxy returned no stream body' } }, 502)
       }
-      return new Response(response.body, {
-        status: response.status,
-        headers: {
-          'Content-Type': 'text/event-stream',
-          'Cache-Control': 'no-cache',
-          'X-Proxy-Provider': 'shogo-cloud',
+      return new Response(
+        wrapSseForErrorVisibility(response.body, 'shogo-cloud'),
+        {
+          status: response.status,
+          headers: {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache',
+            'X-Proxy-Provider': 'shogo-cloud',
+          },
         },
-      })
+      )
     }
 
     const data = await response.json()
@@ -1979,12 +2490,16 @@ export function aiProxyRoutes() {
         headers['anthropic-version'] = '2023-06-01'
       }
 
-      const response = await fetch('https://api.anthropic.com/v1/messages', {
-        method: 'POST',
-        headers,
-        body: forwardBody,
-        signal: c.req.raw.signal,
-      })
+      const response = await fetchAnthropicWithRetry(
+        'https://api.anthropic.com/v1/messages',
+        {
+          method: 'POST',
+          headers,
+          body: forwardBody,
+          signal: c.req.raw.signal,
+        },
+        { label: 'anthropic', signal: c.req.raw.signal },
+      )
 
       if (!response.ok) {
         const errorBody = await response.text()
@@ -2049,13 +2564,21 @@ export function aiProxyRoutes() {
         },
       })
 
-      const trackedBody = response.body!.pipeThrough(tokenTrackingTransform)
+      // Wrap with keepalive + mid-stream error visibility *before* token
+      // tracking, so synthetic error frames are also scanned for usage fields
+      // (they have none — harmless) but kept in the stream for downstream.
+      const wrapped = wrapSseForErrorVisibility(response.body!, 'anthropic')
+      const trackedBody = wrapped.pipeThrough(tokenTrackingTransform)
 
       return new Response(trackedBody, {
         status: response.status,
         headers: responseHeaders,
       })
     } catch (error: any) {
+      // Client cancelled — surface 499 silently, don't log as a server error.
+      if (error?.name === 'AbortError') {
+        return new Response(null, { status: 499 })
+      }
       console.error('[AI Proxy] Anthropic pass-through error:', error.message)
       return c.json(
         { type: 'error', error: { type: 'api_error', message: error.message || 'Proxy error' } },
@@ -2080,16 +2603,20 @@ export function aiProxyRoutes() {
     if (isShogoCloudForwarding()) {
       const cloudUrl = getShogoCloudUrl()
       const body = await c.req.text()
-      const response = await fetch(`${cloudUrl}/api/ai/anthropic/v1/messages/count_tokens`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-api-key': process.env.SHOGO_API_KEY!,
-          'anthropic-version': c.req.header('anthropic-version') || '2023-06-01',
+      const response = await fetchAnthropicWithRetry(
+        `${cloudUrl}/api/ai/anthropic/v1/messages/count_tokens`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': process.env.SHOGO_API_KEY!,
+            'anthropic-version': c.req.header('anthropic-version') || '2023-06-01',
+          },
+          body,
+          signal: c.req.raw.signal,
         },
-        body,
-        signal: c.req.raw.signal,
-      })
+        { label: 'shogo-cloud', signal: c.req.raw.signal },
+      )
       const responseBody = await response.text()
       return new Response(responseBody, {
         status: response.status,
@@ -2112,12 +2639,16 @@ export function aiProxyRoutes() {
       'anthropic-version': c.req.header('anthropic-version') || '2023-06-01',
     }
 
-    const response = await fetch('https://api.anthropic.com/v1/messages/count_tokens', {
-      method: 'POST',
-      headers,
-      body,
-      signal: c.req.raw.signal,
-    })
+    const response = await fetchAnthropicWithRetry(
+      'https://api.anthropic.com/v1/messages/count_tokens',
+      {
+        method: 'POST',
+        headers,
+        body,
+        signal: c.req.raw.signal,
+      },
+      { label: 'anthropic', signal: c.req.raw.signal },
+    )
 
     const responseBody = await response.text()
     return new Response(responseBody, {

--- a/apps/api/src/routes/project-chat.ts
+++ b/apps/api/src/routes/project-chat.ts
@@ -681,7 +681,12 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
       // Open a billing session so the AI proxy accumulates tokens across
       // all API calls in the agentic loop instead of charging per-call.
       // The session is closed in trackUsageFromStream after the stream ends.
+      // Guard: if the handler exits without starting a stream (retry
+      // exhaustion, client disconnect, thrown error), the finally block
+      // ensures closeSession runs so we don't leak an open session.
       openSession(projectId, project.workspaceId, billingUserId || 'system')
+      let billingSessionHandedOff = false
+      try {
 
       // Forward headers
       const headers: Record<string, string> = {
@@ -893,6 +898,10 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
             },
           })
 
+          // trackUsageFromStream takes ownership of billing — it calls
+          // closeSession after the stream finishes. Mark the handoff so
+          // our finally guard doesn't double-close.
+          billingSessionHandedOff = true
           trackUsageFromStream(trackingStream, parsedBody, project).catch((err) =>
             console.error("[ProjectChat] Usage tracking error:", err)
           )
@@ -949,6 +958,17 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
         { error: { code: "proxy_error", message: lastError?.message || "Max retries exceeded" } },
         503
       )
+
+      } finally {
+        // Guard: close the billing session if trackUsageFromStream never
+        // took ownership (retry exhaustion, client disconnect, thrown error).
+        // closeSession is idempotent — safe to call even if already closed.
+        if (!billingSessionHandedOff) {
+          closeSession(projectId).catch((err) =>
+            console.error(`[ProjectChat] Failed to close orphaned billing session for ${projectId}:`, err)
+          )
+        }
+      }
     } catch (error: any) {
       console.error("[ProjectChat] Proxy error:", error)
       chatSpan.setStatus({ code: SpanStatusCode.ERROR, message: error.message })


### PR DESCRIPTION
## Summary

Closes #405.

Hardens the Anthropic proxy and project-chat billing path so **"Claude connection lost"** is addressed at the server layer: connection-phase retries, SSE keepalive + truncation handling, typed error payloads, idle watchdog, and a billing-session `finally` guard when no stream is handed off.

## Changes

| Area | Change |
|------|--------|
| `ai-proxy.ts` | `fetchAnthropicWithRetry`, `wrapSseForErrorVisibility` (keepalive, typed `stream_error` with `code`/`retryable`/`meta`, 120s idle watchdog, split-frame terminal detection), `parseRetryAfterMs`, integration on Anthropic paths |
| `project-chat.ts` | `try`/`finally` + `billingSessionHandedOff` so `closeSession` runs if handler exits before `trackUsageFromStream` |
| Tests | `apps/api/src/routes/__tests__/ai-proxy-streaming.test.ts` (Bun) |

## How to verify

```bash
bun test apps/api/src/routes/__tests__/ai-proxy-streaming.test.ts
```

## Notes

- Mid-stream **resume** against Anthropic is intentionally not implemented (no event-id resume; turn-level retry remains upstream).
- Production mobile client POST retry is **not** in this PR (separate issue if needed).


Made with [Cursor](https://cursor.com)