### PR TITLE
fix(chat): preserve file attachments on retry after errors

### DIFF
--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -2745,12 +2745,30 @@ export const ChatPanel = observer(function ChatPanel({
     if (messages.length > 0) {
       const lastUserMsg = [...messages].reverse().find((m) => m.role === "user")
       if (lastUserMsg) {
-        const textPart = (lastUserMsg as any).parts?.find((p: any) => p.type === "text")
+        const parts = ((lastUserMsg as any).parts ?? []) as any[]
+        const textPart = parts.find((p: any) => p.type === "text")
         const content = textPart?.text || ""
-        if (content) {
+
+        // Preserve file attachments on retry — previously dropped, so images/
+        // PDFs/etc. were lost and the model got a text-only prompt.
+        const fileParts = parts.filter((p: any) => p?.type === "file" && p?.url)
+        const cachedFiles = lastUserInputRef.current?.files
+        const filesFromParts: FileAttachment[] = fileParts.map((p: any) => ({
+          dataUrl: p.url,
+          name: p.name ?? p.filename ?? "file",
+          type: p.mediaType ?? extractMediaType(p.url),
+        }))
+        const files: FileAttachment[] | undefined =
+          cachedFiles && cachedFiles.length > 0
+            ? cachedFiles
+            : filesFromParts.length > 0
+              ? filesFromParts
+              : undefined
+
+        if (content || (files && files.length > 0)) {
           const lastUserIdx = messages.lastIndexOf(lastUserMsg)
           setMessages(messages.slice(0, lastUserIdx))
-          sendMessageInternal(content).catch((err) =>
+          sendMessageInternal(content, files).catch((err) =>
             console.error("[ChatPanel] Retry failed:", err)
           )
         }

--- a/packages/sdk/examples/ai-chat/src/components/message-editor.tsx
+++ b/packages/sdk/examples/ai-chat/src/components/message-editor.tsx
@@ -93,9 +93,17 @@ export function MessageEditor({
               const index = messages.findIndex((m) => m.id === message.id);
 
               if (index !== -1) {
+                // Preserve non-text parts (file attachments, images, etc.) so
+                // a retry/edit never silently drops the original upload.
+                const nonTextParts = (message.parts ?? []).filter(
+                  (p: any) => p?.type && p.type !== "text"
+                );
                 const updatedMessage: ChatMessage = {
                   ...message,
-                  parts: [{ type: "text", text: draftContent }],
+                  parts: [
+                    { type: "text", text: draftContent },
+                    ...nonTextParts,
+                  ],
                 };
 
                 return [...messages.slice(0, index), updatedMessage];


### PR DESCRIPTION
## Summary

Fixes retry/edit flows so **file parts (images, PDFs, etc.) are not dropped** when resending after an error or when updating a message in the SDK example.

Closes #407

## Changes

- **Mobile `ChatPanel`**: On Retry, walk the last user message `parts`, collect `type: "file"` entries into `FileAttachment[]`, prefer `lastUserInputRef.current.files` when available, and call `sendMessageInternal(content, files)`. Retry runs when there is text **or** at least one attachment (image-only sends work).
- **SDK `message-editor` example**: When applying an edit, merge non-text `parts` back with the new text so attachments stay on the message.

## Test plan

- [ ] Mobile: attach image + prompt → force stream error → Retry → model receives image + text (or image-only).
- [ ] SDK example: edit message with attachment → non-text parts preserved.


Made with [Cursor](https://cursor.com)