### PR TITLE
Persist unsent chat drafts across refresh

### DIFF
--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -14,7 +14,7 @@
  * Native: Expo ImagePicker + DocumentPicker (AttachSourceSheet + native-attachment-picker).
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import {
   View,
   Text,
@@ -73,6 +73,11 @@ import {
 } from "./long-text-utils"
 import { FileViewerModal } from "./FileViewerModal"
 import { PastedTextChip } from "./PastedTextChip"
+import {
+  clearChatDraft,
+  loadChatDraft,
+  saveChatDraft,
+} from "../../lib/chat-draft-storage"
 
 export const DEFAULT_MODEL_PRO = "claude-sonnet-4-6"
 export const DEFAULT_MODEL_FREE = "claude-haiku-4-5-20251001"
@@ -127,10 +132,11 @@ const MAX_FILES = 10
 
 interface AttachedFile {
   id: string
-  dataUrl: string
+  dataUrl?: string
   name: string
   type: string
   size: number
+  requiresReattach?: boolean
 }
 
 export interface FileAttachment {
@@ -156,6 +162,7 @@ export type QueuedMessage = {
 
 export interface ChatInputProps {
   onSubmit: (content: string, files?: FileAttachment[], modelId?: string) => void
+  draftStorageKey?: string | null
   disabled?: boolean
   placeholder?: string
   isStreaming?: boolean
@@ -176,6 +183,7 @@ export interface ChatInputProps {
 
 export function ChatInput({
   onSubmit,
+  draftStorageKey,
   disabled = false,
   placeholder = "Ask Shogo...",
   isStreaming = false,
@@ -200,6 +208,8 @@ export function ChatInput({
   const dropZoneRef = useRef<View>(null)
   const dragCounterRef = useRef(0)
   const inputValueRef = useRef("")
+  const skipNextSaveRef = useRef(false)
+  const isFirstDraftKeyRef = useRef(true)
   // Guards against the DOM paste listener AND onChangeText both firing for
   // the same clipboard event, which would create duplicate chips.
   const pasteHandledRef = useRef(false)
@@ -213,6 +223,8 @@ export function ChatInput({
   const [modelPickerOpen, setModelPickerOpen] = useState(false)
   const [interactionModeOpen, setInteractionModeOpen] = useState(false)
   const [attachSheetOpen, setAttachSheetOpen] = useState(false)
+  const [isDraftHydrated, setIsDraftHydrated] = useState(false)
+  const [draftPersistenceWarning, setDraftPersistenceWarning] = useState<string | null>(null)
 
   useEffect(() => {
     inputValueRef.current = inputValue
@@ -268,6 +280,111 @@ export function ChatInput({
   const [pastedTexts, setPastedTexts] = useState<PastedTextEntry[]>([])
   const [viewingPastedId, setViewingPastedId] = useState<string | null>(null)
 
+  useLayoutEffect(() => {
+    if (isFirstDraftKeyRef.current) {
+      isFirstDraftKeyRef.current = false
+      return
+    }
+    skipNextSaveRef.current = false
+    inputValueRef.current = ""
+    setInputValue("")
+    setPendingFiles([])
+    setPastedTexts([])
+    setViewingPastedId(null)
+    setFileError(null)
+    setDraftPersistenceWarning(null)
+  }, [draftStorageKey])
+
+  useEffect(() => {
+    let cancelled = false
+    setIsDraftHydrated(false)
+
+    if (!draftStorageKey) {
+      setIsDraftHydrated(true)
+      return
+    }
+
+    loadChatDraft(draftStorageKey).then((draft) => {
+      if (cancelled) return
+
+      if (draft) {
+        const shouldHydrateText =
+          draft.text.length > 0 || inputValueRef.current.length === 0
+        if (shouldHydrateText) {
+          setInputValue(draft.text)
+        }
+      }
+      setPendingFiles(draft?.files ?? [])
+      setPastedTexts(
+        draft?.pastedTexts?.map((entry) => ({
+          id: entry.id,
+          content: entry.content,
+          info: analyzeContent(entry.content),
+        })) ?? []
+      )
+      setViewingPastedId(null)
+      const hasPlaceholderFiles = !!draft?.files?.some(
+        (file) => file.requiresReattach || !file.dataUrl
+      )
+      setFileError(
+        hasPlaceholderFiles
+          ? "Some attachments could not be safely restored. Re-attach them before sending."
+          : null
+      )
+      setDraftPersistenceWarning(
+        hasPlaceholderFiles
+          ? "Large attachments were restored as placeholders and must be re-attached before sending."
+          : null
+      )
+      skipNextSaveRef.current = true
+      setIsDraftHydrated(true)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [draftStorageKey])
+
+  useEffect(() => {
+    if (!isDraftHydrated || !draftStorageKey) return
+    if (skipNextSaveRef.current) {
+      skipNextSaveRef.current = false
+      return
+    }
+
+    void saveChatDraft(draftStorageKey, {
+      text: inputValue,
+      files: pendingFiles,
+      pastedTexts: pastedTexts.map((entry) => ({
+        id: entry.id,
+        content: entry.content,
+      })),
+    }).then((result) => {
+      if (result === "metadata-only") {
+        setDraftPersistenceWarning(
+          "Large attachments are saved as placeholders only and must be re-attached after refresh."
+        )
+        return
+      }
+      if (result === "failed") {
+        setDraftPersistenceWarning(
+          "Draft persistence failed for the current attachments. Re-attach them after refresh if needed."
+        )
+        return
+      }
+      if (result === "full" || result === "cleared") {
+        const hasPlaceholderFiles = pendingFiles.some(
+          (file) => file.requiresReattach || !file.dataUrl
+        )
+        setDraftPersistenceWarning(
+          hasPlaceholderFiles
+            ? "Large attachments were restored as placeholders and must be re-attached before sending."
+            : null
+        )
+      }
+    })
+  }, [draftStorageKey, inputValue, isDraftHydrated, pastedTexts, pendingFiles])
+
   const addPastedText = useCallback((content: string) => {
     const info = analyzeContent(content)
     if (!info.isLong) return false
@@ -317,8 +434,21 @@ export function ChatInput({
   }, [])
 
   const handleRemoveFile = useCallback((fileId: string) => {
-    setPendingFiles((prev) => prev.filter((f) => f.id !== fileId))
-    setFileError(null)
+    setPendingFiles((prev) => {
+      const next = prev.filter((f) => f.id !== fileId)
+      const hasPlaceholderFiles = next.some((file) => file.requiresReattach || !file.dataUrl)
+      setFileError(
+        hasPlaceholderFiles
+          ? "Some attachments could not be safely restored. Re-attach them before sending."
+          : null
+      )
+      setDraftPersistenceWarning(
+        hasPlaceholderFiles
+          ? "Large attachments were restored as placeholders and must be re-attached before sending."
+          : null
+      )
+      return next
+    })
   }, [])
 
   const fileInputRef = useRef<HTMLInputElement | null>(null)
@@ -496,6 +626,10 @@ export function ChatInput({
 
   const handleSubmit = useCallback(() => {
     const trimmedContent = inputValue.trim()
+    if (pendingFiles.some((file) => file.requiresReattach || !file.dataUrl)) {
+      setFileError("Re-attach the restored placeholder attachments before sending.")
+      return
+    }
     if (
       (!trimmedContent && pendingFiles.length === 0 && pastedTexts.length === 0) ||
       disabled ||
@@ -510,7 +644,7 @@ export function ChatInput({
     // text part and the file parts so it sees everything.
     const pastedAttachments: FileAttachment[] = buildPastedAttachments(pastedTexts)
     const combinedFiles: FileAttachment[] = [
-      ...pendingFiles.map((f) => ({ dataUrl: f.dataUrl, name: f.name, type: f.type })),
+      ...pendingFiles.map((f) => ({ dataUrl: f.dataUrl!, name: f.name, type: f.type })),
       ...pastedAttachments,
     ]
     const fileData = combinedFiles.length > 0 ? combinedFiles : undefined
@@ -521,9 +655,11 @@ export function ChatInput({
     setPastedTexts([])
     setViewingPastedId(null)
     setFileError(null)
+    setDraftPersistenceWarning(null)
+    void clearChatDraft(draftStorageKey)
 
     textInputRef.current?.focus()
-  }, [disabled, onSubmit, pendingFiles, isProcessingFiles, currentModelId, inputValue, pastedTexts, voiceInput.isBusy])
+  }, [disabled, draftStorageKey, onSubmit, pendingFiles, isProcessingFiles, currentModelId, inputValue, pastedTexts, voiceInput.isBusy])
 
   const handleChangeText = useCallback(
     (text: string) => {
@@ -583,7 +719,8 @@ export function ChatInput({
           contentContainerClassName="gap-2 mb-2"
         >
           {pendingFiles.map((file) => {
-            const isImage = file.type.startsWith("image/")
+            const isImage = file.type.startsWith("image/") && !!file.dataUrl
+            const needsReattach = file.requiresReattach || !file.dataUrl
             return (
               <View
                 key={file.id}
@@ -613,6 +750,11 @@ export function ChatInput({
                       <Text className="text-xs text-muted-foreground">
                         {formatFileSize(file.size)}
                       </Text>
+                      {needsReattach && (
+                        <Text className="text-xs text-amber-600">
+                          Re-attach to send
+                        </Text>
+                      )}
                     </View>
                   </View>
                 )}
@@ -639,6 +781,10 @@ export function ChatInput({
       {/* Error message */}
       {fileError && (
         <Text className="text-sm text-destructive mb-2">{fileError}</Text>
+      )}
+
+      {draftPersistenceWarning && !fileError && (
+        <Text className="text-sm text-amber-600 mb-2">{draftPersistenceWarning}</Text>
       )}
 
       {voiceInput.error && (

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -242,6 +242,11 @@ async function setStoredCollapsed(collapsed: boolean): Promise<void> {
   }
 }
 
+function buildDraftStorageKey(projectId?: string, sessionId?: string | null): string | null {
+  if (!projectId || !sessionId) return null
+  return `project:${projectId}:session:${sessionId}`
+}
+
 // ============================================================
 // Tool Call Extraction Helper
 // ============================================================
@@ -749,6 +754,10 @@ export const ChatPanel = observer(function ChatPanel({
 
   // Chat session state — each ChatPanel instance receives a stable chatSessionId
   const currentSessionId = chatSessionId ?? null
+  const draftStorageKey = useMemo(
+    () => buildDraftStorageKey(projectId, currentSessionId),
+    [projectId, currentSessionId]
+  )
   const [isInitialLoadComplete, setIsInitialLoadComplete] = useState(false)
   const prevSessionIdRef = useRef<string | null>(currentSessionId)
   const [internalSelectedModel, setInternalSelectedModel] = useState<string>(DEFAULT_MODEL_FREE)
@@ -2853,6 +2862,7 @@ export const ChatPanel = observer(function ChatPanel({
         disabled={false}
         value={compactValue}
         onChange={onCompactValueChange}
+        draftStorageKey={draftStorageKey}
         className={className}
       />
     )
@@ -3190,6 +3200,7 @@ export const ChatPanel = observer(function ChatPanel({
           <View className="bg-transparent max-w-3xl w-full self-center mt-1">
             <ChatInput
               onSubmit={handleInputSubmit}
+              draftStorageKey={draftStorageKey}
               disabled={!currentSessionId}
               placeholder={
                 !featureId

--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -13,7 +13,7 @@
  * Drag-and-drop is omitted (not available on mobile).
  */
 
-import { useState, useRef, useCallback, forwardRef, useEffect, useMemo } from "react"
+import { useState, useRef, useCallback, forwardRef, useEffect, useLayoutEffect, useMemo } from "react"
 import { View, Text, TextInput, Pressable, Image, ScrollView, Platform } from "react-native"
 import { cn } from "@shogo/shared-ui/primitives"
 import {
@@ -64,6 +64,12 @@ import {
 } from "./long-text-utils"
 import { FileViewerModal } from "./FileViewerModal"
 import { PastedTextChip } from "./PastedTextChip"
+import {
+  clearChatDraft,
+  loadChatDraft,
+  saveChatDraft,
+} from "../../lib/chat-draft-storage"
+import { AttachSourceSheet } from "./AttachSourceSheet"
 
 const MODEL_GROUPS = getModelsByProvider().map((g) => ({
   label: g.label,
@@ -79,21 +85,22 @@ const TIER_LABELS: Record<ModelTier, string> = {
   standard: "Standard",
   economy: "Economy",
 }
-import { AttachSourceSheet } from "./AttachSourceSheet"
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024
 const MAX_FILES = 10
 
 interface AttachedFile {
   id: string
-  dataUrl: string
+  dataUrl?: string
   name: string
   type: string
   size: number
+  requiresReattach?: boolean
 }
 
 export interface CompactChatInputProps {
   onSubmit: (prompt: string, files?: FileAttachment[]) => void
+  draftStorageKey?: string | null
   disabled?: boolean
   isLoading?: boolean
   placeholder?: string
@@ -112,6 +119,7 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
   function CompactChatInput(
     {
       onSubmit,
+      draftStorageKey,
       disabled = false,
       isLoading = false,
       placeholder: placeholderProp,
@@ -139,6 +147,8 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
     const [attachSheetOpen, setAttachSheetOpen] = useState(false)
     const [interactionModeOpen, setInteractionModeOpen] = useState(false)
     const [modelPickerOpen, setModelPickerOpen] = useState(false)
+    const [isDraftHydrated, setIsDraftHydrated] = useState(false)
+    const [draftPersistenceWarning, setDraftPersistenceWarning] = useState<string | null>(null)
     const [internalInteractionMode, setInternalInteractionMode] =
       useState<InteractionMode>("agent")
     const interactionMode = controlledInteractionMode ?? internalInteractionMode
@@ -186,11 +196,23 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
 
     const value = controlledValue ?? internalValue
     const setValue = controlledOnChange ?? setInternalValue
+    const controlledValueRef = useRef(controlledValue)
+    const setValueRef = useRef(setValue)
+    const skipNextSaveRef = useRef(false)
+    const isFirstDraftKeyRef = useRef(true)
     const valueRef = useRef(value)
 
     useEffect(() => {
       valueRef.current = value
     }, [value])
+
+    useEffect(() => {
+      controlledValueRef.current = controlledValue
+    }, [controlledValue])
+
+    useEffect(() => {
+      setValueRef.current = setValue
+    }, [setValue])
 
     const placeholderText =
       placeholderProp ??
@@ -207,8 +229,21 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
     }, [])
 
     const handleRemoveFile = useCallback((fileId: string) => {
-      setPendingFiles((prev) => prev.filter((f) => f.id !== fileId))
-      setFileError(null)
+      setPendingFiles((prev) => {
+        const next = prev.filter((f) => f.id !== fileId)
+        const hasPlaceholderFiles = next.some((file) => file.requiresReattach || !file.dataUrl)
+        setFileError(
+          hasPlaceholderFiles
+            ? "Some attachments could not be safely restored. Re-attach them before sending."
+            : null
+        )
+        setDraftPersistenceWarning(
+          hasPlaceholderFiles
+            ? "Large attachments were restored as placeholders and must be re-attached before sending."
+            : null
+        )
+        return next
+      })
     }, [])
 
     const handleAttachClick = useCallback(() => {
@@ -265,6 +300,114 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
     // keep typing and paste multiple long blocks (each becomes a chip).
     const [pastedTexts, setPastedTexts] = useState<PastedTextEntry[]>([])
     const [viewingPastedId, setViewingPastedId] = useState<string | null>(null)
+
+    useLayoutEffect(() => {
+      if (isFirstDraftKeyRef.current) {
+        isFirstDraftKeyRef.current = false
+        return
+      }
+      skipNextSaveRef.current = false
+      if (controlledValueRef.current === undefined) {
+        setInternalValue("")
+      }
+      setPendingFiles([])
+      setPastedTexts([])
+      setViewingPastedId(null)
+      setFileError(null)
+      setDraftPersistenceWarning(null)
+    }, [draftStorageKey])
+
+    useEffect(() => {
+      let cancelled = false
+      setIsDraftHydrated(false)
+
+      if (!draftStorageKey) {
+        setIsDraftHydrated(true)
+        return
+      }
+
+      loadChatDraft(draftStorageKey).then((draft) => {
+        if (cancelled) return
+
+        if (draft) {
+          const shouldHydrateText =
+            controlledValueRef.current === undefined ||
+            draft.text.length > 0 ||
+            valueRef.current.length === 0
+          if (shouldHydrateText) {
+            setValueRef.current(draft.text)
+          }
+        }
+        setPendingFiles(draft?.files ?? [])
+        setPastedTexts(
+          draft?.pastedTexts?.map((entry) => ({
+            id: entry.id,
+            content: entry.content,
+            info: analyzeContent(entry.content),
+          })) ?? []
+        )
+        setViewingPastedId(null)
+        const hasPlaceholderFiles = !!draft?.files?.some(
+          (file) => file.requiresReattach || !file.dataUrl
+        )
+        setFileError(
+          hasPlaceholderFiles
+            ? "Some attachments could not be safely restored. Re-attach them before sending."
+            : null
+        )
+        setDraftPersistenceWarning(
+          hasPlaceholderFiles
+            ? "Large attachments were restored as placeholders and must be re-attached before sending."
+            : null
+        )
+        skipNextSaveRef.current = true
+        setIsDraftHydrated(true)
+      })
+
+      return () => {
+        cancelled = true
+      }
+    }, [draftStorageKey])
+
+    useEffect(() => {
+      if (!isDraftHydrated || !draftStorageKey) return
+      if (skipNextSaveRef.current) {
+        skipNextSaveRef.current = false
+        return
+      }
+
+      void saveChatDraft(draftStorageKey, {
+        text: value,
+        files: pendingFiles,
+        pastedTexts: pastedTexts.map((entry) => ({
+          id: entry.id,
+          content: entry.content,
+        })),
+      }).then((result) => {
+        if (result === "metadata-only") {
+          setDraftPersistenceWarning(
+            "Large attachments are saved as placeholders only and must be re-attached after refresh."
+          )
+          return
+        }
+        if (result === "failed") {
+          setDraftPersistenceWarning(
+            "Draft persistence failed for the current attachments. Re-attach them after refresh if needed."
+          )
+          return
+        }
+        if (result === "full" || result === "cleared") {
+          const hasPlaceholderFiles = pendingFiles.some(
+            (file) => file.requiresReattach || !file.dataUrl
+          )
+          setDraftPersistenceWarning(
+            hasPlaceholderFiles
+              ? "Large attachments were restored as placeholders and must be re-attached before sending."
+              : null
+          )
+        }
+      })
+    }, [draftStorageKey, isDraftHydrated, pastedTexts, pendingFiles, value])
 
     const addPastedText = useCallback((content: string) => {
       const info = analyzeContent(content)
@@ -372,6 +515,10 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
 
     const handleSubmit = useCallback(() => {
       const trimmedContent = value.trim()
+      if (pendingFiles.some((file) => file.requiresReattach || !file.dataUrl)) {
+        setFileError("Re-attach the restored placeholder attachments before sending.")
+        return
+      }
       if (
         (!trimmedContent && pendingFiles.length === 0 && pastedTexts.length === 0) ||
         disabled ||
@@ -386,7 +533,7 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
       // text part and the file parts so it sees everything.
       const pastedAttachments: FileAttachment[] = buildPastedAttachments(pastedTexts)
       const combinedFiles: FileAttachment[] = [
-        ...pendingFiles.map((f) => ({ dataUrl: f.dataUrl, name: f.name, type: f.type })),
+        ...pendingFiles.map((f) => ({ dataUrl: f.dataUrl!, name: f.name, type: f.type })),
         ...pastedAttachments,
       ]
       const fileData = combinedFiles.length > 0 ? combinedFiles : undefined
@@ -397,8 +544,10 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
       setFileError(null)
       setPastedTexts([])
       setViewingPastedId(null)
+      setDraftPersistenceWarning(null)
+      void clearChatDraft(draftStorageKey)
       textInputRef.current?.focus()
-    }, [value, disabled, isLoading, onSubmit, pendingFiles, pastedTexts, voiceInput.isBusy, setValue])
+    }, [value, disabled, draftStorageKey, isLoading, onSubmit, pendingFiles, pastedTexts, voiceInput.isBusy, setValue])
 
     // Fallback paste detection for platforms where the DOM paste listener
     // doesn't fire (native). If a large chunk was just inserted, pull it
@@ -464,7 +613,8 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
               contentContainerClassName="gap-2 p-4 pb-2"
             >
               {pendingFiles.map((file) => {
-                const isImage = file.type.startsWith("image/")
+                const isImage = file.type.startsWith("image/") && !!file.dataUrl
+                const needsReattach = file.requiresReattach || !file.dataUrl
                 return (
                   <View
                     key={file.id}
@@ -492,6 +642,11 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
                           <Text className="text-xs text-muted-foreground">
                             {formatFileSize(file.size)}
                           </Text>
+                          {needsReattach && (
+                            <Text className="text-xs text-amber-600">
+                              Re-attach to send
+                            </Text>
+                          )}
                         </View>
                       </View>
                     )}
@@ -510,6 +665,10 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
           {/* Error message */}
           {fileError && (
             <Text className="text-sm text-destructive px-4 pb-2">{fileError}</Text>
+          )}
+
+          {draftPersistenceWarning && !fileError && (
+            <Text className="text-sm text-amber-600 px-4 pb-2">{draftPersistenceWarning}</Text>
           )}
 
           {voiceInput.error && (

--- a/apps/mobile/lib/chat-draft-storage.ts
+++ b/apps/mobile/lib/chat-draft-storage.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import AsyncStorage from "@react-native-async-storage/async-storage"
+
+export interface PersistedDraftFile {
+  id: string
+  dataUrl?: string
+  name: string
+  type: string
+  size: number
+  requiresReattach?: boolean
+}
+
+export interface PersistedPastedText {
+  id: string
+  content: string
+}
+
+export interface PersistedChatDraft {
+  text: string
+  files: PersistedDraftFile[]
+  pastedTexts: PersistedPastedText[]
+}
+
+export type SaveChatDraftResult = "full" | "metadata-only" | "cleared" | "failed"
+
+const STORAGE_KEY_PREFIX = "chat-draft-v1:"
+
+function buildStorageKey(draftKey: string): string {
+  return `${STORAGE_KEY_PREFIX}${draftKey}`
+}
+
+export async function loadChatDraft(
+  draftKey: string | null | undefined
+): Promise<PersistedChatDraft | null> {
+  if (!draftKey) return null
+
+  try {
+    const raw = await AsyncStorage.getItem(buildStorageKey(draftKey))
+    if (!raw) return null
+
+    const parsed = JSON.parse(raw) as Partial<PersistedChatDraft> | null
+    if (!parsed || typeof parsed !== "object") return null
+
+    const text = typeof parsed.text === "string" ? parsed.text : ""
+    const files = Array.isArray(parsed.files)
+      ? parsed.files.filter(
+          (file): file is PersistedDraftFile =>
+            !!file &&
+            typeof file.id === "string" &&
+            typeof file.name === "string" &&
+            typeof file.type === "string" &&
+            typeof file.size === "number" &&
+            (file.dataUrl === undefined || typeof file.dataUrl === "string") &&
+            (file.requiresReattach === undefined || typeof file.requiresReattach === "boolean")
+        )
+      : []
+    const pastedTexts = Array.isArray(parsed.pastedTexts)
+      ? parsed.pastedTexts.filter(
+          (entry): entry is PersistedPastedText =>
+            !!entry &&
+            typeof entry.id === "string" &&
+            typeof entry.content === "string"
+        )
+      : []
+
+    if (!text && files.length === 0 && pastedTexts.length === 0) {
+      return null
+    }
+
+    return { text, files, pastedTexts }
+  } catch {
+    return null
+  }
+}
+
+export async function saveChatDraft(
+  draftKey: string | null | undefined,
+  draft: PersistedChatDraft
+): Promise<SaveChatDraftResult> {
+  if (!draftKey) return "failed"
+
+  const hasContent =
+    draft.text.trim().length > 0 ||
+    draft.files.length > 0 ||
+    draft.pastedTexts.length > 0
+
+  try {
+    if (!hasContent) {
+      await AsyncStorage.removeItem(buildStorageKey(draftKey))
+      return "cleared"
+    }
+
+    await AsyncStorage.setItem(buildStorageKey(draftKey), JSON.stringify(draft))
+    return "full"
+  } catch {
+    const metadataOnlyDraft: PersistedChatDraft = {
+      text: draft.text,
+      pastedTexts: draft.pastedTexts,
+      files: draft.files.map((file) => ({
+        id: file.id,
+        name: file.name,
+        type: file.type,
+        size: file.size,
+        requiresReattach: true,
+      })),
+    }
+
+    try {
+      await AsyncStorage.setItem(buildStorageKey(draftKey), JSON.stringify(metadataOnlyDraft))
+      return "metadata-only"
+    } catch {
+      return "failed"
+    }
+  }
+}
+
+export async function clearChatDraft(
+  draftKey: string | null | undefined
+): Promise<void> {
+  if (!draftKey) return
+
+  try {
+    await AsyncStorage.removeItem(buildStorageKey(draftKey))
+  } catch {
+    // Silently ignore storage failures to avoid blocking input usage.
+  }
+}


### PR DESCRIPTION
## Summary
- persist unsent chat drafts per project/session across refreshes
- harden chat input hydration and session switching to avoid stale draft overwrites
- fall back to metadata-only attachment draft persistence with visible re-attach warnings

https://github.com/user-attachments/assets/160352ae-17ae-40e9-959d-50937e1956b5



