### PR TITLE
fix(mobile): standalone HttpClient for /auth/local-link (Sentry)

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -76,6 +76,7 @@ function RootLayoutInner() {
             <Stack screenOptions={{ headerShown: false, lazy: true }}>
               <Stack.Screen name="index" />
               <Stack.Screen name="(auth)" />
+              <Stack.Screen name="auth" />
               <Stack.Screen name="(onboarding)" />
               <Stack.Screen name="(app)" />
               <Stack.Screen name="(admin)" />

--- a/apps/mobile/app/auth/local-link.tsx
+++ b/apps/mobile/app/auth/local-link.tsx
@@ -28,9 +28,10 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { View, Text, ActivityIndicator, Platform } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { Button } from '@shogo/shared-ui/primitives'
-import { PlatformApi } from '@shogo-ai/sdk'
+import { HttpClient, PlatformApi } from '@shogo-ai/sdk'
 import { useAuth } from '../../contexts/auth'
-import { useDomainHttp } from '../../contexts/domain'
+import { API_URL } from '../../lib/api'
+import { authClient } from '../../lib/auth-client'
 
 interface LocalLinkParams {
   state?: string
@@ -47,7 +48,20 @@ export default function LocalLinkBridge() {
   const router = useRouter()
   const params = useLocalSearchParams<LocalLinkParams>()
   const { user, isLoading: isAuthLoading, isAuthenticated } = useAuth()
-  const http = useDomainHttp()
+  // Standalone HttpClient: this route must not depend on <DomainProvider> /
+  // SDKDomainProvider. Deep links and some web navigations can mount the
+  // screen before nested layouts hydrate, which caused useDomainHttp() to throw.
+  const isNative = Platform.OS !== 'web'
+  const http = useMemo(
+    () =>
+      new HttpClient({
+        baseUrl: API_URL!,
+        getToken: () => null,
+        credentials: isNative ? 'omit' : 'include',
+        getAuthCookie: isNative ? () => authClient.getCookie() || null : undefined,
+      }),
+    [isNative],
+  )
   const platform = useMemo(() => new PlatformApi(http), [http])
 
   const [status, setStatus] = useState<Status>('checking-auth')


### PR DESCRIPTION
## Problem

Sentry (`staging_web`): `useSDKHttp must be used within SDKDomainProvider` on `/auth/local-link` (desktop cloud-login bridge). `useDomainHttp()` depends on `SDKDomainProvider`; some web navigations can still surface the screen without that context reliably mounted.

## Solution

- **`apps/mobile/app/auth/local-link.tsx`**: Build a dedicated `HttpClient` with the same web/native auth behavior as `DomainProvider` (`credentials: 'include'` on web; `omit` + `getAuthCookie` on native). `PlatformApi` only needs HTTP for `createDeviceApiKey`, so the bridge no longer calls `useDomainHttp()`.
- **`apps/mobile/app/_layout.tsx`**: Add `<Stack.Screen name="auth" />` so the top-level `auth/*` segment is explicitly registered alongside the other root screens.

Closes #416.

Made with [Cursor](https://cursor.com)