### PR TITLE
fix(mobile): friendly plan label in workspace switcher list

### DIFF
--- a/apps/mobile/components/layout/AppSidebar.tsx
+++ b/apps/mobile/components/layout/AppSidebar.tsx
@@ -802,7 +802,7 @@ function WorkspaceSwitcher({
                         || 'free'
                       const isPaid = wsPlanId !== 'free'
                       const label = isPaid
-                        ? wsPlanId.charAt(0).toUpperCase() + wsPlanId.slice(1)
+                        ? getPlanDisplayName(wsPlanId)
                         : 'Free'
                       return (
                         <View className={cn('rounded px-1.5 py-0.5', isPaid ? 'bg-primary/10' : 'bg-muted')}>


### PR DESCRIPTION
## What
Replaces the All workspaces row plan badge logic so tiered plan ids (e.g. `business_1200`) display as **Business** via `getPlanDisplayName`, matching the header and avoiding internal-looking labels like **Business_1200**.

## Issue
<img width="311" height="335" alt="Screenshot 2026-04-22 at 1 15 47 PM" src="https://github.com/user-attachments/assets/a20b7b07-7a57-48e2-afb9-5a76128066e8" />
Fixes https://github.com/shogo-labs/shogo-ai/issues/418

## Change
- `apps/mobile/components/layout/AppSidebar.tsx`: one-line swap to `getPlanDisplayName(wsPlanId)` for paid workspaces in the list.

Made with [Cursor](https://cursor.com)