### PR TITLE
fix(api): let /api/projects/import fall through :projectId middleware

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -494,6 +494,13 @@ app.use(
 )
 app.use('/api/projects/:projectId/*', async (c, next) => {
   const path = new URL(c.req.url).pathname
+  // Reserved non-:projectId collection-level routes under /api/projects.
+  // Hono's `*` wildcard matches zero or more segments, so e.g.
+  // POST /api/projects/import would otherwise be matched by this middleware
+  // with :projectId = 'import' and fail with "Project not found".
+  if (path === '/api/projects/import' || path.startsWith('/api/projects/import/')) {
+    return next()
+  }
   if (isAllowedUnauthWebchatProxyPath(path)) {
     return next()
   }


### PR DESCRIPTION
Fixes #420.

## Summary

- `POST /api/projects/import` was being swallowed by the `/api/projects/:projectId/*` middleware (Hono's `*` matches zero-or-more segments, so `:projectId` resolved to `"import"`), causing `requireProjectAccess` to 403 with `"Project not found"` before the real import handler could run.
- Short-circuit the middleware for `/api/projects/import` (and any sub-paths) so it falls through to `routes/project-export-import.ts`, matching the pattern already used for `isAllowedUnauthWebchatProxyPath` and `/heartbeat/sync`.

## Change

Single file, 7 lines added in \`apps/api/src/server.ts\`:

\`\`\`ts
app.use('/api/projects/:projectId/*', async (c, next) => {
  const path = new URL(c.req.url).pathname
+ // Reserved non-:projectId collection-level routes under /api/projects.
+ // Hono's `*` wildcard matches zero or more segments, so e.g.
+ // POST /api/projects/import would otherwise be matched by this middleware
+ // with :projectId = 'import' and fail with "Project not found".
+ if (path === '/api/projects/import' || path.startsWith('/api/projects/import/')) {
+   return next()
+ }
  if (isAllowedUnauthWebchatProxyPath(path)) {
    return next()
  }
  ...
})
\`\`\`

## Test plan

- [ ] Existing e2e `e2e/project-export-import.test.ts` continues to pass.
- [ ] Manual: `POST /api/projects/import` with a valid `.shogo-project` bundle succeeds end-to-end (mobile \"Import project\" flow in `apps/mobile/lib/api.ts` no longer 403s).
- [ ] `POST /api/projects/<real-id>/...` routes still hit `requireProjectAccess` (unchanged for every path except `/api/projects/import[...]`).
- [ ] CI (typecheck + unit + e2e for `apps/api`).

## Scope

Single-purpose branch and commit — only this middleware carve-out, no other changes.

Made with [Cursor](https://cursor.com)