### PR TITLE
fix: Skills survive project export and appear in IDE tree

### DIFF
--- a/apps/api/src/routes/project-export-import.ts
+++ b/apps/api/src/routes/project-export-import.ts
@@ -4,10 +4,12 @@ import { AgentClient, type WorkspaceBundle } from '@shogo-ai/sdk/agent'
 import { Hono } from 'hono'
 import {
   existsSync,
+  lstatSync,
   readdirSync,
   readFileSync,
   writeFileSync,
   mkdirSync,
+  rmSync,
   statSync,
 } from 'node:fs'
 import { join, resolve, relative } from 'node:path'
@@ -32,6 +34,22 @@ const EXCLUDED_DIRS = new Set([
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10 MB per file
 const MAX_TOTAL_SIZE = 200 * 1024 * 1024 // 200 MB total bundle
+
+/**
+ * Remove a broken .shogo symlink left by a previous VM 9p mount.
+ * The VM creates .shogo -> /tmp/shogo-local/<id>/.shogo which becomes
+ * dangling on the host after the VM exits, causing collectWorkspaceFiles
+ * to silently skip the entire .shogo tree.
+ */
+function cleanBrokenShogoSymlink(workspaceDir: string): void {
+  const shogoDir = join(workspaceDir, '.shogo')
+  try {
+    const st = lstatSync(shogoDir)
+    if (st.isSymbolicLink()) {
+      try { statSync(shogoDir) } catch { rmSync(shogoDir, { force: true }) }
+    }
+  } catch {}
+}
 
 function collectWorkspaceFiles(
   dir: string,
@@ -138,6 +156,7 @@ export function projectExportImportRoutes() {
 
     zipContents['project.json'] = strToU8(JSON.stringify(projectJson, null, 2))
 
+    let gotWorkspaceFiles = false
     if (isKubernetes()) {
       try {
         const { getProjectPodUrl } = await import('../lib/knative-project-manager')
@@ -149,11 +168,15 @@ export function projectExportImportRoutes() {
             Buffer.from(base64Data, 'base64'),
           )
         }
+        gotWorkspaceFiles = true
       } catch (err: any) {
-        console.warn(`[Export] Could not reach agent pod for workspace files: ${err.message}`)
+        console.warn(`[Export] Could not reach agent pod, falling back to local workspace: ${err.message}`)
       }
-    } else {
+    }
+
+    if (!gotWorkspaceFiles) {
       const workspaceDir = join(WORKSPACES_DIR, projectId)
+      cleanBrokenShogoSymlink(workspaceDir)
       const workspaceFiles = collectWorkspaceFiles(workspaceDir, workspaceDir)
       for (const [relPath, data] of Object.entries(workspaceFiles)) {
         zipContents[`workspace/${relPath}`] = data

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -1704,7 +1704,10 @@ const WORKSPACE_TREE_EXCLUDE_DIRS = new Set([
   'node_modules', 'dist', '.next', '.cache', '.turbo', '.parcel-cache',
   'coverage', '.nyc_output', '__pycache__', '.venv', 'venv',
   'memory', 'scripts',
+  'server', 'generated',
 ])
+
+const DOT_DIR_ALLOWLIST = new Set(['.shogo'])
 
 const WORKSPACE_TREE_EXCLUDE_FILES = new Set([
   'bun.lock', '.virtfs_metadata',
@@ -1712,7 +1715,11 @@ const WORKSPACE_TREE_EXCLUDE_FILES = new Set([
   'package.json', 'tsconfig.json', 'vite.config.ts', 'tailwind.config.ts',
   'postcss.config.js', 'postcss.config.mjs', 'components.json',
   'pyrightconfig.json', 'LICENSE', 'README.md',
-  '.app-template',
+  '.app-template', '__lsp_warmup__.ts',
+])
+
+const WORKSPACE_TREE_EXCLUDE_EXTENSIONS = new Set([
+  '.db', '.db-shm', '.db-wal', '.db-journal',
 ])
 
 function walkFilesTree(
@@ -1724,7 +1731,7 @@ function walkFilesTree(
   if (!existsSync(dir)) return []
   const results: any[] = []
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    if (entry.name.startsWith('.')) continue
+    if (entry.name.startsWith('.') && !DOT_DIR_ALLOWLIST.has(entry.name)) continue
     const absPath = join(dir, entry.name)
     const relPath = absPath.slice(rootDir.length + 1)
     const stat = statSync(absPath)
@@ -1739,6 +1746,8 @@ function walkFilesTree(
       })
     } else {
       if (excludeFiles?.has(entry.name)) continue
+      const dotIdx = entry.name.indexOf('.')
+      if (dotIdx >= 0 && WORKSPACE_TREE_EXCLUDE_EXTENSIONS.has(entry.name.slice(dotIdx))) continue
       results.push({
         name: entry.name,
         path: relPath,


### PR DESCRIPTION
## Summary

Project export sometimes omitted workspace skill files (especially when the K8s agent pod was unreachable), and the IDE file explorer hid everything under dot-directories including `.shogo/skills/`.

## Changes

- **Agent runtime (`packages/agent-runtime/src/server.ts`):** Allowlist `.shogo` in `walkFilesTree` so skills and related config appear in the IDE explorer. Exclude noisy/generated paths (`server`, `generated`, SQLite sidecars, `__lsp_warmup__.ts`) from the visible tree.

- **API (`apps/api/src/routes/project-export-import.ts`):** When export runs in Kubernetes and the agent bundle fetch fails, fall back to scanning `WORKSPACES_DIR/<projectId>` instead of shipping an empty workspace ZIP. Before local collection, remove broken `.shogo` symlinks left by VM overlays so collected files are not silently skipped.

<img width="1918" height="895" alt="image" src="https://github.com/user-attachments/assets/f7e8d39d-3d95-417d-86c4-fc120d76a7ad" />