### PR TITLE
fix(ide): avoid non-extensible Monaco namespace for agent-fix HMR flag

### DIFF
--- a/apps/mobile/components/project/panels/ide/agentFixProvider.ts
+++ b/apps/mobile/components/project/panels/ide/agentFixProvider.ts
@@ -54,7 +54,10 @@ export interface FixInAgentPayload {
  * initial value on every dev hot-reload, but Monaco's internal registry
  * keeps previously-registered hover and code-action providers alive — which
  * would stack up duplicate "Fix with Shogo" entries with every save. Pin
- * the flag to the Monaco singleton so it survives module re-evaluation.
+ * the flag on `globalThis` so it survives module re-evaluation. We avoid
+ * storing it on the Monaco namespace object because some bundlers ship a
+ * non-extensible namespace (`Object.preventExtensions`), which throws when
+ * assigning ad-hoc properties.
  */
 const CONFIGURED_FLAG = "__shogoFixConfigured__";
 const disposables: IDisposable[] = [];
@@ -145,7 +148,7 @@ function buildPayload(
  * to call more than once — subsequent calls are no-ops.
  */
 export function setupAgentFix(monaco: MonacoNs): void {
-  const flagHost = monaco as unknown as Record<string, unknown>;
+  const flagHost = globalThis as unknown as Record<string, unknown>;
   if (flagHost[CONFIGURED_FLAG]) return;
   flagHost[CONFIGURED_FLAG] = true;
 


### PR DESCRIPTION
Fixes #423

## Problem

Web builds could crash with `Cannot add property __shogoFixConfigured__, object is not extensible` because `setupAgentFix` wrote the HMR guard onto the Monaco namespace, which is non-extensible in some bundles.

## Change

Store `CONFIGURED_FLAG` on `globalThis` instead. Behavior is unchanged for deduping provider registration across Fast Refresh, without mutating Monaco.

## How to verify

1. Open the mobile/web app on Metro (e.g. `localhost:8081`).
2. Open a screen that mounts the Monaco workbench / code editor.
3. Confirm no error modal; "Fix with Shogo" integrations still work.