### PR TITLE
fix(starred): right-size grid cards to match Projects page

### DIFF
--- a/apps/mobile/app/(app)/starred.tsx
+++ b/apps/mobile/app/(app)/starred.tsx
@@ -10,6 +10,7 @@ import {
   Modal,
   Alert,
   ActivityIndicator,
+  Platform,
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
@@ -90,6 +91,9 @@ export default observer(function StarredProjectsPage() {
   const [deleteProject, setDeleteProject] = useState<any>(null)
 
   const actions = useDomainActions()
+
+  const isNativeMobile = Platform.OS === 'ios' || Platform.OS === 'android'
+  const gridColumns = isNativeMobile ? 2 : 3
 
   useEffect(() => {
     if (!isAuthenticated || !user?.id) return
@@ -241,7 +245,13 @@ export default observer(function StarredProjectsPage() {
           onPress={() => handleProjectPress(project)}
           className="flex-1 mx-1.5 mb-3 rounded-xl bg-card overflow-hidden border border-border"
         >
-          <View className={cn('aspect-video items-center justify-center', getPlaceholderColor(project.name || ''))}>
+          <View
+            className={cn(
+              isNativeMobile ? 'h-[100px]' : 'h-[140px]',
+              'items-center justify-center',
+              getPlaceholderColor(project.name || ''),
+            )}
+          >
             <FolderOpen size={28} className="text-white/30" />
             <Pressable
               onPress={() => handleUnstar(entry)}
@@ -477,10 +487,10 @@ export default observer(function StarredProjectsPage() {
         </View>
       ) : viewMode === 'grid' ? (
         <FlatList
-          key="grid-2"
+          key={`grid-${gridColumns}`}
           data={filteredEntries}
           keyExtractor={(item: any) => item.id}
-          numColumns={2}
+          numColumns={gridColumns}
           contentContainerClassName="p-2.5 pt-4"
           renderItem={renderGridItem}
         />


### PR DESCRIPTION
## Summary
<img width="1512" height="982" alt="Screenshot 2026-04-22 at 6 23 45 PM" src="https://github.com/user-attachments/assets/43fe05e8-7c08-4dad-813f-eb804e5dd676" />
- The Starred Projects grid (`/starred`) was rendering cards at roughly 2x the size of the All Projects grid on web because it hard-coded `numColumns={2}` and used `aspect-video` on the thumbnail header — as columns grew wider on web, `aspect-video` scaled the card height up and cards ballooned.
- Switched `numColumns` to be responsive (3 on web, 2 on native), matching `apps/mobile/app/(app)/projects/index.tsx`.
- Replaced `aspect-video` with a fixed tailwind height (`h-[100px]` native / `h-[140px]` web) so the header no longer grows with column width.
- No inline styles — only NativeWind class changes.

Closes #426

## Test plan

- [x] Load studio on web, navigate to Starred, toggle grid view → cards render in a 3-column grid at normal size (comparable to All Projects).
- [ ] On iOS / Android, Starred grid shows 2 columns with a compact 100px header (consistent with the compact mobile Projects grid).
- [x] List view unchanged.
- [x] Star / unstar, rename, and delete actions still work from the grid view.

Made with [Cursor](https://cursor.com)