### PR TITLE
feat(mobile-ide): theme-aware workbench, explorer multi-select, image preview

### DIFF
--- a/apps/mobile/components/project/panels/IDEPanel.tsx
+++ b/apps/mobile/components/project/panels/IDEPanel.tsx
@@ -41,12 +41,12 @@ export function IDEPanel({ visible, projectId, projectName, agentUrl }: IDEPanel
   if (Platform.OS !== 'web') {
     if (!visible) return null
     return (
-      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24, backgroundColor: '#1e1e1e' }}>
+      <View className="flex-1 items-center justify-center p-6 bg-background">
         <Code2 size={32} color="#0078d4" />
-        <Text style={{ color: '#cccccc', fontSize: 14, fontWeight: '600', marginTop: 12 }}>
+        <Text className="text-foreground text-sm font-semibold mt-3">
           IDE requires a desktop browser
         </Text>
-        <Text style={{ color: '#858585', fontSize: 12, marginTop: 6, textAlign: 'center', maxWidth: 320 }}>
+        <Text className="text-muted-foreground text-xs mt-1.5 text-center max-w-[320px]">
           The full code editor is built on Monaco (DOM-only). Open this project
           in Chrome or Edge on your desktop to use the IDE tab.
         </Text>
@@ -57,8 +57,8 @@ export function IDEPanel({ visible, projectId, projectName, agentUrl }: IDEPanel
   if (!agentService) {
     if (!visible) return null
     return (
-      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24, backgroundColor: '#1e1e1e' }}>
-        <Text style={{ color: '#858585', fontSize: 12 }}>Agent not ready yet…</Text>
+      <View className="flex-1 items-center justify-center p-6 bg-background">
+        <Text className="text-muted-foreground text-xs">Agent not ready yet…</Text>
       </View>
     )
   }

--- a/apps/mobile/components/project/panels/ide/ActivityBar.tsx
+++ b/apps/mobile/components/project/panels/ide/ActivityBar.tsx
@@ -14,7 +14,7 @@ export function ActivityBar({
   onSelect: (id: ActivityId) => void;
 }) {
   return (
-    <div className="flex h-full w-12 flex-col items-center justify-between bg-[#1a1a1a] border-r border-[#2a2a2a] py-2">
+    <div className="flex h-full w-12 flex-col items-center justify-between bg-[color:var(--ide-panel)] border-r border-[color:var(--ide-border)] py-2">
       <div className="flex flex-col items-center gap-1">
         {ITEMS.map(({ id, icon: Icon, label }) => {
           const isActive = active === id;
@@ -25,12 +25,12 @@ export function ActivityBar({
               onClick={() => onSelect(id)}
               className={`relative flex h-10 w-10 items-center justify-center rounded-md transition-colors ${
                 isActive
-                  ? "text-white"
-                  : "text-[#858585] hover:text-white"
+                  ? "text-[color:var(--ide-text-strong)]"
+                  : "text-[color:var(--ide-muted)] hover:text-[color:var(--ide-text-strong)]"
               }`}
             >
               {isActive && (
-                <span className="absolute left-0 top-1/2 h-6 -translate-y-1/2 w-0.5 bg-white rounded-r" />
+                <span className="absolute left-0 top-1/2 h-6 -translate-y-1/2 w-0.5 bg-[color:var(--ide-text-strong)] rounded-r" />
               )}
               <Icon size={20} />
             </button>
@@ -41,7 +41,9 @@ export function ActivityBar({
         title="Settings"
         onClick={() => onSelect("settings")}
         className={`flex h-10 w-10 items-center justify-center rounded-md transition-colors ${
-          active === "settings" ? "text-white" : "text-[#858585] hover:text-white"
+          active === "settings"
+            ? "text-[color:var(--ide-text-strong)]"
+            : "text-[color:var(--ide-muted)] hover:text-[color:var(--ide-text-strong)]"
         }`}
       >
         <Settings size={20} />

--- a/apps/mobile/components/project/panels/ide/AgentEditBanner.tsx
+++ b/apps/mobile/components/project/panels/ide/AgentEditBanner.tsx
@@ -31,14 +31,14 @@ export function AgentEditBanner({
   const othersCount = conflicts.length - 1;
 
   return (
-    <div className="flex items-center gap-3 border-b border-[#f9826c]/60 bg-[#f9826c]/15 px-3 py-1.5 text-[12px] text-[#f9d7cf]">
+    <div className="flex items-center gap-3 border-b border-[color:var(--ide-conflict-border)] bg-[color:var(--ide-conflict-bg)] px-3 py-1.5 text-[12px] text-[color:var(--ide-conflict-text)]">
       <FileWarning size={14} className="shrink-0" />
       <span className="flex-1 truncate">
         Agent edited{" "}
-        <span className="font-medium text-white">{current.path}</span>{" "}
+        <span className="font-medium text-[color:var(--ide-text-strong)]">{current.path}</span>{" "}
         while you had unsaved changes.
         {othersCount > 0 && (
-          <span className="ml-2 rounded bg-[#f9826c]/30 px-1.5 py-[1px] text-[11px] text-[#f9d7cf]">
+          <span className="ml-2 rounded bg-[color:var(--ide-conflict-pill-bg)] px-1.5 py-[1px] text-[11px]">
             +{othersCount} more file{othersCount === 1 ? "" : "s"}
           </span>
         )}
@@ -46,7 +46,7 @@ export function AgentEditBanner({
       <button
         type="button"
         onClick={() => onReload(current.fileId)}
-        className="flex items-center gap-1 rounded bg-[#0e639c] px-2 py-0.5 text-white hover:bg-[#1177bb]"
+        className="flex items-center gap-1 rounded bg-[color:var(--ide-btn-primary-bg)] px-2 py-0.5 text-white hover:bg-[color:var(--ide-btn-primary-hover)]"
         title="Discard your changes and load the agent's version"
       >
         <RotateCw size={12} />
@@ -55,7 +55,7 @@ export function AgentEditBanner({
       <button
         type="button"
         onClick={() => onKeepMine(current.fileId)}
-        className="flex items-center gap-1 rounded bg-[#3a3d41] px-2 py-0.5 text-[#cccccc] hover:bg-[#4a4d51]"
+        className="flex items-center gap-1 rounded bg-[color:var(--ide-btn-secondary-bg)] px-2 py-0.5 text-[color:var(--ide-text)] hover:bg-[color:var(--ide-btn-secondary-hover)]"
         title="Keep your unsaved edits; ignore the agent's write"
       >
         <X size={12} />

--- a/apps/mobile/components/project/panels/ide/Breadcrumbs.tsx
+++ b/apps/mobile/components/project/panels/ide/Breadcrumbs.tsx
@@ -3,11 +3,11 @@ import { ChevronRight } from "lucide-react-native";
 export function Breadcrumbs({ path }: { path: string }) {
   const parts = path.split("/").filter(Boolean);
   return (
-    <div className="flex h-7 items-center gap-1 bg-[#1e1e1e] px-3 text-[12px] text-[#858585] border-b border-[#2a2a2a]">
+    <div className="flex h-7 items-center gap-1 bg-[color:var(--ide-bg)] px-3 text-[12px] text-[color:var(--ide-muted)] border-b border-[color:var(--ide-border)]">
       {parts.map((p, i) => (
         <span key={i} className="flex items-center gap-1">
           {i > 0 && <ChevronRight size={12} />}
-          <span className={i === parts.length - 1 ? "text-[#cccccc]" : ""}>{p}</span>
+          <span className={i === parts.length - 1 ? "text-[color:var(--ide-text)]" : ""}>{p}</span>
         </span>
       ))}
     </div>

--- a/apps/mobile/components/project/panels/ide/CodeEditor.tsx
+++ b/apps/mobile/components/project/panels/ide/CodeEditor.tsx
@@ -1,5 +1,5 @@
 import Editor, { type OnMount } from "@monaco-editor/react";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import type { editor } from "monaco-editor";
 import type { EditorSettings } from "./types";
 import { setupAgentFix } from "./agentFixProvider";
@@ -25,6 +25,17 @@ function configureMonaco(monaco: MonacoNs) {
       "editor.background": "#1e1e1e",
       "editor.lineHighlightBackground": "#2a2a2a",
       "editorGutter.background": "#1e1e1e",
+    },
+  });
+
+  monaco.editor.defineTheme("shogo-light", {
+    base: "vs",
+    inherit: true,
+    rules: [],
+    colors: {
+      "editor.background": "#ffffff",
+      "editor.lineHighlightBackground": "#f3f3f3",
+      "editorGutter.background": "#ffffff",
     },
   });
 
@@ -73,6 +84,7 @@ export function CodeEditor({
   language,
   pathKey,
   settings,
+  themeMode,
   onChange,
   onCursor,
   onMount,
@@ -82,16 +94,28 @@ export function CodeEditor({
   /** Stable unique path used as the Monaco model URI so IntelliSense scopes per-file. */
   pathKey: string;
   settings: EditorSettings;
+  /** Resolved app theme — Monaco flips between shogo-dark / shogo-light. */
+  themeMode: "dark" | "light";
   onChange: (v: string) => void;
   onCursor: (line: number, col: number) => void;
   onMount?: (ed: editor.IStandaloneCodeEditor, monaco: MonacoNs) => void;
 }) {
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
+  const monacoRef = useRef<MonacoNs | null>(null);
+
+  const themeName = themeMode === "light" ? "shogo-light" : "shogo-dark";
+
+  // Live-swap Monaco theme when the app theme changes under an already-mounted
+  // editor (e.g. user toggles theme while a file is open).
+  useEffect(() => {
+    monacoRef.current?.editor.setTheme(themeName);
+  }, [themeName]);
 
   const handleMount: OnMount = (ed, monaco) => {
     editorRef.current = ed;
+    monacoRef.current = monaco;
     configureMonaco(monaco);
-    monaco.editor.setTheme("shogo-dark");
+    monaco.editor.setTheme(themeName);
 
     ed.onDidChangeCursorPosition((e) => {
       onCursor(e.position.lineNumber, e.position.column);
@@ -106,7 +130,7 @@ export function CodeEditor({
       path={pathKey}
       language={language}
       value={value}
-      theme="shogo-dark"
+      theme={themeName}
       onChange={(v) => onChange(v ?? "")}
       onMount={handleMount}
       options={{

--- a/apps/mobile/components/project/panels/ide/ContextMenu.tsx
+++ b/apps/mobile/components/project/panels/ide/ContextMenu.tsx
@@ -48,11 +48,11 @@ export function ContextMenu({
       ref={ref}
       role="menu"
       style={{ left: Math.min(x, maxX), top: Math.min(y, maxY) }}
-      className="fixed z-50 min-w-[200px] rounded-md border border-[#454545] bg-[#252526] py-1 shadow-xl text-[#cccccc]"
+      className="fixed z-50 min-w-[200px] rounded-md border border-[color:var(--ide-border-muted)] bg-[color:var(--ide-surface)] py-1 shadow-xl text-[color:var(--ide-text)]"
     >
       {items.map((it, i) =>
         "separator" in it && it.separator ? (
-          <div key={i} className="my-1 h-px bg-[#454545]" />
+          <div key={i} className="my-1 h-px bg-[color:var(--ide-border-muted)]" />
         ) : (
           <button
             key={i}
@@ -63,10 +63,10 @@ export function ContextMenu({
             }}
             className={`flex w-full items-center justify-between gap-6 px-3 py-1 text-left text-[13px] ${
               (it as MenuItem).disabled
-                ? "cursor-not-allowed text-[#6b6b6b]"
+                ? "cursor-not-allowed text-[color:var(--ide-muted-strong)]"
                 : (it as MenuItem).danger
-                ? "hover:bg-[#c4314b] hover:text-white"
-                : "hover:bg-[#094771] hover:text-white"
+                ? "hover:bg-[color:var(--ide-danger-hover)] hover:text-white"
+                : "hover:bg-[color:var(--ide-active-bg)] hover:text-white"
             }`}
           >
             <span className="flex items-center gap-2">
@@ -74,7 +74,7 @@ export function ContextMenu({
               {(it as MenuItem).label}
             </span>
             {(it as MenuItem).shortcut && (
-              <span className="text-[11px] text-[#858585]">{(it as MenuItem).shortcut}</span>
+              <span className="text-[11px] text-[color:var(--ide-muted)]">{(it as MenuItem).shortcut}</span>
             )}
           </button>
         ),

--- a/apps/mobile/components/project/panels/ide/EditorGroup.tsx
+++ b/apps/mobile/components/project/panels/ide/EditorGroup.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle } from "lucide-react-native";
 import { EditorTabs } from "./EditorTabs";
 import { Breadcrumbs } from "./Breadcrumbs";
 import { CodeEditor } from "./CodeEditor";
+import { ImagePreview } from "./ImagePreview";
 import type { EditorGroup as GroupState, EditorSettings, OpenFile } from "./types";
 import type { editor } from "monaco-editor";
 
@@ -19,6 +20,7 @@ export function EditorGroupView({
   onCursor,
   onEditorMount,
   settings,
+  themeMode,
 }: {
   group: GroupState;
   focused: boolean;
@@ -31,6 +33,7 @@ export function EditorGroupView({
   onCursor: (line: number, col: number) => void;
   onEditorMount?: (ed: editor.IStandaloneCodeEditor, monaco: MonacoNs) => void;
   settings: EditorSettings;
+  themeMode: "dark" | "light";
 }) {
   const active: OpenFile | null =
     group.files.find((f) => f.id === group.activeId) ?? null;
@@ -38,7 +41,7 @@ export function EditorGroupView({
   return (
     <div
       onMouseDown={onFocus}
-      className={`flex h-full flex-col bg-[#1e1e1e] ${
+      className={`flex h-full flex-col bg-[color:var(--ide-bg)] ${
         focused ? "" : "opacity-95"
       }`}
     >
@@ -56,21 +59,24 @@ export function EditorGroupView({
       <div className="flex-1 min-h-0 relative">
         {active ? (
           active.loading ? (
-            <div className="flex h-full items-center justify-center text-[13px] text-[#858585]">
+            <div className="flex h-full items-center justify-center text-[13px] text-[color:var(--ide-muted)]">
               Loading {active.name}…
             </div>
           ) : active.error ? (
-            <div className="flex h-full flex-col items-center justify-center gap-2 text-[#f48771]">
+            <div className="flex h-full flex-col items-center justify-center gap-2 text-[color:var(--ide-error)]">
               <AlertTriangle size={24} />
               <div className="text-[13px]">Could not open {active.name}</div>
-              <div className="text-[12px] text-[#858585]">{active.error}</div>
+              <div className="text-[12px] text-[color:var(--ide-muted)]">{active.error}</div>
             </div>
+          ) : active.language === "image" ? (
+            <ImagePreview url={active.content} name={active.name} path={active.path} />
           ) : (
             <CodeEditor
               value={active.content}
               language={active.language}
               pathKey={active.id}
               settings={settings}
+              themeMode={themeMode}
               onChange={onChange}
               onCursor={onCursor}
               onMount={onEditorMount}
@@ -86,15 +92,15 @@ export function EditorGroupView({
 
 function EmptyGroup() {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-3 text-[#858585]">
+    <div className="flex h-full flex-col items-center justify-center gap-3 text-[color:var(--ide-muted)]">
       <div className="text-4xl">⚡</div>
       <div className="text-[13px]">No editor</div>
       <div className="flex gap-4 text-[11px]">
         <span>
-          <kbd className="rounded bg-[#2a2a2a] px-1.5 py-0.5">⌘P</kbd> Go to file
+          <kbd className="rounded bg-[color:var(--ide-kbd-bg)] px-1.5 py-0.5">⌘P</kbd> Go to file
         </span>
         <span>
-          <kbd className="rounded bg-[#2a2a2a] px-1.5 py-0.5">⌘⇧P</kbd> Commands
+          <kbd className="rounded bg-[color:var(--ide-kbd-bg)] px-1.5 py-0.5">⌘⇧P</kbd> Commands
         </span>
       </div>
     </div>

--- a/apps/mobile/components/project/panels/ide/EditorTabs.tsx
+++ b/apps/mobile/components/project/panels/ide/EditorTabs.tsx
@@ -87,11 +87,11 @@ export function EditorTabs({
       onDragOver={(e) => {
         if (dragId) e.preventDefault();
       }}
-      className="relative flex h-9 items-stretch bg-[#1e1e1e] border-b border-[#2a2a2a] overflow-x-auto"
+      className="relative flex h-9 items-stretch bg-[color:var(--ide-bg)] border-b border-[color:var(--ide-border)] overflow-x-auto"
     >
       {sorted.map((f) => {
         const isActive = f.id === activeId;
-        const accent = isActive && groupFocused !== false ? "#0078d4" : "#555";
+        const isFocusedActive = isActive && groupFocused !== false;
         const isDragging = dragId === f.id;
         const showBefore = dropTarget?.id === f.id && dropTarget.pos === "before";
         const showAfter = dropTarget?.id === f.id && dropTarget.pos === "after";
@@ -126,12 +126,23 @@ export function EditorTabs({
               setDragId(null);
               setDropTarget(null);
             }}
-            className={`group relative flex cursor-pointer items-center gap-2 border-r border-[#2a2a2a] px-3 text-[13px] transition-opacity ${
+            className={`group relative flex cursor-pointer items-center gap-2 border-r border-[color:var(--ide-border)] px-3 text-[13px] transition-opacity ${
               isActive
-                ? "bg-[#1e1e1e] text-white"
-                : "bg-[#2d2d2d] text-[#969696] hover:text-white"
+                ? "bg-[color:var(--ide-bg)] text-[color:var(--ide-text-strong)]"
+                : "bg-[color:var(--ide-tab-inactive)] text-[color:var(--ide-tab-inactive-text)] hover:text-[color:var(--ide-text-strong)]"
             } ${isDragging ? "opacity-40" : ""}`}
-            style={isActive ? { borderTop: `2px solid ${accent}`, marginTop: -1 } : undefined}
+            style={
+              isActive
+                ? {
+                    borderTop: `2px solid ${
+                      isFocusedActive
+                        ? "var(--ide-active-ring)"
+                        : "var(--ide-border-strong)"
+                    }`,
+                    marginTop: -1,
+                  }
+                : undefined
+            }
             onClick={() => onSelect(f.id)}
             onMouseDown={(e) => {
               if (e.button === 1) {
@@ -141,13 +152,13 @@ export function EditorTabs({
             }}
           >
             {showBefore && (
-              <span className="pointer-events-none absolute left-0 top-0 h-full w-[2px] bg-[#0078d4]" />
+              <span className="pointer-events-none absolute left-0 top-0 h-full w-[2px] bg-[color:var(--ide-active-ring)]" />
             )}
-            {f.pinned && <Pin size={11} className="text-[#858585]" />}
+            {f.pinned && <Pin size={11} className="text-[color:var(--ide-muted)]" />}
             <span className="truncate max-w-[120px] sm:max-w-[160px] lg:max-w-[220px]">{f.name}</span>
             <button
               title={f.pinned ? "Unpin" : f.dirty ? "Close (unsaved)" : "Close"}
-              className="flex h-4 w-4 items-center justify-center rounded-sm hover:bg-[#ffffff1a]"
+              className="flex h-4 w-4 items-center justify-center rounded-sm hover:bg-[color:var(--ide-hover-subtle)]"
               onClick={(e) => {
                 e.stopPropagation();
                 if (f.pinned && onTogglePin) onTogglePin(f.id);
@@ -165,7 +176,7 @@ export function EditorTabs({
               )}
             </button>
             {showAfter && (
-              <span className="pointer-events-none absolute right-0 top-0 h-full w-[2px] bg-[#0078d4]" />
+              <span className="pointer-events-none absolute right-0 top-0 h-full w-[2px] bg-[color:var(--ide-active-ring)]" />
             )}
           </div>
         );

--- a/apps/mobile/components/project/panels/ide/FileTree.tsx
+++ b/apps/mobile/components/project/panels/ide/FileTree.tsx
@@ -54,8 +54,12 @@ function iconFor(ext: string) {
   if (ext === "html") return "text-[#e44d26]";
   if (ext === "prisma") return "text-[#a78bfa]";
   if (ext === "py") return "text-[#3572a5]";
-  return "text-[#75beff]";
+  return "text-[color:var(--ide-accent-file-icon)]";
 }
+
+/** Stable key used across the selection state (root-aware so folder names
+ *  collisions across roots don't stomp each other). */
+const keyOf = (node: TreeNode) => `${node.rootId}::${node.path}`;
 
 export function FileTree({
   tree,
@@ -74,6 +78,12 @@ export function FileTree({
     return s;
   });
   const [selected, setSelected] = useState<string | null>(null);
+  /** Additional selected entries (stored by stable keyOf()). Always includes
+   *  `selected` when it's set. Used for multi-select actions (Cmd/Shift+click).
+   *  VS Code semantics: Cmd/Ctrl toggles a single entry, Shift extends a range
+   *  between the anchor and the clicked row. */
+  const [multiSelected, setMultiSelected] = useState<Set<string>>(new Set());
+  const anchorRef = useRef<string | null>(null);
   const [renaming, setRenaming] = useState<{ path: string; draft: string } | null>(null);
   const [creating, setCreating] = useState<{
     rootId: string;
@@ -113,6 +123,31 @@ export function FileTree({
     return base;
   }, [tree, expanded, creating]);
 
+  /** Linear view of *visible* nodes used by keyboard nav and range selection. */
+  const visibleNodes = useMemo(
+    () =>
+      rows
+        .filter((r): r is Extract<FlatRow, { kind: "node" }> => r.kind === "node")
+        .map((r) => r.node),
+    [rows],
+  );
+
+  /** Prune selections that are no longer visible (e.g. after a parent was
+   *  collapsed or the tree refreshed). Keeps behaviour predictable. */
+  useEffect(() => {
+    setMultiSelected((prev) => {
+      if (prev.size === 0) return prev;
+      const visible = new Set(visibleNodes.map(keyOf));
+      let changed = false;
+      const next = new Set<string>();
+      for (const k of prev) {
+        if (visible.has(k)) next.add(k);
+        else changed = true;
+      }
+      return changed ? next : prev;
+    });
+  }, [visibleNodes]);
+
   const toggle = useCallback((path: string) => {
     setExpanded((prev) => {
       const n = new Set(prev);
@@ -134,7 +169,13 @@ export function FileTree({
   const openContextMenu = (e: React.MouseEvent, node: TreeNode | null) => {
     e.preventDefault();
     e.stopPropagation();
-    setSelected(node?.path ?? null);
+    // If right-clicking on a row that's part of a multi-selection, preserve the
+    // set so "Delete" / "Copy Path" can operate on everything at once.
+    if (node && !multiSelected.has(keyOf(node))) {
+      setSelected(node.path);
+      setMultiSelected(new Set([keyOf(node)]));
+      anchorRef.current = keyOf(node);
+    }
     setMenu({ x: e.clientX, y: e.clientY, node });
   };
 
@@ -186,14 +227,95 @@ export function FileTree({
     }
   };
 
-  const handleDelete = async (node: TreeNode) => {
-    if (!confirm(`Delete ${node.kind === "dir" ? "folder" : "file"} "${node.name}"?`)) return;
-    try {
-      await handlers.onDelete(node);
-    } catch {
-      /* toast */
+  const selectedNodes = useMemo(() => {
+    if (multiSelected.size === 0) return [] as TreeNode[];
+    const byKey = new Map(visibleNodes.map((n) => [keyOf(n), n]));
+    const out: TreeNode[] = [];
+    for (const k of multiSelected) {
+      const n = byKey.get(k);
+      if (n) out.push(n);
     }
+    return out;
+  }, [multiSelected, visibleNodes]);
+
+  const handleDelete = async (node: TreeNode) => {
+    // Batch delete path: if the clicked node is part of a multi-selection of
+    // >1 entries, confirm once and delete all (files + folders). Otherwise
+    // fall back to the single-item confirm.
+    const targets =
+      multiSelected.size > 1 && multiSelected.has(keyOf(node))
+        ? selectedNodes
+        : [node];
+    if (targets.length === 1) {
+      const t = targets[0];
+      if (!confirm(`Delete ${t.kind === "dir" ? "folder" : "file"} "${t.name}"?`)) return;
+    } else {
+      if (
+        !confirm(
+          `Delete ${targets.length} items? Folders will be removed recursively.`,
+        )
+      ) {
+        return;
+      }
+    }
+    for (const t of targets) {
+      try {
+        await handlers.onDelete(t);
+      } catch {
+        /* toast handled by parent */
+      }
+    }
+    setMultiSelected(new Set());
+    setSelected(null);
   };
+
+  const openSelected = useCallback(() => {
+    const files = selectedNodes.filter((n) => n.kind === "file");
+    for (const f of files) handlers.onOpen(f);
+  }, [selectedNodes, handlers]);
+
+  /** Cmd/Ctrl-click toggles, Shift-click extends a range between anchor and
+   *  the clicked row, plain click resets to a single-selection. */
+  const handleRowClick = useCallback(
+    (e: React.MouseEvent, node: TreeNode) => {
+      e.stopPropagation();
+      const k = keyOf(node);
+      const meta = e.metaKey || e.ctrlKey;
+      const shift = e.shiftKey;
+
+      if (shift && anchorRef.current) {
+        const keys = visibleNodes.map(keyOf);
+        const a = keys.indexOf(anchorRef.current);
+        const b = keys.indexOf(k);
+        if (a >= 0 && b >= 0) {
+          const [lo, hi] = a < b ? [a, b] : [b, a];
+          const range = new Set(keys.slice(lo, hi + 1));
+          setMultiSelected(range);
+          setSelected(node.path);
+        }
+        return;
+      }
+
+      if (meta) {
+        setMultiSelected((prev) => {
+          const next = new Set(prev);
+          if (next.has(k)) next.delete(k);
+          else next.add(k);
+          return next;
+        });
+        anchorRef.current = k;
+        setSelected(node.path);
+        return;
+      }
+
+      anchorRef.current = k;
+      setMultiSelected(new Set([k]));
+      setSelected(node.path);
+      if (node.kind === "dir") toggle(node.path);
+      else handlers.onOpen(node);
+    },
+    [visibleNodes, toggle, handlers],
+  );
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -201,18 +323,44 @@ export function FileTree({
       if (!containerRef.current?.contains(document.activeElement) && document.activeElement !== document.body) {
         return;
       }
-      const nodes = rows
-        .filter((r): r is Extract<FlatRow, { kind: "node" }> => r.kind === "node")
-        .map((r) => r.node);
+      const nodes = visibleNodes;
       const idx = selected ? nodes.findIndex((n) => n.path === selected) : -1;
       if (e.key === "ArrowDown") {
         e.preventDefault();
         const next = nodes[Math.min(idx + 1, nodes.length - 1)];
-        if (next) setSelected(next.path);
+        if (next) {
+          setSelected(next.path);
+          if (e.shiftKey && anchorRef.current) {
+            const keys = nodes.map(keyOf);
+            const a = keys.indexOf(anchorRef.current);
+            const b = keys.indexOf(keyOf(next));
+            if (a >= 0 && b >= 0) {
+              const [lo, hi] = a < b ? [a, b] : [b, a];
+              setMultiSelected(new Set(keys.slice(lo, hi + 1)));
+            }
+          } else {
+            anchorRef.current = keyOf(next);
+            setMultiSelected(new Set([keyOf(next)]));
+          }
+        }
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
         const prev = nodes[Math.max(idx - 1, 0)];
-        if (prev) setSelected(prev.path);
+        if (prev) {
+          setSelected(prev.path);
+          if (e.shiftKey && anchorRef.current) {
+            const keys = nodes.map(keyOf);
+            const a = keys.indexOf(anchorRef.current);
+            const b = keys.indexOf(keyOf(prev));
+            if (a >= 0 && b >= 0) {
+              const [lo, hi] = a < b ? [a, b] : [b, a];
+              setMultiSelected(new Set(keys.slice(lo, hi + 1)));
+            }
+          } else {
+            anchorRef.current = keyOf(prev);
+            setMultiSelected(new Set([keyOf(prev)]));
+          }
+        }
       } else if (e.key === "ArrowRight") {
         const n = nodes[idx];
         if (n?.kind === "dir") {
@@ -234,10 +382,23 @@ export function FileTree({
         }
         e.preventDefault();
       } else if (e.key === "Enter") {
+        if (multiSelected.size > 1) {
+          e.preventDefault();
+          openSelected();
+          return;
+        }
         const n = nodes[idx];
         if (!n) return;
         if (n.kind === "dir") toggle(n.path);
         else handlers.onOpen(n);
+      } else if (e.key === "a" && (e.metaKey || e.ctrlKey)) {
+        // Select-all *visible* entries (don't clobber browser find/replace
+        // since Monaco owns that when focused — FileTree only reacts when
+        // it has focus).
+        e.preventDefault();
+        setMultiSelected(new Set(nodes.map(keyOf)));
+      } else if (e.key === "Escape") {
+        setMultiSelected((prev) => (prev.size > 1 ? new Set() : prev));
       } else if (e.key === "F2") {
         const n = nodes[idx];
         if (n) beginRename(n);
@@ -249,9 +410,7 @@ export function FileTree({
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [rows, selected, expanded, renaming, creating, handlers, expand, toggle]);
-
-  const selectedNode = selected ? findNode(tree, selected) : null;
+  }, [visibleNodes, selected, expanded, renaming, creating, handlers, expand, toggle, multiSelected, openSelected]);
 
   const menuItems = (node: TreeNode | null): MenuEntry[] => {
     const defaultRootId = tree[0]?.rootId ?? "agent";
@@ -266,6 +425,37 @@ export function FileTree({
           label: "New Folder",
           icon: <FolderPlus size={14} />,
           onClick: () => beginCreate(defaultRootId, "", "dir"),
+        },
+      ];
+    }
+    // Multi-select context menu: hides per-node ops (rename/create) that don't
+    // make sense for a batch, and scopes actions to the whole selection.
+    if (multiSelected.size > 1 && multiSelected.has(keyOf(node))) {
+      const count = multiSelected.size;
+      const fileCount = selectedNodes.filter((n) => n.kind === "file").length;
+      return [
+        ...(fileCount > 0
+          ? [
+              {
+                label: `Open ${fileCount} file${fileCount === 1 ? "" : "s"}`,
+                onClick: () => openSelected(),
+              } as MenuEntry,
+            ]
+          : []),
+        {
+          label: "Copy Paths",
+          onClick: () =>
+            void navigator.clipboard.writeText(
+              selectedNodes.map((n) => n.path).join("\n"),
+            ),
+        },
+        { separator: true },
+        {
+          label: `Delete ${count} items`,
+          shortcut: "⌫",
+          icon: <Trash2 size={14} />,
+          danger: true,
+          onClick: () => void handleDelete(node),
         },
       ];
     }
@@ -315,7 +505,10 @@ export function FileTree({
       onContextMenu={(e) => {
         if (e.target === containerRef.current) openContextMenu(e, null);
       }}
-      onClick={() => setSelected(null)}
+      onClick={() => {
+        setSelected(null);
+        setMultiSelected(new Set());
+      }}
     >
       {rows.map((row, i) => {
         if (row.kind === "new") {
@@ -325,9 +518,9 @@ export function FileTree({
               depth={row.depth}
               icon={
                 row.mode === "dir" ? (
-                  <Folder size={15} className="text-[#dcb67a]" />
+                  <Folder size={15} className="text-[color:var(--ide-accent-folder)]" />
                 ) : (
-                  <File size={15} className="text-[#75beff]" />
+                  <File size={15} className="text-[color:var(--ide-accent-file-icon)]" />
                 )
               }
               value={creating?.draft ?? ""}
@@ -342,6 +535,7 @@ export function FileTree({
         const isExpanded = node.kind === "dir" && expanded.has(node.path);
         const isActive = node.path === activePath;
         const isSelected = node.path === selected;
+        const isMulti = multiSelected.has(keyOf(node));
         const isDropInto = dropTarget === node.path && node.kind === "dir";
         const ext = node.name.split(".").pop()?.toLowerCase() ?? "";
 
@@ -352,7 +546,7 @@ export function FileTree({
               depth={depth}
               icon={
                 node.kind === "dir" ? (
-                  <Folder size={15} className="text-[#dcb67a]" />
+                  <Folder size={15} className="text-[color:var(--ide-accent-folder)]" />
                 ) : (
                   <File size={15} className={iconFor(ext)} />
                 )
@@ -394,28 +588,29 @@ export function FileTree({
               const srcNode = findNode(tree, src);
               if (srcNode) void handlers.onMove(srcNode, node);
             }}
-            onClick={(e) => {
+            onClick={(e) => handleRowClick(e, node)}
+            onDoubleClick={(e) => {
               e.stopPropagation();
-              setSelected(node.path);
-              if (node.kind === "dir") toggle(node.path);
-              else handlers.onOpen(node);
+              if (node.kind === "file") handlers.onOpen(node);
             }}
             onContextMenu={(e) => openContextMenu(e, node)}
             className={
               isWorkspaceRoot
                 ? `group flex cursor-pointer items-center gap-1 px-2 py-[4px] text-[11px] font-semibold uppercase tracking-wider min-w-0 ${
                     isDropInto
-                      ? "bg-[#094771] text-white"
-                      : "text-[#858585] hover:text-white hover:bg-[#2a2d2e]"
+                      ? "bg-[color:var(--ide-active-bg)] text-white"
+                      : "text-[color:var(--ide-muted)] hover:text-[color:var(--ide-text-strong)] hover:bg-[color:var(--ide-hover)]"
                   }`
                 : `group flex cursor-pointer items-center gap-1 px-2 py-[3px] text-[13px] min-w-0 ${
                     isDropInto
-                      ? "bg-[#094771] ring-1 ring-inset ring-[#0078d4]"
+                      ? "bg-[color:var(--ide-active-bg)] ring-1 ring-inset ring-[color:var(--ide-active-ring)]"
+                      : isMulti
+                      ? "bg-[color:var(--ide-active)] text-[color:var(--ide-text-strong)]"
                       : isActive
-                      ? "bg-[#37373d] text-white"
+                      ? "bg-[color:var(--ide-active)] text-[color:var(--ide-text-strong)]"
                       : isSelected
-                      ? "bg-[#2a2d2e] text-white"
-                      : "text-[#cccccc] hover:bg-[#2a2d2e]"
+                      ? "bg-[color:var(--ide-hover)] text-[color:var(--ide-text-strong)]"
+                      : "text-[color:var(--ide-text)] hover:bg-[color:var(--ide-hover)]"
                   }`
             }
             style={{ paddingLeft: 8 + depth * 12 }}
@@ -424,15 +619,15 @@ export function FileTree({
               <>
                 <ChevronRight
                   size={14}
-                  className={`text-[#858585] transition-transform ${
+                  className={`text-[color:var(--ide-muted)] transition-transform ${
                     isExpanded ? "rotate-90" : ""
                   }`}
                 />
                 {!isWorkspaceRoot &&
                   (isExpanded ? (
-                    <FolderOpen size={15} className="text-[#dcb67a]" />
+                    <FolderOpen size={15} className="text-[color:var(--ide-accent-folder)]" />
                   ) : (
-                    <Folder size={15} className="text-[#dcb67a]" />
+                    <Folder size={15} className="text-[color:var(--ide-accent-folder)]" />
                   ))}
               </>
             ) : (
@@ -500,7 +695,7 @@ function InlineInput({
   }, []);
   return (
     <div
-      className="flex items-center gap-1 bg-[#1e1e1e] px-2 py-[2px]"
+      className="flex items-center gap-1 bg-[color:var(--ide-bg)] px-2 py-[2px]"
       style={{ paddingLeft: 8 + depth * 12 }}
     >
       <span className="w-[14px]" />
@@ -519,7 +714,7 @@ function InlineInput({
             onCancel();
           }
         }}
-        className="no-focus-ring flex-1 min-w-0 bg-[#3c3c3c] px-1 py-[1px] text-[13px] text-white outline outline-1 outline-[#0078d4]"
+        className="no-focus-ring flex-1 min-w-0 bg-[color:var(--ide-input)] px-1 py-[1px] text-[13px] text-[color:var(--ide-text-strong)] outline outline-1 outline-[color:var(--ide-active-ring)]"
       />
     </div>
   );

--- a/apps/mobile/components/project/panels/ide/ImagePreview.tsx
+++ b/apps/mobile/components/project/panels/ide/ImagePreview.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Image as ImageIcon,
+  Minus,
+  Plus,
+  RefreshCw,
+  ExternalLink,
+} from "lucide-react-native";
+
+const IMAGE_EXTS = new Set([
+  "png", "jpg", "jpeg", "gif", "webp", "bmp", "ico", "avif", "svg",
+]);
+
+export function isImagePath(path: string): boolean {
+  const ext = path.toLowerCase().split(".").pop() ?? "";
+  return IMAGE_EXTS.has(ext);
+}
+
+/**
+ * Renders a single image inside an editor tab. Supports zoom in/out, reset,
+ * and "open in new tab". The image URL is owned by the caller (Workbench)
+ * and revoked on tab close so we don't leak blob: URLs.
+ */
+export function ImagePreview({
+  url,
+  name,
+  path,
+}: {
+  url: string;
+  name: string;
+  path: string;
+}) {
+  const [zoom, setZoom] = useState(1);
+  const [natural, setNatural] = useState<{ w: number; h: number } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+  const imgRef = useRef<HTMLImageElement>(null);
+
+  useEffect(() => {
+    setZoom(1);
+    setNatural(null);
+    setError(null);
+  }, [url]);
+
+  const prettySize = useMemo(() => {
+    if (!natural) return "";
+    return `${natural.w} × ${natural.h}`;
+  }, [natural]);
+
+  const isSvg = path.toLowerCase().endsWith(".svg");
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-8 items-center justify-between gap-2 border-b border-[color:var(--ide-border)] bg-[color:var(--ide-surface)] px-3 text-[12px] text-[color:var(--ide-muted)]">
+        <div className="flex items-center gap-2 min-w-0">
+          <ImageIcon size={13} className="shrink-0 text-[color:var(--ide-accent-file-icon)]" />
+          <span className="truncate text-[color:var(--ide-text)]">{name}</span>
+          {prettySize && <span className="shrink-0">· {prettySize}</span>}
+        </div>
+        <div className="flex items-center gap-1">
+          <IconBtn
+            title="Zoom out"
+            onClick={() => setZoom((z) => Math.max(0.1, +(z - 0.25).toFixed(2)))}
+          >
+            <Minus size={13} />
+          </IconBtn>
+          <button
+            onClick={() => setZoom(1)}
+            className="rounded px-1.5 py-0.5 text-[11px] hover:bg-[color:var(--ide-hover-subtle)] hover:text-[color:var(--ide-text-strong)]"
+            title="Reset zoom"
+          >
+            {Math.round(zoom * 100)}%
+          </button>
+          <IconBtn
+            title="Zoom in"
+            onClick={() => setZoom((z) => Math.min(16, +(z + 0.25).toFixed(2)))}
+          >
+            <Plus size={13} />
+          </IconBtn>
+          <IconBtn
+            title="Reload"
+            onClick={() => setReloadKey((k) => k + 1)}
+          >
+            <RefreshCw size={12} />
+          </IconBtn>
+          <IconBtn
+            title="Open in new tab"
+            onClick={() => window.open(url, "_blank", "noopener,noreferrer")}
+          >
+            <ExternalLink size={12} />
+          </IconBtn>
+        </div>
+      </div>
+
+      <div className="relative flex flex-1 items-center justify-center overflow-auto bg-[color:var(--ide-bg)] [background-image:linear-gradient(45deg,var(--ide-hover-subtle)_25%,transparent_25%),linear-gradient(-45deg,var(--ide-hover-subtle)_25%,transparent_25%),linear-gradient(45deg,transparent_75%,var(--ide-hover-subtle)_75%),linear-gradient(-45deg,transparent_75%,var(--ide-hover-subtle)_75%)] [background-size:16px_16px] [background-position:0_0,0_8px,8px_-8px,-8px_0]">
+        {error ? (
+          <div className="text-[13px] text-[color:var(--ide-error)]">{error}</div>
+        ) : (
+          <img
+            ref={imgRef}
+            key={reloadKey}
+            src={url}
+            alt={name}
+            onLoad={(e) => {
+              const img = e.currentTarget;
+              setNatural({ w: img.naturalWidth, h: img.naturalHeight });
+            }}
+            onError={() => setError(`Could not load ${name}`)}
+            draggable={false}
+            className={[
+              "origin-center transition-transform duration-[80ms] ease-linear",
+              isSvg ? "max-h-[90%] max-w-[90%]" : "",
+              zoom >= 2 ? "[image-rendering:pixelated]" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            style={{ transform: `scale(${zoom})` }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function IconBtn({
+  title,
+  onClick,
+  children,
+}: {
+  title: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      title={title}
+      onClick={onClick}
+      className="rounded p-1 text-[color:var(--ide-muted)] hover:bg-[color:var(--ide-hover-subtle)] hover:text-[color:var(--ide-text-strong)]"
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/mobile/components/project/panels/ide/Palette.tsx
+++ b/apps/mobile/components/project/panels/ide/Palette.tsx
@@ -73,7 +73,7 @@ export function Palette({
       onClick={onClose}
     >
       <div
-        className="mt-[12vh] w-[560px] max-w-[calc(100vw-40px)] overflow-hidden rounded-md border border-[#454545] bg-[#252526] shadow-2xl"
+        className="mt-[12vh] w-[560px] max-w-[calc(100vw-40px)] overflow-hidden rounded-md border border-[color:var(--ide-border-muted)] bg-[color:var(--ide-surface)] shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         <input
@@ -96,11 +96,11 @@ export function Palette({
               onClose();
             }
           }}
-          className="no-focus-ring w-full border-b border-[#2a2a2a] bg-transparent px-4 py-3 text-[14px] text-white placeholder:text-[#858585] outline-none"
+          className="no-focus-ring w-full border-b border-[color:var(--ide-border)] bg-transparent px-4 py-3 text-[14px] text-[color:var(--ide-text-strong)] placeholder:text-[color:var(--ide-muted)] outline-none"
         />
         <div ref={listRef} className="max-h-[50vh] overflow-auto py-1">
           {results.length === 0 ? (
-            <div className="px-4 py-4 text-center text-[12px] text-[#858585]">
+            <div className="px-4 py-4 text-center text-[12px] text-[color:var(--ide-muted)]">
               {emptyHint ?? "No matches"}
             </div>
           ) : (
@@ -113,7 +113,7 @@ export function Palette({
                   onMouseMove={() => setActive(i)}
                   onClick={() => pick(i)}
                   className={`flex cursor-pointer items-center justify-between gap-4 px-4 py-[6px] text-[13px] ${
-                    isActive ? "bg-[#094771] text-white" : "text-[#cccccc]"
+                    isActive ? "bg-[color:var(--ide-active-bg)] text-white" : "text-[color:var(--ide-text)]"
                   }`}
                 >
                   <div className="min-w-0 flex-1">
@@ -121,13 +121,13 @@ export function Palette({
                       {query ? highlightMatch(item.label, indices) : item.label}
                     </div>
                     {item.sublabel && (
-                      <div className="truncate text-[11px] text-[#858585]">
+                      <div className="truncate text-[11px] text-[color:var(--ide-muted)]">
                         {item.sublabel}
                       </div>
                     )}
                   </div>
                   {item.hint && (
-                    <span className="shrink-0 text-[11px] text-[#858585]">
+                    <span className="shrink-0 text-[11px] text-[color:var(--ide-muted)]">
                       {item.hint}
                     </span>
                   )}

--- a/apps/mobile/components/project/panels/ide/SearchPane.tsx
+++ b/apps/mobile/components/project/panels/ide/SearchPane.tsx
@@ -100,7 +100,7 @@ export function SearchPane({
       while ((m = re.exec(line)) && i++ < 50) {
         if (m.index > last) parts.push(line.slice(last, m.index));
         parts.push(
-          <span key={`${m.index}-${i}`} className="bg-[#514b17] text-[#ffd75e]">
+          <span key={`${m.index}-${i}`} className="bg-[color:var(--ide-highlight-bg)] text-[color:var(--ide-highlight-text)]">
             {m[0]}
           </span>,
         );
@@ -116,14 +116,14 @@ export function SearchPane({
 
   return (
     <div className="flex h-full flex-col">
-      <div className="px-4 py-2 text-[11px] font-semibold uppercase tracking-wider text-[#858585]">
+      <div className="px-4 py-2 text-[11px] font-semibold uppercase tracking-wider text-[color:var(--ide-muted)]">
         Search
       </div>
 
       {/* Query input */}
       <div className="px-3 pb-1">
-        <div className="relative flex items-center rounded border border-[#3a3a3a] bg-[#1a1a1a] focus-within:border-[#0078d4]">
-          <Search size={14} className="ml-2.5 mr-1 shrink-0 text-[#858585]" />
+        <div className="relative flex items-center rounded border border-[color:var(--ide-border-strong)] bg-[color:var(--ide-input-bg)] focus-within:border-[color:var(--ide-active-ring)]">
+          <Search size={14} className="ml-2.5 mr-1 shrink-0 text-[color:var(--ide-muted)]" />
           <input
             ref={inputRef}
             value={query}
@@ -133,12 +133,12 @@ export function SearchPane({
               if (e.key === "Escape") setQuery("");
             }}
             placeholder="Search across all workspaces"
-            className="no-focus-ring min-w-0 flex-1 bg-transparent pl-1 pr-2 py-1.5 text-[12px] text-white placeholder:text-[#666] outline-none"
+            className="no-focus-ring min-w-0 flex-1 bg-transparent pl-1 pr-2 py-1.5 text-[12px] text-[color:var(--ide-text-strong)] placeholder:text-[color:var(--ide-muted-strong)] outline-none"
           />
           {query && (
             <button
               onClick={() => setQuery("")}
-              className="mr-1 rounded p-0.5 text-[#858585] hover:bg-[#ffffff1a] hover:text-white"
+              className="mr-1 rounded p-0.5 text-[color:var(--ide-muted)] hover:bg-[color:var(--ide-hover-subtle)] hover:text-[color:var(--ide-text-strong)]"
             >
               <X size={12} />
             </button>
@@ -152,7 +152,7 @@ export function SearchPane({
           <ToggleBtn on={useRegex} onClick={() => setUseRegex((v) => !v)} title="Use Regular Expression">
             <Regex size={12} />
           </ToggleBtn>
-          <div className="ml-auto flex items-center gap-2 text-[10px] text-[#858585]">
+          <div className="ml-auto flex items-center gap-2 text-[10px] text-[color:var(--ide-muted)]">
             {running && <Loader2 size={11} className="animate-spin" />}
             {query && !running && (
               <span>
@@ -167,9 +167,9 @@ export function SearchPane({
       {/* Results */}
       <div className="mt-2 flex-1 overflow-auto text-[12px]">
         {!query && (
-          <div className="px-4 py-6 text-center text-[11px] text-[#666]">
+          <div className="px-4 py-6 text-center text-[11px] text-[color:var(--ide-muted-strong)]">
             Type to search across{" "}
-            <span className="text-[#cccccc]">
+            <span className="text-[color:var(--ide-text)]">
               {roots.length} workspace{roots.length === 1 ? "" : "s"}
             </span>
             .
@@ -178,7 +178,7 @@ export function SearchPane({
         )}
 
         {query && !running && rootResults.every((r) => r.results.length === 0 && !r.error) && (
-          <div className="px-4 py-6 text-center text-[11px] text-[#666]">No results</div>
+          <div className="px-4 py-6 text-center text-[11px] text-[color:var(--ide-muted-strong)]">No results</div>
         )}
 
         {rootResults.map((rr) => {
@@ -187,13 +187,13 @@ export function SearchPane({
           return (
             <div key={rr.rootId} className="mb-1">
               {multi && (
-                <div className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-[#858585]">
+                <div className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--ide-muted)]">
                   {rr.rootLabel}
-                  {rr.truncated && <span className="ml-2 text-[#ffb74d]">(truncated)</span>}
+                  {rr.truncated && <span className="ml-2 text-[color:var(--ide-warning)]">(truncated)</span>}
                 </div>
               )}
               {rr.error && (
-                <div className="px-4 py-1 text-[11px] text-[#f48771]">{rr.error}</div>
+                <div className="px-4 py-1 text-[11px] text-[color:var(--ide-error)]">{rr.error}</div>
               )}
               {rr.results.map((file) => {
                 const key = `${rr.rootId}::${file.path}`;
@@ -204,16 +204,16 @@ export function SearchPane({
                       onClick={() =>
                         setCollapsed((c) => ({ ...c, [key]: !c[key] }))
                       }
-                      className="flex w-full items-center gap-1 px-2 py-0.5 text-left text-[12px] hover:bg-[#2a2a2a]"
+                      className="flex w-full items-center gap-1 px-2 py-0.5 text-left text-[12px] hover:bg-[color:var(--ide-hover)]"
                     >
                       {hidden ? <ChevronRight size={12} /> : <ChevronDown size={12} />}
-                      <span className="truncate text-[#cccccc]">
+                      <span className="truncate text-[color:var(--ide-text)]">
                         {file.path.split("/").pop()}
                       </span>
-                      <span className="truncate text-[11px] text-[#858585]">
+                      <span className="truncate text-[11px] text-[color:var(--ide-muted)]">
                         {file.path.includes("/") ? file.path.slice(0, file.path.lastIndexOf("/")) : ""}
                       </span>
-                      <span className="ml-auto rounded bg-[#2a2a2a] px-1.5 text-[10px] text-[#858585]">
+                      <span className="ml-auto rounded bg-[color:var(--ide-border)] px-1.5 text-[10px] text-[color:var(--ide-muted)]">
                         {file.matches.length}
                       </span>
                     </button>
@@ -222,11 +222,11 @@ export function SearchPane({
                         <button
                           key={`${key}-${i}`}
                           onClick={() => onReveal(rr.rootId, file.path, m.line, m.col)}
-                          className="flex w-full items-baseline gap-2 px-6 py-[2px] text-left font-mono text-[11px] hover:bg-[#2a2a2a]"
+                          className="flex w-full items-baseline gap-2 px-6 py-[2px] text-left font-mono text-[11px] hover:bg-[color:var(--ide-hover)]"
                           title={`${file.path}:${m.line}:${m.col}`}
                         >
-                          <span className="w-10 shrink-0 text-right text-[#666]">{m.line}</span>
-                          <span className="truncate text-[#d4d4d4]">{highlight(m.preview)}</span>
+                          <span className="w-10 shrink-0 text-right text-[color:var(--ide-muted-strong)]">{m.line}</span>
+                          <span className="truncate text-[color:var(--ide-text)]">{highlight(m.preview)}</span>
                         </button>
                       ))}
                   </div>
@@ -257,8 +257,8 @@ function ToggleBtn({
       title={title}
       className={`rounded border px-1.5 py-0.5 ${
         on
-          ? "border-[#0078d4] bg-[#0078d4]/20 text-[#75beff]"
-          : "border-[#3a3a3a] text-[#858585] hover:bg-[#2a2a2a] hover:text-white"
+          ? "border-[color:var(--ide-active-ring)] bg-[color:var(--ide-active-ring)]/20 text-[color:var(--ide-accent-file-icon)]"
+          : "border-[color:var(--ide-border-strong)] text-[color:var(--ide-muted)] hover:bg-[color:var(--ide-hover)] hover:text-[color:var(--ide-text-strong)]"
       }`}
     >
       {children}

--- a/apps/mobile/components/project/panels/ide/SettingsPane.tsx
+++ b/apps/mobile/components/project/panels/ide/SettingsPane.tsx
@@ -14,13 +14,13 @@ export function SettingsPane({
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center justify-between px-4 py-2">
-        <span className="text-[11px] font-semibold uppercase tracking-wider text-[#858585]">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-[color:var(--ide-muted)]">
           Settings
         </span>
         <button
           onClick={() => onChange(DEFAULT_SETTINGS)}
           title="Reset to defaults"
-          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-[#858585] hover:bg-[#ffffff1a] hover:text-white"
+          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-[color:var(--ide-muted)] hover:bg-[color:var(--ide-hover-subtle)] hover:text-[color:var(--ide-text-strong)]"
         >
           <RotateCcw size={11} /> Reset
         </button>
@@ -108,10 +108,10 @@ export function SettingsPane({
           />
         </Section>
 
-        <div className="mt-4 rounded border border-[#2a2a2a] bg-[#1a1a1a] p-2 text-[10px] text-[#858585]">
+        <div className="mt-4 rounded border border-[color:var(--ide-border)] bg-[color:var(--ide-panel)] p-2 text-[10px] text-[color:var(--ide-muted)]">
           Settings are stored in{" "}
-          <code className="text-[#cccccc]">localStorage</code> under{" "}
-          <code className="text-[#cccccc]">shogo.ide.settings</code>.
+          <code className="text-[color:var(--ide-text)]">localStorage</code> under{" "}
+          <code className="text-[color:var(--ide-text)]">shogo.ide.settings</code>.
         </div>
       </div>
     </div>
@@ -127,10 +127,10 @@ function Section({
 }) {
   return (
     <div className="mb-4">
-      <div className="mb-1 px-1 text-[10px] font-semibold uppercase tracking-wider text-[#858585]">
+      <div className="mb-1 px-1 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--ide-muted)]">
         {title}
       </div>
-      <div className="flex flex-col gap-1 rounded border border-[#2a2a2a] bg-[#1a1a1a] p-1">
+      <div className="flex flex-col gap-1 rounded border border-[color:var(--ide-border)] bg-[color:var(--ide-panel)] p-1">
         {children}
       </div>
     </div>
@@ -149,10 +149,10 @@ function ToggleRow({
   onChange: (v: boolean) => void;
 }) {
   return (
-    <label className="flex cursor-pointer items-center justify-between gap-3 rounded px-2 py-1.5 hover:bg-[#2a2a2a]">
+    <label className="flex cursor-pointer items-center justify-between gap-3 rounded px-2 py-1.5 hover:bg-[color:var(--ide-hover)]">
       <div className="min-w-0">
-        <div className="text-[12px] text-[#cccccc]">{label}</div>
-        {hint && <div className="truncate text-[10px] text-[#858585]">{hint}</div>}
+        <div className="text-[12px] text-[color:var(--ide-text)]">{label}</div>
+        {hint && <div className="truncate text-[10px] text-[color:var(--ide-muted)]">{hint}</div>}
       </div>
       <button
         type="button"
@@ -160,22 +160,14 @@ function ToggleRow({
         aria-checked={value}
         onClick={() => onChange(!value)}
         className={`relative inline-block h-4 w-7 shrink-0 rounded-full transition-colors ${
-          value ? "bg-[#0078d4]" : "bg-[#3a3a3a]"
+          value ? "bg-[color:var(--ide-active-ring)]" : "bg-[color:var(--ide-border-strong)]"
         }`}
       >
         <span
           aria-hidden
-          style={{
-            position: "absolute",
-            top: 2,
-            left: 2,
-            width: 12,
-            height: 12,
-            borderRadius: 9999,
-            background: "#ffffff",
-            transform: `translateX(${value ? 12 : 0}px)`,
-            transition: "transform 150ms",
-          }}
+          className={`absolute left-0.5 top-0.5 h-3 w-3 rounded-full bg-[color:var(--ide-toggle-knob)] transition-transform duration-150 ${
+            value ? "translate-x-3" : "translate-x-0"
+          }`}
         />
       </button>
     </label>
@@ -194,12 +186,12 @@ function SelectRow({
   onChange: (v: string) => void;
 }) {
   return (
-    <div className="flex items-center justify-between gap-3 rounded px-2 py-1.5 hover:bg-[#2a2a2a]">
-      <div className="text-[12px] text-[#cccccc]">{label}</div>
+    <div className="flex items-center justify-between gap-3 rounded px-2 py-1.5 hover:bg-[color:var(--ide-hover)]">
+      <div className="text-[12px] text-[color:var(--ide-text)]">{label}</div>
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="no-focus-ring rounded border border-[#3a3a3a] bg-[#1a1a1a] px-1.5 py-0.5 text-[11px] text-[#cccccc] outline-none hover:border-[#0078d4]"
+        className="no-focus-ring rounded border border-[color:var(--ide-border-strong)] bg-[color:var(--ide-panel)] px-1.5 py-0.5 text-[11px] text-[color:var(--ide-text)] outline-none hover:border-[color:var(--ide-active-ring)]"
       >
         {options.map((o) => (
           <option key={o.value} value={o.value}>
@@ -227,8 +219,8 @@ function SliderRow({
   onChange: (v: number) => void;
 }) {
   return (
-    <div className="flex items-center justify-between gap-3 rounded px-2 py-1.5 hover:bg-[#2a2a2a]">
-      <div className="text-[12px] text-[#cccccc]">{label}</div>
+    <div className="flex items-center justify-between gap-3 rounded px-2 py-1.5 hover:bg-[color:var(--ide-hover)]">
+      <div className="text-[12px] text-[color:var(--ide-text)]">{label}</div>
       <div className="flex items-center gap-2">
         <input
           type="range"
@@ -236,9 +228,9 @@ function SliderRow({
           max={max}
           value={value}
           onChange={(e) => onChange(parseInt(e.target.value, 10))}
-          className="h-1 w-24 accent-[#0078d4]"
+          className="h-1 w-24 accent-[color:var(--ide-active-ring)]"
         />
-        <span className="w-10 text-right text-[11px] text-[#858585]">
+        <span className="w-10 text-right text-[11px] text-[color:var(--ide-muted)]">
           {value}
           {unit}
         </span>

--- a/apps/mobile/components/project/panels/ide/Splitter.tsx
+++ b/apps/mobile/components/project/panels/ide/Splitter.tsx
@@ -59,7 +59,7 @@ export function VerticalSplit({ onMouseDown }: { onMouseDown: (e: React.MouseEve
   return (
     <div
       onMouseDown={onMouseDown}
-      className="w-1 cursor-col-resize bg-[#2a2a2a] hover:bg-[#0078d4] transition-colors"
+      className="w-1 cursor-col-resize bg-[color:var(--ide-border)] hover:bg-[color:var(--ide-active-ring)] transition-colors"
     />
   );
 }
@@ -68,7 +68,7 @@ export function HorizontalSplit({ onMouseDown }: { onMouseDown: (e: React.MouseE
   return (
     <div
       onMouseDown={onMouseDown}
-      className="h-1 cursor-row-resize bg-[#2a2a2a] hover:bg-[#0078d4] transition-colors"
+      className="h-1 cursor-row-resize bg-[color:var(--ide-border)] hover:bg-[color:var(--ide-active-ring)] transition-colors"
     />
   );
 }

--- a/apps/mobile/components/project/panels/ide/StatusBar.tsx
+++ b/apps/mobile/components/project/panels/ide/StatusBar.tsx
@@ -12,7 +12,7 @@ export function StatusBar({
   saved: boolean;
 }) {
   return (
-    <div className="flex h-6 items-center justify-between bg-[#0078d4] px-3 text-[12px] text-white">
+    <div className="flex h-6 items-center justify-between bg-[color:var(--ide-primary)] px-3 text-[12px] text-white">
       <div className="flex items-center gap-4" />
       <div className="flex items-center gap-4">
         <span>

--- a/apps/mobile/components/project/panels/ide/Workbench.tsx
+++ b/apps/mobile/components/project/panels/ide/Workbench.tsx
@@ -5,6 +5,7 @@ import { ActivityBar } from "./ActivityBar";
 import { FileTree, type FileTreeHandlers } from "./FileTree";
 import { StatusBar } from "./StatusBar";
 import { EditorGroupView } from "./EditorGroup";
+import { isImagePath } from "./ImagePreview";
 import { Palette, type PaletteItem } from "./Palette";
 import {
   DEFAULT_SETTINGS,
@@ -27,6 +28,7 @@ import type { WorkspaceService } from "./workspace/types";
 import { isFsaSupported, pickDirectory, ensurePermission, LocalFs } from "./workspace/localFs";
 import { saveRoot, listRoots, deleteRoot, touchRoot } from "./workspace/handleStore";
 import { matchesShortcut, type Command } from "./commands";
+import { useTheme } from "../../../../contexts/theme";
 import {
   RefreshCw,
   History,
@@ -39,14 +41,39 @@ import {
 
 let groupSeq = 1;
 const newGroupId = () => `g${groupSeq++}`;
+/** Binary files we refuse to open at all — Monaco can't render them and we
+ *  have no viewer. Images are handled separately (see isImagePath) and open
+ *  in the in-editor ImagePreview instead. */
 const BINARY_EXTENSIONS = new Set([
-  "png","jpg","jpeg","gif","webp","bmp","ico","avif","heic","tiff","tif",
+  "heic","tiff","tif",
   "pdf","zip","gz","tar","tgz","bz2","xz","7z","rar",
   "mp3","mp4","m4a","m4v","mov","avi","mkv","webm","wav","flac","ogg","aac",
   "woff","woff2","ttf","otf","eot",
   "exe","dll","so","dylib","bin","class","jar","wasm",
   "sqlite","db","pack","idx","psd","ai","sketch","fig",
 ]);
+
+/** Resolve the theme preference to a concrete "light" | "dark" — mirrors the
+ *  logic in ThemeProvider so the IDE's Monaco and chrome colours stay in sync
+ *  with the rest of the app, including when the user picks "system" and the
+ *  OS-level scheme flips underfoot. */
+function useResolvedTheme(): "light" | "dark" {
+  const { theme } = useTheme();
+  const [systemDark, setSystemDark] = useState<boolean>(() => {
+    if (typeof window === "undefined") return true;
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  });
+  useEffect(() => {
+    if (theme !== "system" || typeof window === "undefined") return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = (e: MediaQueryListEvent) => setSystemDark(e.matches);
+    mq.addEventListener?.("change", onChange);
+    return () => mq.removeEventListener?.("change", onChange);
+  }, [theme]);
+  if (theme === "dark") return "dark";
+  if (theme === "light") return "light";
+  return systemDark ? "dark" : "light";
+}
 
 const fileId = (rootId: string, path: string) => `${rootId}::${path}`;
 
@@ -70,6 +97,7 @@ function flattenFiles(tree: TreeNode[], out: TreeNode[] = []): TreeNode[] {
 }
 
 export function Workbench({ agentService, agentLabel = "agent-workspace" }: { agentService: WorkspaceService; agentLabel?: string }) {
+  const themeMode = useResolvedTheme();
   const [activity, setActivity] = useState<ActivityId>("files");
   const [services, setServices] = useState<Record<string, WorkspaceService>>({ agent: agentService });
   const [roots, setRoots] = useState<Root[]>([
@@ -361,7 +389,8 @@ export function Workbench({ agentService, agentLabel = "agent-workspace" }: { ag
     async (node: TreeNode, groupIdx: number) => {
       if (node.kind !== "file") return;
       const ext = node.name.toLowerCase().split(".").pop() ?? "";
-      if (BINARY_EXTENSIONS.has(ext)) {
+      const isImage = isImagePath(node.path);
+      if (!isImage && BINARY_EXTENSIONS.has(ext)) {
         showToast(`Cannot open binary file: ${node.name}`, 2500);
         return;
       }
@@ -382,7 +411,7 @@ export function Workbench({ agentService, agentLabel = "agent-workspace" }: { ag
         rootId: node.rootId,
         name: node.name,
         path: node.path,
-        language: node.language ?? "plaintext",
+        language: isImage ? "image" : node.language ?? "plaintext",
         content: "",
         savedContent: "",
         dirty: false,
@@ -395,6 +424,34 @@ export function Workbench({ agentService, agentLabel = "agent-workspace" }: { ag
       }));
       setActiveGroupIdx(groupIdx);
       try {
+        if (isImage) {
+          // Images never hit readFile() — that path is text-only and rejects
+          // binaries. Instead resolve a URL (blob: for local, http: for the
+          // agent download endpoint) and stash it as the file content. The
+          // EditorGroupView notices language === "image" and mounts
+          // <ImagePreview> instead of Monaco.
+          if (!svc.readFileUrl) {
+            throw new Error("Image preview not supported for this workspace");
+          }
+          const url = await svc.readFileUrl(node.path);
+          setGroups((prev) =>
+            prev.map((g) => ({
+              ...g,
+              files: g.files.map((f) =>
+                f.id === id
+                  ? {
+                      ...f,
+                      content: url,
+                      savedContent: url,
+                      language: "image",
+                      loading: false,
+                    }
+                  : f,
+              ),
+            })),
+          );
+          return;
+        }
         const file = await svc.readFile(node.path);
         setGroups((prev) =>
           prev.map((g) => ({
@@ -458,6 +515,11 @@ export function Workbench({ agentService, agentLabel = "agent-workspace" }: { ag
       if (idx < 0) return prev;
       const f = g.files[idx];
       if (f.dirty && !confirm(`Close ${f.name} without saving?`)) return prev;
+      // Image tabs allocate a blob: URL on open — revoke it on close so long
+      // browsing sessions don't leak one per image opened.
+      if (f.language === "image" && f.content.startsWith("blob:")) {
+        try { URL.revokeObjectURL(f.content); } catch { /* ignore */ }
+      }
       const nextFiles = g.files.filter((x) => x.id !== id);
       const nextActive =
         g.activeId === id ? nextFiles[Math.max(0, idx - 1)]?.id ?? null : g.activeId;
@@ -953,31 +1015,17 @@ export function Workbench({ agentService, agentLabel = "agent-workspace" }: { ag
   ]);
 
   return (
-    <div className="flex h-full w-full min-w-0 min-h-0 flex-col bg-[#1e1e1e] text-white overflow-hidden">
-      {/* Title bar */}
-      <div className="flex h-9 items-center justify-between border-b border-[#2a2a2a] bg-[#1a1a1a] px-3 text-[12px]">
-        <div className="flex items-center gap-2 min-w-0 flex-1">
-          <span className="text-[#cccccc] shrink-0 font-medium">shogo-ai</span>
-          <span className="text-[#858585] shrink-0 hidden sm:inline">—</span>
-          <span className="text-[#858585] truncate max-w-[40vw]">
-            {roots.length === 1 ? roots[0].label : `${roots.length} workspaces`}
-          </span>
-        </div>
-        <div className="hidden lg:flex items-center gap-3 text-[#858585]">
-          <span>⌘P files</span>
-          <span>⌘⇧P commands</span>
-          <span>⌘⇧F search</span>
-          <span className="hidden xl:inline">⌘⇧O open folder</span>
-        </div>
-      </div>
-
+    <div
+      className="shogo-ide flex h-full w-full min-w-0 min-h-0 flex-col overflow-hidden"
+      data-theme={themeMode}
+    >
       <div className="flex flex-1 min-h-0">
         <ActivityBar active={activity} onSelect={setActivity} />
 
         <div className="flex flex-1 min-w-0">
           <div
             style={{ width: sidebarSplit.size, flexShrink: 0, maxWidth: "55%", minWidth: 0 }}
-            className="h-full bg-[#252526] overflow-hidden"
+            className="h-full bg-[color:var(--ide-surface)] overflow-hidden"
           >
             {activity === "files" && (
               <FilesPane
@@ -1036,6 +1084,7 @@ export function Workbench({ agentService, agentLabel = "agent-workspace" }: { ag
                     <EditorGroupView
                       group={g}
                       focused={i === activeGroupIdx}
+                      themeMode={themeMode}
                       onFocus={() => setActiveGroupIdx(i)}
                       onSelect={(id) => updateGroup(i, (gg) => ({ ...gg, activeId: id }))}
                       onClose={(id) => closeInGroup(i, id)}
@@ -1085,7 +1134,7 @@ export function Workbench({ agentService, agentLabel = "agent-workspace" }: { ag
                 }, [])}
 
               {toast && (
-                <div className="pointer-events-none absolute bottom-4 right-4 z-40 rounded bg-[#0078d4] px-3 py-1.5 text-[12px] text-white shadow-lg">
+                <div className="pointer-events-none absolute bottom-4 right-4 z-40 rounded bg-[color:var(--ide-primary)] px-3 py-1.5 text-[12px] text-white shadow-lg">
                   {toast}
                 </div>
               )}
@@ -1178,7 +1227,7 @@ function FilesPane({
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center justify-between px-4 py-2">
-        <span className="text-[11px] font-semibold uppercase tracking-wider text-[#858585]">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-[color:var(--ide-muted)]">
           Explorer
         </span>
         <div className="flex items-center gap-1">
@@ -1186,7 +1235,7 @@ function FilesPane({
             onClick={onOpenFolder}
             title={fsaSupported ? "Add local folder…" : "Local folders require Chrome or Edge"}
             disabled={!fsaSupported}
-            className="rounded p-1 text-[#858585] hover:bg-[#ffffff1a] hover:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+            className="rounded p-1 text-[color:var(--ide-muted)] hover:bg-[color:var(--ide-hover-subtle)] hover:text-[color:var(--ide-text-strong)] disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <FolderOpen size={13} />
           </button>
@@ -1194,7 +1243,7 @@ function FilesPane({
             <button
               onClick={onRestore}
               title="Reopen recent local folder"
-              className="rounded p-1 text-[#858585] hover:bg-[#ffffff1a] hover:text-white"
+              className="rounded p-1 text-[color:var(--ide-muted)] hover:bg-[color:var(--ide-hover-subtle)] hover:text-[color:var(--ide-text-strong)]"
             >
               <History size={13} />
             </button>
@@ -1202,21 +1251,21 @@ function FilesPane({
           <button
             onClick={() => onNew("file")}
             title="New File"
-            className="rounded p-1 text-[#858585] hover:bg-[#ffffff1a] hover:text-white"
+            className="rounded p-1 text-[color:var(--ide-muted)] hover:bg-[color:var(--ide-hover-subtle)] hover:text-[color:var(--ide-text-strong)]"
           >
             <FilePlus size={13} />
           </button>
           <button
             onClick={() => onNew("dir")}
             title="New Folder"
-            className="rounded p-1 text-[#858585] hover:bg-[#ffffff1a] hover:text-white"
+            className="rounded p-1 text-[color:var(--ide-muted)] hover:bg-[color:var(--ide-hover-subtle)] hover:text-[color:var(--ide-text-strong)]"
           >
             <FolderPlus size={13} />
           </button>
           <button
             onClick={onRefresh}
             title="Refresh All"
-            className="rounded p-1 text-[#858585] hover:bg-[#ffffff1a] hover:text-white"
+            className="rounded p-1 text-[color:var(--ide-muted)] hover:bg-[color:var(--ide-hover-subtle)] hover:text-[color:var(--ide-text-strong)]"
           >
             <RefreshCw size={13} className={anyLoading ? "animate-spin" : ""} />
           </button>
@@ -1225,11 +1274,11 @@ function FilesPane({
 
 
       {anyError ? (
-        <div className="px-4 py-3 text-[12px] text-[#f48771]">
+        <div className="px-4 py-3 text-[12px] text-[color:var(--ide-error)]">
           <div className="flex items-center gap-1 mb-1">
             <AlertTriangle size={13} /> {anyError.label}
           </div>
-          <div className="text-[#858585]">{anyError.error}</div>
+          <div className="text-[color:var(--ide-muted)]">{anyError.error}</div>
         </div>
       ) : null}
 
@@ -1244,18 +1293,18 @@ function FilesPane({
 
       {/* Local root badges at the bottom for quick close */}
       {roots.filter((r) => r.kind === "local").length > 0 && (
-        <div className="border-t border-[#2a2a2a] px-3 py-2">
+        <div className="border-t border-[color:var(--ide-border)] px-3 py-2">
           {roots
             .filter((r) => r.kind === "local")
             .map((r) => (
               <div
                 key={r.id}
-                className="flex items-center justify-between gap-2 rounded px-1 py-[2px] text-[11px] text-[#858585] hover:bg-[#2a2a2a]"
+                className="flex items-center justify-between gap-2 rounded px-1 py-[2px] text-[11px] text-[color:var(--ide-muted)] hover:bg-[color:var(--ide-hover)]"
               >
                 <span className="truncate">📁 {r.label}</span>
                 <button
                   onClick={() => onCloseRoot(r.id)}
-                  className="rounded p-[2px] hover:bg-[#ffffff1a] hover:text-white"
+                  className="rounded p-[2px] hover:bg-[color:var(--ide-hover-subtle)] hover:text-[color:var(--ide-text-strong)]"
                   title="Close folder"
                 >
                   <X size={11} />
@@ -1279,11 +1328,11 @@ function Placeholder({
 }) {
   return (
     <div className="flex h-full flex-col">
-      <div className="px-4 py-2 text-[11px] font-semibold uppercase tracking-wider text-[#858585]">
+      <div className="px-4 py-2 text-[11px] font-semibold uppercase tracking-wider text-[color:var(--ide-muted)]">
         {title}
       </div>
-      <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center text-[#858585]">
-        <div className="text-[#4ec9b0]">{icon}</div>
+      <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center text-[color:var(--ide-muted)]">
+        <div className="text-[color:var(--ide-primary)]">{icon}</div>
         <div className="text-[13px]">{hint}</div>
       </div>
     </div>

--- a/apps/mobile/components/project/panels/ide/fuzzy.tsx
+++ b/apps/mobile/components/project/panels/ide/fuzzy.tsx
@@ -63,7 +63,7 @@ export function highlightMatch(text: string, indices: number[]): React.ReactNode
       run += text[i];
     } else if (runStart !== -1) {
       parts.push(
-        <mark key={runStart} className="bg-transparent text-[#0078d4] font-semibold">
+        <mark key={runStart} className="bg-transparent text-[color:var(--ide-active-ring)] font-semibold">
           {run}
         </mark>,
       );
@@ -74,7 +74,7 @@ export function highlightMatch(text: string, indices: number[]): React.ReactNode
   }
   if (runStart !== -1) {
     parts.push(
-      <mark key={runStart} className="bg-transparent text-[#0078d4] font-semibold">
+      <mark key={runStart} className="bg-transparent text-[color:var(--ide-active-ring)] font-semibold">
         {run}
       </mark>,
     );

--- a/apps/mobile/components/project/panels/ide/useLiveAgentEdits.ts
+++ b/apps/mobile/components/project/panels/ide/useLiveAgentEdits.ts
@@ -38,6 +38,7 @@ import type { Dispatch, SetStateAction } from "react";
 
 import type { EditorGroup, OpenFile } from "./types";
 import type { WorkspaceService } from "./workspace/types";
+import { isImagePath } from "./ImagePreview";
 
 const AGENT_ROOT_ID = "agent";
 const fileId = (rootId: string, path: string) => `${rootId}::${path}`;
@@ -269,7 +270,16 @@ export function useLiveAgentEdits({
     const openAgentFiles = new Set<string>();
     for (const g of groupsRef.current) {
       for (const f of g.files) {
-        if (f.rootId === AGENT_ROOT_ID && !f.loading && !f.error) {
+        // Skip image tabs — their content is a blob: URL, not text, and
+        // running readFile() on them would clobber the URL with the raw
+        // bytes interpreted as a string (which breaks <img src>).
+        if (
+          f.rootId === AGENT_ROOT_ID &&
+          !f.loading &&
+          !f.error &&
+          f.language !== "image" &&
+          !isImagePath(f.path)
+        ) {
           openAgentFiles.add(f.path);
         }
       }
@@ -311,6 +321,9 @@ export function useLiveAgentEdits({
 
       if (evt.type !== "file.changed") return;
       const { path, mtime } = evt;
+      // file.changed on an image doesn't round-trip through readFile — the
+      // image viewer owns a blob: URL that we mustn't replace with text.
+      if (isImagePath(path)) return;
 
       void (async () => {
         const svc = serviceRef.current;
@@ -371,7 +384,9 @@ export function useLiveAgentEdits({
         active.rootId !== AGENT_ROOT_ID ||
         active.loading ||
         active.error ||
-        active.dirty
+        active.dirty ||
+        active.language === "image" ||
+        isImagePath(active.path)
       ) {
         return;
       }

--- a/apps/mobile/components/project/panels/ide/workspace/localFs.ts
+++ b/apps/mobile/components/project/panels/ide/workspace/localFs.ts
@@ -168,6 +168,15 @@ export class LocalFs implements WorkspaceService {
     };
   }
 
+  /** Read a file as a blob: URL — used by the image viewer for png/jpg/etc. */
+  async readFileUrl(path: string): Promise<string> {
+    const { parent, name } = await this.resolve(path);
+    if (!name) throw new Error("Invalid path");
+    const handle = await parent.getFileHandle(name);
+    const file = await handle.getFile();
+    return URL.createObjectURL(file);
+  }
+
   async writeFile(path: string, content: string) {
     const { parent, name } = await this.resolve(path, { create: true });
     if (!name) throw new Error("Invalid path");

--- a/apps/mobile/components/project/panels/ide/workspace/sdkFs.ts
+++ b/apps/mobile/components/project/panels/ide/workspace/sdkFs.ts
@@ -113,6 +113,16 @@ export class SdkFs implements WorkspaceService {
     })
   }
 
+  /**
+   * Fetch a binary asset (images, pdfs, etc.) as a blob: URL via the SDK so
+   * auth headers / agent-proxy cookie travel with the request. The returned
+   * URL is owned by the caller and must be revoked on cleanup.
+   */
+  async readFileUrl(path: string): Promise<string> {
+    const blob = await retry429(() => this.client.readFileBlob(path))
+    return URL.createObjectURL(blob)
+  }
+
   async listTree(): Promise<WsNode[]> {
     const tree = await retry429(() => this.client.getWorkspaceTree())
     return tree.map(toWsNode)

--- a/apps/mobile/components/project/panels/ide/workspace/types.ts
+++ b/apps/mobile/components/project/panels/ide/workspace/types.ts
@@ -60,6 +60,16 @@ export interface WorkspaceService {
   rename(from: string, to: string): Promise<void>;
   search(query: string, opts?: SearchOptions): Promise<SearchResponse>;
   /**
+   * Resolve a path to a URL that can be used by <img>, <video>, etc. Used for
+   * previewing binary assets (images, pdfs) that can't round-trip through the
+   * text-only readFile path. The returned URL may be a blob: URL (local) or
+   * an http(s): URL pointing at the backing server (agent).
+   *
+   * Callers are responsible for revoking blob: URLs when done — each call
+   * may allocate a fresh one. Optional: not all backends support it.
+   */
+  readFileUrl?(path: string): Promise<string>;
+  /**
    * Subscribe to live file-level edits performed by the backing agent.
    * Returns a disposer. Optional — not all backends support it.
    */

--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -393,3 +393,112 @@ body {
   margin-right: 6px;
   animation: agent-tab-pulse 1s ease-in-out infinite;
 }
+
+/* ──────────────────────────────────────────────────────────────────────────
+   IDE theme tokens. The Workbench wraps itself in `.shogo-ide` and uses
+   `var(--ide-*)` for all chrome colors (bg, text, borders, hovers, accents).
+   Switching the app between light and dark (`html.dark`) flips the palette
+   below, so the in-app code editor follows the rest of the UI.
+   ────────────────────────────────────────────────────────────────────────── */
+.shogo-ide {
+  /* Dark defaults — matches the VS Code "Dark+" look the IDE started with. */
+  --ide-bg: #1e1e1e;
+  --ide-surface: #252526;
+  --ide-panel: #1a1a1a;
+  --ide-border: #2a2a2a;
+  --ide-border-strong: #3a3a3a;
+  --ide-border-muted: #454545;
+  --ide-hover: #2a2d2e;
+  --ide-hover-subtle: rgba(255, 255, 255, 0.06);
+  --ide-active: #37373d;
+  --ide-active-bg: #094771;
+  --ide-active-ring: #0078d4;
+  --ide-input: #3c3c3c;
+  --ide-input-bg: #1a1a1a;
+  --ide-muted: #858585;
+  --ide-muted-strong: #666666;
+  --ide-text: #cccccc;
+  --ide-text-strong: #ffffff;
+  --ide-primary: #0078d4;
+  --ide-error: #f48771;
+  --ide-warning: #ffb74d;
+  --ide-tab-inactive: #2d2d2d;
+  --ide-tab-inactive-text: #969696;
+  --ide-accent-file-icon: #75beff;
+  --ide-accent-folder: #dcb67a;
+  --ide-highlight-bg: #514b17;
+  --ide-highlight-text: #ffd75e;
+  --ide-selected-bg: #264f78;
+  --ide-conflict-border: rgba(249, 130, 108, 0.6);
+  --ide-conflict-bg: rgba(249, 130, 108, 0.15);
+  --ide-conflict-pill-bg: rgba(249, 130, 108, 0.25);
+  --ide-conflict-text: #f9d7cf;
+  --ide-toggle-knob: #ffffff;
+  --ide-btn-primary-bg: #0e639c;
+  --ide-btn-primary-hover: #1177bb;
+  --ide-btn-secondary-bg: #3a3d41;
+  --ide-btn-secondary-hover: #4a4d51;
+  --ide-danger-hover: #c4314b;
+  --ide-kbd-bg: #2a2a2a;
+  --ide-scrollbar: rgba(255, 255, 255, 0.2);
+
+  color: var(--ide-text);
+  background: var(--ide-bg);
+}
+
+html:not(.dark) .shogo-ide,
+.shogo-ide[data-theme="light"] {
+  --ide-bg: #ffffff;
+  --ide-surface: #f3f3f3;
+  --ide-panel: #ececec;
+  --ide-border: #e5e5e5;
+  --ide-border-strong: #cecece;
+  --ide-border-muted: #cccccc;
+  --ide-hover: #e8e8e8;
+  --ide-hover-subtle: rgba(0, 0, 0, 0.05);
+  --ide-active: #d6ebff;
+  --ide-active-bg: #cce6f7;
+  --ide-active-ring: #0066b8;
+  --ide-input: #ffffff;
+  --ide-input-bg: #ffffff;
+  --ide-muted: #616161;
+  --ide-muted-strong: #9d9d9d;
+  --ide-text: #1f1f1f;
+  --ide-text-strong: #000000;
+  --ide-primary: #0066b8;
+  --ide-error: #e51400;
+  --ide-warning: #b88217;
+  --ide-tab-inactive: #ececec;
+  --ide-tab-inactive-text: #5f5f5f;
+  --ide-accent-file-icon: #316dca;
+  --ide-accent-folder: #d6a558;
+  --ide-highlight-bg: #fff3b0;
+  --ide-highlight-text: #3a2e00;
+  --ide-selected-bg: #add6ff;
+  --ide-conflict-border: rgba(215, 58, 73, 0.45);
+  --ide-conflict-bg: rgba(255, 225, 220, 0.8);
+  --ide-conflict-pill-bg: rgba(215, 58, 73, 0.2);
+  --ide-conflict-text: #7a1f03;
+  --ide-toggle-knob: #ffffff;
+  --ide-btn-primary-bg: #0066b8;
+  --ide-btn-primary-hover: #1177bb;
+  --ide-btn-secondary-bg: #e5e5e5;
+  --ide-btn-secondary-hover: #d0d0d0;
+  --ide-danger-hover: #e51400;
+  --ide-kbd-bg: #e5e5e5;
+  --ide-scrollbar: rgba(0, 0, 0, 0.25);
+}
+
+/* Scrollbars inside the IDE pick up the current palette so the light theme
+   doesn't end up with a dark-on-light scrollbar. */
+.shogo-ide *::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+.shogo-ide *::-webkit-scrollbar-thumb {
+  background: var(--ide-scrollbar);
+  border-radius: 6px;
+}
+.shogo-ide *::-webkit-scrollbar-track {
+  background: transparent;
+}

--- a/packages/sdk/src/agent/client.ts
+++ b/packages/sdk/src/agent/client.ts
@@ -320,6 +320,24 @@ export class AgentClient {
     return this.url(`/agent/workspace/download/${this.encodePath(relativePath)}`)
   }
 
+  /**
+   * Fetch a workspace file as a raw Blob — used for images, PDFs, and other
+   * binaries the text-only `readFile` can't represent. Goes through the same
+   * authed fetch wrapper as every other SDK call, so auth headers / cookies
+   * travel with the request automatically.
+   */
+  async readFileBlob(relativePath: string): Promise<Blob> {
+    const res = await this.doFetch(
+      this.url(`/agent/workspace/download/${this.encodePath(relativePath)}`),
+      { headers: this.ambientHeaders },
+    )
+    if (!res.ok) {
+      const text = await res.text().catch(() => res.statusText)
+      throw new Error(`Agent readFileBlob ${res.status}: ${text}`)
+    }
+    return res.blob()
+  }
+
   async exportAgentBundle(): Promise<AgentExportBundle> {
     return this.fetchJson<AgentExportBundle>('/agent/export')
   }


### PR DESCRIPTION
Closes #428
<img width="1512" height="982" alt="Screenshot 2026-04-23 at 10 27 01 AM" src="https://github.com/user-attachments/assets/5563ab82-0b01-4a12-a906-1760dd3f2454" />
## What changed
- **Theme:** `--ide-*` variables in `apps/mobile/global.css`, `.shogo-ide` + `data-theme` on `Workbench`, Monaco `shogo-dark` / `shogo-light` from app theme (`CodeEditor`).
- **Explorer multi-select:** `FileTree` — Cmd/Ctrl toggle, Shift range, keyboard selection, batch open / copy paths / delete in context menu.
- **Images:** `ImagePreview`, `WorkspaceService.readFileUrl`, `localFs` / `SdkFs` implementations; `AgentClient.readFileBlob` in SDK for authenticated binary download; `useLiveAgentEdits` skips image tabs so blob URLs are not overwritten by `readFile`.
- **Chrome:** IDE panels use CSS variables instead of hardcoded dark hex where applicable; removed the workbench title bar (shortcut hints row).
- **IDEPanel:** Non-web placeholder uses semantic Tailwind classes for theme alignment.

## After merge / local dev
Run `bun run build:sdk` (repo root) or `bun run build` in `packages/sdk` so `dist/` includes `readFileBlob` — the app resolves `@shogo-ai/sdk/agent` from built output. EAS already runs SDK build in `eas-build-post-install`.