### PR TITLE
fix(shared-ui): badge variant text readable in dark mode

### DIFF
--- a/packages/shared-ui/src/primitives/Badge.tsx
+++ b/packages/shared-ui/src/primitives/Badge.tsx
@@ -25,19 +25,14 @@ export interface BadgeProps {
 }
 
 export function Badge({ variant = 'default', className, children }: BadgeProps) {
+  const textClass = cn('text-xs font-semibold', variantTextStyles[variant])
   return (
     <View className={cn(
       'flex-row items-center rounded-full px-2.5 py-0.5',
       variantStyles[variant],
       className,
     )}>
-      {typeof children === 'string' ? (
-        <Text className={cn('text-xs font-semibold', variantTextStyles[variant])}>
-          {children}
-        </Text>
-      ) : (
-        children
-      )}
+      <Text className={textClass}>{children}</Text>
     </View>
   )
 }


### PR DESCRIPTION
## Problem
Closes #432.

`Badge` only applied `variantTextStyles` when `children` was a string. Nested `<Text>` children (common for custom font sizes) did not inherit `text-foreground` for the outline variant, which made labels like the platform pill on the API Keys / devices list hard to read in dark mode on web.

## Change
Always render children inside a `Text` with `text-xs font-semibold` and the variant foreground class. Explicit colors on inner `Text` still win where call sites set them.

## Testing
- [ ] Open Devices & API Keys in dark mode (app or system) and confirm platform badge text has proper contrast.

Made with [Cursor](https://cursor.com)