### PR TITLE
fix(ide-terminal): free-form shell run, streaming cwd, and abort cleanup

### DIFF
--- a/apps/api/src/routes/terminal.ts
+++ b/apps/api/src/routes/terminal.ts
@@ -3,18 +3,51 @@
 /**
  * Terminal API Routes
  *
- * Endpoints for executing preset shell commands on project workspaces.
- * Only allows a predefined set of safe commands to prevent arbitrary execution.
- *
  * Endpoints:
- * - POST /projects/:projectId/terminal/exec - Execute a preset command
- * - GET /projects/:projectId/terminal/commands - List available commands
+ * - GET  /projects/:projectId/terminal/commands - List curated preset commands
+ * - POST /projects/:projectId/terminal/exec     - Run a curated preset command
+ * - POST /projects/:projectId/terminal/run      - Run an arbitrary shell command
+ *                                                 inside the project workspace
+ *
+ * The `run` endpoint is what gives the IDE a real terminal: `ls`, `cat`,
+ * pipes, redirects, `git status`, `bun run foo`, … all work. It's the
+ * free-form counterpart to `exec` (which only knows curated commands).
+ *
+ * Shell semantics:
+ *   - Each call runs in an ephemeral `bash -c` process. `cd`, `export`,
+ *     shell-local aliases, background jobs etc. do not persist on their own.
+ *   - To give users the illusion of a persistent shell we track the CWD on
+ *     the client: the client sends the session's current `cwd` (and
+ *     previous `prevCwd` for `cd -`), we `cd` into it before running the
+ *     command, then report back the post-command `pwd` through a per-request
+ *     tempfile which we read once the child exits. The client uses that to
+ *     update its state so the *next* command starts from the right place.
+ *     (We initially used an fd-3 pipe, but Bun's `child_process` silently
+ *     merges extra fds into stdout, which would leak the pwd bytes into the
+ *     user-visible stream. A tempfile is boring and 100% portable.)
+ *   - Output (stdout+stderr) is streamed as a chunked text response. A
+ *     trailing, base64-encoded JSON sentinel carries the new cwd + exit
+ *     code. The sentinel is wrapped in ASCII Record-Separator (0x1E) bytes
+ *     so it cannot be confused with command output; the client strips it
+ *     before rendering.
+ *   - If the client disconnects mid-stream (Stop button / navigation /
+ *     tab close), we SIGTERM the child and SIGKILL it 2s later. This is
+ *     what makes Ctrl+C / Stop actually *stop* the command on the server.
  */
 
 import { Hono } from "hono"
 import { spawn, execSync } from "child_process"
-import { existsSync } from "fs"
-import { join } from "path"
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs"
+import { tmpdir } from "os"
+import { isAbsolute, join, resolve } from "path"
+
+/**
+ * ASCII Record-Separator framed sentinel used to carry post-command metadata
+ * (new cwd, exit code) out-of-band on the same HTTP stream. Keep in sync with
+ * the client-side regex in apps/mobile/components/project/panels/ide/Terminal.tsx.
+ */
+const META_SENTINEL_PREFIX = "\u001eSHOGO_TERM_META:"
+const META_SENTINEL_SUFFIX = "\u001e\n"
 
 /**
  * Preset command definition
@@ -245,6 +278,7 @@ export function terminalRoutes(config: TerminalRoutesConfig) {
     const { readable, writable } = new TransformStream()
     const writer = writable.getWriter()
     const encoder = new TextEncoder()
+    const clientSignal = c.req.raw.signal
 
     // Execute command asynchronously
     ;(async () => {
@@ -252,7 +286,10 @@ export function terminalRoutes(config: TerminalRoutesConfig) {
         // Write header
         await writer.write(encoder.encode(`$ ${preset.command}\n\n`))
 
-        // Spawn the command
+        // Spawn the command in its own process group so that Stop / client
+        // abort / timeout can signal the whole tree (sh + children like
+        // `playwright test` workers) instead of orphaning grandchildren.
+        // See `makeKillChild` for the negative-pid group-signal mechanics.
         const child = spawn('sh', ['-c', preset.command], {
           cwd: projectDir,
           env: {
@@ -263,52 +300,61 @@ export function terminalRoutes(config: TerminalRoutesConfig) {
             CI: 'true',
           },
           stdio: ['ignore', 'pipe', 'pipe'],
+          detached: true,
         })
+
+        const killChild = makeKillChild(child)
 
         // Set up timeout
         const timeoutId = setTimeout(() => {
-          child.kill('SIGTERM')
-          writer.write(encoder.encode('\n\n[ERROR] Command timed out\n'))
+          writer.write(encoder.encode('\n\n[ERROR] Command timed out\n')).catch(() => {})
+          killChild('SIGTERM')
         }, timeout)
 
-        // Stream stdout
-        child.stdout?.on('data', async (data: Buffer) => {
-          try {
-            await writer.write(data)
-          } catch {
-            // Writer closed, ignore
-          }
-        })
+        // Kill child if the client goes away (Stop button / tab close / nav)
+        const onAbort = () => killChild('SIGTERM')
+        clientSignal?.addEventListener('abort', onAbort)
 
-        // Stream stderr
-        child.stderr?.on('data', async (data: Buffer) => {
+        // Guard against both 'error' and 'close' firing (Node allows this).
+        let settled = false
+        const settle = async (trailer: string) => {
+          if (settled) return
+          settled = true
+          clearTimeout(timeoutId)
+          clientSignal?.removeEventListener('abort', onAbort)
           try {
-            await writer.write(data)
+            await writer.write(encoder.encode(trailer))
+            await writer.close()
           } catch {
-            // Writer closed, ignore
+            // Writer already closed, ignore
           }
-        })
+        }
 
-        // Handle completion
+        // Pipe with backpressure so a verbose preset (e.g. `bun install`
+        // resolving 1k deps) can't balloon server memory when the HTTP
+        // client reads slowly.
+        const pipe = (src: NodeJS.ReadableStream | null) => {
+          if (!src) return
+          src.on('data', (data: Buffer) => {
+            const p = writer.write(data).catch(() => {})
+            if (writer.desiredSize !== null && writer.desiredSize <= 0) {
+              src.pause()
+              void Promise.resolve(p)
+                .then(() => writer.ready)
+                .then(() => src.resume())
+                .catch(() => src.resume())
+            }
+          })
+        }
+        pipe(child.stdout)
+        pipe(child.stderr)
+
         child.on('close', async (code) => {
-          clearTimeout(timeoutId)
-          try {
-            await writer.write(encoder.encode(`\n\n[Process exited with code ${code}]\n`))
-            await writer.close()
-          } catch {
-            // Writer already closed, ignore
-          }
+          await settle(`\n\n[Process exited with code ${code}]\n`)
         })
 
-        // Handle errors
         child.on('error', async (err) => {
-          clearTimeout(timeoutId)
-          try {
-            await writer.write(encoder.encode(`\n\n[ERROR] ${err.message}\n`))
-            await writer.close()
-          } catch {
-            // Writer already closed, ignore
-          }
+          await settle(`\n\n[ERROR] ${err.message}\n`)
         })
 
       } catch (err: any) {
@@ -332,7 +378,321 @@ export function terminalRoutes(config: TerminalRoutesConfig) {
     })
   })
 
+  /**
+   * POST /projects/:projectId/terminal/run - Execute a free-form shell command
+   *
+   * Body:
+   *   command:   string              // required, the shell line to run
+   *   cwd?:      string              // absolute path; must exist. Defaults to projectDir.
+   *   prevCwd?:  string              // absolute path for OLDPWD (so `cd -` works)
+   *   timeoutMs?: number             // 1s … 30min, default 10min
+   *
+   * Response: `text/plain; charset=utf-8` streaming stdout+stderr, followed by
+   * a single Record-Separator framed JSON sentinel carrying { cwd, exitCode,
+   * signal } so the client can keep its synthetic shell state in sync.
+   */
+  router.post("/projects/:projectId/terminal/run", async (c) => {
+    const projectId = c.req.param("projectId")
+    const projectDir = join(workspacesDir, projectId)
+
+    if (!existsSync(projectDir)) {
+      return c.json(
+        { error: { code: "project_not_found", message: "Project not found" } },
+        404,
+      )
+    }
+
+    let body: { command?: string; cwd?: string; prevCwd?: string; timeoutMs?: number }
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json(
+        { error: { code: "invalid_body", message: "Invalid request body" } },
+        400,
+      )
+    }
+
+    const command = typeof body.command === "string" ? body.command : ""
+    if (!command.trim()) {
+      return c.json(
+        { error: { code: "empty_command", message: "Command is required" } },
+        400,
+      )
+    }
+
+    // Clamp timeout to a sane window. Mirrors VS Code's "long running tasks
+    // are fine" stance without letting a stuck curl keep a worker busy forever.
+    const rawTimeout = typeof body.timeoutMs === "number" ? body.timeoutMs : 10 * 60_000
+    const timeout = Math.min(Math.max(rawTimeout, 1_000), 30 * 60_000)
+
+    const effectiveCwd = pickCwd(body.cwd, projectDir)
+    const prevCwd = pickCwd(body.prevCwd, projectDir)
+
+    const { readable, writable } = new TransformStream()
+    const writer = writable.getWriter()
+    const encoder = new TextEncoder()
+    const clientSignal = c.req.raw.signal
+
+    // Allocate a per-request temp dir that the launcher can drop its
+    // post-command pwd into. We initially tried a stdio[3] pipe (fd 3), but
+    // Bun's child_process implementation silently glues extra fds onto
+    // stdout, which both broke cwd reporting and leaked path bytes into the
+    // user-visible stream. A tempfile is boring and 100% portable.
+    const metaDir = mkdtempSync(join(tmpdir(), "shogo-term-"))
+    const pwdFile = join(metaDir, "pwd")
+    const cleanup = () => {
+      try {
+        rmSync(metaDir, { recursive: true, force: true })
+      } catch {
+        /* best-effort */
+      }
+    }
+
+    ;(async () => {
+      // Launcher script. We run the user command via `eval "$SHOGO_CMD"` so
+      // that aliases, pipes, redirects, env-var expansion and multi-statement
+      // lines all work. After the user command finishes we dump the current
+      // pwd to a side-file that the server reads once the child exits, so
+      // `cd`, `cd ..`, `cd -`, `cd ~` all persist across requests without any
+      // fd multiplexing tricks.
+      // NB: we re-export OLDPWD *after* the initial cd. Bash's own `cd`
+      // rewrites OLDPWD to "the pwd before the cd", which in our case is
+      // always effectiveCwd — that would silently destroy the prevCwd the
+      // client passed in, breaking `cd -`. Setting it again afterwards
+      // restores the caller's intent so `cd -` jumps back to the user's
+      // actual previous directory.
+      const launcher =
+        'cd -- "${SHOGO_CWD:-$SHOGO_ROOT}" 2>/dev/null || cd -- "$SHOGO_ROOT"; ' +
+        'export OLDPWD="${SHOGO_OLDPWD:-$PWD}"; ' +
+        'eval "$SHOGO_CMD"; ' +
+        '__shogo_rc=$?; ' +
+        '{ pwd > "$SHOGO_PWD_FILE"; } 2>/dev/null; ' +
+        'exit $__shogo_rc'
+
+      let child: ReturnType<typeof spawn>
+      try {
+        child = spawn("bash", ["-c", launcher], {
+          cwd: effectiveCwd,
+          env: {
+            ...process.env,
+            // Hand the command and target cwd through env so we don't have to
+            // worry about escaping them into the `bash -c` argv. This is the
+            // standard technique for safely wrapping arbitrary user input in
+            // a shell launcher.
+            SHOGO_CMD: command,
+            SHOGO_CWD: effectiveCwd,
+            SHOGO_ROOT: projectDir,
+            SHOGO_PWD_FILE: pwdFile,
+            // OLDPWD makes `cd -` work across separate spawns. We pass it
+            // twice: as OLDPWD so programs that read it early (before our
+            // launcher's explicit export) still see it, and as SHOGO_OLDPWD
+            // so the launcher can restore it *after* its own initial `cd`
+            // stomps on bash's built-in OLDPWD tracking.
+            OLDPWD: prevCwd,
+            SHOGO_OLDPWD: prevCwd,
+            // Scope tilde-expansion and programs that look at $HOME (npm, git,
+            // etc.) to the project workspace by default. Users can still pass
+            // HOME=... explicitly on the command line if they want.
+            HOME: projectDir,
+            PWD: effectiveCwd,
+            // Colors / TTY-ish hints so tools like `ls --color=auto`, `git`,
+            // `eslint` produce helpful output even without a PTY.
+            FORCE_COLOR: "1",
+            CLICOLOR: "1",
+            CLICOLOR_FORCE: "1",
+            TERM: process.env.TERM || "xterm-256color",
+          },
+          stdio: ["ignore", "pipe", "pipe"],
+          // Put the child in its own process group so we can signal the
+          // whole tree (bash + any grandchildren like `sleep`) at once.
+          // Without this, SIGTERM'ing bash while it's `wait`ing on a child
+          // orphans the child — the visible symptom was "Stop doesn't stop
+          // a running sleep".
+          detached: true,
+        })
+      } catch (err: any) {
+        cleanup()
+        try {
+          await writer.write(
+            encoder.encode(`\n[shogo] failed to spawn shell: ${err?.message ?? String(err)}\n`),
+          )
+          await writeMetaSentinel(writer, encoder, {
+            cwd: effectiveCwd,
+            exitCode: null,
+            signal: null,
+          })
+          await writer.close()
+        } catch {
+          /* writer already closed */
+        }
+        return
+      }
+
+      const killChild = makeKillChild(child)
+
+      const timeoutId = setTimeout(() => {
+        writer
+          .write(encoder.encode("\n[shogo] command timed out\n"))
+          .catch(() => {})
+        killChild("SIGTERM")
+      }, timeout)
+
+      const onAbort = () => killChild("SIGTERM")
+      clientSignal?.addEventListener("abort", onAbort)
+
+      // Single-shot teardown. Node's ChildProcess can emit both 'error' and
+      // 'close', and we also tear down from timeout/abort. Without this
+      // flag we'd write the metadata sentinel twice and hit "writer already
+      // closed" on the second path.
+      let settled = false
+      const settle = async (meta: {
+        cwd: string
+        exitCode: number | null
+        signal: string | null
+      }) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timeoutId)
+        clientSignal?.removeEventListener("abort", onAbort)
+        cleanup()
+        try {
+          await writeMetaSentinel(writer, encoder, meta)
+          await writer.close()
+        } catch {
+          /* writer already closed */
+        }
+      }
+
+      // Pipe stdout/stderr with backpressure: if the HTTP sink slows down
+      // we pause the child's stream so memory doesn't balloon under chatty
+      // commands like `yes` or `find /`. Resuming once the writer is ready
+      // keeps throughput high for normal output.
+      const pipeWithBackpressure = (src: NodeJS.ReadableStream | null) => {
+        if (!src) return
+        src.on("data", (data: Buffer) => {
+          const p = writer.write(data).catch(() => {})
+          if (writer.desiredSize !== null && writer.desiredSize <= 0) {
+            src.pause()
+            void Promise.resolve(p)
+              .then(() => writer.ready)
+              .then(() => src.resume())
+              .catch(() => src.resume())
+          }
+        })
+      }
+      pipeWithBackpressure(child.stdout)
+      pipeWithBackpressure(child.stderr)
+
+      child.on("error", async (err) => {
+        try {
+          await writer.write(encoder.encode(`\n[shogo] ${err.message}\n`))
+        } catch {
+          /* writer already closed */
+        }
+        await settle({ cwd: effectiveCwd, exitCode: null, signal: null })
+      })
+
+      child.on("close", async (code, signal) => {
+        let reported = ""
+        try {
+          if (existsSync(pwdFile)) {
+            reported = readFileSync(pwdFile, "utf8").trim()
+          }
+        } catch {
+          /* fall through — we'll use effectiveCwd as fallback */
+        }
+        // If the child was killed before it could write pwd (abort, timeout,
+        // SIGKILL from a panicking command) fall back to the starting cwd so
+        // the client doesn't get stuck at some half-updated state.
+        const finalCwd = reported && existsSync(reported) ? reported : effectiveCwd
+        await settle({
+          cwd: finalCwd,
+          exitCode: typeof code === "number" ? code : null,
+          signal: signal ?? null,
+        })
+      })
+    })()
+
+    return new Response(readable, {
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Transfer-Encoding": "chunked",
+        "Cache-Control": "no-cache",
+        "X-Content-Type-Options": "nosniff",
+      },
+    })
+  })
+
   return router
+}
+
+/**
+ * Resolve a caller-supplied cwd to an absolute path, falling back to the
+ * project root if the candidate is missing, relative, or no longer exists.
+ * We intentionally *allow* absolute paths outside the project dir: users
+ * frequently `cd /tmp` etc. during debugging and we don't want to surprise
+ * them. The project dir is only a default.
+ */
+function pickCwd(candidate: string | undefined, projectDir: string): string {
+  if (!candidate || typeof candidate !== "string") return projectDir
+  const abs = isAbsolute(candidate) ? candidate : resolve(projectDir, candidate)
+  return existsSync(abs) ? abs : projectDir
+}
+
+/**
+ * Returns a function that terminates the child **and every grandchild** it
+ * spawned. Two-phase: SIGTERM first so well-behaved programs can clean up,
+ * SIGKILL 2s later for anything that ignores it (looking at you,
+ * `sleep infinity`). Safe to call repeatedly.
+ *
+ * We need group killing because the launcher is `bash -c '…; eval "$CMD"; …'`
+ * and bash does not forward signals to its children in non-job-control mode.
+ * If we only killed `child` (the bash process), its running `sleep` would be
+ * reparented to init and keep ticking — which is exactly the bug the test
+ * harness caught. Spawn must pass `detached: true` so `child.pid` is also
+ * the process-group id that we negate below.
+ */
+function makeKillChild(child: ReturnType<typeof spawn>) {
+  let killed = false
+  const killGroup = (sig: NodeJS.Signals) => {
+    if (!child.pid) return
+    try {
+      // Negative pid = "signal the whole process group".
+      process.kill(-child.pid, sig)
+    } catch {
+      // Group may already be gone; fall back to a direct child.kill so we at
+      // least try to terminate the known process.
+      try {
+        child.kill(sig)
+      } catch {
+        /* already exited */
+      }
+    }
+  }
+  return function killChild(signal: NodeJS.Signals = "SIGTERM") {
+    if (killed) return
+    killed = true
+    killGroup(signal)
+    setTimeout(() => {
+      if (!child.killed && child.exitCode === null) killGroup("SIGKILL")
+    }, 2_000).unref?.()
+  }
+}
+
+/**
+ * Serialize the out-of-band metadata trailer. Base64-wrapping the JSON means
+ * the payload itself cannot contain our Record-Separator framing bytes, so
+ * there's no way for a weird cwd string to break the parser on the client.
+ */
+async function writeMetaSentinel(
+  writer: WritableStreamDefaultWriter<Uint8Array>,
+  encoder: TextEncoder,
+  meta: { cwd: string; exitCode: number | null; signal: string | null },
+) {
+  const payload = Buffer.from(JSON.stringify(meta), "utf8").toString("base64")
+  await writer.write(
+    encoder.encode(META_SENTINEL_PREFIX + payload + META_SENTINEL_SUFFIX),
+  )
 }
 
 export default terminalRoutes

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2505,6 +2505,71 @@ app.post('/api/projects/:projectId/terminal/exec', async (c) => {
     method: 'POST',
     headers: c.req.raw.headers,
     body: c.req.raw.body,
+    // @ts-expect-error - required when forwarding a streaming request body in Node
+    duplex: 'half',
+    signal: c.req.raw.signal,
+  })
+  return router.fetch(newReq)
+})
+
+// Execute a free-form shell command (the IDE "$" prompt). Mirrors /exec but
+// forwards arbitrary user input instead of a curated command id.
+app.post('/api/projects/:projectId/terminal/run', async (c) => {
+  const projectId = c.req.param('projectId')
+
+  if (isKubernetes()) {
+    // In Kubernetes: Proxy to the project's runtime pod.
+    try {
+      const { getProjectPodUrl } = await import('./lib/knative-project-manager')
+      const podUrl = await getProjectPodUrl(projectId)
+      const targetUrl = `${podUrl}/terminal/run`
+
+      console.log(`[TerminalProxy] Proxying run to ${targetUrl}`)
+
+      const body = await c.req.text()
+
+      const response = await fetch(targetUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': c.req.header('Content-Type') || 'application/json',
+        },
+        body,
+        signal: c.req.raw.signal,
+      })
+
+      console.log(`[TerminalProxy] run response status: ${response.status}`)
+
+      const responseHeaders = new Headers()
+      response.headers.forEach((value, key) => {
+        if (!['transfer-encoding', 'connection'].includes(key.toLowerCase())) {
+          responseHeaders.set(key, value)
+        }
+      })
+
+      return new Response(response.body, {
+        status: response.status,
+        headers: responseHeaders,
+      })
+    } catch (error: any) {
+      console.error('[TerminalProxy] Error:', error)
+      return c.json({
+        error: { code: 'proxy_error', message: error.message || 'Failed to run command' }
+      }, 502)
+    }
+  }
+
+  // Local development: Use local filesystem
+  const workspacesDir = process.env.WORKSPACES_DIR || resolve(PROJECT_ROOT, 'workspaces')
+  const router = terminalRoutes({ workspacesDir })
+  const url = new URL(c.req.url)
+  url.pathname = `/projects/${projectId}/terminal/run`
+  const newReq = new Request(url.toString(), {
+    method: 'POST',
+    headers: c.req.raw.headers,
+    body: c.req.raw.body,
+    // @ts-expect-error - required when forwarding a streaming request body in Node
+    duplex: 'half',
+    signal: c.req.raw.signal,
   })
   return router.fetch(newReq)
 })

--- a/apps/mobile/components/project/panels/ide/Terminal.tsx
+++ b/apps/mobile/components/project/panels/ide/Terminal.tsx
@@ -32,6 +32,18 @@ import { agentFetch } from "../../../../lib/agent-fetch";
  *     the user's mental model: "X on the last terminal should hide the
  *     whole thing, not spawn a new one").
  *
+ * Synthetic persistent shell:
+ *   - `bash -c` is spawned fresh for every command, so shell-local state
+ *     (`cd`, `export`, aliases) doesn't naturally survive. We give users the
+ *     illusion of a long-lived shell by tracking `cwd` + `prevCwd` per
+ *     session and passing them with every run. The server `cd`s into `cwd`
+ *     before the command and reports the post-command `pwd` back on an
+ *     out-of-band stream channel (wrapped in 0x1E record-separator bytes so
+ *     it can't collide with program output). The client parses it, updates
+ *     state, and the next command starts from the new directory. Enough to
+ *     make `cd`, `cd -`, `cd ..`, `pwd`, pipes, redirects, subshells, etc.
+ *     all feel like a real terminal.
+ *
  * Why no raw PTY / xterm.js: the product is agent-first (commit 7f9bdd0), so
  * we lean on simple streamed stdout over HTTP instead of a persistent shell.
  * That covers ~all real workflows (`ls`, `cat`, `bun run …`, `git status`,
@@ -54,6 +66,51 @@ interface Session {
   abort: AbortController | null;
   /** Free-form prompt history, oldest → newest. */
   history: string[];
+  /**
+   * Synthetic-shell cwd for this tab. `null` means "server default"
+   * (project workspace root) — we resolve it lazily on first command so
+   * new tabs don't need an up-front API call. Updated from the
+   * out-of-band metadata trailer after every command.
+   */
+  cwd: string | null;
+  /** Previous cwd so `cd -` works across independent `bash -c` invocations. */
+  prevCwd: string | null;
+}
+
+/**
+ * Record-Separator framed trailer emitted by the server after a free-form
+ * command finishes. Carries `{ cwd, exitCode, signal }` as base64-encoded
+ * JSON. Kept in sync with META_SENTINEL_{PREFIX,SUFFIX} in
+ * apps/api/src/routes/terminal.ts — change both or neither.
+ */
+const META_SENTINEL_RE = /\u001eSHOGO_TERM_META:([A-Za-z0-9+/=]+)\u001e\n?/;
+
+interface RunMeta {
+  cwd?: string;
+  exitCode?: number | null;
+  signal?: string | null;
+}
+
+/**
+ * Strip any complete metadata sentinel out of `buf`, returning the decoded
+ * payload (if any) plus the remaining buffer with the sentinel removed.
+ * Callers feed chunks in progressively and hold back a tail to handle
+ * sentinels that straddle chunk boundaries.
+ */
+function extractMeta(buf: string): { meta: RunMeta | null; rest: string } {
+  const m = META_SENTINEL_RE.exec(buf);
+  if (!m) return { meta: null, rest: buf };
+  let meta: RunMeta | null = null;
+  try {
+    const json =
+      typeof atob === "function"
+        ? atob(m[1])
+        : Buffer.from(m[1], "base64").toString("utf8");
+    meta = JSON.parse(json) as RunMeta;
+  } catch {
+    meta = null;
+  }
+  return { meta, rest: buf.slice(0, m.index) + buf.slice(m.index + m[0].length) };
 }
 
 const CATEGORY_LABEL: Record<string, string> = {
@@ -73,7 +130,25 @@ const makeSession = (): Session => ({
   runningCmdId: null,
   abort: null,
   history: [],
+  cwd: null,
+  prevCwd: null,
 });
+
+/**
+ * Best-effort "looks like an absolute POSIX path inside this project".
+ * Purely cosmetic — used to decide whether to render the prompt as `~/foo`
+ * (inside project) or `/abs/path` (user cd'd elsewhere). Not a security
+ * boundary; the server enforces/ignores escape as it sees fit.
+ */
+function formatPromptCwd(cwd: string | null): string {
+  if (!cwd) return "";
+  // Show last two path segments for compactness, but keep absolute form if we
+  // only have one (`/tmp` stays `/tmp`).
+  const parts = cwd.split("/").filter(Boolean);
+  if (parts.length === 0) return "/";
+  if (parts.length === 1) return "/" + parts[0];
+  return parts.slice(-2).join("/");
+}
 
 export function Terminal({
   projectId,
@@ -220,6 +295,57 @@ export function Terminal({
     setSessions((prev) => prev.map((s) => (s.id === id ? patch(s) : s)));
   }, []);
 
+  // ─── Output batching ────────────────────────────────────────────────
+  // Chunks from `fetch().body.getReader()` arrive as often as the TCP
+  // stack delivers them — for verbose commands (`yes`, `find /`,
+  // `bun install`) that's thousands of tiny writes per second. Rendering
+  // a fresh React tree for each chunk pegs the main thread. Instead we
+  // accumulate per-session text in a ref and flush once per animation
+  // frame, so React only runs reconciliation ~60×/sec regardless of how
+  // chatty the command is.
+  const pendingOutputRef = useRef<Map<string, string>>(new Map());
+  const flushScheduledRef = useRef(false);
+  const flushPending = useCallback(() => {
+    flushScheduledRef.current = false;
+    const pending = pendingOutputRef.current;
+    if (pending.size === 0) return;
+    const snapshot = new Map(pending);
+    pending.clear();
+    setSessions((prev) =>
+      prev.map((s) => {
+        const extra = snapshot.get(s.id);
+        return extra ? { ...s, output: s.output + extra } : s;
+      }),
+    );
+  }, []);
+  const scheduleFlush = useCallback(() => {
+    if (flushScheduledRef.current) return;
+    flushScheduledRef.current = true;
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(flushPending);
+    } else {
+      // Tests / non-browser environments: fall back to microtask.
+      queueMicrotask(flushPending);
+    }
+  }, [flushPending]);
+  const appendOutput = useCallback(
+    (id: string, text: string) => {
+      if (!text) return;
+      const map = pendingOutputRef.current;
+      map.set(id, (map.get(id) ?? "") + text);
+      scheduleFlush();
+    },
+    [scheduleFlush],
+  );
+
+  // Drain any pending rAF-buffered output on unmount so we don't leak
+  // state into a next mount that happens to reuse a session id.
+  useEffect(() => {
+    return () => {
+      pendingOutputRef.current.clear();
+    };
+  }, []);
+
   // ─── Shared streaming helper ────────────────────────────────────────
   /**
    * Stream a text-chunked HTTP response into a session's output buffer.
@@ -240,9 +366,12 @@ export function Terminal({
           const { done, value } = await reader.read();
           if (done) break;
           const chunk = decoder.decode(value, { stream: true });
-          if (chunk) patchSession(targetId, (s) => ({ ...s, output: s.output + chunk }));
+          if (chunk) appendOutput(targetId, chunk);
         }
       } catch (err) {
+        // Flush any batched output first so the trailer always lands
+        // *after* the actual command output, not a frame earlier.
+        flushPending();
         if ((err as { name?: string })?.name === "AbortError") {
           patchSession(targetId, (s) => ({ ...s, output: s.output + "\n[Cancelled]\n" }));
         } else {
@@ -250,12 +379,13 @@ export function Terminal({
           patchSession(targetId, (s) => ({ ...s, output: s.output + `\n[Error ${tag}] ${msg}\n` }));
         }
       } finally {
+        flushPending();
         patchSession(targetId, (s) =>
           s.abort === ctl ? { ...s, runningCmdId: null, abort: null } : s,
         );
       }
     },
-    [patchSession],
+    [appendOutput, flushPending, patchSession],
   );
 
   // ─── Run preset ─────────────────────────────────────────────────────
@@ -272,6 +402,9 @@ export function Terminal({
       }
       setConfirming(null);
       const ctl = new AbortController();
+      // Flush any rAF-batched chunks so the preset header lands after
+      // whatever output the previous command was still emitting.
+      flushPending();
       patchSession(targetId, (s) => ({
         ...s,
         runningCmdId: cmd.id,
@@ -290,7 +423,7 @@ export function Terminal({
       });
       await streamInto(targetId, cmd.label, res, ctl);
     },
-    [apiBase, projectId, activeId, patchSession, streamInto],
+    [apiBase, projectId, activeId, patchSession, streamInto, flushPending],
   );
 
   // ─── Run free-form command from the prompt ──────────────────────────
@@ -302,24 +435,69 @@ export function Terminal({
       const target = sessionsRef.current.find((s) => s.id === targetId);
       if (!target) return;
       if (target.runningCmdId) return;
-      const ctl = new AbortController();
-      patchSession(targetId, (s) => ({
+
+      // Record the command in history *before* handling built-ins so that ↑
+      // recalls `clear` / `exit` the same as any other line.
+      const pushHistory = (s: Session): Session => ({
         ...s,
-        runningCmdId: `free:${trimmed}`,
-        abort: ctl,
         history:
           s.history[s.history.length - 1] === trimmed
             ? s.history
             : [...s.history, trimmed].slice(-100),
-      }));
+      });
+
+      // Built-ins handled client-side — these have no meaningful output or
+      // would require a real PTY to behave correctly (`clear` emits raw ANSI
+      // escapes that our <pre> can't interpret). Mirrors VS Code's behavior
+      // where ⌘K also clears the buffer without a server round-trip.
+      if (trimmed === "clear" || trimmed === "cls") {
+        // Drop any rAF-batched chunks for this session so they don't bleed
+        // back in on the next animation frame.
+        pendingOutputRef.current.delete(targetId);
+        patchSession(targetId, (s) => pushHistory({ ...s, output: "" }));
+        return;
+      }
+      if (trimmed === "exit" || trimmed === "logout") {
+        flushPending();
+        patchSession(targetId, (s) =>
+          pushHistory({ ...s, output: s.output + "\n[session closed]\n" }),
+        );
+        return;
+      }
+
+      const ctl = new AbortController();
+      // Render the prompt line that the user just submitted, the way a real
+      // shell echoes what you typed before showing output. Using the tab's
+      // current cwd (best-effort formatted) makes `cd somewhere` + next
+      // command obviously originate from the new directory.
+      const echoPrefix = `${formatPromptCwd(target.cwd) || "~"} $ `;
+      // Make sure any output still sitting in the rAF batch is committed
+      // so the echoed prompt doesn't appear before the previous command's
+      // last lines.
+      flushPending();
+      patchSession(targetId, (s) =>
+        pushHistory({
+          ...s,
+          runningCmdId: `free:${trimmed}`,
+          abort: ctl,
+          output:
+            (s.output ? s.output.replace(/\n?$/, "\n") : "") +
+            `${echoPrefix}${trimmed}\n`,
+        }),
+      );
+
       try {
         const res = await agentFetch(`${apiBase}/api/projects/${projectId}/terminal/run`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ command: trimmed }),
+          body: JSON.stringify({
+            command: trimmed,
+            cwd: target.cwd ?? undefined,
+            prevCwd: target.prevCwd ?? undefined,
+          }),
           signal: ctl.signal,
         });
-        await streamInto(targetId, "run", res, ctl);
+        await streamRunInto(targetId, res, ctl);
       } catch (err) {
         if ((err as { name?: string })?.name !== "AbortError") {
           const msg = err instanceof Error ? err.message : String(err);
@@ -330,7 +508,117 @@ export function Terminal({
         );
       }
     },
-    [apiBase, projectId, activeId, patchSession, streamInto],
+    // streamRunInto is defined below and stable via useCallback
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [apiBase, projectId, activeId, patchSession, flushPending],
+  );
+
+  // ─── Free-form streaming: filters the meta sentinel out of display ──
+  /**
+   * Specialised streamer for `/terminal/run`. Unlike `streamInto`, we need
+   * to strip a trailing base64 metadata sentinel from the visible output
+   * and apply the `{ cwd, exitCode }` it carries to the session. The
+   * sentinel is framed in Record-Separator bytes, so we hold back any
+   * partial tail that *could* be the start of a sentinel until we see the
+   * closing byte.
+   */
+  const streamRunInto = useCallback(
+    async (targetId: string, res: Response, ctl: AbortController) => {
+      try {
+        if (!res.ok || !res.body) {
+          const body = (await res.json().catch(() => ({}))) as {
+            error?: { code?: string; message?: string };
+          };
+          throw new Error(body.error?.message ?? `HTTP ${res.status}`);
+        }
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let pending = ""; // bytes we've decoded but not yet flushed to `output`
+        let meta: RunMeta | null = null;
+        const flush = (chunk: string) => {
+          if (!chunk) return;
+          appendOutput(targetId, chunk);
+        };
+
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          pending += decoder.decode(value, { stream: true });
+
+          // 1. Pull out a complete sentinel, if present. There's only ever
+          //    one (emitted at the very end by the server), but we keep
+          //    looping defensively in case the server ever sends more.
+          for (;;) {
+            const { meta: found, rest } = extractMeta(pending);
+            if (!found) break;
+            meta = found;
+            pending = rest;
+          }
+
+          // 2. Flush whatever precedes a possibly-incomplete sentinel tail.
+          //    If pending ends with a 0x1E that hasn't been closed yet, it
+          //    *could* be the start of the sentinel — hold it back so we
+          //    don't accidentally render `\x1eSHOGO_TERM_META:...` to the
+          //    user if the TCP chunk boundary lands mid-sentinel.
+          const tail = pending.lastIndexOf("\u001e");
+          if (tail === -1) {
+            flush(pending);
+            pending = "";
+          } else {
+            flush(pending.slice(0, tail));
+            pending = pending.slice(tail);
+          }
+        }
+
+        // Drain any final decoder bytes.
+        pending += decoder.decode();
+        // One last try to pluck a meta sentinel out of the remainder…
+        const finalExtract = extractMeta(pending);
+        if (finalExtract.meta) {
+          meta = finalExtract.meta;
+          pending = finalExtract.rest;
+        }
+        // If what's left *still* looks like an unterminated sentinel, drop
+        // it rather than leaking control bytes into the display.
+        if (/^\u001eSHOGO_TERM_META:[A-Za-z0-9+/=]*$/.test(pending)) {
+          pending = "";
+        }
+        flush(pending);
+
+        // Make sure any batched chunks hit state before we append the
+        // trailing `[exit N]` line — otherwise the exit marker can race
+        // ahead of the last few bytes of command output.
+        flushPending();
+        if (meta?.cwd) {
+          patchSession(targetId, (s) =>
+            s.cwd === meta!.cwd
+              ? s
+              : { ...s, prevCwd: s.cwd ?? s.prevCwd, cwd: meta!.cwd ?? s.cwd },
+          );
+        }
+        if (typeof meta?.exitCode === "number" && meta.exitCode !== 0) {
+          patchSession(targetId, (s) => ({
+            ...s,
+            output: s.output + `[exit ${meta!.exitCode}]\n`,
+          }));
+        }
+      } catch (err) {
+        flushPending();
+        if ((err as { name?: string })?.name === "AbortError") {
+          patchSession(targetId, (s) => ({ ...s, output: s.output + "\n[Cancelled]\n" }));
+        } else {
+          const msg = err instanceof Error ? err.message : String(err);
+          patchSession(targetId, (s) => ({ ...s, output: s.output + `\n[Error run] ${msg}\n` }));
+        }
+      } finally {
+        flushPending();
+        patchSession(targetId, (s) =>
+          s.abort === ctl ? { ...s, runningCmdId: null, abort: null } : s,
+        );
+      }
+    },
+    [appendOutput, flushPending, patchSession],
   );
 
   const stop = useCallback(() => {
@@ -422,7 +710,9 @@ export function Terminal({
             ref={promptInputRef}
             disabled={!projectId}
             history={active?.history ?? []}
+            cwdLabel={formatPromptCwd(active?.cwd ?? null)}
             onRun={(cmd) => void runFreeCommand(cmd)}
+            onClear={clear}
           />
         )}
       </div>
@@ -722,9 +1012,11 @@ const Prompt = React.forwardRef<
   {
     disabled: boolean;
     history: string[];
+    cwdLabel: string;
     onRun: (cmd: string) => void;
+    onClear: () => void;
   }
->(function Prompt({ disabled, history, onRun }, ref) {
+>(function Prompt({ disabled, history, cwdLabel, onRun, onClear }, ref) {
   const [value, setValue] = useState("");
   const [histIdx, setHistIdx] = useState<number | null>(null);
 
@@ -747,6 +1039,9 @@ const Prompt = React.forwardRef<
         setHistIdx(null);
       }}
     >
+      {cwdLabel && (
+        <span className="shrink-0 select-none text-[#6a9955]">{cwdLabel}</span>
+      )}
       <span className="shrink-0 select-none text-[#4ec9b0]">$</span>
       <input
         ref={ref}
@@ -773,6 +1068,26 @@ const Prompt = React.forwardRef<
               setHistIdx(next);
               setValue(history[next] ?? "");
             }
+          } else if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "l") {
+            // Ctrl+L / ⌘K parity with a real shell: clear the buffer but
+            // preserve whatever the user was typing. We swallow the event so
+            // the browser doesn't focus the URL bar on Ctrl+L.
+            e.preventDefault();
+            onClear();
+          } else if (e.ctrlKey && e.key.toLowerCase() === "c" && !value) {
+            // Empty-line Ctrl+C in a real shell just reprints the prompt.
+            // With text selected we let the browser handle copy normally.
+            const sel = window.getSelection?.()?.toString();
+            if (!sel) {
+              e.preventDefault();
+              setValue("");
+              setHistIdx(null);
+            }
+          } else if (e.ctrlKey && e.key.toLowerCase() === "u") {
+            // Ctrl+U: kill line (shell parity).
+            e.preventDefault();
+            setValue("");
+            setHistIdx(null);
           }
         }}
         disabled={disabled}


### PR DESCRIPTION
## Closes

Closes #434

## What changed

- **API (`apps/api/src/routes/terminal.ts`)**: Add `POST /projects/:projectId/terminal/run` — stream combined stdout/stderr, clamp timeouts, spawn in a new process group, report final `pwd` via a per-request tempfile, append RS-framed base64 JSON metadata (`cwd`, `exitCode`, `signal`), single-shot teardown so `error` and `close` cannot double-close the stream, and pause child streams when the HTTP writer back-pressures. Preset `/terminal/exec` now uses the same detached spawn, backpressure, and single-settlement pattern so Stop/timeouts kill the full tree.
- **Proxy (`apps/api/src/server.ts`)**: Register `/api/projects/:projectId/terminal/run` for local `terminalRoutes` and Kubernetes pod proxy; forward `AbortSignal` and streaming bodies (`duplex: 'half'`) for both `run` and existing `exec` forward.
- **Client (`Terminal.tsx`)**: Track `cwd` / `prevCwd` per session, POST them with each run, parse and strip the metadata sentinel, local handling for `clear` / `cls` / `exit`, prompt cwd display, and rAF-batched output appends to avoid one React render per network chunk.

## How to verify

1. Open a project in the web IDE, Terminal panel: run `ls`, `pwd`, `mkdir demo && cd demo`, `pwd`, `cd -`, `pwd`.
2. Run something long-lived (`sleep 30`) and hit Stop — request should finish quickly and server child tree should not keep running.
3. Run a preset (e.g. typecheck) and Stop mid-run — same expectation.

## Notes

- Streaming terminal I/O uses `agentFetch` (session cookies on web, cookie header on native), consistent with `/terminal/exec` and other agent-proxy streaming in this app. The SDK `HttpClient` is not used here because it does not expose a streaming `Response` body for arbitrary shell output.

Made with [Cursor](https://cursor.com)