### PR TITLE
Persist AskUserQuestion poll drafts across app cold start

### DIFF
--- a/apps/mobile/components/chat/turns/AskUserQuestionWidget.tsx
+++ b/apps/mobile/components/chat/turns/AskUserQuestionWidget.tsx
@@ -15,12 +15,14 @@ import {
   ChevronRight,
   ChevronDown,
   MessageCircleQuestion,
+  RefreshCw,
 } from "lucide-react-native"
 import {
   type ToolCallData,
   type AskUserQuestionArgs,
   type AskUserQuestionItem,
 } from "../tools/types"
+import { useAskUserQuestionDraft } from "./useAskUserQuestionDraft"
 
 export interface AskUserQuestionWidgetProps {
   tool: ToolCallData
@@ -232,22 +234,29 @@ export function AskUserQuestionWidget({
   const questions = useMemo(() => parseQuestions(tool.args), [tool.args])
 
   const isPending = tool.result === undefined
-  const isAnswered = !isPending
 
-  const [isSubmitted, setIsSubmitted] = useState(false)
-  const [submittedResponse, setSubmittedResponse] = useState<string | null>(null)
+  const {
+    selections,
+    setSelections,
+    otherTexts,
+    setOtherTexts,
+    activeTab,
+    setActiveTab,
+    submittedResponse,
+    markSubmitted,
+    needsRetry,
+    answered: effectivelyAnswered,
+    displayResponse: hookDisplayResponse,
+  } = useAskUserQuestionDraft(tool.id, tool.result)
 
-  const effectivelyAnswered = isAnswered || isSubmitted
-  const effectivelyPending = isPending && !isSubmitted
+  // Poll stays interactive whenever the server hasn't resolved it AND we don't
+  // already have a locally-persisted submission. If a previous session died
+  // mid-submit, the Retry button below drives the re-send instead of letting
+  // the user accidentally re-answer.
+  const effectivelyPending = isPending && submittedResponse == null
 
   const [internalExpanded, setInternalExpanded] = useState(isPending)
   const isExpanded = controlledExpanded ?? internalExpanded
-
-  const [selections, setSelections] = useState<Map<number, string[]>>(
-    new Map()
-  )
-  const [otherTexts, setOtherTexts] = useState<Map<number, string>>(new Map())
-  const [activeTab, setActiveTab] = useState(0)
 
   const handleToggle = useCallback(() => {
     if (onToggle) {
@@ -311,16 +320,31 @@ export function AskUserQuestionWidget({
     if (!isValid) return
 
     const response = formatResponse(questions, selections, otherTexts)
-    setIsSubmitted(true)
-    setSubmittedResponse(response)
-    onSubmitResponse(response)
+    // Persist BEFORE firing the network call so a mid-submit app kill still
+    // leaves a recoverable record on disk.
+    void markSubmitted(response).then(() => {
+      onSubmitResponse(response)
+    })
 
     if (!onToggle) {
       setInternalExpanded(false)
     }
-  }, [isValid, questions, selections, otherTexts, onSubmitResponse, onToggle])
+  }, [
+    isValid,
+    questions,
+    selections,
+    otherTexts,
+    onSubmitResponse,
+    onToggle,
+    markSubmitted,
+  ])
 
-  const displayResult = submittedResponse ?? (typeof tool.result === "string" ? tool.result : null)
+  const handleRetry = useCallback(() => {
+    if (!submittedResponse) return
+    onSubmitResponse(submittedResponse)
+  }, [submittedResponse, onSubmitResponse])
+
+  const displayResult = hookDisplayResponse
 
   const summaryText = useMemo(() => {
     if (!effectivelyAnswered) return null
@@ -574,6 +598,29 @@ export function AskUserQuestionWidget({
               <Text className="text-xs text-foreground">
                 {displayResult}
               </Text>
+
+              {/*
+                Mid-submit recovery: we persisted a response locally but the
+                server never reported a result (likely because the app was
+                killed before sendMessage/saveToolOutput completed). Let the
+                user resend without re-answering the whole poll.
+              */}
+              {needsRetry && (
+                <View className="flex-row items-center justify-between mt-1.5 pt-1.5 border-t border-border/30">
+                  <Text className="text-[9px] text-muted-foreground">
+                    Response not yet confirmed by the assistant.
+                  </Text>
+                  <Pressable
+                    onPress={handleRetry}
+                    className="flex-row items-center gap-1 h-6 rounded-md border border-primary/30 bg-primary/5 px-2"
+                  >
+                    <RefreshCw className="w-2.5 h-2.5 text-primary" />
+                    <Text className="text-[10px] font-medium text-primary">
+                      Retry
+                    </Text>
+                  </Pressable>
+                </View>
+              )}
             </View>
           )}
         </View>

--- a/apps/mobile/components/chat/turns/__tests__/askUserQuestionDraftStore.test.ts
+++ b/apps/mobile/components/chat/turns/__tests__/askUserQuestionDraftStore.test.ts
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Tests for askUserQuestionDraftStore — the cold-start persistence layer
+ * that keeps a user's in-progress AskUserQuestion poll state alive across
+ * app background/kill cycles.
+ *
+ * These assertions directly characterize the two bugs the draft store is
+ * meant to fix:
+ *   Bug A: half-filled selections were lost when the app was backgrounded
+ *          or killed (no auto-save).
+ *   Bug B: an in-flight submission silently vanished if the app died
+ *          mid-send, leaving the poll appearing fresh/unanswered with no
+ *          trace that the user had already replied.
+ *
+ * Each test simulates a cold start by dropping the in-memory storage Map
+ * reference and re-running load against a freshly-constructed store.
+ *
+ * Run: bun test apps/mobile/components/chat/turns/__tests__/askUserQuestionDraftStore.test.ts
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test"
+import {
+  type DraftState,
+  type DraftStorage,
+  clearDraft,
+  deriveSubmissionStatus,
+  deserializeDraft,
+  draftKey,
+  emptyDraft,
+  entriesToOtherTexts,
+  entriesToSelections,
+  loadDraft,
+  otherTextsToEntries,
+  saveDraft,
+  selectionsToEntries,
+  serializeDraft,
+} from "../askUserQuestionDraftStore"
+
+function makeStorage(): { store: Map<string, string>; storage: DraftStorage } {
+  const store = new Map<string, string>()
+  const storage: DraftStorage = {
+    async getItem(key) {
+      return store.get(key) ?? null
+    },
+    async setItem(key, value) {
+      store.set(key, value)
+    },
+    async removeItem(key) {
+      store.delete(key)
+    },
+  }
+  return { store, storage }
+}
+
+let store: Map<string, string>
+let storage: DraftStorage
+
+beforeEach(() => {
+  const created = makeStorage()
+  store = created.store
+  storage = created.storage
+})
+
+describe("draftKey", () => {
+  test("namespaces keys under shogo:askUserDraft:", () => {
+    expect(draftKey("tc_123")).toBe("shogo:askUserDraft:tc_123")
+  })
+})
+
+describe("persistence round-trip (fixes Bug A)", () => {
+  test("draft persists selections across simulated cold start", async () => {
+    const toolCallId = "tc_coldstart"
+    const draft: DraftState = {
+      selections: selectionsToEntries(
+        new Map<number, string[]>([
+          [0, ["Option A"]],
+          [1, ["Option X", "__other__"]],
+        ])
+      ),
+      otherTexts: otherTextsToEntries(
+        new Map<number, string>([[1, "custom answer"]])
+      ),
+      activeTab: 1,
+      submittedResponse: null,
+      submittedAt: null,
+    }
+
+    await saveDraft(storage, toolCallId, draft)
+
+    // Simulate cold start: keep the underlying bytes in `store`, but hand
+    // them to a freshly-created storage façade. This models an app kill
+    // and relaunch — the in-memory widget state vanished, but AsyncStorage
+    // (backed by `store`) survives.
+    const coldStorage: DraftStorage = {
+      async getItem(key) {
+        return store.get(key) ?? null
+      },
+      async setItem(key, value) {
+        store.set(key, value)
+      },
+      async removeItem(key) {
+        store.delete(key)
+      },
+    }
+
+    const loaded = await loadDraft(coldStorage, toolCallId)
+    expect(loaded).not.toBeNull()
+    expect(loaded!.selections).toEqual(draft.selections)
+    expect(loaded!.otherTexts).toEqual(draft.otherTexts)
+    expect(loaded!.activeTab).toBe(1)
+  })
+
+  test("loadDraft returns null when nothing was saved", async () => {
+    expect(await loadDraft(storage, "tc_never_saved")).toBeNull()
+  })
+
+  test("loadDraft returns null on corrupt JSON", async () => {
+    store.set(draftKey("tc_corrupt"), "{ not valid json")
+    expect(await loadDraft(storage, "tc_corrupt")).toBeNull()
+  })
+
+  test("loadDraft returns null on non-object payloads", async () => {
+    store.set(draftKey("tc_null"), "null")
+    expect(await loadDraft(storage, "tc_null")).toBeNull()
+
+    store.set(draftKey("tc_num"), "42")
+    expect(await loadDraft(storage, "tc_num")).toBeNull()
+  })
+
+  test("saveDraft overwrites any previous value for the same tool call", async () => {
+    const toolCallId = "tc_overwrite"
+    await saveDraft(storage, toolCallId, {
+      ...emptyDraft(),
+      selections: [[0, ["first"]]],
+    })
+    await saveDraft(storage, toolCallId, {
+      ...emptyDraft(),
+      selections: [[0, ["second"]]],
+    })
+
+    const loaded = await loadDraft(storage, toolCallId)
+    expect(loaded!.selections).toEqual([[0, ["second"]]])
+  })
+})
+
+describe("hydration (fixes Bug A — widget reducer start state)", () => {
+  test("draft hydrates on first render when a previous session saved one", async () => {
+    const toolCallId = "tc_hydrate"
+    await saveDraft(storage, toolCallId, {
+      ...emptyDraft(),
+      selections: [[0, ["Yes"]]],
+      activeTab: 2,
+    })
+
+    const loaded = (await loadDraft(storage, toolCallId)) ?? emptyDraft()
+    const selections = entriesToSelections(loaded.selections)
+    const otherTexts = entriesToOtherTexts(loaded.otherTexts)
+
+    expect(selections.get(0)).toEqual(["Yes"])
+    expect(otherTexts.size).toBe(0)
+    expect(loaded.activeTab).toBe(2)
+  })
+
+  test("hydration falls back to empty state when no draft exists", async () => {
+    const loaded = (await loadDraft(storage, "tc_fresh")) ?? emptyDraft()
+    expect(loaded.selections).toEqual([])
+    expect(loaded.otherTexts).toEqual([])
+    expect(loaded.activeTab).toBe(0)
+    expect(loaded.submittedResponse).toBeNull()
+  })
+})
+
+describe("clear-on-tool-result (fixes Bug A — cleanup)", () => {
+  test("clearDraft removes the persisted entry", async () => {
+    const toolCallId = "tc_clear"
+    await saveDraft(storage, toolCallId, {
+      ...emptyDraft(),
+      selections: [[0, ["x"]]],
+    })
+    expect(store.has(draftKey(toolCallId))).toBe(true)
+
+    await clearDraft(storage, toolCallId)
+    expect(store.has(draftKey(toolCallId))).toBe(false)
+    expect(await loadDraft(storage, toolCallId)).toBeNull()
+  })
+
+  test("clearDraft is a no-op when nothing was saved", async () => {
+    await clearDraft(storage, "tc_empty")
+    expect(store.size).toBe(0)
+  })
+})
+
+describe("mid-submit survival (fixes Bug B)", () => {
+  test("submittedResponse survives a simulated mid-submit kill", async () => {
+    const toolCallId = "tc_midsubmit"
+
+    // handleSubmit wrote the response to disk BEFORE calling onSubmitResponse
+    await saveDraft(storage, toolCallId, {
+      selections: [[0, ["Approve"]]],
+      otherTexts: [],
+      activeTab: 0,
+      submittedResponse: "Approve",
+      submittedAt: 1_700_000_000_000,
+    })
+
+    // App dies here — sendMessage/saveToolOutput never fires.
+    // Cold start: widget mounts again with tool.result still undefined.
+    const loaded = await loadDraft(storage, toolCallId)
+    expect(loaded).not.toBeNull()
+    expect(loaded!.submittedResponse).toBe("Approve")
+
+    const status = deriveSubmissionStatus(undefined, loaded)
+    expect(status.answered).toBe(true)
+    expect(status.needsRetry).toBe(true)
+    expect(status.displayResponse).toBe("Approve")
+  })
+
+  test("server-confirmed result takes precedence over local submittedResponse", async () => {
+    const draft: DraftState = {
+      ...emptyDraft(),
+      submittedResponse: "locally stashed",
+      submittedAt: 1,
+    }
+    const status = deriveSubmissionStatus("server accepted", draft)
+    expect(status.answered).toBe(true)
+    expect(status.needsRetry).toBe(false)
+    expect(status.displayResponse).toBe("server accepted")
+  })
+
+  test("no draft + no server result = fresh/unanswered", () => {
+    const status = deriveSubmissionStatus(undefined, null)
+    expect(status.answered).toBe(false)
+    expect(status.needsRetry).toBe(false)
+    expect(status.displayResponse).toBeNull()
+  })
+
+  test("no local submission + server result = normal answered path", () => {
+    const status = deriveSubmissionStatus("ok", emptyDraft())
+    expect(status.answered).toBe(true)
+    expect(status.needsRetry).toBe(false)
+    expect(status.displayResponse).toBe("ok")
+  })
+})
+
+describe("cross-id isolation", () => {
+  test("stale draft from a different toolCallId is ignored", async () => {
+    await saveDraft(storage, "tc_other", {
+      ...emptyDraft(),
+      selections: [[0, ["leaked"]]],
+    })
+
+    const loaded = await loadDraft(storage, "tc_mine")
+    expect(loaded).toBeNull()
+  })
+
+  test("clearing one draft does not affect another", async () => {
+    await saveDraft(storage, "tc_a", {
+      ...emptyDraft(),
+      selections: [[0, ["a"]]],
+    })
+    await saveDraft(storage, "tc_b", {
+      ...emptyDraft(),
+      selections: [[0, ["b"]]],
+    })
+
+    await clearDraft(storage, "tc_a")
+
+    expect(await loadDraft(storage, "tc_a")).toBeNull()
+    const b = await loadDraft(storage, "tc_b")
+    expect(b!.selections).toEqual([[0, ["b"]]])
+  })
+})
+
+describe("Map <-> tuple serialization", () => {
+  test("selections round-trip preserves ordering and contents", () => {
+    const source = new Map<number, string[]>([
+      [0, ["a", "b"]],
+      [2, ["c"]],
+    ])
+    const roundtripped = entriesToSelections(selectionsToEntries(source))
+    expect(roundtripped.get(0)).toEqual(["a", "b"])
+    expect(roundtripped.get(2)).toEqual(["c"])
+    expect(roundtripped.size).toBe(2)
+  })
+
+  test("otherTexts round-trip preserves entries", () => {
+    const source = new Map<number, string>([
+      [1, "hello"],
+      [3, "world"],
+    ])
+    const roundtripped = entriesToOtherTexts(otherTextsToEntries(source))
+    expect(roundtripped.get(1)).toBe("hello")
+    expect(roundtripped.get(3)).toBe("world")
+  })
+
+  test("serializeDraft -> deserializeDraft preserves shape", () => {
+    const draft: DraftState = {
+      selections: [
+        [0, ["x"]],
+        [1, ["y", "__other__"]],
+      ],
+      otherTexts: [[1, "typed value"]],
+      activeTab: 1,
+      submittedResponse: null,
+      submittedAt: null,
+    }
+    const roundtripped = deserializeDraft(JSON.parse(serializeDraft(draft)))
+    expect(roundtripped).toEqual(draft)
+  })
+
+  test("deserializeDraft drops malformed entries instead of throwing", () => {
+    const result = deserializeDraft({
+      selections: [
+        [0, ["good"]],
+        ["bad-key", ["also bad"]],
+        [1, "not-an-array"],
+      ],
+      otherTexts: [
+        [0, "ok"],
+        [1, 42],
+      ],
+      activeTab: "not-a-number",
+      submittedResponse: 123,
+      submittedAt: "nope",
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.selections).toEqual([[0, ["good"]]])
+    expect(result!.otherTexts).toEqual([[0, "ok"]])
+    expect(result!.activeTab).toBe(0)
+    expect(result!.submittedResponse).toBeNull()
+    expect(result!.submittedAt).toBeNull()
+  })
+})

--- a/apps/mobile/components/chat/turns/askUserQuestionDraftStore.ts
+++ b/apps/mobile/components/chat/turns/askUserQuestionDraftStore.ts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * AskUserQuestion draft persistence.
+ *
+ * Pure, dependency-injected functions that persist the user's in-progress
+ * selections (and any in-flight submission) for the AskUserQuestion poll,
+ * keyed by tool call id. Keeping this module storage-agnostic lets us unit
+ * test the round-trip + lifecycle semantics with bun:test and an in-memory
+ * Map — no React, no AsyncStorage native module required.
+ *
+ * Lifecycle:
+ *   - saveDraft is called (debounced) whenever the user edits selections.
+ *   - loadDraft is called once on widget mount to hydrate local state.
+ *   - clearDraft is called once the server-side tool.result transitions from
+ *     undefined to defined (the agent accepted our answer) — or when the user
+ *     successfully re-submits after a crash.
+ *
+ * A non-null `submittedResponse` in the persisted draft means we already sent
+ * (or tried to send) a final answer. If the app was killed mid-submit, the
+ * widget uses this to render an "answered" state and expose a Retry button.
+ */
+
+export interface DraftState {
+  /** Entries of the `selections` Map<number, string[]> used in the widget. */
+  selections: Array<[number, string[]]>
+  /** Entries of the `otherTexts` Map<number, string> used in the widget. */
+  otherTexts: Array<[number, string]>
+  /** Which question tab was last focused. */
+  activeTab: number
+  /** Set once handleSubmit has formatted a response, even if the network call that follows never completed. */
+  submittedResponse: string | null
+  /** Wall-clock ms when submittedResponse was written. Useful for retry/stale heuristics. */
+  submittedAt: number | null
+}
+
+/**
+ * Minimal storage surface — a strict subset of AsyncStorage so it can be
+ * satisfied by an in-memory Map in tests. Intentionally Promise-based to
+ * match AsyncStorage even though the test double is synchronous.
+ */
+export interface DraftStorage {
+  getItem(key: string): Promise<string | null>
+  setItem(key: string, value: string): Promise<void>
+  removeItem(key: string): Promise<void>
+}
+
+/** Storage key namespace. Kept stable so drafts survive JS reloads. */
+export const DRAFT_KEY_PREFIX = "shogo:askUserDraft:"
+
+export function draftKey(toolCallId: string): string {
+  return `${DRAFT_KEY_PREFIX}${toolCallId}`
+}
+
+export function emptyDraft(): DraftState {
+  return {
+    selections: [],
+    otherTexts: [],
+    activeTab: 0,
+    submittedResponse: null,
+    submittedAt: null,
+  }
+}
+
+/**
+ * Normalizes a decoded value into a DraftState, tolerating partial/legacy
+ * shapes. Returns null if the value is not recognizable as a draft at all.
+ */
+export function deserializeDraft(raw: unknown): DraftState | null {
+  if (!raw || typeof raw !== "object") return null
+  const r = raw as Record<string, unknown>
+
+  const selections = Array.isArray(r.selections)
+    ? r.selections.filter(
+        (entry): entry is [number, string[]] =>
+          Array.isArray(entry) &&
+          entry.length === 2 &&
+          typeof entry[0] === "number" &&
+          Array.isArray(entry[1]) &&
+          entry[1].every((s) => typeof s === "string")
+      )
+    : []
+
+  const otherTexts = Array.isArray(r.otherTexts)
+    ? r.otherTexts.filter(
+        (entry): entry is [number, string] =>
+          Array.isArray(entry) &&
+          entry.length === 2 &&
+          typeof entry[0] === "number" &&
+          typeof entry[1] === "string"
+      )
+    : []
+
+  return {
+    selections,
+    otherTexts,
+    activeTab: typeof r.activeTab === "number" ? r.activeTab : 0,
+    submittedResponse:
+      typeof r.submittedResponse === "string" ? r.submittedResponse : null,
+    submittedAt: typeof r.submittedAt === "number" ? r.submittedAt : null,
+  }
+}
+
+export function serializeDraft(draft: DraftState): string {
+  return JSON.stringify(draft)
+}
+
+/** Convert a Map<number, string[]> to the tuple form persisted on disk. */
+export function selectionsToEntries(
+  selections: Map<number, string[]>
+): Array<[number, string[]]> {
+  return Array.from(selections.entries())
+}
+
+/** Convert a Map<number, string> to the tuple form persisted on disk. */
+export function otherTextsToEntries(
+  otherTexts: Map<number, string>
+): Array<[number, string]> {
+  return Array.from(otherTexts.entries())
+}
+
+/** Inverse of selectionsToEntries — returns a fresh Map. */
+export function entriesToSelections(
+  entries: Array<[number, string[]]>
+): Map<number, string[]> {
+  return new Map(entries)
+}
+
+/** Inverse of otherTextsToEntries — returns a fresh Map. */
+export function entriesToOtherTexts(
+  entries: Array<[number, string]>
+): Map<number, string> {
+  return new Map(entries)
+}
+
+export async function saveDraft(
+  storage: DraftStorage,
+  toolCallId: string,
+  draft: DraftState
+): Promise<void> {
+  await storage.setItem(draftKey(toolCallId), serializeDraft(draft))
+}
+
+export async function loadDraft(
+  storage: DraftStorage,
+  toolCallId: string
+): Promise<DraftState | null> {
+  const raw = await storage.getItem(draftKey(toolCallId))
+  if (raw == null) return null
+  try {
+    return deserializeDraft(JSON.parse(raw))
+  } catch {
+    return null
+  }
+}
+
+export async function clearDraft(
+  storage: DraftStorage,
+  toolCallId: string
+): Promise<void> {
+  await storage.removeItem(draftKey(toolCallId))
+}
+
+/**
+ * Derives the widget-facing view of the current draft + server result:
+ *
+ *   - answered:    we should render the "answered" UI (either server confirmed or we have a locally persisted submittedResponse)
+ *   - needsRetry:  we have a persisted submittedResponse but the server still reports undefined — the last submit likely died with the app
+ *   - displayResponse: what to show under "Your Response" (server result wins over local draft)
+ */
+export function deriveSubmissionStatus(
+  toolResult: unknown,
+  draft: DraftState | null
+): {
+  answered: boolean
+  needsRetry: boolean
+  displayResponse: string | null
+} {
+  const serverAnswered = toolResult !== undefined
+  const locallySubmitted = draft?.submittedResponse != null
+
+  const displayResponse = serverAnswered
+    ? typeof toolResult === "string"
+      ? toolResult
+      : null
+    : (draft?.submittedResponse ?? null)
+
+  return {
+    answered: serverAnswered || locallySubmitted,
+    needsRetry: !serverAnswered && locallySubmitted,
+    displayResponse,
+  }
+}

--- a/apps/mobile/components/chat/turns/useAskUserQuestionDraft.ts
+++ b/apps/mobile/components/chat/turns/useAskUserQuestionDraft.ts
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * React hook wrapping askUserQuestionDraftStore with the lifecycle the
+ * AskUserQuestionWidget needs:
+ *
+ *   - Hydrate once on mount from AsyncStorage, keyed by toolCallId.
+ *   - Debounce writes so every keystroke in the "Other" text field doesn't
+ *     hit AsyncStorage.
+ *   - Clear the persisted draft when the server reports a result, i.e. the
+ *     agent accepted our answer. This is also the single point where we
+ *     reconcile the "mid-submit kill" retry state.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import AsyncStorage from "@react-native-async-storage/async-storage"
+import {
+  type DraftState,
+  type DraftStorage,
+  clearDraft,
+  deriveSubmissionStatus,
+  emptyDraft,
+  entriesToOtherTexts,
+  entriesToSelections,
+  loadDraft,
+  otherTextsToEntries,
+  saveDraft,
+  selectionsToEntries,
+} from "./askUserQuestionDraftStore"
+
+const DEBOUNCE_MS = 250
+
+export interface UseAskUserQuestionDraftOptions {
+  /** Override the backing storage. Defaults to AsyncStorage. Useful for tests. */
+  storage?: DraftStorage
+}
+
+export interface UseAskUserQuestionDraftResult {
+  /** True once the first load attempt has completed. Until then the widget should render from empty defaults. */
+  hydrated: boolean
+  selections: Map<number, string[]>
+  setSelections: React.Dispatch<React.SetStateAction<Map<number, string[]>>>
+  otherTexts: Map<number, string>
+  setOtherTexts: React.Dispatch<React.SetStateAction<Map<number, string>>>
+  activeTab: number
+  setActiveTab: React.Dispatch<React.SetStateAction<number>>
+  /** Locally persisted response, if the user submitted in a previous (or the current) session. */
+  submittedResponse: string | null
+  /** Marks the draft as submitted and flushes to storage synchronously. Call BEFORE firing network submit. */
+  markSubmitted: (response: string) => Promise<void>
+  /** We have a local submission but the server has not yet confirmed it — the widget should offer Retry. */
+  needsRetry: boolean
+  /** Either the server confirmed, or we locally submitted — the widget should render "answered". */
+  answered: boolean
+  /** String to show under "Your Response" (server result preferred over local draft). */
+  displayResponse: string | null
+}
+
+export function useAskUserQuestionDraft(
+  toolCallId: string,
+  toolResult: unknown,
+  options: UseAskUserQuestionDraftOptions = {}
+): UseAskUserQuestionDraftResult {
+  const storage: DraftStorage = options.storage ?? AsyncStorage
+  const storageRef = useRef(storage)
+  storageRef.current = storage
+
+  const [hydrated, setHydrated] = useState(false)
+  const [selections, setSelections] = useState<Map<number, string[]>>(
+    () => new Map()
+  )
+  const [otherTexts, setOtherTexts] = useState<Map<number, string>>(
+    () => new Map()
+  )
+  const [activeTab, setActiveTab] = useState(0)
+  const [submittedResponse, setSubmittedResponse] = useState<string | null>(
+    null
+  )
+  const submittedAtRef = useRef<number | null>(null)
+
+  // Hydrate on mount (or when toolCallId changes — rare, but harmless).
+  useEffect(() => {
+    let cancelled = false
+    setHydrated(false)
+
+    loadDraft(storageRef.current, toolCallId)
+      .then((loaded) => {
+        if (cancelled) return
+        if (loaded) {
+          setSelections(entriesToSelections(loaded.selections))
+          setOtherTexts(entriesToOtherTexts(loaded.otherTexts))
+          setActiveTab(loaded.activeTab)
+          setSubmittedResponse(loaded.submittedResponse)
+          submittedAtRef.current = loaded.submittedAt
+        } else {
+          setSelections(new Map())
+          setOtherTexts(new Map())
+          setActiveTab(0)
+          setSubmittedResponse(null)
+          submittedAtRef.current = null
+        }
+      })
+      .catch(() => {
+        // Non-fatal: widget keeps working in-memory if AsyncStorage is unavailable.
+      })
+      .finally(() => {
+        if (!cancelled) setHydrated(true)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [toolCallId])
+
+  // Once the server confirms a result, drop the local draft — no point
+  // keeping it around, and it would shadow a future ask_user with the same
+  // (highly unlikely) reused id. Also rearms the hook for any fresh state.
+  const serverAnswered = toolResult !== undefined
+  useEffect(() => {
+    if (!hydrated) return
+    if (!serverAnswered) return
+    clearDraft(storageRef.current, toolCallId).catch(() => {
+      // Best-effort cleanup.
+    })
+  }, [hydrated, serverAnswered, toolCallId])
+
+  // Debounced auto-save on any editable-state change.
+  useEffect(() => {
+    if (!hydrated) return
+    if (serverAnswered) return // Nothing left to persist; cleanup above will run.
+
+    const handle = setTimeout(() => {
+      const draft: DraftState = {
+        selections: selectionsToEntries(selections),
+        otherTexts: otherTextsToEntries(otherTexts),
+        activeTab,
+        submittedResponse,
+        submittedAt: submittedAtRef.current,
+      }
+      saveDraft(storageRef.current, toolCallId, draft).catch(() => {
+        // Best-effort; next state change will try again.
+      })
+    }, DEBOUNCE_MS)
+
+    return () => clearTimeout(handle)
+  }, [
+    hydrated,
+    serverAnswered,
+    toolCallId,
+    selections,
+    otherTexts,
+    activeTab,
+    submittedResponse,
+  ])
+
+  // Flush the submitted response synchronously so a mid-submit app kill
+  // still leaves a recoverable record on disk. The debounced effect above
+  // would race the network call otherwise.
+  const markSubmitted = useCallback(
+    async (response: string) => {
+      const now = Date.now()
+      submittedAtRef.current = now
+      setSubmittedResponse(response)
+      const draft: DraftState = {
+        selections: selectionsToEntries(selections),
+        otherTexts: otherTextsToEntries(otherTexts),
+        activeTab,
+        submittedResponse: response,
+        submittedAt: now,
+      }
+      try {
+        await saveDraft(storageRef.current, toolCallId, draft)
+      } catch {
+        // If persistence fails, the widget still functions in-memory.
+      }
+    },
+    [toolCallId, selections, otherTexts, activeTab]
+  )
+
+  const status = deriveSubmissionStatus(
+    toolResult,
+    submittedResponse != null
+      ? {
+          ...emptyDraft(),
+          submittedResponse,
+          submittedAt: submittedAtRef.current,
+        }
+      : null
+  )
+
+  return {
+    hydrated,
+    selections,
+    setSelections,
+    otherTexts,
+    setOtherTexts,
+    activeTab,
+    setActiveTab,
+    submittedResponse,
+    markSubmitted,
+    needsRetry: status.needsRetry,
+    answered: status.answered,
+    displayResponse: status.displayResponse,
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes two cold-start bugs in the mobile AskUserQuestion poll widget: partial selections were lost when the app was backgrounded/killed (no auto-save), and an in-flight submission could silently vanish before the server acked, leaving the poll looking unanswered with no retry path.
- Extracts a pure `askUserQuestionDraftStore` (AsyncStorage injected as a `DraftStorage` interface) plus a `useAskUserQuestionDraft` hook that hydrates on mount, auto-saves with a 250 ms debounce, clears the draft when `tool.result` resolves, and exposes `needsRetry` for mid-submit recovery.
- `handleSubmit` now flushes the response to disk **before** firing the network call, and the widget renders a Retry affordance (`Response not yet confirmed by the assistant.` + button) when a persisted submission has not yet been confirmed.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Half-fill poll, background/kill app, return | Selections gone | Selections restored from `shogo:askUserDraft:<toolCallId>` |
| Submit poll, app killed before server ack | Poll re-renders blank, pending, no trace of answer | Poll shows "Your Response" with a Retry button; user re-sends with one tap |
| Server confirms answer normally | Widget shows result | Widget shows result AND clears the on-disk draft |
| Two `ask_user` polls in flight simultaneously | n/a (purely in-memory) | Each poll's draft is isolated by `tool.id` |

## Test plan

- [x] 20 new `bun:test` cases in `apps/mobile/components/chat/turns/__tests__/askUserQuestionDraftStore.test.ts` (persistence round-trip across simulated cold start, hydration, clear-on-result, mid-submit survival, cross-id isolation, serialization invariants). All green.
- [x] All pre-existing `apps/mobile/components/chat/**` tests still pass (35/35 total).
- [ ] Manual smoke on a device: half-fill a poll, swipe-kill the app, relaunch — selections should restore.
- [ ] Manual smoke on a device: submit a poll while offline or with airplane mode flipped mid-submit — Retry affordance should appear, tapping it re-sends the stashed response.

## Files

- New: `apps/mobile/components/chat/turns/askUserQuestionDraftStore.ts`
- New: `apps/mobile/components/chat/turns/useAskUserQuestionDraft.ts`
- New: `apps/mobile/components/chat/turns/__tests__/askUserQuestionDraftStore.test.ts`
- Edit: `apps/mobile/components/chat/turns/AskUserQuestionWidget.tsx` (swap raw `useState` for the hook; add Retry affordance)

## Out of scope

- Network-disconnect while mounted (socket drop) — separate concern from app-background; can layer on later via the same store.
- Web/desktop parity; this PR targets `apps/mobile` only.
- Cross-device sync of drafts (local-only persistence is sufficient for cold-start recovery).
