### PR TITLE
fix(mobile): sync Plans Build model with chat selection

### DIFF
--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -1508,7 +1508,7 @@ export default observer(function ProjectLayout() {
               <ChannelsPanel visible={previewTab === 'channels'} projectId={projectId!} agentUrl={agentUrl} hasAdvancedModelAccess={features.billing ? billingData.hasAdvancedModelAccess : true} />
               <AgentsPanel visible={previewTab === 'agents'} selectedToolId={selectedAgentToolId} agentUrl={agentUrl} />
               <MonitorPanel visible={previewTab === 'monitor'} projectId={projectId!} agentUrl={agentUrl} isPaidPlan={effectiveHasActiveSubscription} />
-              <PlansPanel visible={previewTab === 'plans'} projectId={projectId!} agentUrl={agentUrl} onBuildPlan={handleBuildPlan} />
+              <PlansPanel visible={previewTab === 'plans'} projectId={projectId!} agentUrl={agentUrl} selectedModel={selectedModel} onBuildPlan={handleBuildPlan} />
               <CheckpointsPanel visible={previewTab === 'checkpoints'} projectId={projectId!} />
             </View>
           </View>

--- a/apps/mobile/components/project/panels/PlansPanel.tsx
+++ b/apps/mobile/components/project/panels/PlansPanel.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
-import { useState, useEffect, useCallback, useMemo } from "react"
+import { useState, useEffect, useCallback, useMemo, useRef } from "react"
 import {
   View,
   Text,
@@ -55,6 +55,7 @@ interface PlansPanelProps {
   visible: boolean
   projectId: string
   agentUrl?: string | null
+  selectedModel?: string
   onBuildPlan?: (plan: PlanData, modelId: string) => void
 }
 
@@ -100,7 +101,7 @@ function extractTodos(
   return todos
 }
 
-export function PlansPanel({ visible, projectId, agentUrl, onBuildPlan }: PlansPanelProps) {
+export function PlansPanel({ visible, projectId, agentUrl, selectedModel, onBuildPlan }: PlansPanelProps) {
   const planStream = usePlanStreamSafe()
   const [plans, setPlans] = useState<AgentPlanSummary[]>([])
   const [loading, setLoading] = useState(false)
@@ -108,8 +109,28 @@ export function PlansPanel({ visible, projectId, agentUrl, onBuildPlan }: PlansP
   const [planContent, setPlanContent] = useState<string | null>(null)
   const [detailLoading, setDetailLoading] = useState(false)
   const [searchQuery, setSearchQuery] = useState("")
-  const [buildMode, setBuildMode] = useState<string>(DEFAULT_MODEL_PRO)
+  const [buildMode, setBuildMode] = useState<string>(selectedModel || DEFAULT_MODEL_PRO)
   const [showModelPicker, setShowModelPicker] = useState(false)
+  const prevSelectedPlanRef = useRef<string | null>(null)
+
+  // Align Build model with chat when opening a plan or switching plans — not when only
+  // `selectedModel` changes while staying on the same plan (preserves Plans-picker override).
+  useEffect(() => {
+    const prev = prevSelectedPlanRef.current
+    prevSelectedPlanRef.current = selectedPlan
+
+    if (!selectedPlan || selectedPlan === "__streaming__") return
+
+    const enteredFromList = !prev && !!selectedPlan
+    const switchedBetweenPlans =
+      !!prev && prev !== "__streaming__" && prev !== selectedPlan
+    const leftStreamingToFile =
+      prev === "__streaming__" && selectedPlan !== "__streaming__"
+
+    if (enteredFromList || switchedBetweenPlans || leftStreamingToFile) {
+      setBuildMode(selectedModel || DEFAULT_MODEL_PRO)
+    }
+  }, [selectedPlan, selectedModel])
 
   const baseUrl = agentUrl || `${API_URL}/api/projects/${projectId}/agent-proxy`
 


### PR DESCRIPTION
## Summary
<img width="1512" height="982" alt="Screenshot 2026-04-24 at 3 39 15 PM" src="https://github.com/user-attachments/assets/43cf6e37-c5c9-4fd8-ae2f-125ddc5dafce" />
Aligns the **Plans** tab **Build** model dropdown with the project chat model, and documents the behavior in #439.

## Changes

- **Layout:** pass `selectedModel` into `PlansPanel` (same source as `ChatPanel` / capabilities).
- **PlansPanel:** initialize `buildMode` from `selectedModel`, use `DEFAULT_MODEL_PRO` as fallback, and resync when the user **opens** a plan, **switches** plans, or finishes **streaming** to a saved file — not when only the chat model changes while viewing the same plan (preserves a deliberate Plans-only override).

Closes #439
