### PR TITLE
feat: durable long-running agent sessions and turn recovery

### DIFF
--- a/apps/api/src/lib/runtime/manager.ts
+++ b/apps/api/src/lib/runtime/manager.ts
@@ -766,6 +766,10 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         console.log(`[RuntimeManager] Vite process exited for ${projectId}: code=${code}, signal=${signal}`)
         if (runtime.status !== 'stopping' && runtime.status !== 'stopped') {
           runtime.status = 'stopped'
+          this.stopHealthCheck(projectId)
+          if (runtime.agentProcess && !runtime.agentProcess.killed) {
+            runtime.agentProcess.kill('SIGTERM')
+          }
         }
         this.releasePort(port)
       })
@@ -930,6 +934,11 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           console.log(`[RuntimeManager] Agent process exited for ${projectId}: code=${code}, signal=${signal}`)
           if (runtime.status !== 'stopping' && runtime.status !== 'stopped') {
             runtime.status = 'stopped'
+            this.stopHealthCheck(projectId)
+            if (runtime.process && !runtime.process.killed) {
+              runtime.process.kill('SIGTERM')
+            }
+            this.releasePort(port)
           }
         })
 
@@ -1061,32 +1070,104 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     throw new Error(`Timeout waiting for agent server ${projectId} to start on port ${port} after ${MAX_RETRIES} attempts`)
   }
 
-  async stop(projectId: string): Promise<void> {
+  /**
+   * Stop a project's runtime processes.
+   *
+   * For long-running agent turns we must not SIGKILL eagerly; the agent
+   * runtime's own graceful shutdown needs time to drain active streams and
+   * mark unfinished turns `interrupted_recoverable`. Callers with urgency
+   * (force remove, unit tests, project delete) can pass a small
+   * `maxAgentWaitMs`; API graceful-shutdown passes the drain-aligned value.
+   *
+   * Defaults:
+   *   AGENT_KILL_GRACE_MS (env) — SIGTERM→SIGKILL window for the agent
+   *     process. Defaults to AGENT_DRAIN_TIMEOUT_MS if not set, else 30 min.
+   *   VITE_KILL_GRACE_MS (env) — same for the Vite child. Defaults 10s.
+   *
+   * During the wait we poll the agent's /agent/health?waitDrain=1 so a clean
+   * drain resolves before the hard-kill timer fires.
+   */
+  async stop(projectId: string, options: {
+    reason?: 'api-shutdown' | 'project-removed' | 'health-failure' | 'user-stop' | 'restart'
+    maxAgentWaitMs?: number
+    maxViteWaitMs?: number
+  } = {}): Promise<void> {
     const runtime = this.runtimes.get(projectId)
     if (!runtime) {
-      // Idempotent: succeed silently if not running
       return
     }
 
     this.stopHealthCheck(projectId)
     runtime.status = 'stopping'
 
-    // Stop agent process first
-    if (runtime.agentProcess) {
-      runtime.agentProcess.kill('SIGTERM')
-      await new Promise<void>((resolve) => {
-        const timeout = setTimeout(() => {
-          if (runtime.agentProcess && !runtime.agentProcess.killed) {
-            runtime.agentProcess.kill('SIGKILL')
-          }
-          resolve()
-        }, 3000)
+    const defaultAgentGrace = Number(
+      process.env.AGENT_KILL_GRACE_MS
+        || process.env.AGENT_DRAIN_TIMEOUT_MS
+        || 30 * 60 * 1000,
+    )
+    const defaultViteGrace = Number(process.env.VITE_KILL_GRACE_MS || 10_000)
+    const agentWaitMs = Math.max(1_000, options.maxAgentWaitMs ?? defaultAgentGrace)
+    const viteWaitMs = Math.max(1_000, options.maxViteWaitMs ?? defaultViteGrace)
 
-        runtime.agentProcess?.on('exit', () => {
-          clearTimeout(timeout)
-          resolve()
+    console.log(
+      `[RuntimeManager] Stopping runtime ${projectId} ` +
+      `(reason=${options.reason || 'unspecified'}, agent-grace=${agentWaitMs}ms, vite-grace=${viteWaitMs}ms)`,
+    )
+
+    if (runtime.agentProcess && runtime.agentPort) {
+      runtime.agentProcess.kill('SIGTERM')
+      const agentPort = runtime.agentPort
+      const start = Date.now()
+      const processRef = runtime.agentProcess
+      const drainedOrExited = await Promise.race([
+        new Promise<'exited'>((resolve) => {
+          processRef.once('exit', () => resolve('exited'))
+        }),
+        new Promise<'drained'>(async (resolve) => {
+          while (Date.now() - start < agentWaitMs) {
+            if (processRef.killed || processRef.exitCode !== null) {
+              resolve('drained')
+              return
+            }
+            try {
+              const res = await fetch(
+                `http://localhost:${agentPort}/agent/health`,
+                { signal: AbortSignal.timeout(1_500) },
+              )
+              if (res.ok) {
+                const body = await res.json().catch(() => null) as any
+                const activeTurns = Number(body?.activeTurns ?? body?.activeStreams ?? 0)
+                if (activeTurns === 0) {
+                  resolve('drained')
+                  return
+                }
+              } else if (res.status === 503) {
+                resolve('drained')
+                return
+              }
+            } catch {
+              // agent not responding — probably gone; wait for exit event
+            }
+            await new Promise((r) => setTimeout(r, 500))
+          }
+          resolve('drained')
+        }),
+      ])
+
+      if (drainedOrExited !== 'exited' && processRef && !processRef.killed && processRef.exitCode === null) {
+        console.warn(
+          `[RuntimeManager] Agent ${projectId} did not exit within ${agentWaitMs}ms ` +
+          `(reason=${options.reason || 'unspecified'}) — sending SIGKILL`,
+        )
+        processRef.kill('SIGKILL')
+        await new Promise<void>((resolve) => {
+          const t = setTimeout(resolve, 1_000)
+          processRef.once('exit', () => {
+            clearTimeout(t)
+            resolve()
+          })
         })
-      })
+      }
     }
 
     if (runtime.process) {
@@ -1097,7 +1178,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
             runtime.process.kill('SIGKILL')
           }
           resolve()
-        }, 5000)
+        }, viteWaitMs)
 
         runtime.process?.on('exit', () => {
           clearTimeout(timeout)
@@ -1117,7 +1198,11 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     const existing = this.runtimes.get(projectId)
     if (existing && existing.status !== 'stopped') {
       console.log(`[RuntimeManager] Stopping existing runtime for ${projectId}`)
-      await this.stop(projectId)
+      // Restart is called to recover from an unresponsive runtime — cap the
+      // drain wait to something short so the caller isn't blocked forever
+      // on a process that can't gracefully shut down.
+      const restartWait = Number(process.env.RUNTIME_RESTART_WAIT_MS || 10_000)
+      await this.stop(projectId, { reason: 'restart', maxAgentWaitMs: restartWait, maxViteWaitMs: restartWait })
     }
 
     console.log(`[RuntimeManager] Starting fresh runtime for ${projectId}`)
@@ -1170,9 +1255,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     }
   }
 
-  async stopAll(): Promise<void> {
+  async stopAll(options: { reason?: 'api-shutdown' | 'project-removed' | 'restart'; maxAgentWaitMs?: number } = {}): Promise<void> {
     const stopPromises = Array.from(this.runtimes.keys()).map((projectId) =>
-      this.stop(projectId).catch((err) =>
+      this.stop(projectId, { reason: options.reason || 'api-shutdown', maxAgentWaitMs: options.maxAgentWaitMs }).catch((err) =>
         console.error(`[RuntimeManager] Failed to stop ${projectId}:`, err)
       )
     )

--- a/apps/api/src/lib/runtime/types.ts
+++ b/apps/api/src/lib/runtime/types.ts
@@ -75,8 +75,19 @@ export interface IRuntimeManager {
 
   /**
    * Stop the runtime for the specified project.
+   *
+   * The optional `options` let callers pick an urgency profile:
+   *   - reason: label for logs/metrics
+   *   - maxAgentWaitMs / maxViteWaitMs: upper bound before SIGKILL
+   *
+   * Defaults align with AGENT_DRAIN_TIMEOUT_MS so long-running turns can
+   * drain before the agent process is forcibly killed.
    */
-  stop(projectId: string): Promise<void>
+  stop(projectId: string, options?: {
+    reason?: 'api-shutdown' | 'project-removed' | 'health-failure' | 'user-stop' | 'restart'
+    maxAgentWaitMs?: number
+    maxViteWaitMs?: number
+  }): Promise<void>
 
   /**
    * Restart the runtime for the specified project.
@@ -96,7 +107,7 @@ export interface IRuntimeManager {
   /**
    * Stop all active runtimes.
    */
-  stopAll(): Promise<void>
+  stopAll(options?: { reason?: 'api-shutdown' | 'project-removed' | 'restart'; maxAgentWaitMs?: number }): Promise<void>
 
   /**
    * Get list of all active project IDs.

--- a/apps/api/src/lib/turns/turn-store.ts
+++ b/apps/api/src/lib/turns/turn-store.ts
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * In-memory turn store on the API side.
+ *
+ * Runtimes (via `/agent/turns/:turnId/status` and a best-effort push to
+ * `/projects/:projectId/turns/ingest`) populate this store with the
+ * semantic lifecycle of every active turn. The store is NOT the source of
+ * truth — the runtime's on-disk TurnCheckpointLedger is — but it lets the
+ * API answer health/observability and UI-poll queries without round-tripping
+ * to the runtime for every request.
+ *
+ * Design:
+ * - Bounded retention: evict entries older than `retentionMs` (default 1h)
+ *   on every mutation. Keeps memory constant even under heavy churn.
+ * - Per-turn history capped to `maxCheckpointsPerTurn` (default 64) to
+ *   protect against runaway producers.
+ * - Thread-safe for Node single-thread JS — no async in hot paths.
+ */
+
+export type TurnStatus =
+  | 'active'
+  | 'completed'
+  | 'aborted'
+  | 'interrupted_recoverable'
+  | 'max_continuations'
+  | 'provider_fatal'
+  | 'loop_detected'
+
+export interface StoredTurnCheckpoint {
+  seq: number
+  at: number
+  attempt: number
+  reason: string
+  willContinue: boolean
+  iterations: number
+  toolCallsThisAttempt: number
+  toolCallsTotal: number
+  outputTokensTotal: number
+  lastStopReason?: string
+  modelId?: string
+  error?: string
+  extra?: Record<string, unknown>
+}
+
+export interface StoredTurn {
+  turnId: string
+  projectId: string
+  chatSessionId?: string
+  runtimeId?: string
+  status: TurnStatus
+  createdAt: number
+  updatedAt: number
+  terminalReason?: string
+  checkpoints: StoredTurnCheckpoint[]
+}
+
+export interface TurnStoreOptions {
+  retentionMs?: number
+  maxCheckpointsPerTurn?: number
+  maxTurns?: number
+}
+
+const DEFAULT_RETENTION_MS = 60 * 60 * 1000
+const DEFAULT_MAX_CHECKPOINTS = 64
+const DEFAULT_MAX_TURNS = 1024
+
+export class TurnStore {
+  private readonly retentionMs: number
+  private readonly maxCheckpointsPerTurn: number
+  private readonly maxTurns: number
+  private readonly turns = new Map<string, StoredTurn>()
+
+  constructor(options: TurnStoreOptions = {}) {
+    this.retentionMs = options.retentionMs ?? DEFAULT_RETENTION_MS
+    this.maxCheckpointsPerTurn = options.maxCheckpointsPerTurn ?? DEFAULT_MAX_CHECKPOINTS
+    this.maxTurns = options.maxTurns ?? DEFAULT_MAX_TURNS
+  }
+
+  upsertStart(input: {
+    turnId: string
+    projectId: string
+    chatSessionId?: string
+    runtimeId?: string
+  }): StoredTurn {
+    this.evictIfNeeded()
+    const existing = this.turns.get(input.turnId)
+    if (existing) {
+      existing.updatedAt = Date.now()
+      return existing
+    }
+    const now = Date.now()
+    const turn: StoredTurn = {
+      turnId: input.turnId,
+      projectId: input.projectId,
+      chatSessionId: input.chatSessionId,
+      runtimeId: input.runtimeId,
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+      checkpoints: [],
+    }
+    this.turns.set(input.turnId, turn)
+    return turn
+  }
+
+  appendCheckpoint(turnId: string, cp: Omit<StoredTurnCheckpoint, 'seq' | 'at'> & Partial<Pick<StoredTurnCheckpoint, 'seq' | 'at'>>): StoredTurn | null {
+    const turn = this.turns.get(turnId)
+    if (!turn) return null
+    const seq = cp.seq ?? (turn.checkpoints.length > 0 ? turn.checkpoints[turn.checkpoints.length - 1].seq + 1 : 1)
+    const record: StoredTurnCheckpoint = {
+      seq,
+      at: cp.at ?? Date.now(),
+      attempt: cp.attempt,
+      reason: cp.reason,
+      willContinue: cp.willContinue,
+      iterations: cp.iterations,
+      toolCallsThisAttempt: cp.toolCallsThisAttempt,
+      toolCallsTotal: cp.toolCallsTotal,
+      outputTokensTotal: cp.outputTokensTotal,
+      lastStopReason: cp.lastStopReason,
+      modelId: cp.modelId,
+      error: cp.error,
+      extra: cp.extra,
+    }
+    turn.checkpoints.push(record)
+    if (turn.checkpoints.length > this.maxCheckpointsPerTurn) {
+      turn.checkpoints.splice(0, turn.checkpoints.length - this.maxCheckpointsPerTurn)
+    }
+    turn.updatedAt = record.at
+    return turn
+  }
+
+  finalize(turnId: string, status: TurnStatus, terminalReason?: string): StoredTurn | null {
+    const turn = this.turns.get(turnId)
+    if (!turn) return null
+    turn.status = status
+    turn.terminalReason = terminalReason
+    turn.updatedAt = Date.now()
+    return turn
+  }
+
+  get(turnId: string): StoredTurn | null {
+    return this.turns.get(turnId) ?? null
+  }
+
+  listActive(projectId?: string): StoredTurn[] {
+    const out: StoredTurn[] = []
+    for (const turn of this.turns.values()) {
+      if (turn.status !== 'active') continue
+      if (projectId && turn.projectId !== projectId) continue
+      out.push(turn)
+    }
+    return out
+  }
+
+  private evictIfNeeded(): void {
+    const cutoff = Date.now() - this.retentionMs
+    for (const [turnId, turn] of this.turns) {
+      if (turn.status !== 'active' && turn.updatedAt < cutoff) {
+        this.turns.delete(turnId)
+      }
+    }
+    if (this.turns.size > this.maxTurns) {
+      const entries = [...this.turns.entries()].sort(
+        (a, b) => a[1].updatedAt - b[1].updatedAt,
+      )
+      const toDrop = this.turns.size - this.maxTurns
+      for (let i = 0; i < toDrop; i++) this.turns.delete(entries[i][0])
+    }
+  }
+}
+
+export const turnStore = new TurnStore()

--- a/apps/api/src/routes/project-chat.ts
+++ b/apps/api/src/routes/project-chat.ts
@@ -25,6 +25,9 @@ import * as checkpointService from "../services/checkpoint.service"
 import { isGitAvailable } from "../services/git.service"
 import { setProjectUser } from "../lib/project-user-context"
 import { openSession, closeSession } from "../lib/proxy-billing-session"
+import { turnStore, type StoredTurnCheckpoint } from "../lib/turns/turn-store"
+
+type StoredTurnCheckpointLike = StoredTurnCheckpoint
 
 const chatTracer = trace.getTracer("shogo-api-chat")
 
@@ -467,7 +470,24 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
    * - Starting the runtime if stopped/error/missing
    * - Waiting if runtime is already starting from another request
    */
-  async function getProjectUrl(projectId: string): Promise<string> {
+  async function probeAgentHealth(baseUrl: string, projectId: string): Promise<boolean> {
+    try {
+      const response = await fetch(`${baseUrl}/health`, {
+        method: 'GET',
+        signal: AbortSignal.timeout(3_000),
+      })
+      if (!response.ok) return false
+      const data = await response.json().catch(() => ({})) as { projectId?: string }
+      return !data.projectId || data.projectId === projectId
+    } catch {
+      return false
+    }
+  }
+
+  async function getProjectUrl(
+    projectId: string,
+    options: { forceRestart?: boolean; verifyAgentHealth?: boolean } = {},
+  ): Promise<string> {
     if (isKubernetes()) {
       // In Kubernetes: Use Knative project manager
       const { getProjectPodUrl } = await import("../lib/knative-project-manager")
@@ -509,6 +529,11 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
       // Local development: Use RuntimeManager
       let runtime = runtimeManager.status(projectId)
 
+      if (options.forceRestart && runtime && runtime.status !== "starting") {
+        console.warn(`[ProjectChat] Restarting local runtime for ${projectId} before retry due to stale/unhealthy agent URL`)
+        runtime = await runtimeManager.restart(projectId)
+      }
+
       if (!runtime || runtime.status === "stopped" || runtime.status === "error") {
         // No runtime or failed - start it
         console.log(`[ProjectChat] Starting runtime for ${projectId}...`)
@@ -523,7 +548,20 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
 
       const agentPort = runtime.agentPort || (runtime.port + 1000)
       const runtimeHost = new URL(runtime.url).hostname
-      return `http://${runtimeHost}:${agentPort}`
+      const agentUrl = `http://${runtimeHost}:${agentPort}`
+
+      if (options.verifyAgentHealth !== false && runtime.status === "running") {
+        const healthy = await probeAgentHealth(agentUrl, projectId)
+        if (!healthy) {
+          console.warn(`[ProjectChat] Agent runtime for ${projectId} failed health probe at ${agentUrl}; restarting`)
+          runtime = await runtimeManager.restart(projectId)
+          const restartedPort = runtime.agentPort || (runtime.port + 1000)
+          const restartedHost = new URL(runtime.url).hostname
+          return `http://${restartedHost}:${restartedPort}`
+        }
+      }
+
+      return agentUrl
     } else {
       throw new Error("No runtime manager available for local development")
     }
@@ -538,14 +576,28 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
     path: string,
     init?: RequestInit,
   ): Promise<Response> {
-    const baseUrl = await getProjectUrl(projectId)
     const { deriveRuntimeToken } = await import("../lib/runtime-token")
     const headers = new Headers(init?.headers)
     if (!headers.has("Content-Type")) {
       headers.set("Content-Type", "application/json")
     }
     headers.set("x-runtime-token", deriveRuntimeToken(projectId))
-    return fetch(`${baseUrl}${path}`, { ...init, headers })
+
+    let baseUrl = await getProjectUrl(projectId)
+    try {
+      return await fetch(`${baseUrl}${path}`, { ...init, headers })
+    } catch (err: any) {
+      const isConnectionFailure =
+        err.code === 'ECONNREFUSED' ||
+        err.cause?.code === 'ECONNREFUSED' ||
+        err.message?.includes('ECONNREFUSED') ||
+        err.message?.includes('connection refused')
+      if (!isConnectionFailure) throw err
+
+      console.warn(`[ProjectChat] Runtime fetch to ${baseUrl}${path} failed with connection refused; reacquiring runtime URL`)
+      baseUrl = await getProjectUrl(projectId, { forceRestart: true, verifyAgentHealth: true })
+      return fetch(`${baseUrl}${path}`, { ...init, headers })
+    }
   }
 
   /**
@@ -718,19 +770,24 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
 
       // Retry configuration for transient errors during cold starts.
       // Uses exponential backoff: 500ms, 1s, 2s, 4s, 4s... (capped at 4s)
-      // Max 30 retries (~45 seconds total) with explicit 30min fetch timeout
+      // Max 30 retries (~45 seconds total). Long-running agent streams should
+      // not have an absolute HTTP timeout by default; recovery is handled by
+      // reconnect/replay and runtime health checks.
       const MAX_RETRIES = 30
       const BASE_DELAY_MS = 500
       const MAX_DELAY_MS = 4000
-      const FETCH_TIMEOUT_MS = 1_800_000
+      const FETCH_TIMEOUT_MS = Number(process.env.AGENT_STREAM_ABSOLUTE_TIMEOUT_MS || '0')
       let lastError: Error | null = null
+      let refreshRuntimeBeforeNextAttempt = false
 
       // Do NOT include clientSignal in fetchSignal. A client disconnect
       // (e.g. page refresh) must NOT abort the upstream fetch — the runtime
       // keeps the agent running in memory so the client can resume the stream.
       // trackUsageFromStream also needs the full stream for billing/persistence.
       const clientSignal = c.req.raw.signal
-      const fetchSignal = AbortSignal.timeout(FETCH_TIMEOUT_MS)
+      const makeFetchSignal = () => (
+        FETCH_TIMEOUT_MS > 0 ? AbortSignal.timeout(FETCH_TIMEOUT_MS) : undefined
+      )
 
       for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
         // Check if client already disconnected before retrying
@@ -742,11 +799,20 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
         }
 
         try {
+          if (attempt > 1 || refreshRuntimeBeforeNextAttempt) {
+            podUrl = await getProjectUrl(projectId, {
+              forceRestart: refreshRuntimeBeforeNextAttempt,
+              verifyAgentHealth: true,
+            })
+            console.log(`[ProjectChat] Retry attempt ${attempt} using runtime URL: ${podUrl}${chatEndpoint}`)
+            refreshRuntimeBeforeNextAttempt = false
+          }
+
           const response = await fetch(`${podUrl}${chatEndpoint}`, {
             method: "POST",
             headers,
             body,
-            signal: fetchSignal,
+            signal: makeFetchSignal(),
           })
 
           // Check for errors
@@ -783,6 +849,7 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
             if (isTransientAuthError) {
               const delay = Math.min(BASE_DELAY_MS * Math.pow(2, attempt - 1), MAX_DELAY_MS)
               console.log(`[ProjectChat] Transient ${response.status} from pod, retrying in ${delay}ms (attempt ${attempt}/${MAX_RETRIES})`)
+              refreshRuntimeBeforeNextAttempt = response.status === 404
               await new Promise(resolve => setTimeout(resolve, delay))
               continue
             }
@@ -798,6 +865,7 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
             if (attempt < MAX_RETRIES) {
               const delay = Math.min(BASE_DELAY_MS * Math.pow(2, attempt - 1), MAX_DELAY_MS)
               console.log(`[ProjectChat] Retrying in ${delay}ms (attempt ${attempt}/${MAX_RETRIES})...`)
+              refreshRuntimeBeforeNextAttempt = true
               await new Promise(resolve => setTimeout(resolve, delay))
               continue
             }
@@ -942,6 +1010,7 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
           if ((isTransientError || isAbortError) && attempt < MAX_RETRIES) {
             const delay = Math.min(BASE_DELAY_MS * Math.pow(2, attempt - 1), MAX_DELAY_MS)
             console.log(`[ProjectChat] Connection error, retrying in ${delay}ms (attempt ${attempt}/${MAX_RETRIES}):`, fetchError.message || fetchError.code)
+            refreshRuntimeBeforeNextAttempt = isTransientError
             await new Promise(resolve => setTimeout(resolve, delay))
             continue
           }
@@ -992,6 +1061,9 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
   router.get("/projects/:projectId/chat/:chatSessionId/stream", async (c) => {
     const projectId = c.req.param("projectId")
     const chatSessionId = c.req.param("chatSessionId")
+    const url = new URL(c.req.url)
+    const fromSeq = url.searchParams.get("fromSeq")
+    const lastEventId = c.req.header("Last-Event-ID")
 
     try {
       const project = await validateProject(projectId)
@@ -1002,15 +1074,276 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
         )
       }
 
+      const qs = fromSeq ? `?fromSeq=${encodeURIComponent(fromSeq)}` : ""
       const response = await fetchFromRuntime(
         projectId,
-        `/agent/chat/${chatSessionId}/stream`,
-        { method: "GET" },
+        `/agent/chat/${chatSessionId}/stream${qs}`,
+        {
+          method: "GET",
+          headers: lastEventId ? { "Last-Event-ID": lastEventId } : undefined,
+        },
       )
 
-      if (response.status === 204) {
-        return new Response(null, { status: 204 })
+      // Forward the runtime's response verbatim. We no longer collapse any
+      // response to 204 — callers rely on structured status headers
+      // (X-Shogo-Turn-Status, X-Shogo-Terminal-Reason) and JSON error bodies
+      // to decide whether to retry, show a terminal state, or resume.
+      const responseHeaders = new Headers()
+      response.headers.forEach((value, key) => {
+        if (!["content-length", "transfer-encoding", "connection"].includes(key.toLowerCase())) {
+          responseHeaders.set(key, value)
+        }
+      })
+      responseHeaders.set("Access-Control-Allow-Origin", "*")
+      responseHeaders.set("X-Accel-Buffering", "no")
+
+      return new Response(response.body, {
+        status: response.status,
+        headers: responseHeaders,
+      })
+    } catch (err: any) {
+      console.warn(`[ProjectChat] Resume stream failed for ${projectId}/${chatSessionId}:`, err?.message || err)
+      return c.json(
+        { error: { code: "runtime_recovering", message: "Project runtime is recovering. Retry stream resume shortly.", retryable: true } },
+        503,
+      )
+    }
+  })
+
+  router.get("/projects/:projectId/chat/:chatSessionId/turns/active", async (c) => {
+    const projectId = c.req.param("projectId")
+    const chatSessionId = c.req.param("chatSessionId")
+
+    try {
+      const project = await validateProject(projectId)
+      if (!project) {
+        return c.json(
+          { error: { code: "project_not_found", message: "Project not found" } },
+          404,
+        )
       }
+
+      const response = await fetchFromRuntime(
+        projectId,
+        `/agent/chat/${chatSessionId}/turns/active`,
+        { method: "GET" },
+      )
+      return new Response(response.body, { status: response.status, headers: response.headers })
+    } catch (err: any) {
+      console.warn(`[ProjectChat] Active turn lookup failed for ${projectId}/${chatSessionId}:`, err?.message || err)
+      return c.json(
+        { error: { code: "runtime_recovering", message: "Project runtime is recovering. Retry active turn lookup shortly.", retryable: true } },
+        503,
+      )
+    }
+  })
+
+  /**
+   * GET /projects/:projectId/turns/:turnId/status
+   * Returns the semantic turn status (meta + checkpoint history) so a client
+   * UI or reconciler can decide whether to resume, mark recoverable, or
+   * finalize. Served from the in-memory TurnStore first; falls back to the
+   * runtime's on-disk ledger if the entry is missing.
+   */
+  router.get("/projects/:projectId/turns/:turnId/status", async (c) => {
+    const projectId = c.req.param("projectId")
+    const turnId = c.req.param("turnId")
+    const url = new URL(c.req.url)
+    const fromSeq = Number(url.searchParams.get("fromSeq") || 0)
+    try {
+      const project = await validateProject(projectId)
+      if (!project) {
+        return c.json(
+          { error: { code: "project_not_found", message: "Project not found" } },
+          404,
+        )
+      }
+
+      const cached = turnStore.get(turnId)
+      if (cached && cached.projectId === projectId) {
+        const checkpoints = cached.checkpoints.filter((cp) => cp.seq > fromSeq)
+        return c.json({
+          ok: true,
+          source: "cache",
+          meta: {
+            turnId: cached.turnId,
+            projectId: cached.projectId,
+            chatSessionId: cached.chatSessionId,
+            runtimeId: cached.runtimeId,
+            status: cached.status,
+            createdAt: cached.createdAt,
+            updatedAt: cached.updatedAt,
+            terminalReason: cached.terminalReason,
+          },
+          checkpoints,
+        })
+      }
+
+      const path = `/agent/turns/${encodeURIComponent(turnId)}/status${fromSeq ? `?fromSeq=${fromSeq}` : ""}`
+      const response = await fetchFromRuntime(projectId, path, { method: "GET" })
+      return new Response(response.body, { status: response.status, headers: response.headers })
+    } catch (err: any) {
+      console.warn(`[ProjectChat] Turn status lookup failed for ${projectId}/${turnId}:`, err?.message || err)
+      return c.json(
+        { error: { code: "runtime_recovering", message: "Project runtime is recovering. Retry turn status shortly.", retryable: true } },
+        503,
+      )
+    }
+  })
+
+  /**
+   * GET /projects/:projectId/turns/active
+   * Returns active turns from the API's in-memory store. Falls back to the
+   * runtime's /agent/turns/active endpoint if the cache is empty (e.g.
+   * after an API restart).
+   */
+  router.get("/projects/:projectId/turns/active", async (c) => {
+    const projectId = c.req.param("projectId")
+    try {
+      const project = await validateProject(projectId)
+      if (!project) {
+        return c.json(
+          { error: { code: "project_not_found", message: "Project not found" } },
+          404,
+        )
+      }
+
+      const cached = turnStore.listActive(projectId)
+      if (cached.length > 0) {
+        return c.json({ ok: true, source: "cache", active: cached })
+      }
+
+      const response = await fetchFromRuntime(projectId, `/agent/turns/active`, { method: "GET" })
+      return new Response(response.body, { status: response.status, headers: response.headers })
+    } catch (err: any) {
+      console.warn(`[ProjectChat] Active turns lookup failed for ${projectId}:`, err?.message || err)
+      return c.json(
+        { error: { code: "runtime_recovering", message: "Project runtime is recovering. Retry active turns shortly.", retryable: true } },
+        503,
+      )
+    }
+  })
+
+  /**
+   * POST /projects/:projectId/turns/:turnId/resume
+   * Proxies the runtime's /agent/turns/:turnId/resume decision endpoint.
+   */
+  router.post("/projects/:projectId/turns/:turnId/resume", async (c) => {
+    const projectId = c.req.param("projectId")
+    const turnId = c.req.param("turnId")
+    try {
+      const project = await validateProject(projectId)
+      if (!project) {
+        return c.json(
+          { error: { code: "project_not_found", message: "Project not found" } },
+          404,
+        )
+      }
+      const response = await fetchFromRuntime(
+        projectId,
+        `/agent/turns/${encodeURIComponent(turnId)}/resume`,
+        { method: "POST" },
+      )
+      return new Response(response.body, { status: response.status, headers: response.headers })
+    } catch (err: any) {
+      console.warn(`[ProjectChat] Turn resume failed for ${projectId}/${turnId}:`, err?.message || err)
+      return c.json(
+        { error: { code: "runtime_recovering", message: "Project runtime is recovering. Retry resume shortly.", retryable: true } },
+        503,
+      )
+    }
+  })
+
+  /**
+   * POST /projects/:projectId/turns/ingest
+   * Internal ingestion endpoint called by the runtime to push turn lifecycle
+   * events into the API's in-memory TurnStore. Low-trust by design — the
+   * runtime's on-disk TurnCheckpointLedger remains the source of truth.
+   */
+  router.post("/projects/:projectId/turns/ingest", async (c) => {
+    const projectId = c.req.param("projectId")
+    try {
+      const body = await c.req.json().catch(() => null) as {
+        kind?: 'start' | 'checkpoint' | 'finalize'
+        turnId?: string
+        chatSessionId?: string
+        runtimeId?: string
+        status?: string
+        terminalReason?: string
+        checkpoint?: Partial<StoredTurnCheckpointLike>
+      } | null
+      if (!body?.turnId || !body?.kind) {
+        return c.json({ ok: false, error: "invalid_body" }, 400)
+      }
+      if (body.kind === 'start') {
+        turnStore.upsertStart({
+          turnId: body.turnId,
+          projectId,
+          chatSessionId: body.chatSessionId,
+          runtimeId: body.runtimeId,
+        })
+      } else if (body.kind === 'checkpoint' && body.checkpoint) {
+        // Make sure the entry exists even if we missed the start event.
+        if (!turnStore.get(body.turnId)) {
+          turnStore.upsertStart({
+            turnId: body.turnId,
+            projectId,
+            chatSessionId: body.chatSessionId,
+            runtimeId: body.runtimeId,
+          })
+        }
+        turnStore.appendCheckpoint(body.turnId, {
+          attempt: body.checkpoint.attempt ?? 0,
+          reason: body.checkpoint.reason ?? 'unknown',
+          willContinue: body.checkpoint.willContinue ?? false,
+          iterations: body.checkpoint.iterations ?? 0,
+          toolCallsThisAttempt: body.checkpoint.toolCallsThisAttempt ?? 0,
+          toolCallsTotal: body.checkpoint.toolCallsTotal ?? 0,
+          outputTokensTotal: body.checkpoint.outputTokensTotal ?? 0,
+          lastStopReason: body.checkpoint.lastStopReason,
+          modelId: body.checkpoint.modelId,
+          error: body.checkpoint.error,
+          extra: body.checkpoint.extra,
+          seq: body.checkpoint.seq,
+          at: body.checkpoint.at,
+        })
+      } else if (body.kind === 'finalize') {
+        turnStore.finalize(
+          body.turnId,
+          (body.status as any) || 'completed',
+          body.terminalReason,
+        )
+      }
+      return c.json({ ok: true })
+    } catch (err: any) {
+      console.warn(`[ProjectChat] Turn ingest failed for ${projectId}:`, err?.message || err)
+      return c.json({ ok: false, error: err?.message || "ingest_failed" }, 500)
+    }
+  })
+
+  router.get("/projects/:projectId/chat/:chatSessionId/turns/:turnId/stream", async (c) => {
+    const projectId = c.req.param("projectId")
+    const chatSessionId = c.req.param("chatSessionId")
+    const turnId = c.req.param("turnId")
+    const url = new URL(c.req.url)
+    const fromSeq = url.searchParams.get("fromSeq")
+
+    try {
+      const project = await validateProject(projectId)
+      if (!project) {
+        return c.json(
+          { error: { code: "project_not_found", message: "Project not found" } },
+          404,
+        )
+      }
+
+      const path = `/agent/chat/${chatSessionId}/turns/${turnId}/stream${fromSeq ? `?fromSeq=${encodeURIComponent(fromSeq)}` : ""}`
+      const response = await fetchFromRuntime(projectId, path, {
+        method: "GET",
+        headers: {
+          ...(c.req.header("Last-Event-ID") ? { "Last-Event-ID": c.req.header("Last-Event-ID")! } : {}),
+        },
+      })
 
       if (response.body) {
         const responseHeaders = new Headers()
@@ -1027,9 +1360,13 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
         })
       }
 
-      return new Response(null, { status: 204 })
-    } catch {
-      return new Response(null, { status: 204 })
+      return new Response(null, { status: response.status })
+    } catch (err: any) {
+      console.warn(`[ProjectChat] Durable replay failed for ${projectId}/${chatSessionId}/${turnId}:`, err?.message || err)
+      return c.json(
+        { error: { code: "runtime_recovering", message: "Project runtime is recovering. Retry durable replay shortly.", retryable: true } },
+        503,
+      )
     }
   })
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1950,29 +1950,30 @@ app.all('/api/projects/:projectId/agent-proxy/*', async (c) => {
 
   let podUrl: string
 
-  if (isKubernetes()) {
-    try {
+  async function resolveAgentProxyPodUrl(forceRestart = false): Promise<string> {
+    if (isKubernetes()) {
       const { getProjectPodUrl } = await import('./lib/knative-project-manager')
-      podUrl = await getProjectPodUrl(projectId)
-    } catch (error: any) {
-      console.error('[AgentProxy] K8s pod resolution error:', error)
-      return c.json({ error: { code: 'proxy_error', message: error.message || 'Failed to resolve agent pod' } }, 502)
+      return getProjectPodUrl(projectId)
     }
-  } else {
+
     const manager = getRuntimeManager()
     let runtime = manager.status(projectId)
-    if (!runtime || !runtime.agentPort) {
-      try {
-        runtime = await manager.start(projectId)
-      } catch (error: any) {
-        console.error(`[AgentProxy] Failed to auto-start runtime for ${projectId}:`, error)
-        return c.json({ error: { code: 'agent_start_failed', message: error.message || 'Failed to start agent runtime' } }, 503)
-      }
+    if (forceRestart && runtime && runtime.status !== 'starting') {
+      console.warn(`[AgentProxy] Restarting local runtime for ${projectId} before retry due to stale/unhealthy agent URL`)
+      runtime = await manager.restart(projectId)
     }
-    podUrl = `http://localhost:${runtime.agentPort}`
+    if (!runtime || !runtime.agentPort) {
+      runtime = await manager.start(projectId)
+    }
+    return `http://localhost:${runtime.agentPort}`
   }
 
-  const targetUrl = `${podUrl}${path}${qs}`
+  try {
+    podUrl = await resolveAgentProxyPodUrl()
+  } catch (error: any) {
+    console.error(`[AgentProxy] Failed to resolve runtime for ${projectId}:`, error)
+    return c.json({ error: { code: 'agent_start_failed', message: error.message || 'Failed to resolve agent runtime' } }, isKubernetes() ? 502 : 503)
+  }
 
   const headers = new Headers()
   const contentType = c.req.header('content-type')
@@ -2001,6 +2002,7 @@ app.all('/api/projects/:projectId/agent-proxy/*', async (c) => {
   const MAX_DELAY_MS = 5000
   const FETCH_TIMEOUT_MS = 1_800_000
   let lastError: Error | null = null
+  let refreshRuntimeBeforeNextAttempt = false
 
   const proxyClientSignal = c.req.raw.signal
   const proxyFetchSignal = proxyClientSignal
@@ -2009,6 +2011,11 @@ app.all('/api/projects/:projectId/agent-proxy/*', async (c) => {
 
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     try {
+      if (attempt > 1 && refreshRuntimeBeforeNextAttempt) {
+        podUrl = await resolveAgentProxyPodUrl(true)
+        refreshRuntimeBeforeNextAttempt = false
+      }
+      const targetUrl = `${podUrl}${path}${qs}`
       const response = await fetch(targetUrl, {
         method: c.req.method,
         headers,
@@ -2021,6 +2028,7 @@ app.all('/api/projects/:projectId/agent-proxy/*', async (c) => {
         if (attempt === 1) {
           console.log(`[AgentProxy] ${c.req.method} ${path} → ${response.status}, retrying (cold start?)...`)
         }
+        refreshRuntimeBeforeNextAttempt = !isKubernetes()
         await new Promise(resolve => setTimeout(resolve, delay))
         continue
       }
@@ -2088,6 +2096,7 @@ app.all('/api/projects/:projectId/agent-proxy/*', async (c) => {
         if (attempt <= 2) {
           console.log(`[AgentProxy] ${c.req.method} ${path} ${isTimeout ? 'timeout' : 'connection failed'}, retrying in ${delay}ms (attempt ${attempt}/${MAX_RETRIES})`)
         }
+        refreshRuntimeBeforeNextAttempt = isTransient && !isKubernetes()
         await new Promise(resolve => setTimeout(resolve, delay))
         continue
       }
@@ -3657,6 +3666,43 @@ app.get('/api/projects/:projectId/chat/:chatSessionId/stream', async (c) => {
   const router = projectChatRoutes({ runtimeManager: manager })
   const url = new URL(c.req.url)
   url.pathname = `/projects/${c.req.param('projectId')}/chat/${c.req.param('chatSessionId')}/stream`
+  const newReq = new Request(url.toString(), { method: 'GET', headers: c.req.raw.headers })
+  const resp = await router.fetch(newReq)
+
+  if (resp.body && resp.status !== 204) {
+    const trackedBody = resp.body.pipeThrough(new TransformStream({
+      flush() { activeProxyConnections-- },
+    }))
+    activeProxyConnections++
+    c.req.raw.signal.addEventListener('abort', () => { activeProxyConnections = Math.max(0, activeProxyConnections - 1) })
+    return new Response(trackedBody, { status: resp.status, headers: resp.headers })
+  }
+
+  return resp
+})
+
+// GET /api/projects/:projectId/chat/:chatSessionId/turns/active - Active durable turn status
+app.get('/api/projects/:projectId/chat/:chatSessionId/turns/active', async (c) => {
+  const authResult = await requireProjectAuth(c)
+  if ('error' in authResult) return authResult.error
+
+  const manager = getRuntimeManager()
+  const router = projectChatRoutes({ runtimeManager: manager })
+  const url = new URL(c.req.url)
+  url.pathname = `/projects/${c.req.param('projectId')}/chat/${c.req.param('chatSessionId')}/turns/active`
+  const newReq = new Request(url.toString(), { method: 'GET', headers: c.req.raw.headers })
+  return router.fetch(newReq)
+})
+
+// GET /api/projects/:projectId/chat/:chatSessionId/turns/:turnId/stream - Durable replay by sequence
+app.get('/api/projects/:projectId/chat/:chatSessionId/turns/:turnId/stream', async (c) => {
+  const authResult = await requireProjectAuth(c)
+  if ('error' in authResult) return authResult.error
+
+  const manager = getRuntimeManager()
+  const router = projectChatRoutes({ runtimeManager: manager })
+  const url = new URL(c.req.url)
+  url.pathname = `/projects/${c.req.param('projectId')}/chat/${c.req.param('chatSessionId')}/turns/${c.req.param('turnId')}/stream`
   const newReq = new Request(url.toString(), { method: 'GET', headers: c.req.raw.headers })
   const resp = await router.fetch(newReq)
 
@@ -5701,8 +5747,36 @@ app.route('/api', generatedRoutes)
 // Graceful shutdown handling
 // =============================================================================
 
-const DRAIN_TIMEOUT_MS = 600_000
+const DRAIN_TIMEOUT_MS = Number(process.env.API_DRAIN_TIMEOUT_MS || 30 * 60 * 1000)
 const DRAIN_POLL_MS = 1_000
+
+/**
+ * Poll /agent/health on every active local runtime and return the sum of
+ * activeTurns / activeStreams. Used by gracefulShutdown so we wait for the
+ * agent to actually finish turns, not just for HTTP proxy bodies to close.
+ */
+async function sumActiveAgentTurns(): Promise<number> {
+  if (!runtimeManager) return 0
+  const projectIds = runtimeManager.getActiveProjects()
+  if (projectIds.length === 0) return 0
+  let total = 0
+  await Promise.all(projectIds.map(async (projectId) => {
+    try {
+      const runtime = runtimeManager!.status(projectId)
+      if (!runtime?.agentPort) return
+      const res = await fetch(`http://localhost:${runtime.agentPort}/agent/health`, {
+        signal: AbortSignal.timeout(1_500),
+      })
+      if (!res.ok) return
+      const body = await res.json().catch(() => null) as any
+      const count = Number(body?.activeTurns ?? body?.activeStreams ?? 0)
+      if (Number.isFinite(count)) total += count
+    } catch {
+      // Unreachable runtime doesn't count as active.
+    }
+  }))
+  return total
+}
 
 async function gracefulShutdown(signal: string) {
   if (isShuttingDown) return
@@ -5719,13 +5793,54 @@ async function gracefulShutdown(signal: string) {
     } catch (_) { /* may not be initialized */ }
   }
 
-  // In local dev mode, stop child-process runtimes and VM warm pool.
-  // In K8s mode the project runtimes are independent Knative services and must NOT be killed.
+  // Drain in two layers:
+  //  1) Wait for active agent TURNS to finish (authoritative signal — a
+  //     proxy connection may have closed while the runtime is still
+  //     working, e.g. client refresh during a long multi-tool turn).
+  //  2) Wait for active proxy connections to drain (last bytes to flush
+  //     to clients that are still attached).
+  const deadline = Date.now() + DRAIN_TIMEOUT_MS
+
+  try {
+    let activeTurns = await sumActiveAgentTurns()
+    if (activeTurns > 0) {
+      console.log(`[Server] Draining ${activeTurns} active agent turn(s)...`)
+      while (Date.now() < deadline) {
+        activeTurns = await sumActiveAgentTurns()
+        if (activeTurns <= 0) break
+        await new Promise(resolve => setTimeout(resolve, DRAIN_POLL_MS))
+      }
+      if (activeTurns > 0) {
+        console.log(`[Server] Drain timeout reached with ${activeTurns} agent turn(s) remaining — runtime will mark them interrupted_recoverable`)
+      } else {
+        console.log('[Server] All agent turns drained')
+      }
+    }
+  } catch (err: any) {
+    console.warn('[Server] sumActiveAgentTurns threw during drain:', err?.message || err)
+  }
+
+  if (activeProxyConnections > 0) {
+    console.log(`[Server] Draining ${activeProxyConnections} active proxy connection(s)...`)
+    while (activeProxyConnections > 0 && Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, DRAIN_POLL_MS))
+    }
+    if (activeProxyConnections > 0) {
+      console.log(`[Server] Drain timeout reached with ${activeProxyConnections} connection(s) remaining`)
+    } else {
+      console.log('[Server] All proxy connections drained')
+    }
+  }
+
+  // In local dev mode, stop child-process runtimes and VM warm pool only after
+  // API proxy streams have drained. Stopping runtimes first breaks long chat
+  // turns in the middle of a response.
   if (!isKubernetes()) {
     if (runtimeManager) {
       console.log('[Server] Stopping local project runtimes...')
       try {
-        await runtimeManager.stopAll()
+        const remainingMs = Math.max(5_000, deadline - Date.now())
+        await runtimeManager.stopAll({ reason: 'api-shutdown', maxAgentWaitMs: remainingMs })
         console.log('[Server] All local runtimes stopped')
       } catch (err: any) {
         console.error('[Server] Error stopping runtimes:', err.message)
@@ -5737,20 +5852,6 @@ async function gracefulShutdown(signal: string) {
       await stopVMWarmPool()
       console.log('[Server] VM warm pool stopped')
     } catch (_) { /* may not be initialized */ }
-  }
-
-  // Drain active proxy connections (SSE streams, chat)
-  if (activeProxyConnections > 0) {
-    console.log(`[Server] Draining ${activeProxyConnections} active proxy connection(s)...`)
-    const deadline = Date.now() + DRAIN_TIMEOUT_MS
-    while (activeProxyConnections > 0 && Date.now() < deadline) {
-      await new Promise(resolve => setTimeout(resolve, DRAIN_POLL_MS))
-    }
-    if (activeProxyConnections > 0) {
-      console.log(`[Server] Drain timeout reached with ${activeProxyConnections} connection(s) remaining`)
-    } else {
-      console.log('[Server] All proxy connections drained')
-    }
   }
 
   stopAllPrismaStudios()
@@ -5769,6 +5870,10 @@ process.on('SIGTERM', () => gracefulShutdown('SIGTERM'))
 process.on('SIGINT', () => gracefulShutdown('SIGINT'))
 
 // Start server
+try {
+  const { logDurableTurnStartup } = await import('@shogo/shared-runtime')
+  logDurableTurnStartup('api')
+} catch { /* optional */ }
 console.log(`🚀 API server running on http://localhost:${API_PORT}`)
 console.log(`   Chat endpoint: POST http://localhost:${API_PORT}/api/chat`)
 console.log(`   Runtime endpoints: POST/GET http://localhost:${API_PORT}/api/projects/:id/runtime/*`)
@@ -6063,4 +6168,3 @@ if (isKubernetes()) {
     }
   })()
 }
-

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -948,6 +948,19 @@ export const ChatPanel = observer(function ChatPanel({
   const processedProgressEventsRef = useRef<Set<string>>(new Set())
 
   const [toolErrorBanner, setToolErrorBanner] = useState<{ toolkitName: string; error: string; isAuthError?: boolean } | null>(null)
+  // Banner state driven by the runtime's `data-turn-checkpoint` frames so we
+  // can surface "continuing…"/"paused" states for durable long-running turns.
+  const [turnContinuation, setTurnContinuation] = useState<
+    | {
+        attempt: number
+        reason: string
+        willContinue: boolean
+        toolCallsTotal: number
+        outputTokensTotal: number
+        unfinishedMutating?: Array<{ toolCallId: string; toolName: string }>
+      }
+    | null
+  >(null)
   const [reconnecting, setReconnecting] = useState(false)
   const [contextUsage, setContextUsage] = useState<{ inputTokens: number; contextWindowTokens: number } | null>(null)
   const contextUsageThrottleRef = useRef<{ inputTokens: number; contextWindowTokens: number } | null>(null)
@@ -1400,6 +1413,22 @@ export const ChatPanel = observer(function ChatPanel({
         })
       }
 
+      // DurableTurnRunner emits one of these every time an attempt boundary
+      // is crossed. Use it to render a "continuing…" banner during auto-
+      // continuations and a stronger warning when mutating tools started
+      // but never reported completion (so the user can verify state).
+      if ((dataPart as any).type === "data-turn-checkpoint") {
+        const cp = (dataPart as any).data ?? {}
+        setTurnContinuation({
+          attempt: cp.attempt ?? 0,
+          reason: cp.reason ?? "unknown",
+          willContinue: !!cp.willContinue,
+          toolCallsTotal: cp.toolCallsTotal ?? 0,
+          outputTokensTotal: cp.outputTokensTotal ?? 0,
+          unfinishedMutating: cp.unfinishedMutating,
+        })
+      }
+
       if (dataPart.type === "data-canvas-preview") {
         const { surfaceId, components } = (dataPart as any).data
         onCanvasPreview?.(surfaceId, components)
@@ -1716,12 +1745,8 @@ export const ChatPanel = observer(function ChatPanel({
     }
   }, [messages])
 
-  // Abort any active stream when this panel unmounts (e.g. tab closed)
-  const stopRef = useRef(stop)
-  stopRef.current = stop
-  useEffect(() => {
-    return () => { stopRef.current() }
-  }, [])
+  // Let active turns survive panel unmounts, tab switches, and browser refreshes.
+  // Explicit user Stop is the only path that should cancel the backend turn.
 
   useEffect(() => {
     if (status === 'ready' && stoppedMessages !== null) {
@@ -1767,6 +1792,7 @@ export const ChatPanel = observer(function ChatPanel({
   const [emptyResponseError, setEmptyResponseError] = useState<string | null>(null)
   const [errorBannerExpanded, setErrorBannerExpanded] = useState(false)
   const [tunnelReconnecting, setTunnelReconnecting] = useState(false)
+  const [streamStalled, setStreamStalled] = useState(false)
 
   const isRemoteInstance = !!localAgentUrl
   const isTunnelError = !!(error && isRemoteInstance && isTunnelDisconnectError(error.message))
@@ -1775,9 +1801,10 @@ export const ChatPanel = observer(function ChatPanel({
     () => {
       if (isTunnelError && tunnelReconnecting) return 'Connection to desktop instance lost. Reconnecting\u2026'
       if (isTunnelError) return 'Connection to desktop instance lost. Tap Reconnect to retry.'
+      if (streamStalled && isStreaming) return 'Still working. Waiting for the agent to send more progress\u2026'
       return (error ? formatErrorMessage(error.message) : emptyResponseError) ?? ''
     },
-    [error?.message, emptyResponseError, isTunnelError, tunnelReconnecting]
+    [error?.message, emptyResponseError, isTunnelError, tunnelReconnecting, streamStalled, isStreaming]
   )
   useEffect(() => {
     setErrorBannerExpanded(false)
@@ -1801,7 +1828,7 @@ export const ChatPanel = observer(function ChatPanel({
         try {
           const fetchFn = expoFetch ?? globalThis.fetch
           const hdrs: Record<string, string> = nativeHeaders ? nativeHeaders() : {}
-          const res = await fetchFn(`${localAgentUrl}/agent/health`, {
+          const res = await fetchFn(`${localAgentUrl}/health`, {
             headers: hdrs,
             credentials: Platform.OS === 'web' ? 'include' : undefined,
             signal: AbortSignal.timeout(5000),
@@ -1823,6 +1850,7 @@ export const ChatPanel = observer(function ChatPanel({
 
   const errorBannerNeedsReadMore =
     errorBannerText.split(/\n/).length > 4 || errorBannerText.length > 220
+  const isWarningBanner = isTunnelError || (streamStalled && isStreaming)
 
   const [pendingInitialMessage, setPendingInitialMessage] = useState<string | null>(null)
 
@@ -1940,7 +1968,9 @@ export const ChatPanel = observer(function ChatPanel({
     return () => { configureSubagentStop(null) }
   }, [localAgentUrl, projectId, expoFetch])
 
-  // Idle timeout to force-complete hung streams
+  // Idle detection should never cancel an agent turn. Long tool calls and
+  // extended model thinking can legitimately go quiet from the UI's point of
+  // view, so we surface a stalled state and let durable replay/reconnect recover.
   const idleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastMessageContentRef = useRef<string>("")
   const IDLE_TIMEOUT_MS = 600_000
@@ -1957,12 +1987,13 @@ export const ChatPanel = observer(function ChatPanel({
 
       if (currentContent !== lastMessageContentRef.current) {
         lastMessageContentRef.current = currentContent
+        setStreamStalled(false)
       }
 
       idleTimeoutRef.current = setTimeout(() => {
         if (isStreaming) {
-          console.warn("[ChatPanel] Stream idle timeout - forcing stop()")
-          handleStop()
+          console.warn("[ChatPanel] Stream idle timeout - marking stream as stalled without stopping backend turn")
+          setStreamStalled(true)
         }
       }, IDLE_TIMEOUT_MS)
     } else {
@@ -1971,6 +2002,7 @@ export const ChatPanel = observer(function ChatPanel({
         idleTimeoutRef.current = null
       }
       lastMessageContentRef.current = ""
+      setStreamStalled(false)
     }
 
     return () => {
@@ -1978,7 +2010,7 @@ export const ChatPanel = observer(function ChatPanel({
         clearTimeout(idleTimeoutRef.current)
       }
     }
-  }, [isStreaming, messages, handleStop])
+  }, [isStreaming, messages])
 
   // Fallback: detect file changes when streaming ends
   const prevStreamingForScanRef = useRef(false)
@@ -2001,6 +2033,13 @@ export const ChatPanel = observer(function ChatPanel({
     if (isStreaming && !wasStreaming) {
       filesChangedFiredRef.current = false
       setToolErrorBanner(null)
+      setTurnContinuation(null)
+    }
+    if (!isStreaming && wasStreaming) {
+      // Stream ended cleanly — fade any lingering continuation banner after
+      // a short delay so users still see the last status briefly.
+      const timer = setTimeout(() => setTurnContinuation(null), 2_000)
+      return () => clearTimeout(timer)
     }
   }, [isStreaming, messages, onFilesChanged])
 
@@ -3267,6 +3306,58 @@ export const ChatPanel = observer(function ChatPanel({
 
           </ScrollView>
 
+          {/* Durable-turn continuation banner. Shown when the runtime reports
+              an auto-continuation in progress, or warns about mutating tools
+              that started but never confirmed completion. */}
+          {turnContinuation && (turnContinuation.willContinue || (turnContinuation.unfinishedMutating?.length ?? 0) > 0) && (
+            <View className="px-4 pb-2">
+              <View className={cn(
+                "flex-row items-start gap-2 rounded-lg p-3",
+                (turnContinuation.unfinishedMutating?.length ?? 0) > 0
+                  ? "border border-orange-400/50 bg-orange-50 dark:bg-orange-900/20"
+                  : "border border-blue-400/50 bg-blue-50 dark:bg-blue-900/20",
+              )}>
+                <AlertCircle
+                  className={cn(
+                    "shrink-0 mt-0.5",
+                    (turnContinuation.unfinishedMutating?.length ?? 0) > 0
+                      ? "text-orange-600 dark:text-orange-400"
+                      : "text-blue-600 dark:text-blue-400",
+                  )}
+                  size={16}
+                />
+                <View className="flex-1 gap-1">
+                  <Text className={cn(
+                    "text-sm font-medium",
+                    (turnContinuation.unfinishedMutating?.length ?? 0) > 0
+                      ? "text-orange-800 dark:text-orange-200"
+                      : "text-blue-800 dark:text-blue-200",
+                  )}>
+                    {(turnContinuation.unfinishedMutating?.length ?? 0) > 0
+                      ? "Continuing — verifying in-flight tool work"
+                      : `Continuing (attempt ${turnContinuation.attempt + 1})`}
+                  </Text>
+                  <Text className={cn(
+                    "text-xs",
+                    (turnContinuation.unfinishedMutating?.length ?? 0) > 0
+                      ? "text-orange-700 dark:text-orange-300"
+                      : "text-blue-700 dark:text-blue-300",
+                  )}>
+                    {turnContinuation.reason.replace(/^continuation_/, "").replace(/_/g, " ")}
+                    {" · "}
+                    {turnContinuation.toolCallsTotal} tool call(s), {turnContinuation.outputTokensTotal} tokens so far
+                    {(turnContinuation.unfinishedMutating?.length ?? 0) > 0 && (
+                      <>
+                        {"\nUnfinished: "}
+                        {turnContinuation.unfinishedMutating!.map(t => t.toolName).join(", ")}
+                      </>
+                    )}
+                  </Text>
+                </View>
+              </View>
+            </View>
+          )}
+
           {/* Tool Error Banner */}
           {toolErrorBanner && (
             <View className="px-4 pb-2">
@@ -3382,15 +3473,15 @@ export const ChatPanel = observer(function ChatPanel({
           )}
 
           {/* Error Alert — cap long messages so the sidebar layout stays usable */}
-          {(error || emptyResponseError) && (
+          {(error || emptyResponseError || (streamStalled && isStreaming)) && (
             <View className="px-4 pb-2 max-w-3xl w-full self-center">
               <View className={`flex-row items-start gap-2 rounded-lg border p-3 ${
-                isTunnelError
+                isWarningBanner
                   ? 'border-orange-400/50 bg-orange-50 dark:bg-orange-950/30'
                   : 'border-destructive/50 bg-destructive/10'
               }`}>
                 <AlertCircle className={`h-4 w-4 shrink-0 mt-0.5 ${
-                  isTunnelError ? 'text-orange-600 dark:text-orange-400' : 'text-destructive'
+                  isWarningBanner ? 'text-orange-600 dark:text-orange-400' : 'text-destructive'
                 }`} size={16} />
                 <View className="flex-1 min-w-0 flex-row items-start justify-between gap-2">
                   <View className="flex-1 min-w-0 pr-1">
@@ -3400,13 +3491,13 @@ export const ChatPanel = observer(function ChatPanel({
                         className="max-h-48"
                         showsVerticalScrollIndicator
                       >
-                        <Text className={`text-sm ${isTunnelError ? 'text-orange-700 dark:text-orange-300' : 'text-destructive'}`} selectable>
+                        <Text className={`text-sm ${isWarningBanner ? 'text-orange-700 dark:text-orange-300' : 'text-destructive'}`} selectable>
                           {errorBannerText}
                         </Text>
                       </ScrollView>
                     ) : (
                       <Text
-                        className={`text-sm ${isTunnelError ? 'text-orange-700 dark:text-orange-300' : 'text-destructive'}`}
+                        className={`text-sm ${isWarningBanner ? 'text-orange-700 dark:text-orange-300' : 'text-destructive'}`}
                         numberOfLines={4}
                         selectable
                       >

--- a/packages/agent-runtime/src/__tests__/durable-turn-runner.test.ts
+++ b/packages/agent-runtime/src/__tests__/durable-turn-runner.test.ts
@@ -253,6 +253,72 @@ describe('runDurableTurn', () => {
     expect(captured[1]?.prompt).not.toBe(captured[0]?.prompt)
     expect(captured[1]?.prompt?.toLowerCase()).toMatch(/resume|continue|pick/i)
   })
+
+  test('aborts with host_cancelled when prepareNextHistory throws (f5)', async () => {
+    const scripted: AgentLoopResult[] = [
+      makeResult({
+        text: 'part1',
+        outputTokens: 10,
+        maxIterationsExhausted: true,
+        lastStopReason: 'length',
+      }),
+      makeResult({ text: 'should not reach', outputTokens: 1 }),
+    ]
+    const checkpoints: TurnCheckpoint[] = []
+    const opts = baseOptions(scripted, {
+      prepareNextHistory: async () => {
+        throw new Error('session store unreachable')
+      },
+    })
+
+    const res = await runDurableTurn({ ...opts, onCheckpoint: cp => checkpoints.push(cp) })
+
+    expect(res.terminationReason).toBe('host_cancelled')
+    expect(res.attempts).toHaveLength(1)
+    expect(checkpoints.find(c => c.reason === 'terminal_history_sync_failed')).toBeDefined()
+  })
+
+  test('refuses provider retry when registry has unfinished mutating tool (f1)', async () => {
+    const registry = new ToolIdempotencyRegistry()
+    registry.start('call-write-1', 'write_file', { path: '/tmp/a' })
+    // Not finished on purpose — this simulates a mid-stream failure right
+    // after a mutating tool started but before its result streamed back.
+
+    const scripted: AgentLoopResult[] = [
+      makeResult({ error: new Error('ECONNRESET during mutation'), outputTokens: 0 }),
+    ]
+    const opts = baseOptions(scripted, {
+      providerRetriesPerAttempt: 5,
+      toolRegistry: registry,
+    })
+
+    const res = await runDurableTurn(opts)
+
+    // With an unfinished mutating tool, the retry is refused and the
+    // outer classifier surfaces the error as provider_fatal.
+    expect(res.terminationReason).toBe('provider_fatal')
+    expect(res.attempts).toHaveLength(1)
+  })
+
+  test('still retries provider error when only READ-ONLY tools are unfinished (f1)', async () => {
+    const registry = new ToolIdempotencyRegistry()
+    registry.start('call-read-1', 'read_file', { path: '/tmp/a' })
+    // read_file is classified read-only, so replaying is safe.
+
+    const scripted: AgentLoopResult[] = [
+      makeResult({ error: new Error('ECONNRESET transient'), outputTokens: 0 }),
+      makeResult({ text: 'finished', outputTokens: 5, lastStopReason: 'end_turn' }),
+    ]
+    const opts = baseOptions(scripted, {
+      providerRetriesPerAttempt: 2,
+      toolRegistry: registry,
+    })
+
+    const res = await runDurableTurn(opts)
+
+    expect(res.terminationReason).toBe('completed')
+    expect(res.text).toBe('finished')
+  })
 })
 
 describe('classifyAttempt', () => {

--- a/packages/agent-runtime/src/__tests__/durable-turn-runner.test.ts
+++ b/packages/agent-runtime/src/__tests__/durable-turn-runner.test.ts
@@ -1,0 +1,347 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Unit tests for DurableTurnRunner (Phase 8).
+ *
+ * We inject a fake `runAgentLoop` via the `_runLoopForTests` hook so these
+ * tests run offline — no provider mocking, no pi-agent-core wiring.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import {
+  runDurableTurn,
+  classifyAttempt,
+  type TurnCheckpoint,
+  type DurableTurnRunnerOptions,
+} from '../durable-turn-runner'
+import type { AgentLoopOptions, AgentLoopResult } from '../agent-loop'
+import { ToolIdempotencyRegistry } from '../tool-idempotency'
+
+function makeResult(partial: Partial<AgentLoopResult> = {}): AgentLoopResult {
+  return {
+    text: '',
+    toolCalls: [],
+    iterations: 1,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    newMessages: [],
+    maxIterationsExhausted: false,
+    ...partial,
+  }
+}
+
+function baseOptions(
+  scripted: AgentLoopResult[],
+  extra: Partial<DurableTurnRunnerOptions> = {},
+): DurableTurnRunnerOptions {
+  const fake = async (_opts: AgentLoopOptions) => {
+    const next = scripted.shift()
+    if (!next) throw new Error('Test bug: ran out of scripted loop results')
+    return next
+  }
+  return {
+    model: 'claude-sonnet-4-5',
+    system: 'Test system',
+    history: [],
+    prompt: 'Start',
+    tools: [],
+    _runLoopForTests: fake,
+    ...extra,
+  }
+}
+
+describe('runDurableTurn', () => {
+  test('completes a single attempt when the loop naturally finishes', async () => {
+    const opts = baseOptions([
+      makeResult({ text: 'done', outputTokens: 10, lastStopReason: 'end_turn' }),
+    ])
+    const checkpoints: TurnCheckpoint[] = []
+
+    const res = await runDurableTurn({ ...opts, onCheckpoint: cp => checkpoints.push(cp) })
+
+    expect(res.terminationReason).toBe('completed')
+    expect(res.attempts).toHaveLength(1)
+    expect(res.text).toBe('done')
+    expect(res.error).toBeUndefined()
+    expect(checkpoints).toHaveLength(1)
+    expect(checkpoints[0]?.reason).toBe('attempt_end')
+    expect(checkpoints[0]?.willContinue).toBe(false)
+  })
+
+  test('auto-continues on max_tokens (lastStopReason=length)', async () => {
+    const scripted: AgentLoopResult[] = [
+      makeResult({
+        text: 'part A',
+        outputTokens: 100,
+        maxIterationsExhausted: true,
+        lastStopReason: 'length',
+      }),
+      makeResult({
+        text: 'part B',
+        outputTokens: 50,
+        lastStopReason: 'end_turn',
+      }),
+    ]
+    const opts = baseOptions(scripted, { maxContinuations: 5 })
+    const checkpoints: TurnCheckpoint[] = []
+
+    const res = await runDurableTurn({ ...opts, onCheckpoint: cp => checkpoints.push(cp) })
+
+    expect(res.terminationReason).toBe('completed')
+    expect(res.attempts).toHaveLength(2)
+    expect(res.text).toBe('part A\n\npart B')
+    expect(res.outputTokens).toBe(150)
+    expect(checkpoints.map(c => c.reason)).toEqual([
+      'continuation_max_tokens',
+      'attempt_end',
+    ])
+    expect(checkpoints[0]?.willContinue).toBe(true)
+  })
+
+  test('auto-continues on iteration_limit (maxIterationsExhausted, no length)', async () => {
+    const scripted: AgentLoopResult[] = [
+      makeResult({
+        text: 'step1',
+        iterations: 10,
+        outputTokens: 30,
+        maxIterationsExhausted: true,
+        error: new Error('Reached maximum iteration limit'),
+        toolCalls: [{ name: 'read_file', input: {}, output: {} } as any],
+      }),
+      makeResult({
+        text: 'step2-final',
+        outputTokens: 20,
+        lastStopReason: 'end_turn',
+      }),
+    ]
+    const opts = baseOptions(scripted)
+    const checkpoints: TurnCheckpoint[] = []
+
+    const res = await runDurableTurn({ ...opts, onCheckpoint: cp => checkpoints.push(cp) })
+
+    expect(res.terminationReason).toBe('completed')
+    expect(res.attempts).toHaveLength(2)
+    expect(checkpoints[0]?.reason).toBe('continuation_iteration_limit')
+  })
+
+  test('retries a transient provider error (no tool calls, no output)', async () => {
+    const scripted: AgentLoopResult[] = [
+      makeResult({ error: new Error('ECONNRESET transient'), outputTokens: 0 }),
+      makeResult({ text: 'ok', outputTokens: 5, lastStopReason: 'end_turn' }),
+    ]
+    const opts = baseOptions(scripted, { providerRetriesPerAttempt: 2 })
+
+    const res = await runDurableTurn(opts)
+
+    expect(res.terminationReason).toBe('completed')
+    expect(res.text).toBe('ok')
+    // First attemptResult was an internal provider retry so `.attempts` sees
+    // the surviving final attempt only (provider retries do not push).
+    expect(res.attempts).toHaveLength(1)
+  })
+
+  test('surfaces non-recoverable billing errors as provider_fatal', async () => {
+    const scripted: AgentLoopResult[] = [
+      makeResult({
+        error: new Error('HTTP 401: unauthorized - billing disabled'),
+        outputTokens: 0,
+      }),
+    ]
+    const opts = baseOptions(scripted, { providerRetriesPerAttempt: 2 })
+    const checkpoints: TurnCheckpoint[] = []
+
+    const res = await runDurableTurn({ ...opts, onCheckpoint: cp => checkpoints.push(cp) })
+
+    expect(res.terminationReason).toBe('provider_fatal')
+    expect(res.error?.message).toMatch(/unauthorized|billing|401/i)
+    expect(checkpoints[0]?.reason).toMatch(/^terminal_/)
+  })
+
+  test('respects maxContinuations budget and stops with max_continuations', async () => {
+    const scripted: AgentLoopResult[] = Array.from({ length: 10 }, () =>
+      makeResult({
+        text: 'chunk',
+        outputTokens: 5,
+        maxIterationsExhausted: true,
+        lastStopReason: 'length',
+      }),
+    )
+    const opts = baseOptions(scripted, { maxContinuations: 2 })
+
+    const res = await runDurableTurn(opts)
+
+    expect(res.terminationReason).toBe('max_continuations')
+    // 1 initial + 2 continuations = 3 attempts
+    expect(res.attempts).toHaveLength(3)
+  })
+
+  test('short-circuits when signal is aborted before next attempt', async () => {
+    const ac = new AbortController()
+    const scripted: AgentLoopResult[] = [
+      makeResult({
+        text: 'partial',
+        outputTokens: 10,
+        maxIterationsExhausted: true,
+        lastStopReason: 'length',
+      }),
+      makeResult({ text: 'should not be reached', outputTokens: 1 }),
+    ]
+    const opts = baseOptions(scripted, {
+      maxContinuations: 5,
+      signal: ac.signal,
+      prepareNextHistory: async () => {
+        ac.abort()
+        return null
+      },
+    })
+
+    const res = await runDurableTurn(opts)
+
+    // prepareNextHistory returning null is "host_cancelled"; aborting the
+    // signal inside it is belt-and-suspenders — either outcome proves we
+    // did NOT run the second attempt.
+    expect(['host_cancelled', 'user_abort']).toContain(res.terminationReason)
+    expect(res.attempts).toHaveLength(1)
+  })
+
+  test('triggers the no-silent-EOF gate on empty completion', async () => {
+    const scripted: AgentLoopResult[] = [
+      makeResult({ text: '', outputTokens: 0, toolCalls: [], lastStopReason: 'end_turn' }),
+    ]
+    const opts = baseOptions(scripted)
+    const checkpoints: TurnCheckpoint[] = []
+
+    const res = await runDurableTurn({ ...opts, onCheckpoint: cp => checkpoints.push(cp) })
+
+    expect(res.terminationReason).toBe('provider_fatal')
+    expect(res.error?.message).toMatch(/without emitting any output/)
+    expect(checkpoints.find(c => c.reason === 'terminal_silent_empty')).toBeDefined()
+  })
+
+  test('uses default continuation prompt that references resume intent', async () => {
+    const scripted: AgentLoopResult[] = [
+      makeResult({
+        text: 'first',
+        outputTokens: 10,
+        maxIterationsExhausted: true,
+        lastStopReason: 'length',
+      }),
+      makeResult({ text: 'second', outputTokens: 5, lastStopReason: 'end_turn' }),
+    ]
+    const captured: AgentLoopOptions[] = []
+    const res = await runDurableTurn({
+      model: 'claude-sonnet-4-5',
+      system: 'Test',
+      history: [],
+      prompt: 'Original user prompt',
+      tools: [],
+      _runLoopForTests: async (o) => {
+        captured.push(o)
+        const next = scripted.shift()
+        if (!next) throw new Error('no more')
+        return next
+      },
+    })
+
+    expect(res.terminationReason).toBe('completed')
+    expect(captured).toHaveLength(2)
+    expect(captured[0]?.prompt).toBe('Original user prompt')
+    // Continuation prompt must be non-empty, DIFFERENT from the original,
+    // and should mention resuming.
+    expect(captured[1]?.prompt).not.toBe(captured[0]?.prompt)
+    expect(captured[1]?.prompt?.toLowerCase()).toMatch(/resume|continue|pick/i)
+  })
+})
+
+describe('classifyAttempt', () => {
+  test('flags loopBreak as terminal loop_detected', () => {
+    const r = makeResult({ loopBreak: { reason: 'repetition' } as any })
+    const c = classifyAttempt(r)
+    expect(c.fatal).toBe(true)
+    expect(c.fatalLabel).toBe('loop_detected')
+  })
+
+  test('length stop => max_tokens continuation', () => {
+    const r = makeResult({
+      maxIterationsExhausted: true,
+      lastStopReason: 'length',
+    })
+    const c = classifyAttempt(r)
+    expect(c.fatal).toBe(false)
+    expect(c.reason).toBe('max_tokens')
+  })
+
+  test('billing error is terminal even without maxIterationsExhausted', () => {
+    const r = makeResult({ error: new Error('billing disabled: insufficient credits') })
+    const c = classifyAttempt(r)
+    expect(c.fatal).toBe(true)
+    expect(c.fatalLabel).toBe('billing_or_auth')
+  })
+
+  test('context overflow is terminal with a dedicated label', () => {
+    const r = makeResult({ error: new Error('Prompt is too long — context overflow') })
+    const c = classifyAttempt(r)
+    expect(c.fatal).toBe(true)
+    expect(c.fatalLabel).toBe('context_overflow')
+  })
+})
+
+describe('ToolIdempotencyRegistry', () => {
+  test('tracks lifecycle: plan → start → completed', () => {
+    const reg = new ToolIdempotencyRegistry()
+    reg.plan('call-1', 'read_file')
+    expect(reg.get('call-1')?.state).toBe('planned')
+
+    reg.start('call-1', 'read_file', { path: '/tmp/x' })
+    expect(reg.get('call-1')?.state).toBe('started')
+    expect(reg.get('call-1')?.args).toEqual({ path: '/tmp/x' })
+
+    reg.finish('call-1', { ok: true }, false)
+    expect(reg.get('call-1')?.state).toBe('completed')
+    expect(reg.isCompleted('call-1')).toBe(true)
+  })
+
+  test('lists started-but-unfinished mutating tools (danger zone)', () => {
+    const reg = new ToolIdempotencyRegistry()
+    reg.start('c1', 'write_file', { path: '/a' })
+    reg.start('c2', 'read_file', { path: '/b' })
+    reg.finish('c2', 'ok', false)
+    reg.start('c3', 'exec', { cmd: 'rm -rf /' })
+    reg.finish('c3', 'done', false)
+    reg.start('c4', 'edit_file', { path: '/c' })
+
+    const unfinished = reg.listStartedButUnfinished()
+    expect(unfinished.map(u => u.toolCallId).sort()).toEqual(['c1', 'c4'])
+    const muts = unfinished.filter(r => r.cls.mutating)
+    expect(muts).toHaveLength(2)
+  })
+
+  test('classifies unknown tools as mutating by default', () => {
+    const reg = new ToolIdempotencyRegistry()
+    const rec = reg.plan('c1', 'some_unknown_custom_tool')
+    expect(rec.cls.mutating).toBe(true)
+    expect(rec.cls.readOnly).toBe(false)
+  })
+
+  test('classifies mcp_*_read tools as read-only', () => {
+    const reg = new ToolIdempotencyRegistry()
+    const rec = reg.plan('c1', 'mcp_github_read')
+    expect(rec.cls.readOnly).toBe(true)
+    expect(rec.cls.mutating).toBe(false)
+  })
+
+  test('reset() clears all state and resets the attempt counter', () => {
+    const reg = new ToolIdempotencyRegistry()
+    reg.beginAttempt(5)
+    reg.start('c1', 'exec', {})
+    expect(reg.snapshot()).toHaveLength(1)
+
+    reg.reset()
+    expect(reg.snapshot()).toHaveLength(0)
+    const rec = reg.plan('c2', 'exec')
+    // reset() should have rewound attempt → 1
+    expect(rec.attempt).toBe(1)
+  })
+})

--- a/packages/agent-runtime/src/__tests__/durable-turn-runner.test.ts
+++ b/packages/agent-runtime/src/__tests__/durable-turn-runner.test.ts
@@ -280,7 +280,7 @@ describe('runDurableTurn', () => {
 
   test('refuses provider retry when registry has unfinished mutating tool (f1)', async () => {
     const registry = new ToolIdempotencyRegistry()
-    registry.start('call-write-1', 'write_file', { path: '/tmp/a' })
+    registry.start('call-write-1', 'write_file', { path: '/tmp/a' }, { readOnly: false, mutating: true })
     // Not finished on purpose — this simulates a mid-stream failure right
     // after a mutating tool started but before its result streamed back.
 
@@ -302,7 +302,7 @@ describe('runDurableTurn', () => {
 
   test('still retries provider error when only READ-ONLY tools are unfinished (f1)', async () => {
     const registry = new ToolIdempotencyRegistry()
-    registry.start('call-read-1', 'read_file', { path: '/tmp/a' })
+    registry.start('call-read-1', 'read_file', { path: '/tmp/a' }, { readOnly: true, mutating: false })
     // read_file is classified read-only, so replaying is safe.
 
     const scripted: AgentLoopResult[] = [

--- a/packages/agent-runtime/src/durable-turn-runner.ts
+++ b/packages/agent-runtime/src/durable-turn-runner.ts
@@ -36,6 +36,8 @@ import {
   type AgentLoopResult,
   type ToolCallRecord,
 } from './agent-loop'
+import { ToolIdempotencyRegistry } from './tool-idempotency'
+import { getDurableTurnEnv } from '@shogo/shared-runtime'
 
 /** A lightweight semantic checkpoint persisted as the runner progresses. */
 export interface TurnCheckpoint {
@@ -105,6 +107,16 @@ export interface DurableTurnRunnerOptions extends AgentLoopOptions {
    */
   buildContinuationPrompt?: (reason: ContinuationReason, previous: AgentLoopResult) => string
   /**
+   * Optional tool-call idempotency registry (PR #442 review: f1). When
+   * provided, the runner consults `listStartedButUnfinished()` before each
+   * mid-stream provider retry and refuses to blind-retry if any *mutating*
+   * tool was started but never completed — re-planning the same tool_use
+   * could double-apply a side-effect (write_file, exec, external API).
+   * The caller (e.g. gateway.ts) is responsible for populating the
+   * registry from its onBeforeToolCall / onAfterToolCall hooks.
+   */
+  toolRegistry?: ToolIdempotencyRegistry
+  /**
    * Test hook: allows unit tests to inject a deterministic agent-loop
    * driver without having to mock pi-agent-core. Do NOT use in production
    * code paths — production always uses the real `runAgentLoop`.
@@ -149,13 +161,6 @@ function defaultBuildContinuationPrompt(
   return DEFAULT_CONTINUATION_PROMPT[reason]
 }
 
-function envInt(name: string, fallback: number): number {
-  const raw = process.env[name]
-  if (!raw) return fallback
-  const n = Number(raw)
-  return Number.isFinite(n) && n >= 0 ? n : fallback
-}
-
 /**
  * Classify a finished attempt into a continuation decision.
  */
@@ -176,14 +181,21 @@ export function classifyAttempt(result: AgentLoopResult): {
     if (result.lastStopReason === 'length') {
       return { reason: 'max_tokens', fatal: false }
     }
-    if (/maximum iteration limit/i.test(msg) || result.iterations > 0) {
+    // Explicit iteration-limit error message is the ONLY signal we trust
+    // for iteration_limit classification. Previously we also accepted
+    // `result.iterations > 0` which was almost always true and masked
+    // genuine provider outages by auto-continuing them up to
+    // `maxContinuations` times (PR #442 review: f2).
+    if (/maximum iteration limit/i.test(msg)) {
       return { reason: 'iteration_limit', fatal: false }
     }
     // A provider error after at least one tool call promotes
-    // maxIterationsExhausted inside runAgentLoop — treat as recoverable.
+    // maxIterationsExhausted inside runAgentLoop — treat as recoverable
+    // with a dedicated reason so the UI can distinguish it from iteration_limit.
     if (result.toolCalls.length > 0) {
       return { reason: 'provider_error_after_tools', fatal: false }
     }
+    // Unrecognized exhaustion falls through to the error branch below.
   }
 
   if (err) {
@@ -248,9 +260,13 @@ function mergeAttempt(acc: AgentLoopResult, next: AgentLoopResult): AgentLoopRes
 export async function runDurableTurn(
   options: DurableTurnRunnerOptions,
 ): Promise<DurableTurnResult> {
-  const maxContinuations = options.maxContinuations ?? envInt('AGENT_MAX_CONTINUATIONS', 5)
+  // Read env once per turn via the single durable-turn-env source of truth
+  // so ops-visible logs from logDurableTurnStartup() match the runtime's
+  // actual behaviour (PR #442 review: f9).
+  const durableEnv = getDurableTurnEnv()
+  const maxContinuations = options.maxContinuations ?? durableEnv.agentMaxContinuations
   const providerRetriesPerAttempt =
-    options.providerRetriesPerAttempt ?? envInt('AGENT_PROVIDER_RETRIES', 2)
+    options.providerRetriesPerAttempt ?? durableEnv.agentProviderRetries
   const buildPrompt = options.buildContinuationPrompt ?? defaultBuildContinuationPrompt
   const runLoop = options._runLoopForTests ?? runAgentLoop
   const emitCheckpoint = (cp: TurnCheckpoint) => {
@@ -319,6 +335,26 @@ export async function runDurableTurn(
 
       if (!needsProviderRetry) break
 
+      // Safety gate (PR #442 review: f1): if any MUTATING tool call from a
+      // prior attempt started but never completed, a blind re-invocation
+      // would let the model re-plan the same tool_use and double-apply a
+      // side-effect (write, exec, external API). Break out of the retry
+      // loop and let the outer classifier surface this as provider_fatal
+      // so the caller can reconcile. Read-only unfinished tools are safe
+      // to replay so we only gate on `mutating`.
+      const unfinishedMutating = options.toolRegistry
+        ?.listStartedButUnfinished()
+        .filter((r) => r.cls.mutating)
+      if (unfinishedMutating && unfinishedMutating.length > 0) {
+        console.warn(
+          `[DurableTurnRunner] Refusing to retry attempt ${attemptIndex}: ` +
+            `${unfinishedMutating.length} mutating tool call(s) started but ` +
+            `not completed — blind retry could double-apply side-effects. ` +
+            `Unfinished: ${unfinishedMutating.map((r) => `${r.toolName}(${r.toolCallId})`).join(', ')}`,
+        )
+        break
+      }
+
       providerRetry++
       const backoffMs = Math.min(1_000 * Math.pow(2, providerRetry - 1), 30_000)
       console.warn(
@@ -386,6 +422,7 @@ export async function runDurableTurn(
     // the session so the next attempt sees completed tool results) and
     // short-circuit if the user has cancelled or the host wants to stop.
     let nextHistory: Message[] | null = null
+    let prepareFailed = false
     try {
       const prepared = options.prepareNextHistory
         ? await options.prepareNextHistory(attemptResult)
@@ -396,7 +433,32 @@ export async function runDurableTurn(
       }
       nextHistory = prepared ?? null
     } catch (err: any) {
-      console.warn('[DurableTurnRunner] prepareNextHistory threw:', err?.message || err)
+      // If the host's history-preparer throws, the session store has NOT been
+      // updated. Continuing with a locally-reconstructed history would diverge
+      // from the source of truth and the next attempt would write into a
+      // split timeline. Safer to surface a terminal state and let the caller
+      // resume from the ledger. (PR #442 review: f5)
+      console.warn(
+        '[DurableTurnRunner] prepareNextHistory threw; aborting turn to avoid ' +
+          'diverging from session store:',
+        err?.message || err,
+      )
+      prepareFailed = true
+      emitCheckpoint({
+        attempt: attemptIndex,
+        at: new Date().toISOString(),
+        reason: 'terminal_history_sync_failed',
+        iterations: attemptResult.iterations,
+        toolCallsThisAttempt: attemptResult.toolCalls.length,
+        toolCallsTotal: cumulativeToolCalls,
+        outputTokensTotal: cumulativeOutputTokens,
+        willContinue: false,
+        error: err?.message || String(err),
+      })
+    }
+    if (prepareFailed) {
+      terminationReason = 'host_cancelled'
+      break
     }
 
     currentHistory = nextHistory ?? [...currentHistory, ...attemptResult.newMessages]

--- a/packages/agent-runtime/src/durable-turn-runner.ts
+++ b/packages/agent-runtime/src/durable-turn-runner.ts
@@ -1,0 +1,465 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * DurableTurnRunner — agent-level auto-continuation and checkpointing.
+ *
+ * Wraps `runAgentLoop` so a single user-visible "turn" can span multiple
+ * LLM iterations, context compactions, and provider retries without the
+ * client ever observing a silent EOF.
+ *
+ * Background: `runAgentLoop` returns `maxIterationsExhausted === true`
+ * when the model stopped because of `max_tokens`, our per-turn iteration
+ * cap, or a mid-stream provider error after at least one tool call.
+ * Previously the gateway translated that into an error UI frame asking
+ * the user to type "continue" — that is what made very long Anthropic
+ * sessions look like they stopped at `tokens: 0, tool calls: 11`.
+ *
+ * Instead, this runner:
+ *   1. Calls `runAgentLoop` as usual.
+ *   2. If the loop ended for a recoverable reason and we still have budget,
+ *      it re-invokes the loop with the carried-over session history and
+ *      a synthetic continuation prompt. No user-visible error is emitted.
+ *   3. It merges results across attempts: text concatenated, toolCalls
+ *      union, usage summed, final `newMessages` from the last attempt
+ *      (since `runAgentLoop` already receives the updated `history`).
+ *   4. On genuine terminal errors (billing/auth, loop detected, user
+ *      abort) it surfaces the error unchanged.
+ *
+ * Inspired by claude-code-source/src/query.ts' `maxOutputTokensRecoveryCount`
+ * and Anthropic's official "Resume directly from the cut-off" guidance.
+ */
+
+import type { Message } from '@mariozechner/pi-ai'
+import {
+  runAgentLoop,
+  type AgentLoopOptions,
+  type AgentLoopResult,
+  type ToolCallRecord,
+} from './agent-loop'
+
+/** A lightweight semantic checkpoint persisted as the runner progresses. */
+export interface TurnCheckpoint {
+  /** Monotonic inside a single turn; reset to 0 for each new user prompt. */
+  attempt: number
+  /** ISO timestamp of the checkpoint. */
+  at: string
+  /**
+   * Reason we recorded this checkpoint — e.g. 'attempt_end',
+   * 'continuation_max_tokens', 'continuation_iteration_limit',
+   * 'continuation_provider_error', 'abort', 'terminal'.
+   */
+  reason: string
+  /** Effective model used for this attempt (routing may differ per attempt). */
+  modelId?: string
+  /** How many LLM iterations this attempt consumed. */
+  iterations: number
+  /** How many new tool calls executed this attempt. */
+  toolCallsThisAttempt: number
+  /** Cumulative tool calls across attempts of this turn. */
+  toolCallsTotal: number
+  /** Cumulative output tokens across attempts. */
+  outputTokensTotal: number
+  /** `lastStopReason` from the LLM at the end of this attempt. */
+  lastStopReason?: string
+  /** Whether the runner intends to auto-continue after this checkpoint. */
+  willContinue: boolean
+  /** Serializable error label for terminal attempts. */
+  error?: string
+}
+
+export type TurnCheckpointListener = (checkpoint: TurnCheckpoint) => void
+
+/**
+ * Options for the runner. Everything except the persistence/metrics hooks
+ * flows into the inner `runAgentLoop` call for the first attempt.
+ */
+export interface DurableTurnRunnerOptions extends AgentLoopOptions {
+  /** Stable turn identifier (propagates to ledger headers). */
+  turnId?: string
+  /**
+   * Max continuation attempts after the first. Default: 5.
+   * Override via env `AGENT_MAX_CONTINUATIONS`.
+   */
+  maxContinuations?: number
+  /**
+   * Mid-stream provider retry budget per attempt. Default: 2.
+   * Override via env `AGENT_PROVIDER_RETRIES`.
+   */
+  providerRetriesPerAttempt?: number
+  /**
+   * Persist callback invoked for every checkpoint. Typically wired to
+   * the turn ledger / stream-buffer.
+   */
+  onCheckpoint?: TurnCheckpointListener
+  /**
+   * After `runAgentLoop` returns — with or without error — but before
+   * deciding to auto-continue. Gives callers (e.g. the gateway) a hook
+   * to update the session history so the next attempt sees the newly
+   * produced tool results. Returning `null` aborts further continuations
+   * (e.g. user cancelled in the meantime).
+   */
+  prepareNextHistory?: (previous: AgentLoopResult) => Promise<Message[] | null> | Message[] | null
+  /**
+   * Build the continuation prompt. Defaults to an Anthropic-friendly
+   * "resume" instruction modeled after claude-code-source/query.ts.
+   */
+  buildContinuationPrompt?: (reason: ContinuationReason, previous: AgentLoopResult) => string
+  /**
+   * Test hook: allows unit tests to inject a deterministic agent-loop
+   * driver without having to mock pi-agent-core. Do NOT use in production
+   * code paths — production always uses the real `runAgentLoop`.
+   * @internal
+   */
+  _runLoopForTests?: (opts: AgentLoopOptions) => Promise<AgentLoopResult>
+}
+
+export type ContinuationReason =
+  | 'max_tokens'
+  | 'iteration_limit'
+  | 'provider_error_after_tools'
+
+export interface DurableTurnResult extends AgentLoopResult {
+  /** Per-attempt results in order. */
+  attempts: AgentLoopResult[]
+  /** Reason we stopped auto-continuing (may be 'completed'). */
+  terminationReason:
+    | 'completed'
+    | 'user_abort'
+    | 'loop_detected'
+    | 'provider_fatal'
+    | 'max_continuations'
+    | 'host_cancelled'
+  /** Aggregate checkpoints emitted during the turn. */
+  checkpoints: TurnCheckpoint[]
+}
+
+const DEFAULT_CONTINUATION_PROMPT: Record<ContinuationReason, string> = {
+  max_tokens:
+    'Output token limit hit. Resume directly where you left off, without repeating anything already said. Complete the remaining work.',
+  iteration_limit:
+    'Agent iteration budget refreshed. Continue from where you paused and finish the user\'s original request. Avoid repeating completed steps.',
+  provider_error_after_tools:
+    'The upstream model stream was interrupted after partial progress. Resume from the last completed tool call and keep going. Do not repeat work you already did.',
+}
+
+function defaultBuildContinuationPrompt(
+  reason: ContinuationReason,
+  _previous: AgentLoopResult,
+): string {
+  return DEFAULT_CONTINUATION_PROMPT[reason]
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const n = Number(raw)
+  return Number.isFinite(n) && n >= 0 ? n : fallback
+}
+
+/**
+ * Classify a finished attempt into a continuation decision.
+ */
+export function classifyAttempt(result: AgentLoopResult): {
+  reason: ContinuationReason | null
+  fatal: boolean
+  fatalLabel?: string
+} {
+  if (result.loopBreak) {
+    return { reason: null, fatal: true, fatalLabel: 'loop_detected' }
+  }
+
+  const err = result.error
+  const msg = err?.message || ''
+
+  // Recoverable iteration/length cases — these populate maxIterationsExhausted.
+  if (result.maxIterationsExhausted) {
+    if (result.lastStopReason === 'length') {
+      return { reason: 'max_tokens', fatal: false }
+    }
+    if (/maximum iteration limit/i.test(msg) || result.iterations > 0) {
+      return { reason: 'iteration_limit', fatal: false }
+    }
+    // A provider error after at least one tool call promotes
+    // maxIterationsExhausted inside runAgentLoop — treat as recoverable.
+    if (result.toolCalls.length > 0) {
+      return { reason: 'provider_error_after_tools', fatal: false }
+    }
+  }
+
+  if (err) {
+    // Non-recoverable: billing, auth, no-output-at-all provider error.
+    const fatalLabel = /billing|insufficient.credits|401|403|unauthorized|forbidden/i.test(msg)
+      ? 'billing_or_auth'
+      : /context|too long|overflow/i.test(msg)
+        ? 'context_overflow'
+        : 'provider_fatal'
+    return { reason: null, fatal: true, fatalLabel }
+  }
+
+  return { reason: null, fatal: false }
+}
+
+/**
+ * Merge a second attempt's result into an accumulating result.
+ *
+ * Text is concatenated with a single blank line separator; tool calls are
+ * unioned; usage is summed. `newMessages`, however, is the LAST attempt
+ * only — the expectation is that between attempts the caller (via
+ * `prepareNextHistory`) has already committed the previous attempt's
+ * messages to the session store, so double-committing would duplicate.
+ * This keeps the semantics identical to `runAgentLoop`: "the new messages
+ * the caller still owes the session after this call."
+ */
+function mergeAttempt(acc: AgentLoopResult, next: AgentLoopResult): AgentLoopResult {
+  const joinedText = [acc.text, next.text].filter(Boolean).join('\n\n')
+  const mergedToolCalls: ToolCallRecord[] = [...acc.toolCalls, ...next.toolCalls]
+  return {
+    text: joinedText,
+    toolCalls: mergedToolCalls,
+    iterations: acc.iterations + next.iterations,
+    inputTokens: acc.inputTokens + next.inputTokens,
+    outputTokens: acc.outputTokens + next.outputTokens,
+    cacheReadTokens: acc.cacheReadTokens + next.cacheReadTokens,
+    cacheWriteTokens: acc.cacheWriteTokens + next.cacheWriteTokens,
+    newMessages: next.newMessages,
+    loopBreak: next.loopBreak ?? acc.loopBreak,
+    error: next.error,
+    effectiveModelId: next.effectiveModelId || acc.effectiveModelId,
+    maxIterationsExhausted: next.maxIterationsExhausted,
+    lastStopReason: next.lastStopReason ?? acc.lastStopReason,
+    lastTurnHadToolCalls:
+      typeof next.lastTurnHadToolCalls === 'boolean'
+        ? next.lastTurnHadToolCalls
+        : acc.lastTurnHadToolCalls,
+  }
+}
+
+/**
+ * Run an agent turn with automatic, bounded continuation.
+ *
+ * Contract:
+ *   - Returns a single AgentLoopResult-compatible object that the gateway
+ *     treats like the original `runAgentLoop` output, plus per-attempt
+ *     metadata under `.attempts` / `.checkpoints` for observability.
+ *   - Never throws from the continuation logic itself: any throw from
+ *     `runAgentLoop` is already caught and surfaced via `.error`.
+ *   - External abort (signal) immediately short-circuits further attempts.
+ */
+export async function runDurableTurn(
+  options: DurableTurnRunnerOptions,
+): Promise<DurableTurnResult> {
+  const maxContinuations = options.maxContinuations ?? envInt('AGENT_MAX_CONTINUATIONS', 5)
+  const providerRetriesPerAttempt =
+    options.providerRetriesPerAttempt ?? envInt('AGENT_PROVIDER_RETRIES', 2)
+  const buildPrompt = options.buildContinuationPrompt ?? defaultBuildContinuationPrompt
+  const runLoop = options._runLoopForTests ?? runAgentLoop
+  const emitCheckpoint = (cp: TurnCheckpoint) => {
+    checkpoints.push(cp)
+    try { options.onCheckpoint?.(cp) } catch (err: any) {
+      console.warn('[DurableTurnRunner] onCheckpoint threw:', err?.message || err)
+    }
+  }
+
+  const attempts: AgentLoopResult[] = []
+  const checkpoints: TurnCheckpoint[] = []
+
+  let currentPrompt = options.prompt
+  let currentHistory = options.history
+  let attemptIndex = 0
+  let cumulativeOutputTokens = 0
+  let cumulativeToolCalls = 0
+
+  // The overall accumulator — seeded with the first attempt.
+  let accumulated: AgentLoopResult | null = null
+  let terminationReason: DurableTurnResult['terminationReason'] = 'completed'
+
+  while (true) {
+    attemptIndex++
+
+    if (options.signal?.aborted) {
+      terminationReason = 'user_abort'
+      emitCheckpoint({
+        attempt: attemptIndex,
+        at: new Date().toISOString(),
+        reason: 'abort_before_attempt',
+        iterations: 0,
+        toolCallsThisAttempt: 0,
+        toolCallsTotal: cumulativeToolCalls,
+        outputTokensTotal: cumulativeOutputTokens,
+        willContinue: false,
+      })
+      break
+    }
+
+    let attemptResult: AgentLoopResult | null = null
+    let providerRetry = 0
+    // Per-attempt provider-mid-stream retry. We re-invoke runAgentLoop with
+    // the same (history, prompt) because pi-agent-core captures the
+    // interrupted stream's state in `newMessages`; each retry begins from
+    // the latest history snapshot prepared by `prepareNextHistory`.
+    while (providerRetry <= providerRetriesPerAttempt) {
+      attemptResult = await runLoop({
+        ...options,
+        prompt: currentPrompt,
+        history: currentHistory,
+      })
+
+      // Retry only if this attempt saw a mid-stream provider failure
+      // AND we made no tool progress AND there's budget left. Progressing
+      // attempts don't retry at this layer — they go through the outer
+      // continuation branch below.
+      const needsProviderRetry =
+        !!attemptResult.error &&
+        attemptResult.toolCalls.length === 0 &&
+        attemptResult.outputTokens === 0 &&
+        providerRetry < providerRetriesPerAttempt &&
+        !/billing|insufficient.credits|401|403|unauthorized|forbidden/i.test(
+          attemptResult.error.message || '',
+        )
+
+      if (!needsProviderRetry) break
+
+      providerRetry++
+      const backoffMs = Math.min(1_000 * Math.pow(2, providerRetry - 1), 30_000)
+      console.warn(
+        `[DurableTurnRunner] Provider error on attempt ${attemptIndex}; ` +
+          `retry ${providerRetry}/${providerRetriesPerAttempt} in ${backoffMs}ms: ` +
+          `${attemptResult.error?.message}`,
+      )
+      await new Promise((r) => setTimeout(r, backoffMs))
+      if (options.signal?.aborted) break
+    }
+
+    if (!attemptResult) break
+    attempts.push(attemptResult)
+    cumulativeOutputTokens += attemptResult.outputTokens
+    cumulativeToolCalls += attemptResult.toolCalls.length
+    accumulated = accumulated ? mergeAttempt(accumulated, attemptResult) : attemptResult
+
+    const { reason, fatal, fatalLabel } = classifyAttempt(attemptResult)
+    const remaining = Math.max(0, maxContinuations - (attemptIndex - 1))
+    const willContinue = !fatal && !!reason && remaining > 0 && !options.signal?.aborted
+
+    emitCheckpoint({
+      attempt: attemptIndex,
+      at: new Date().toISOString(),
+      reason: fatal
+        ? `terminal_${fatalLabel || 'unknown'}`
+        : reason
+          ? `continuation_${reason}`
+          : 'attempt_end',
+      modelId: attemptResult.effectiveModelId,
+      iterations: attemptResult.iterations,
+      toolCallsThisAttempt: attemptResult.toolCalls.length,
+      toolCallsTotal: cumulativeToolCalls,
+      outputTokensTotal: cumulativeOutputTokens,
+      lastStopReason: attemptResult.lastStopReason,
+      willContinue,
+      error: attemptResult.error?.message,
+    })
+
+    if (fatal) {
+      terminationReason = attemptResult.loopBreak ? 'loop_detected' : 'provider_fatal'
+      break
+    }
+
+    if (!reason) {
+      terminationReason = 'completed'
+      break
+    }
+
+    if (options.signal?.aborted) {
+      terminationReason = 'user_abort'
+      break
+    }
+
+    if (remaining <= 0) {
+      terminationReason = 'max_continuations'
+      console.warn(
+        `[DurableTurnRunner] Reached max continuations (${maxContinuations}); stopping. ` +
+          'The turn will surface as incomplete so the caller can decide what to do.',
+      )
+      break
+    }
+
+    // Hand the caller a chance to refresh history (e.g. add newMessages to
+    // the session so the next attempt sees completed tool results) and
+    // short-circuit if the user has cancelled or the host wants to stop.
+    let nextHistory: Message[] | null = null
+    try {
+      const prepared = options.prepareNextHistory
+        ? await options.prepareNextHistory(attemptResult)
+        : undefined
+      if (prepared === null) {
+        terminationReason = 'host_cancelled'
+        break
+      }
+      nextHistory = prepared ?? null
+    } catch (err: any) {
+      console.warn('[DurableTurnRunner] prepareNextHistory threw:', err?.message || err)
+    }
+
+    currentHistory = nextHistory ?? [...currentHistory, ...attemptResult.newMessages]
+    currentPrompt = buildPrompt(reason, attemptResult)
+  }
+
+  const base: AgentLoopResult = accumulated ?? {
+    text: '',
+    toolCalls: [],
+    iterations: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    newMessages: [],
+    maxIterationsExhausted: false,
+  }
+
+  // If we ended on a recoverable condition but exhausted our budget,
+  // don't surface an "error" unless there genuinely is one — the caller
+  // can read terminationReason to decide whether to show a banner.
+  if (terminationReason === 'max_continuations' && base.error) {
+    // Keep the error in place; callers can still interpret it.
+  }
+
+  // No-silent-EOF gate (Phase 5.3): if the turn ended with ZERO output
+  // tokens, ZERO tool calls, no text, no error, and we're marking it
+  // 'completed', something unusual happened (e.g. the provider returned
+  // an empty stream). Promote this to an explicit error so the client
+  // never sees a silent blank response; the caller can still inspect
+  // `terminationReason` to render a more useful banner.
+  const isSilentEmpty =
+    terminationReason === 'completed' &&
+    !base.error &&
+    !base.loopBreak &&
+    base.outputTokens === 0 &&
+    base.toolCalls.length === 0 &&
+    (!base.text || base.text.trim().length === 0)
+  if (isSilentEmpty) {
+    const silentErr = new Error(
+      'Agent turn completed without emitting any output, tool calls, or error. ' +
+        'This is usually caused by a provider returning an empty stream; the client ' +
+        'should retry or rephrase.',
+    )
+    emitCheckpoint({
+      attempt: attemptIndex,
+      at: new Date().toISOString(),
+      reason: 'terminal_silent_empty',
+      iterations: base.iterations,
+      toolCallsThisAttempt: 0,
+      toolCallsTotal: cumulativeToolCalls,
+      outputTokensTotal: cumulativeOutputTokens,
+      willContinue: false,
+      error: silentErr.message,
+    })
+    return {
+      ...base,
+      error: silentErr,
+      attempts,
+      terminationReason: 'provider_fatal',
+      checkpoints,
+    }
+  }
+
+  return { ...base, attempts, terminationReason, checkpoints }
+}

--- a/packages/agent-runtime/src/gateway-tools.ts
+++ b/packages/agent-runtime/src/gateway-tools.ts
@@ -11,6 +11,7 @@
  */
 
 import { getModelTier, resolveModelId, calculateDollarCost } from '@shogo/model-catalog'
+import type { ShogoAgentTool } from './tool-idempotency'
 import { existsSync, readFileSync, writeFileSync, readdirSync, mkdirSync, unlinkSync, statSync, copyFileSync } from 'fs'
 import { join, resolve, extname, dirname, relative } from 'path'
 import { execSync } from 'child_process'
@@ -219,9 +220,10 @@ export function containerToHost(containerPath: string, workspaceDir: string): st
 // Tool Definitions (created via factory)
 // ---------------------------------------------------------------------------
 
-function createExecTool(ctx: ToolContext): AgentTool {
+function createExecTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'exec',
+    cls: { readOnly: false, mutating: true },
     description:
       'Run a shell command. The shell remembers your working directory across calls — ' +
       'do NOT prepend cd to commands, the cwd from your last exec call is preserved automatically. ' +
@@ -313,9 +315,10 @@ const IMAGE_READ_MIME: Record<string, string> = {
 }
 const MAX_IMAGE_READ_BYTES = 20 * 1024 * 1024
 
-function createReadFileTool(ctx: ToolContext): AgentTool {
+function createReadFileTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'read_file',
+    cls: { readOnly: true, mutating: false },
     description:
       'Read a file from the agent workspace. Supports partial reads via offset and limit ' +
       'to handle large files without consuming the full context window. ' +
@@ -457,9 +460,10 @@ function appendImpactHint(ctx: ToolContext, filePath: string, result: Record<str
   } catch { /* best-effort — do not fail the write */ }
 }
 
-function createWriteFileTool(ctx: ToolContext): AgentTool {
+function createWriteFileTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'write_file',
+    cls: { readOnly: false, mutating: true },
     description: 'Create a NEW file in the agent workspace. Creates parent directories as needed. ' +
       'WARNING: Do NOT use write_file to modify existing files — use edit_file instead. ' +
       'write_file overwrites the entire file which risks losing code. Only use for creating brand-new files.',
@@ -667,9 +671,10 @@ function maybeValidateQuickActions(
 // Skill Server Sync Tool
 // ---------------------------------------------------------------------------
 
-function createSkillServerSyncTool(ctx: ToolContext): AgentTool {
+function createSkillServerSyncTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'skill_server_sync',
+    cls: { readOnly: false, mutating: true },
     description:
       'Force the skill server to regenerate routes from schema.prisma and restart. ' +
       'Use this when routes are returning 404 after a schema change, or to verify the server is healthy. ' +
@@ -781,9 +786,10 @@ function fuzzyFindInContent(content: string, needle: string): { index: number; m
 
 const MAX_EDIT_FILE_SIZE = 1024 * 1024 * 1024 // 1 GiB
 
-function createEditFileTool(ctx: ToolContext): AgentTool {
+function createEditFileTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'edit_file',
+    cls: { readOnly: false, mutating: true },
     description:
       'Performs exact string replacements in files.\n\n' +
       'Usage:\n' +
@@ -995,9 +1001,10 @@ const APP_TEMPLATE_METADATA: Array<{
   { name: 'data-explorer', description: 'Data exploration tool with tables, metrics, and agent-driven data collection', complexity: 'intermediate', models: ['User', 'Dataset', 'SavedQuery'] },
 ]
 
-function createTemplateListTool(): AgentTool {
+function createTemplateListTool(): ShogoAgentTool {
   return {
     name: 'template_list',
+    cls: { readOnly: true, mutating: false },
     description:
       'List available app starter templates. Every new app MUST start from a template. ' +
       'Choose the closest match, or use "_template" (blank) if nothing fits. ' +
@@ -1013,9 +1020,10 @@ function createTemplateListTool(): AgentTool {
   }
 }
 
-function createTemplateCopyTool(ctx: ToolContext): AgentTool {
+function createTemplateCopyTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'template_copy',
+    cls: { readOnly: false, mutating: true },
     description:
       'Scaffold a project from a starter template. Extracts the template into project/, ' +
       'sets up the database, installs dependencies, and restarts the preview server. ' +
@@ -1067,9 +1075,10 @@ END APP_MODE_DISABLED */
 
 const todoStores = new Map<string, Array<{ id: string; content: string; status: string }>>()
 
-function createTodoWriteTool(ctx: ToolContext): AgentTool {
+function createTodoWriteTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'todo_write',
+    cls: { readOnly: true, mutating: false },
     description:
       'Manage a session task checklist. Each call replaces the full todo list. ' +
       'Use to track progress on multi-step tasks.',
@@ -1100,9 +1109,10 @@ function createTodoWriteTool(ctx: ToolContext): AgentTool {
 // AskUser Tool (structured multiple-choice questions)
 // ---------------------------------------------------------------------------
 
-function createAskUserTool(_ctx: ToolContext): AgentTool {
+function createAskUserTool(_ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'ask_user',
+    cls: { readOnly: true, mutating: false },
     description:
       'Ask the user structured multiple-choice questions to gather requirements or clarify ambiguity. ' +
       'The UI will render interactive option selectors. Do not call any other tools after this — wait for the user\'s response.',
@@ -1129,9 +1139,10 @@ function createAskUserTool(_ctx: ToolContext): AgentTool {
 // NotifyUserError Tool (prominent error toast in chat UI)
 // ---------------------------------------------------------------------------
 
-function createNotifyUserErrorTool(): AgentTool {
+function createNotifyUserErrorTool(): ShogoAgentTool {
   return {
     name: 'notify_user_error',
+    cls: { readOnly: true, mutating: false },
     description:
       'Show a prominent error notification to the user when a tool fails, an integration is broken, ' +
       'or you cannot complete the requested task. Call this BEFORE explaining the error in chat text. ' +
@@ -1669,9 +1680,10 @@ async function rawFetch(url: string, maxChars: number): Promise<AgentToolResult<
   return textResult({ error: 'All fetch attempts failed', url })
 }
 
-function createWebTool(): AgentTool {
+function createWebTool(): ShogoAgentTool {
   return {
     name: 'web',
+    cls: { readOnly: true, mutating: false },
     description:
       'Unified web tool: fetch a URL or search the web via Google (Serper API). ' +
       'Provide `url` to fetch a page, or `query` to search. Google property URLs (Maps, Flights, Shopping) ' +
@@ -1739,9 +1751,10 @@ function createWebTool(): AgentTool {
   }
 }
 
-function createMemoryReadTool(ctx: ToolContext): AgentTool {
+function createMemoryReadTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'memory_read',
+    cls: { readOnly: true, mutating: false },
     description: 'Read agent memory. Use "MEMORY.md" for long-lived facts or a date like "2026-02-18" for daily logs.',
     label: 'Read Memory',
     parameters: Type.Object({
@@ -1762,7 +1775,7 @@ function createMemoryReadTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createMemorySearchTool(ctx: ToolContext): AgentTool {
+function createMemorySearchTool(ctx: ToolContext): ShogoAgentTool {
   let engine: MemorySearchEngine | null = null
 
   function getEngine(): MemorySearchEngine {
@@ -1774,6 +1787,7 @@ function createMemorySearchTool(ctx: ToolContext): AgentTool {
 
   return {
     name: 'memory_search',
+    cls: { readOnly: true, mutating: false },
     description:
       'Search across all agent memory (MEMORY.md and daily logs) using hybrid keyword + semantic matching. Returns the most relevant memory chunks ranked by relevance.',
     label: 'Search Memory',
@@ -1856,7 +1870,7 @@ function spawnCDPRelay(token: string): Promise<{ cdpEndpoint: string; kill: () =
   })
 }
 
-export function createBrowserTool(ctx: ToolContext): AgentTool {
+export function createBrowserTool(ctx: ToolContext): ShogoAgentTool {
   let browser: any = null
   let page: any = null
   let isExtensionMode = false
@@ -2042,6 +2056,7 @@ export function createBrowserTool(ctx: ToolContext): AgentTool {
 
   return {
     name: 'browser',
+    cls: { readOnly: false, mutating: true },
     description:
       'Control a browser. MUST snapshot before any interaction to get element refs. ' +
       'Actions: navigate, snapshot, click, fill, select, extract, text, screenshot, evaluate, scroll, wait_for, close. ' +
@@ -2311,9 +2326,10 @@ export function createBrowserTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createSendMessageTool(ctx: ToolContext): AgentTool {
+function createSendMessageTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'send_message',
+    cls: { readOnly: false, mutating: true },
     description:
       'Send a message through a connected messaging channel (telegram, discord, slack, whatsapp, email).',
     label: 'Send Message',
@@ -2349,9 +2365,10 @@ function createSendMessageTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createChannelDisconnectTool(ctx: ToolContext): AgentTool {
+function createChannelDisconnectTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'channel_disconnect',
+    cls: { readOnly: false, mutating: true },
     description: 'Disconnect a messaging channel and remove it from config.',
     label: 'Disconnect Channel',
     parameters: Type.Object({
@@ -2384,9 +2401,10 @@ function createChannelDisconnectTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createChannelListTool(ctx: ToolContext): AgentTool {
+function createChannelListTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'channel_list',
+    cls: { readOnly: true, mutating: false },
     description: 'List all configured messaging channels and their connection status.',
     label: 'List Channels',
     parameters: Type.Object({}),
@@ -2424,9 +2442,10 @@ function createChannelListTool(ctx: ToolContext): AgentTool {
 // MCP Discovery Tools
 // ---------------------------------------------------------------------------
 
-function createToolSearchTool(ctx: ToolContext): AgentTool {
+function createToolSearchTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'tool_search',
+    cls: { readOnly: true, mutating: false },
     description: 'Search for managed OAuth integrations and bundled skills by keyword. For MCP servers, use mcp_search.',
     label: 'Search Tools & Skills',
     parameters: Type.Object({
@@ -2491,9 +2510,10 @@ function createToolSearchTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createMcpSearchTool(): AgentTool {
+function createMcpSearchTool(): ShogoAgentTool {
   return {
     name: 'mcp_search',
+    cls: { readOnly: true, mutating: false },
     description: 'Search for MCP protocol servers (databases, file systems, APIs). For managed OAuth integrations, use tool_search.',
     label: 'Search MCP Servers',
     parameters: Type.Object({
@@ -2561,9 +2581,10 @@ function formatToolInstallMessage(
   return `${base} Auth status: needs_auth. The user may need to authorize via the Tools panel.`
 }
 
-function createToolInstallTool(ctx: ToolContext): AgentTool {
+function createToolInstallTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'tool_install',
+    cls: { readOnly: false, mutating: true },
     description: 'Install a managed OAuth integration or bundled skill. For integrations, just provide the name (no API keys needed). For skills, use "skill:" prefix. See read_guide("mcp-discovery") for details.',
     label: 'Install Integration or Skill',
     parameters: Type.Object({
@@ -2666,9 +2687,10 @@ function createToolInstallTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createMcpInstallTool(ctx: ToolContext): AgentTool {
+function createMcpInstallTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'mcp_install',
+    cls: { readOnly: false, mutating: true },
     description: `Install and start an MCP server, making its tools available immediately. Catalog: ${MCP_CATALOG.map(e => e.id).join(', ')}. For remote servers, provide name + url. May require env vars for API keys.`,
     label: 'Install MCP Server',
     parameters: Type.Object({
@@ -2748,9 +2770,10 @@ function createMcpInstallTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createToolUninstallTool(ctx: ToolContext): AgentTool {
+function createToolUninstallTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'tool_uninstall',
+    cls: { readOnly: false, mutating: true },
     description: 'Stop and remove a managed integration. Its tools will no longer be available. For MCP servers, use mcp_uninstall instead.',
     label: 'Uninstall Integration',
     parameters: Type.Object({
@@ -2778,9 +2801,10 @@ function createToolUninstallTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createMcpUninstallTool(ctx: ToolContext): AgentTool {
+function createMcpUninstallTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'mcp_uninstall',
+    cls: { readOnly: false, mutating: true },
     description: 'Stop and remove a running MCP server. Its tools will no longer be available. For managed integrations, use tool_uninstall instead.',
     label: 'Uninstall MCP Server',
     parameters: Type.Object({
@@ -2821,9 +2845,10 @@ import { AgentManager } from './agent-manager'
 import type { ModelTierName, ForkContext } from './subagent'
 import { isInForkChild, buildForkDirective } from './subagent-prompts'
 
-function createAgentCreateTool(ctx: ToolContext): AgentTool {
+function createAgentCreateTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'agent_create',
+    cls: { readOnly: false, mutating: true },
     description:
       'Register a new sub-agent type at runtime. Define its system prompt, allowed tools, and model tier. ' +
       'Use the same name to update an existing type. Set persist: true to save across sessions.',
@@ -2867,9 +2892,10 @@ function createAgentCreateTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createAgentSpawnTool(ctx: ToolContext, allToolsGetter: () => AgentTool[]): AgentTool {
+function createAgentSpawnTool(ctx: ToolContext, allToolsGetter: () => AgentTool[]): ShogoAgentTool {
   return {
     name: 'agent_spawn',
+    cls: { readOnly: false, mutating: true },
     description:
       'Launch an instance of a registered or built-in agent type. Returns an instance_id. ' +
       'Use background: true for async execution, then check with agent_status/agent_result. ' +
@@ -3156,9 +3182,10 @@ export function buildSpawnCallbacks(w: any, spawnToolCallId: string): { callback
   }
 }
 
-function createAgentStatusTool(ctx: ToolContext): AgentTool {
+function createAgentStatusTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'agent_status',
+    cls: { readOnly: true, mutating: false },
     description: 'Check the status of agent instances. Omit instance_id to see all.',
     label: 'Agent Status',
     parameters: Type.Object({
@@ -3186,9 +3213,10 @@ function createAgentStatusTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createAgentCancelTool(ctx: ToolContext): AgentTool {
+function createAgentCancelTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'agent_cancel',
+    cls: { readOnly: false, mutating: true },
     description: 'Cancel a running agent instance.',
     label: 'Cancel Agent',
     parameters: Type.Object({
@@ -3205,9 +3233,10 @@ function createAgentCancelTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createAgentResultTool(ctx: ToolContext): AgentTool {
+function createAgentResultTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'agent_result',
+    cls: { readOnly: true, mutating: false },
     description:
       'Wait for and retrieve the result of an agent instance. Blocks until the agent completes ' +
       'by default (up to 2 min). Set timeout_ms to 0 for an immediate non-blocking check.',
@@ -3282,9 +3311,10 @@ function createAgentResultTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createAgentListTool(ctx: ToolContext, allToolsGetter: () => AgentTool[]): AgentTool {
+function createAgentListTool(ctx: ToolContext, allToolsGetter: () => AgentTool[]): ShogoAgentTool {
   return {
     name: 'agent_list',
+    cls: { readOnly: true, mutating: false },
     description: 'List all registered agent types (built-in and custom) with performance metrics.',
     label: 'List Agents',
     parameters: Type.Object({}),
@@ -3314,9 +3344,10 @@ function ensureTeamContext(ctx: ToolContext): { teamId: string; agentId: string;
   return ctx.teamContext
 }
 
-function createTeamCreateTool(ctx: ToolContext): AgentTool {
+function createTeamCreateTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'team_create',
+    cls: { readOnly: false, mutating: true },
     description: 'Create a team of long-lived agent teammates for complex multi-step projects. Teammates persist across turns, communicate via messages, and claim tasks from a shared queue.',
     label: 'Create Team',
     parameters: Type.Object({
@@ -3354,9 +3385,10 @@ function createTeamCreateTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createTeamDeleteTool(ctx: ToolContext): AgentTool {
+function createTeamDeleteTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'team_delete',
+    cls: { readOnly: false, mutating: true },
     description: 'Delete a team and kill all running teammates. Cascading delete removes all tasks and messages.',
     label: 'Delete Team',
     parameters: Type.Object({
@@ -3386,9 +3418,10 @@ function createTeamDeleteTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createTaskCreateTool(ctx: ToolContext): AgentTool {
+function createTaskCreateTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'task_create',
+    cls: { readOnly: false, mutating: true },
     description: 'Create a task in the team\'s shared task queue. Teammates will automatically claim available tasks when idle.',
     label: 'Create Task',
     parameters: Type.Object({
@@ -3421,9 +3454,10 @@ function createTaskCreateTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createTaskGetTool(ctx: ToolContext): AgentTool {
+function createTaskGetTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'task_get',
+    cls: { readOnly: true, mutating: false },
     description: 'Get detailed information about a specific task including its dependencies.',
     label: 'Get Task',
     parameters: Type.Object({
@@ -3440,9 +3474,10 @@ function createTaskGetTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createTaskListTool(ctx: ToolContext): AgentTool {
+function createTaskListTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'task_list',
+    cls: { readOnly: true, mutating: false },
     description: 'List all tasks in the team\'s queue with their status, owner, and dependencies.',
     label: 'List Tasks',
     parameters: Type.Object({}),
@@ -3456,9 +3491,10 @@ function createTaskListTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createTaskUpdateTool(ctx: ToolContext): AgentTool {
+function createTaskUpdateTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'task_update',
+    cls: { readOnly: false, mutating: true },
     description: 'Update a task\'s status, description, owner, or dependencies. Use to mark tasks in_progress or completed.',
     label: 'Update Task',
     parameters: Type.Object({
@@ -3509,9 +3545,10 @@ function createTaskUpdateTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createSendTeamMessageTool(ctx: ToolContext): AgentTool {
+function createSendTeamMessageTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'send_team_message',
+    cls: { readOnly: false, mutating: true },
     description: 'Send a message to a teammate, the team lead, or broadcast to all team members. Use structured message types for shutdown negotiation.',
     label: 'Send Team Message',
     parameters: Type.Object({
@@ -3569,9 +3606,10 @@ function createSendTeamMessageTool(ctx: ToolContext): AgentTool {
 // Quick Action Tool
 // ---------------------------------------------------------------------------
 
-function createQuickActionTool(ctx: ToolContext): AgentTool {
+function createQuickActionTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'quick_action',
+    cls: { readOnly: true, mutating: false },
     description:
       'Register a quick action — a one-click prompt shortcut shown in the user\'s chat UI. ' +
       'Use this when you notice a user sending a repeatable workflow prompt (commits, tests, deploys, etc.).',
@@ -3595,9 +3633,10 @@ function createQuickActionTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createReadGuideTool(ctx: ToolContext): AgentTool {
+function createReadGuideTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'read_guide',
+    cls: { readOnly: true, mutating: false },
     description: 'Read a capability guide by name. See the Capabilities Index in your system prompt for available guides.',
     label: 'Read Guide',
     parameters: Type.Object({
@@ -3720,9 +3759,10 @@ function inferRuntime(filename: string): string {
   return map[ext || ''] || 'bash'
 }
 
-function createSkillTool(ctx: ToolContext, allToolsGetter: () => AgentTool[]): AgentTool {
+function createSkillTool(ctx: ToolContext, allToolsGetter: () => AgentTool[]): ShogoAgentTool {
   return {
     name: 'skill',
+    cls: { readOnly: false, mutating: true },
     description:
       'Manage and invoke skills. Actions: invoke (default), search, install, run_script. ' +
       'See read_guide("skill-matching") for details.',
@@ -4015,9 +4055,10 @@ function getOrCreateIndex(ctx: ToolContext): IndexEngine {
   return ctx.indexEngine
 }
 
-function createDeleteFileTool(ctx: ToolContext): AgentTool {
+function createDeleteFileTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'delete_file',
+    cls: { readOnly: false, mutating: true },
     description: 'Delete a file from the workspace files/ directory.',
     label: 'Delete File',
     parameters: Type.Object({
@@ -4044,9 +4085,10 @@ function createDeleteFileTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createSearchTool(ctx: ToolContext): AgentTool {
+function createSearchTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'search',
+    cls: { readOnly: true, mutating: false },
     description:
       'Semantic search across the workspace by meaning. Searches code and uploaded files. ' +
       'Returns ranked chunks with file paths and line numbers. ' +
@@ -4109,9 +4151,10 @@ function getOrCreateGraph(ctx: ToolContext): import('./workspace-graph').Workspa
   }
 }
 
-function createImpactRadiusTool(ctx: ToolContext): AgentTool {
+function createImpactRadiusTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'impact_radius',
+    cls: { readOnly: true, mutating: false },
     description:
       'Find all files and symbols affected by changes to given files. ' +
       'Shows blast radius: callers, dependents, importers, and related documents. ' +
@@ -4158,9 +4201,10 @@ function createImpactRadiusTool(ctx: ToolContext): AgentTool {
 // Detect Changes Tool
 // ---------------------------------------------------------------------------
 
-function createDetectChangesTool(ctx: ToolContext): AgentTool {
+function createDetectChangesTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'detect_changes',
+    cls: { readOnly: true, mutating: false },
     description:
       'Analyze git changes and map them to code graph nodes. Shows which functions/classes changed, ' +
       'their risk scores, affected execution flows, and test gaps. ' +
@@ -4298,9 +4342,10 @@ function createDetectChangesTool(ctx: ToolContext): AgentTool {
 // Review Context Tool
 // ---------------------------------------------------------------------------
 
-function createReviewContextTool(ctx: ToolContext): AgentTool {
+function createReviewContextTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'review_context',
+    cls: { readOnly: true, mutating: false },
     description:
       'Get a comprehensive, token-optimized review bundle for changed files. ' +
       'Includes structural subgraph, risk scores, affected flows, test gaps, ' +
@@ -4578,9 +4623,10 @@ const CHANNEL_SETUP_GUIDES: Record<string, { requiredKeys: string[]; guide: stri
   },
 }
 
-function createChannelConnectTool(ctx: ToolContext): AgentTool {
+function createChannelConnectTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'channel_connect',
+    cls: { readOnly: false, mutating: true },
     description:
       'Connect a messaging channel. Supported: telegram, discord, email, slack, whatsapp, webhook, teams, webchat. ' +
       'Saves config and hot-connects immediately.',
@@ -4729,9 +4775,10 @@ function createChannelConnectTool(ctx: ToolContext): AgentTool {
 // Audio Transcription Tool (OpenAI Whisper)
 // ---------------------------------------------------------------------------
 
-function createTranscribeAudioTool(ctx: ToolContext): AgentTool {
+function createTranscribeAudioTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'transcribe_audio',
+    cls: { readOnly: false, mutating: true },
     description:
       'Transcribe an audio file to text using OpenAI Whisper. ' +
       'Supports mp3, mp4, mpeg, mpga, m4a, wav, and webm formats. ' +
@@ -4809,9 +4856,10 @@ function createTranscribeAudioTool(ctx: ToolContext): AgentTool {
 // Image Generation Tool
 // ---------------------------------------------------------------------------
 
-function createGenerateImageTool(ctx: ToolContext): AgentTool {
+function createGenerateImageTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'generate_image',
+    cls: { readOnly: false, mutating: true },
     description:
       'Generate an image from a text prompt using AI (DALL-E, GPT Image, Imagen, etc). ' +
       'The image is saved to the agent workspace. Optionally provide a reference_image path ' +
@@ -4955,9 +5003,10 @@ function createGenerateImageTool(ctx: ToolContext): AgentTool {
 // Heartbeat Tools
 // ---------------------------------------------------------------------------
 
-function createHeartbeatConfigureTool(ctx: ToolContext): AgentTool {
+function createHeartbeatConfigureTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'heartbeat_configure',
+    cls: { readOnly: false, mutating: true },
     description:
       'Configure the heartbeat system: enable/disable, set interval, and quiet hours. ' +
       'Changes are persisted to config.json and synced to the central scheduler database.',
@@ -5025,9 +5074,10 @@ function createHeartbeatConfigureTool(ctx: ToolContext): AgentTool {
   }
 }
 
-function createHeartbeatStatusTool(ctx: ToolContext): AgentTool {
+function createHeartbeatStatusTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'heartbeat_status',
+    cls: { readOnly: true, mutating: false },
     description: 'Get current heartbeat configuration and HEARTBEAT.md checklist preview',
     label: 'Heartbeat Status',
     parameters: Type.Object({}),
@@ -5067,9 +5117,10 @@ function createHeartbeatStatusTool(ctx: ToolContext): AgentTool {
 // Plan Mode: create_plan tool
 // ---------------------------------------------------------------------------
 
-function createCreatePlanTool(ctx: ToolContext): AgentTool {
+function createCreatePlanTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'create_plan',
+    cls: { readOnly: false, mutating: true },
     description: 'Create a structured plan for the user to review and confirm before execution. The plan is saved to .shogo/plans/ as a markdown file and presented to the user for approval.',
     label: 'Create Plan',
     parameters: Type.Object({
@@ -5135,9 +5186,10 @@ function createCreatePlanTool(ctx: ToolContext): AgentTool {
 // Plan Mode: update_plan tool
 // ---------------------------------------------------------------------------
 
-function createUpdatePlanTool(ctx: ToolContext): AgentTool {
+function createUpdatePlanTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'update_plan',
+    cls: { readOnly: false, mutating: true },
     description: 'Update an existing plan file in .shogo/plans/. Provide only the fields you want to change — omitted fields are preserved. Use this instead of create_plan when the user asks to modify, refine, or extend an existing plan.',
     label: 'Update Plan',
     parameters: Type.Object({
@@ -5231,9 +5283,10 @@ function createUpdatePlanTool(ctx: ToolContext): AgentTool {
 // Read Lints Tool (LSP-backed diagnostics for any TypeScript file)
 // ---------------------------------------------------------------------------
 
-function createReadLintsTool(ctx: ToolContext): AgentTool {
+function createReadLintsTool(ctx: ToolContext): ShogoAgentTool {
   return {
     name: 'read_lints',
+    cls: { readOnly: true, mutating: false },
     description:
       'Check files for errors (TypeScript type errors, Python type errors, undefined references, syntax issues) ' +
       'and canvas runtime errors (compile/render failures from the live preview). ' +

--- a/packages/agent-runtime/src/gateway.ts
+++ b/packages/agent-runtime/src/gateway.ts
@@ -30,6 +30,9 @@ import { loadQuickActions, buildQuickActionsPromptSection, type QuickAction } fr
 import { SkillServerManager } from './skill-server-manager'
 import { setLoadedSkills } from './gateway-tools'
 import { runAgentLoop, type LoopDetectorConfig, type ToolContext } from './agent-loop'
+import { runDurableTurn, type TurnCheckpoint } from './durable-turn-runner'
+import { ToolIdempotencyRegistry } from './tool-idempotency'
+import { TurnTelemetry, logTurnEvent } from './turn-telemetry'
 import { createTools, textResult } from './gateway-tools'
 import { PermissionEngine, parseSecurityPolicy } from './permission-engine'
 import { HookEmitter, loadAllHooks } from './hooks'
@@ -1089,6 +1092,18 @@ export class AgentGateway {
       interactionMode?: 'agent' | 'plan' | 'ask'
       confirmedPlan?: { name: string; overview: string; plan: string; todos: Array<{ id: string; content: string }> }
       chatSessionId?: string
+      turnId?: string
+      turnCheckpointSink?: (cp: TurnCheckpoint & { extra?: Record<string, unknown> }) => void
+      turnTerminalSink?: (
+        status:
+          | 'completed'
+          | 'aborted'
+          | 'interrupted_recoverable'
+          | 'max_continuations'
+          | 'provider_fatal'
+          | 'loop_detected',
+        terminalReason?: string,
+      ) => void
     },
   ): Promise<void> {
     const sessionId = options?.chatSessionId || 'chat'
@@ -1157,10 +1172,24 @@ export class AgentGateway {
 
     const interactionMode = options?.interactionMode || 'agent'
     console.log(`[Gateway][processChatMessageStream] resolved interactionMode: ${interactionMode} (options had: ${options?.interactionMode ?? '(undefined)'}), sessionId: ${sessionId}, activeSkill: ${activeSkill ?? '(none)'}`)
-    const response = await this.agentTurn(prompt, sessionId, false, undefined, writer, activeSkill, images, interactionMode)
-    this.emitLog(`Chat response (stream): "${response.substring(0, 100)}"`)
 
-    this.appendDailyMemory(`chat: "${text.substring(0, 100)}" -> "${response.substring(0, 100)}"`)
+    // Stash the per-turn sinks/metadata for _agentTurnInner / runDurableTurn
+    // so we don't have to plumb them through several private signatures.
+    if (options?.turnId || options?.turnCheckpointSink || options?.turnTerminalSink) {
+      this.turnSinksBySession.set(sessionId, {
+        turnId: options.turnId,
+        checkpointSink: options.turnCheckpointSink,
+        terminalSink: options.turnTerminalSink,
+      })
+    }
+    try {
+      const response = await this.agentTurn(prompt, sessionId, false, undefined, writer, activeSkill, images, interactionMode)
+      this.emitLog(`Chat response (stream): "${response.substring(0, 100)}"`)
+
+      this.appendDailyMemory(`chat: "${text.substring(0, 100)}" -> "${response.substring(0, 100)}"`)
+    } finally {
+      this.turnSinksBySession.delete(sessionId)
+    }
   }
 
   async processWebhookMessage(text: string): Promise<string> {
@@ -1660,8 +1689,23 @@ export class AgentGateway {
 
     const streamedToolCalls = new Set<string>()
 
+    // Idempotency registry: survives across DurableTurnRunner auto-continuations
+    // so we can detect tool calls that started in a prior attempt but never
+    // finished (e.g. provider stream died mid tool execution).
+    const toolRegistry = new ToolIdempotencyRegistry()
+
     const turnAbort = new AbortController()
     this.turnAbortControllers.set(sessionId, turnAbort)
+
+    // Start a turn-scoped telemetry span *before* the main try block so the
+    // error/finally branches can always finalize it (the catch branch may
+    // fire before we enter the inner scopes that previously owned this
+    // variable).
+    const telemetryTurnId = this.turnSinksBySession.get(sessionId)?.turnId || sessionId
+    const telemetry = TurnTelemetry.start(telemetryTurnId, {
+      sessionId,
+      interactionMode,
+    })
 
     try {
       const hookEmitter = this.hookEmitter
@@ -1747,7 +1791,97 @@ export class AgentGateway {
       // Reset per-turn edit tracking so read_lints auto-scope starts clean.
       this.fileStateCache.resetTurn()
 
-      const result = await runAgentLoop({
+      // Durable-turn feature flag. When on (default), runAgentLoop is wrapped
+      // by DurableTurnRunner so the gateway can automatically continue after
+      // max_tokens, iteration-limit, or mid-stream provider errors inside the
+      // same visible turn — instead of telling the user to type "continue".
+      // Toggle via DURABLE_AGENT_TURNS=false to fall back to the old path.
+      //
+      // NOTE: We intentionally read the env var *per turn* (not captured at
+      // module load) so the flag can be flipped via SIGHUP/config reload
+      // without requiring a full runtime restart. The cost of one env read
+      // per turn is negligible compared to a provider round-trip.
+      const durableTurnsEnabled =
+        (process.env.DURABLE_AGENT_TURNS ?? 'true').toLowerCase() !== 'false'
+      const runLoop = durableTurnsEnabled ? runDurableTurn : runAgentLoop
+      if (!durableTurnsEnabled) {
+        // Make the legacy path loud — if something goes wrong with a long
+        // turn while this flag is off, we want the log line to explain why
+        // the auto-continuation didn't kick in.
+        console.log(
+          `${this.logPrefix} [durable-turns] DISABLED for session=${sessionId} ` +
+            `(DURABLE_AGENT_TURNS=${process.env.DURABLE_AGENT_TURNS ?? ''}); ` +
+            `falling back to single-shot runAgentLoop — max_tokens/iteration ` +
+            `exhaustion will NOT auto-continue on this turn.`,
+        )
+      }
+
+      // The auto-continuation loop needs to see completed tool results from
+      // the previous attempt. We commit them to the session here and rebuild
+      // history the same way we would for a fresh turn.
+      const prepareNextHistory = async (prev: AgentLoopResult) => {
+        this.sessionManager.addMessages(sessionId, ...prev.newMessages)
+        this.sessionManager.touch(sessionId)
+        let h = this.sessionManager.buildHistory(sessionId)
+        h = applyToolResultBudget(h, contextBudgetChars)
+        h = microcompact(h).messages
+        h = snipConsumedResults(h)
+        return h
+      }
+
+      const turnSinks = this.turnSinksBySession.get(sessionId)
+      const onCheckpoint = (cp: TurnCheckpoint) => {
+        // Detect mutating tools that started but never reported completion.
+        // After a provider-mid-stream failure, we don't know whether the
+        // side-effect landed — surface the names so a client/operator can
+        // decide. Read-only tools are safe to silently re-execute, so we
+        // don't flag them.
+        const unfinished = toolRegistry
+          .listStartedButUnfinished()
+          .filter(r => r.cls.mutating)
+          .map(r => ({ toolCallId: r.toolCallId, toolName: r.toolName, attempt: r.attempt }))
+
+        console.log(
+          `${this.logPrefix} [turn-checkpoint session=${sessionId}] ` +
+          `attempt=${cp.attempt} reason=${cp.reason} iterations=${cp.iterations} ` +
+          `toolCallsTotal=${cp.toolCallsTotal} outTokensTotal=${cp.outputTokensTotal} ` +
+          `stopReason=${cp.lastStopReason ?? '-'} willContinue=${cp.willContinue}` +
+          (unfinished.length ? ` unfinishedMutating=${unfinished.length}` : ''),
+        )
+
+        if (uiWriter) {
+          try {
+            uiWriter.write({
+              type: 'data-turn-checkpoint',
+              data: {
+                attempt: cp.attempt,
+                reason: cp.reason,
+                willContinue: cp.willContinue,
+                iterations: cp.iterations,
+                toolCallsTotal: cp.toolCallsTotal,
+                outputTokensTotal: cp.outputTokensTotal,
+                unfinishedMutating: unfinished,
+              },
+            } as any)
+          } catch { /* client disconnected */ }
+        }
+
+        // Persist checkpoint to the semantic turn ledger (see server.ts).
+        if (turnSinks?.checkpointSink) {
+          try {
+            turnSinks.checkpointSink({
+              ...cp,
+              extra: unfinished.length ? { unfinishedMutating: unfinished } : undefined,
+            })
+          } catch (err: any) {
+            console.warn(`${this.logPrefix} turnCheckpointSink threw:`, err?.message || err)
+          }
+        }
+
+        telemetry.attempt(cp)
+      }
+
+      const result = (await runLoop({
         provider,
         model: modelId,
         system: systemPrompt,
@@ -1760,6 +1894,8 @@ export class AgentGateway {
         streamFn: this._streamFn,
         thinkingLevel: resolveThinkingLevel(autoRouting ? undefined : session.modelOverride),
         signal: turnAbort.signal,
+        prepareNextHistory: durableTurnsEnabled ? prepareNextHistory : undefined,
+        onCheckpoint: durableTurnsEnabled ? onCheckpoint : undefined,
         onContextOverflow: async () => {
           console.warn(`${this.logPrefix} Layer 5: Reactive compaction for session ${sessionId}`)
           const fileStateSummary = this.fileStateCache.size > 0
@@ -1834,6 +1970,7 @@ export class AgentGateway {
             uiWriter.write({ type: 'tool-input-start', toolCallId, toolName, dynamic: true })
             streamedToolCalls.add(toolCallId)
           }
+          toolRegistry.plan(toolCallId, toolName)
         },
         onToolCallDelta: (toolName, delta, toolCallId) => {
           if (uiWriter) {
@@ -1852,6 +1989,7 @@ export class AgentGateway {
             uiWriter.write({ type: 'tool-input-delta', toolCallId, inputTextDelta: JSON.stringify(args) })
           }
           streamedToolCalls.delete(toolCallId)
+          toolRegistry.start(toolCallId, toolName, args)
           // Store a flush gate that resolves after a short delay, giving
           // the HTTP layer time to deliver the tool-input-start chunk to
           // the client before tool-output-available arrives.
@@ -1869,6 +2007,7 @@ export class AgentGateway {
           )
         },
         onAfterToolCall: async (toolName, args, result, isError, toolCallId) => {
+          toolRegistry.finish(toolCallId, result, !!isError)
           if (isError) {
             console.error(`${this.logPrefix} Tool error: ${toolName}`, JSON.stringify(result).substring(0, 500))
           } else {
@@ -1932,11 +2071,16 @@ export class AgentGateway {
             })
           )
         },
-      })
+      } as any)) as AgentLoopResult & { terminationReason?: string; attempts?: AgentLoopResult[]; checkpoints?: TurnCheckpoint[] }
 
       // Persist messages to session FIRST — before any uiWriter calls that
-      // could throw due to client disconnect.  This ensures "continue" after
+      // could throw due to client disconnect. This ensures "continue" after
       // stop always has the interrupted turn's context.
+      //
+      // In durable-turn mode, `prepareNextHistory` has already committed
+      // each intermediate attempt's newMessages to the session, and the
+      // merged `result.newMessages` is only the LAST attempt. So the same
+      // one-shot addMessages call is correct for both modes.
       this.sessionManager.addMessages(sessionId, ...result.newMessages)
 
       if (this.sessionManager.needsCompaction(session)) {
@@ -2009,18 +2153,32 @@ export class AgentGateway {
           const isIterationLimit = /maximum iteration limit/i.test(msg)
           const isProviderError = /api error|api key|auth|unauthorized|forbidden|rate.limit|overloaded|timeout|billing|insufficient.credits/i.test(msg)
           const isBillingError = /billing|insufficient.credits|upgrade your plan/i.test(msg)
+          const terminationReason = (result as any).terminationReason as string | undefined
+          const attempts = (result as any).attempts?.length ?? 1
           console.error(
-            `${this.logPrefix} Agent error for session ${sessionId}: ${msg} (${result.toolCalls.length} tool calls, ${result.outputTokens} output tokens)`
+            `${this.logPrefix} Agent error for session ${sessionId}: ${msg} ` +
+            `(attempts=${attempts}, termination=${terminationReason ?? 'n/a'}, ` +
+            `${result.toolCalls.length} tool calls, ${result.outputTokens} output tokens)`
           )
           chunker?.dispose()
           if (uiWriter) {
-            const errorText = isIterationLimit
-              ? 'I reached my iteration limit before finishing the task. Send a follow-up message like "continue" to pick up where I left off.'
-              : isBillingError
-                ? 'Insufficient credits. Please check your plan or AI provider settings.'
-                : isProviderError
-                  ? `AI provider error: ${msg}`
-                  : `I encountered an issue processing your message: ${msg}`
+            // With durable-turn continuations, the runner already made up to
+            // AGENT_MAX_CONTINUATIONS attempts. If we still land here with an
+            // iteration-limit-style error, it means the turn truly ran out of
+            // budget — tell the user it's paused, not "type continue".
+            const isMaxContinuations = terminationReason === 'max_continuations'
+            const isHostCancelled = terminationReason === 'host_cancelled'
+            const errorText = isBillingError
+              ? 'Insufficient credits. Please check your plan or AI provider settings.'
+              : isMaxContinuations
+                ? 'I ran out of my auto-continuation budget on this turn. Part of the work is saved — send "continue" to resume, or rephrase.'
+                : isIterationLimit
+                  ? 'I paused after a very long run. You can send "continue" to resume from the last saved state.'
+                  : isHostCancelled
+                    ? 'Turn paused. You can resume the conversation when ready.'
+                    : isProviderError
+                      ? `AI provider error: ${msg}`
+                      : `I encountered an issue processing your message: ${msg}`
             uiWriter.write({ type: 'error', errorText } as any)
           }
         } else if (result.outputTokens === 0 && result.toolCalls.length === 0 && !isHeartbeat) {
@@ -2038,6 +2196,44 @@ export class AgentGateway {
         console.warn(`${this.logPrefix} Post-loop UI write failed (session messages already persisted): ${uiErr.message}`)
         chunker?.dispose()
       }
+
+      // Finalize the semantic turn ledger. Map DurableTurnRunner
+      // terminationReason → TurnStatus; if no runner ran, default to
+      // 'completed' for non-error turns and let the catch branch below
+      // handle exceptions.
+      const terminationReason = (result as any).terminationReason as string | undefined
+      const finalStatus: 'completed' | 'aborted' | 'interrupted_recoverable' | 'max_continuations' | 'provider_fatal' | 'loop_detected' =
+        result.loopBreak
+          ? 'loop_detected'
+          : result.error
+            ? terminationReason === 'max_continuations'
+              ? 'max_continuations'
+              : terminationReason === 'host_cancelled'
+                ? 'aborted'
+                : 'provider_fatal'
+            : 'completed'
+      const finalReason = result.loopBreak
+        ? result.loopBreak.pattern
+        : result.error
+          ? terminationReason === 'max_continuations'
+            ? 'auto_continuation_exhausted'
+            : terminationReason === 'host_cancelled'
+              ? 'host_cancelled'
+              : result.error.message
+          : (terminationReason ?? 'completed')
+
+      if (turnSinks?.terminalSink) {
+        try { turnSinks.terminalSink(finalStatus, finalReason) }
+        catch (err: any) {
+          console.warn(`${this.logPrefix} turnTerminalSink threw:`, err?.message || err)
+        }
+      }
+      telemetry.end(finalStatus, finalReason, {
+        outputTokens: result.outputTokens,
+        toolCalls: result.toolCalls.length,
+        iterations: result.iterations,
+        attempts: (result as any).attempts?.length ?? 1,
+      })
 
       if (result.text) return result.text
       if (isHeartbeat) return 'HEARTBEAT_OK'
@@ -2058,6 +2254,18 @@ export class AgentGateway {
           } as any)
         }
       } catch { /* writer may be dead — ignore */ }
+      // Finalize as provider_fatal when a hard throw escapes the loop.
+      const turnSinks2 = this.turnSinksBySession.get(sessionId)
+      if (turnSinks2?.terminalSink) {
+        try { turnSinks2.terminalSink('provider_fatal', error?.message || 'unhandled_exception') }
+        catch {}
+      }
+      try {
+        logTurnEvent(turnSinks2?.turnId || sessionId, 'unhandled_throw', {
+          error: error?.message,
+        }, 'error')
+      } catch {}
+      try { telemetry.end('provider_fatal', error?.message || 'unhandled_exception') } catch {}
       if (isHeartbeat) return 'HEARTBEAT_OK'
       return `Sorry, I encountered an error processing your message. Please try again.`
     } finally {
@@ -3242,6 +3450,28 @@ export class AgentGateway {
   /** Per-session turn lock: ensures sequential turn execution so a "continue"
    *  after stop always sees the interrupted turn's messages in the session. */
   private turnLocks = new Map<string, Promise<unknown>>()
+
+  /** Per-session turn metadata + sinks, populated by processChatMessageStream
+   *  before the agent turn runs and consumed by the DurableTurnRunner's
+   *  onCheckpoint callback. Kept as a simple map so private turn helpers
+   *  don't need signature changes. */
+  private turnSinksBySession = new Map<
+    string,
+    {
+      turnId?: string
+      checkpointSink?: (cp: TurnCheckpoint & { extra?: Record<string, unknown> }) => void
+      terminalSink?: (
+        status:
+          | 'completed'
+          | 'aborted'
+          | 'interrupted_recoverable'
+          | 'max_continuations'
+          | 'provider_fatal'
+          | 'loop_detected',
+        terminalReason?: string,
+      ) => void
+    }
+  >()
 
   abortCurrentTurn(sessionId: string): boolean {
     const controller = this.turnAbortControllers.get(sessionId)

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -363,12 +363,34 @@ const turnCheckpointLedger = new TurnCheckpointLedger(
 try {
   const stale = turnCheckpointLedger.listActive()
   if (stale.length > 0) {
-    console.warn(
-      `[AgentRuntime][reconciler] Found ${stale.length} active turn(s) on boot — ` +
-        `marking as interrupted_recoverable:`,
-      stale.map((t) => t.turnId),
-    )
+    // Bucket by staleness (PR #442 review: f6): turns whose last checkpoint
+    // is within 2× the SSE keepalive window are likely genuinely resumable.
+    // Anything older has almost certainly been dead since a prior restart
+    // and should be aborted outright so the UI doesn't offer "resume" on
+    // turns from hours/days ago (until retention GC runs).
+    const now = Date.now()
+    const recoverableWindowMs = Math.max(durableEnv.streamKeepaliveMs * 2, 60_000)
+    const recoverable: typeof stale = []
+    const abandoned: typeof stale = []
     for (const meta of stale) {
+      if (now - meta.updatedAt <= recoverableWindowMs) recoverable.push(meta)
+      else abandoned.push(meta)
+    }
+    if (recoverable.length > 0) {
+      console.warn(
+        `[AgentRuntime][reconciler] ${recoverable.length} recently-active turn(s) — ` +
+          `marking as interrupted_recoverable:`,
+        recoverable.map((t) => t.turnId),
+      )
+    }
+    if (abandoned.length > 0) {
+      console.warn(
+        `[AgentRuntime][reconciler] ${abandoned.length} stale turn(s) (>` +
+          `${recoverableWindowMs}ms since last checkpoint) — marking as aborted:`,
+        abandoned.map((t) => t.turnId),
+      )
+    }
+    for (const meta of recoverable) {
       try {
         turnCheckpointLedger.finalize(
           meta.turnId,
@@ -378,6 +400,16 @@ try {
       } catch (err: any) {
         console.warn(
           `[AgentRuntime][reconciler] Failed to finalize stale turn ${meta.turnId}:`,
+          err?.message || err,
+        )
+      }
+    }
+    for (const meta of abandoned) {
+      try {
+        turnCheckpointLedger.finalize(meta.turnId, 'aborted', 'runtime_restart_stale')
+      } catch (err: any) {
+        console.warn(
+          `[AgentRuntime][reconciler] Failed to finalize abandoned turn ${meta.turnId}:`,
           err?.message || err,
         )
       }

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -36,6 +36,9 @@ import {
   initializePostgresBackup,
   configureAIProxy,
   StreamBufferStore,
+  DurableStreamLedger,
+  TurnCheckpointLedger,
+  logDurableTurnStartup,
 } from '@shogo/shared-runtime'
 import { getModelTier, resolveModelId, calculateDollarCost } from '@shogo/model-catalog'
 import { seedWorkspaceDefaults, seedWorkspaceFromTemplate, seedLSPConfig, seedRuntimeTemplate, ensureWorkspaceDeps, seedTechStack, runTechStackSetup } from './workspace-defaults'
@@ -332,7 +335,84 @@ let gatewayReadyPromise: Promise<void> | null = null
 // Stream Buffer Store (SSE reconnect support)
 // =============================================================================
 
-const streamBufferStore = new StreamBufferStore()
+const durableEnv = logDurableTurnStartup('agent-runtime')
+const durableStreamLedger = new DurableStreamLedger(
+  join(WORKSPACE_DIR, '.shogo', 'stream-ledger'),
+  { retentionMs: durableEnv.agentStreamLedgerRetentionMs },
+)
+const streamBufferStore = new StreamBufferStore({ durableLedger: durableStreamLedger })
+
+// Semantic turn-checkpoint ledger: captures attempt boundaries, continuation
+// reasons, token totals, and terminal status for each turn. Used by the
+// reconciler on runtime boot and by the /agent/turns/:turnId/status endpoint.
+const turnCheckpointLedger = new TurnCheckpointLedger(
+  join(WORKSPACE_DIR, '.shogo', 'turn-ledger'),
+  { retentionMs: durableEnv.agentStreamLedgerRetentionMs },
+)
+
+/**
+ * Reconciler: run on boot to mark any `active` entries in the turn ledger as
+ * `interrupted_recoverable`. We cannot reliably resume them in-process (the
+ * session history and provider connection are gone), so we surface the
+ * interrupt state to callers who can re-drive the turn from the stream
+ * ledger replay + a continuation prompt.
+ *
+ * This intentionally runs synchronously on import so that by the time the
+ * first request is served, no in-flight turn is mis-reported as 'active'.
+ */
+try {
+  const stale = turnCheckpointLedger.listActive()
+  if (stale.length > 0) {
+    console.warn(
+      `[AgentRuntime][reconciler] Found ${stale.length} active turn(s) on boot — ` +
+        `marking as interrupted_recoverable:`,
+      stale.map((t) => t.turnId),
+    )
+    for (const meta of stale) {
+      try {
+        turnCheckpointLedger.finalize(
+          meta.turnId,
+          'interrupted_recoverable',
+          'runtime_restart',
+        )
+      } catch (err: any) {
+        console.warn(
+          `[AgentRuntime][reconciler] Failed to finalize stale turn ${meta.turnId}:`,
+          err?.message || err,
+        )
+      }
+    }
+  }
+  // Also GC aged records.
+  try { turnCheckpointLedger.cleanup() } catch {}
+  try { durableStreamLedger.cleanup() } catch {}
+} catch (err: any) {
+  console.warn('[AgentRuntime][reconciler] Reconciler failed:', err?.message || err)
+}
+
+/**
+ * Best-effort fire-and-forget push of a turn lifecycle event to the API's
+ * in-memory TurnStore. The runtime's on-disk ledger remains authoritative —
+ * this is purely a performance/observability optimization so the API can
+ * answer UI polls without round-tripping.
+ */
+function pushTurnIngest(
+  kind: 'start' | 'checkpoint' | 'finalize',
+  payload: Record<string, unknown>,
+): void {
+  const apiUrl = deriveApiUrl()
+  const projectId = state.currentProjectId
+  if (!apiUrl || !projectId) return
+  const url = `${apiUrl}/api/projects/${projectId}/turns/ingest`
+  fetch(url, {
+    method: 'POST',
+    headers: getInternalHeaders(),
+    body: JSON.stringify({ kind, ...payload }),
+    signal: AbortSignal.timeout(5_000),
+  }).catch(() => {
+    // Intentionally swallow — the ledger on disk is the source of truth.
+  })
+}
 
 // =============================================================================
 // Stream Keep-Alive Utility
@@ -832,7 +912,30 @@ app.post('/agent/chat', async (c) => {
   // The agent writes into this buffer via a background consumer so that
   // a client disconnect (e.g. page refresh) does NOT cancel the agent.
   console.log(`[AgentChat] Creating stream buffer for session: ${chatSessionKey}`)
-  const bufWriter = streamBufferStore.create(chatSessionKey)
+  const requestedTurnId = typeof body.turnId === 'string' ? body.turnId : undefined
+  const runtimeId = `${state.currentProjectId || process.env.PROJECT_ID || 'unassigned'}:${PORT}`
+  const bufWriter = streamBufferStore.create(chatSessionKey, {
+    turnId: requestedTurnId,
+    runtimeId,
+  })
+  const turnId = bufWriter.turnId
+
+  // Open a semantic turn-checkpoint ledger entry alongside the stream ledger.
+  // Checkpoints written through the gateway's onCheckpoint callback flow into
+  // this ledger (see turnCheckpointSink below).
+  try {
+    turnCheckpointLedger.start(turnId, {
+      chatSessionId: chatSessionKey,
+      runtimeId,
+    })
+    pushTurnIngest('start', {
+      turnId,
+      chatSessionId: chatSessionKey,
+      runtimeId,
+    })
+  } catch (err: any) {
+    console.warn(`[AgentChat] Failed to start turn ledger for ${turnId}:`, err?.message || err)
+  }
 
   trackStreamStart()
   const stream = createUIMessageStream({
@@ -846,6 +949,50 @@ app.post('/agent/chat', async (c) => {
           interactionMode,
           confirmedPlan,
           chatSessionId: chatSessionKey,
+          turnId,
+          turnCheckpointSink: (cp) => {
+            try {
+              const record = turnCheckpointLedger.append(turnId, {
+                attempt: cp.attempt,
+                reason: cp.reason,
+                willContinue: cp.willContinue,
+                iterations: cp.iterations,
+                toolCallsThisAttempt: cp.toolCallsThisAttempt,
+                toolCallsTotal: cp.toolCallsTotal,
+                outputTokensTotal: cp.outputTokensTotal,
+                lastStopReason: cp.lastStopReason,
+                modelId: cp.modelId,
+                error: cp.error,
+                extra: cp.extra,
+              })
+              pushTurnIngest('checkpoint', {
+                turnId,
+                chatSessionId: chatSessionKey,
+                runtimeId,
+                checkpoint: record,
+              })
+            } catch (err: any) {
+              console.warn(
+                `[AgentChat] turnCheckpointLedger.append failed for ${turnId}:`,
+                err?.message || err,
+              )
+            }
+          },
+          turnTerminalSink: (status, terminalReason) => {
+            try {
+              turnCheckpointLedger.finalize(turnId, status, terminalReason)
+              pushTurnIngest('finalize', {
+                turnId,
+                status,
+                terminalReason,
+              })
+            } catch (err: any) {
+              console.warn(
+                `[AgentChat] turnCheckpointLedger.finalize failed for ${turnId}:`,
+                err?.message || err,
+              )
+            }
+          },
         })
 
         const usage = agentGateway!.consumeLastTurnUsage()
@@ -891,6 +1038,21 @@ app.post('/agent/chat', async (c) => {
         console.log(`[AgentChat] Background stream error for session: ${chatSessionKey}:`, err?.message || err)
       } finally {
         bufWriter.complete()
+        // Safety net: if the gateway-provided terminal sink was never called
+        // (e.g. synchronous throw before runDurableTurn ran), make sure the
+        // turn ledger is marked completed so the reconciler doesn't treat it
+        // as still-active forever.
+        try {
+          const meta = turnCheckpointLedger.getMeta(turnId)
+          if (meta && meta.status === 'active') {
+            turnCheckpointLedger.finalize(turnId, 'completed', 'stream_closed')
+            pushTurnIngest('finalize', {
+              turnId,
+              status: 'completed',
+              terminalReason: 'stream_closed',
+            })
+          }
+        } catch {}
       }
     })()
 
@@ -898,35 +1060,285 @@ app.post('/agent/chat', async (c) => {
     // If this client disconnects, only the replay subscriber is removed;
     // the background reader + agent keep running.
     const replayStream = streamBufferStore.createReplayStream(chatSessionKey)!
-    const wrappedStream = wrapStreamWithKeepalive(replayStream, 15_000)
+    const wrappedStream = wrapStreamWithKeepalive(replayStream, KEEPALIVE_MS)
+    const headers = new Headers(response.headers)
+    if (turnId) headers.set('X-Shogo-Turn-Id', turnId)
+    headers.set('X-Shogo-Stream-Resumable', 'true')
     return new Response(wrappedStream, {
       status: response.status,
-      headers: response.headers,
+      headers,
     })
   }
   return response
 })
 
+app.get('/agent/health', (c) => {
+  // Aliasing activeTurns == activeStreams for now; when DurableTurnRunner
+  // tracks turn lifecycles independently, activeTurns may exceed/lag
+  // activeStreams (e.g. during provider-retry gaps without an open HTTP body).
+  // Callers that decide whether to drain must treat "either > 0" as "busy".
+  return c.json({
+    status: isShuttingDown ? 'draining' : 'ok',
+    projectId: state.currentProjectId,
+    runtimeType: 'unified',
+    gatewayRunning: !!agentGateway,
+    activeStreams,
+    activeTurns: activeStreams,
+    shuttingDown: isShuttingDown,
+  })
+})
+
+const KEEPALIVE_MS = Number(process.env.STREAM_KEEPALIVE_MS || 15_000)
+
+/**
+ * Build an X-Shogo-Turn-Status header from a buffer/ledger status.
+ * Clients (and the API proxy) use this to decide whether to keep resuming,
+ * stop, or show a terminal/recoverable banner without ever relying on a
+ * silent 204/EOF.
+ */
+function turnStatusHeaders(status: ReturnType<typeof streamBufferStore.getStatus>): Record<string, string> {
+  if (!status) return {}
+  const headers: Record<string, string> = {}
+  if (status.turnId) headers['X-Shogo-Turn-Id'] = status.turnId
+  headers['X-Shogo-Turn-Status'] = status.status
+  if ('lastSeq' in status && typeof status.lastSeq === 'number') {
+    headers['X-Shogo-Last-Seq'] = String(status.lastSeq)
+  }
+  if ('terminalReason' in status && status.terminalReason) {
+    headers['X-Shogo-Terminal-Reason'] = String(status.terminalReason)
+  }
+  return headers
+}
+
 // Reconnect to an active stream — replays buffered SSE events then continues live.
 // URL pattern matches the AI SDK's default resume convention: ${api}/${chatId}/stream
 app.get('/agent/chat/:chatSessionId/stream', (c) => {
   const chatSessionId = c.req.param('chatSessionId')
-  console.log(`[AgentChat] Stream reconnect request for session: ${chatSessionId}, has buffer: ${streamBufferStore.has(chatSessionId)}`)
-  const replayStream = streamBufferStore.createReplayStream(chatSessionId)
+  const fromSeq = Number(new URL(c.req.url).searchParams.get('fromSeq') || c.req.header('Last-Event-ID') || 0)
+  console.log(`[AgentChat] Stream reconnect request for session: ${chatSessionId}, has buffer: ${streamBufferStore.has(chatSessionId)}, fromSeq: ${fromSeq}`)
+  const status = streamBufferStore.getStatus(chatSessionId)
+  const replayStream = streamBufferStore.createReplayStream(chatSessionId, { fromSeq })
 
   if (!replayStream) {
-    console.log(`[AgentChat] No active stream buffer for session: ${chatSessionId}`)
-    return new Response(null, { status: 204 })
+    // Never return 204 with no body: the AI-SDK client interprets that as
+    // "turn complete", which silently hides the fact that the runtime does
+    // not know this session. Return a structured JSON response with headers
+    // that the proxy/client can reason about.
+    if (!status) {
+      console.log(`[AgentChat] No stream record found for session: ${chatSessionId}`)
+      return c.json(
+        {
+          ok: false,
+          code: 'turn_not_found',
+          chatSessionId,
+          message: 'No active or recoverable turn for this chat session.',
+          retryable: false,
+        },
+        404,
+      )
+    }
+    if (status.status === 'aborted') {
+      return c.json(
+        {
+          ok: false,
+          code: 'turn_aborted',
+          chatSessionId,
+          turnId: status.turnId,
+          terminalReason: (status as any).terminalReason || 'aborted',
+          retryable: false,
+        },
+        410,
+        turnStatusHeaders(status),
+      )
+    }
+    if (status.status === 'completed') {
+      // Stream bytes are gone from the hot cache and from the ledger (e.g.
+      // past retention). Return a known-terminal-but-healthy status instead
+      // of 204; the client should treat this as "turn finished" explicitly.
+      return c.json(
+        {
+          ok: true,
+          code: 'turn_completed',
+          chatSessionId,
+          turnId: status.turnId,
+          lastSeq: status.lastSeq,
+        },
+        200,
+        turnStatusHeaders(status),
+      )
+    }
+    return c.json(
+      {
+        ok: false,
+        code: 'turn_recovering',
+        chatSessionId,
+        turnId: status.turnId,
+        turnStatus: status.status,
+        retryable: true,
+        message: 'The turn is recoverable but its stream buffer is not yet available. Retry shortly.',
+      },
+      503,
+      turnStatusHeaders(status),
+    )
   }
 
   console.log(`[AgentChat] Replaying stream buffer for session: ${chatSessionId}`)
-  const wrappedStream = wrapStreamWithKeepalive(replayStream, 15_000)
+  const wrappedStream = wrapStreamWithKeepalive(replayStream, KEEPALIVE_MS)
   return new Response(wrappedStream, {
     headers: {
       'Content-Type': 'text/x-ai-sdk-ui-stream',
       'X-Accel-Buffering': 'no',
       'Cache-Control': 'no-cache',
+      'X-Shogo-Stream-Resumable': 'true',
+      ...turnStatusHeaders(status),
     },
+  })
+})
+
+app.get('/agent/chat/:chatSessionId/turns/active', (c) => {
+  const chatSessionId = c.req.param('chatSessionId')
+  const status = streamBufferStore.getStatus(chatSessionId)
+  if (!status) {
+    return c.json(
+      { ok: false, code: 'turn_not_found', chatSessionId, retryable: false },
+      404,
+    )
+  }
+  if (status.status === 'aborted') {
+    return c.json({ ok: true, status }, 200, turnStatusHeaders(status))
+  }
+  return c.json({ ok: true, status }, 200, turnStatusHeaders(status))
+})
+
+app.get('/agent/chat/:chatSessionId/turns/:turnId/stream', (c) => {
+  const chatSessionId = c.req.param('chatSessionId')
+  const turnId = c.req.param('turnId')
+  const fromSeq = Number(new URL(c.req.url).searchParams.get('fromSeq') || c.req.header('Last-Event-ID') || 0)
+  const status = streamBufferStore.getStatus(chatSessionId)
+  const replayStream = streamBufferStore.createReplayStream(chatSessionId, { turnId, fromSeq })
+
+  if (!replayStream) {
+    if (!status) {
+      return c.json(
+        { ok: false, code: 'turn_not_found', chatSessionId, turnId, retryable: false },
+        404,
+      )
+    }
+    if (status.turnId && status.turnId !== turnId) {
+      return c.json(
+        {
+          ok: false,
+          code: 'turn_id_mismatch',
+          chatSessionId,
+          activeTurnId: status.turnId,
+          requestedTurnId: turnId,
+          retryable: false,
+        },
+        409,
+        turnStatusHeaders(status),
+      )
+    }
+    return c.json(
+      {
+        ok: false,
+        code: 'turn_stream_unavailable',
+        chatSessionId,
+        turnId,
+        turnStatus: status.status,
+        retryable: status.status === 'active' || status.status === 'interrupted_recoverable',
+      },
+      status.status === 'completed' ? 200 : 503,
+      turnStatusHeaders(status),
+    )
+  }
+
+  const wrappedStream = wrapStreamWithKeepalive(replayStream, KEEPALIVE_MS)
+  return new Response(wrappedStream, {
+    headers: {
+      'Content-Type': 'text/x-ai-sdk-ui-stream',
+      'X-Accel-Buffering': 'no',
+      'Cache-Control': 'no-cache',
+      'X-Shogo-Stream-Resumable': 'true',
+      ...turnStatusHeaders(status),
+      'X-Shogo-Turn-Id': turnId,
+    },
+  })
+})
+
+// Semantic turn status + checkpoint history for a single turn. Used by the
+// API reconciler/ingest and by the client UI to display continuation banners.
+app.get('/agent/turns/:turnId/status', (c) => {
+  const turnId = c.req.param('turnId')
+  const fromSeq = Number(new URL(c.req.url).searchParams.get('fromSeq') || 0)
+  const meta = turnCheckpointLedger.getMeta(turnId)
+  if (!meta) {
+    return c.json({ ok: false, code: 'turn_not_found', turnId }, 404)
+  }
+  const checkpoints = turnCheckpointLedger.readCheckpoints(turnId, fromSeq)
+  return c.json({ ok: true, meta, checkpoints })
+})
+
+// List turns still marked active in the checkpoint ledger. On runtime boot
+// the reconciler uses this to decide which turns need to be resumed or
+// marked `interrupted_recoverable`.
+app.get('/agent/turns/active', (c) => {
+  const active = turnCheckpointLedger.listActive()
+  return c.json({ ok: true, active })
+})
+
+/**
+ * POST /agent/turns/:turnId/resume
+ *
+ * Caller-driven reconciliation entry point. Inspects the current ledger
+ * state and returns a decision:
+ *   - `replay`: the turn is still `active`, callers should hit the stream
+ *     replay endpoint to consume remaining frames.
+ *   - `interrupted_recoverable`: the runtime cannot automatically resume
+ *     the turn in this process (no live provider connection). Callers
+ *     should re-issue a chat request to continue the work — the gateway
+ *     will pick up the session history and DurableTurnRunner will finish
+ *     the work.
+ *   - `terminal`: the turn is already completed/aborted/fatal — no action.
+ *   - `not_found`: the turn is unknown to this runtime.
+ *
+ * This endpoint intentionally does not spawn a new turn itself — that
+ * requires the user's chat-session context the API already owns.
+ */
+app.post('/agent/turns/:turnId/resume', (c) => {
+  const turnId = c.req.param('turnId')
+  const meta = turnCheckpointLedger.getMeta(turnId)
+  if (!meta) {
+    return c.json({ ok: false, code: 'turn_not_found', turnId }, 404)
+  }
+  if (meta.status === 'active') {
+    return c.json({
+      ok: true,
+      decision: 'replay',
+      turnId,
+      chatSessionId: meta.chatSessionId,
+      replayPath: meta.chatSessionId
+        ? `/agent/chat/${meta.chatSessionId}/turns/${turnId}/stream`
+        : null,
+      meta,
+    })
+  }
+  if (meta.status === 'interrupted_recoverable') {
+    return c.json({
+      ok: true,
+      decision: 'interrupted_recoverable',
+      turnId,
+      chatSessionId: meta.chatSessionId,
+      meta,
+      hint: 'Re-issue a chat request to continue — session history is preserved.',
+    })
+  }
+  return c.json({
+    ok: true,
+    decision: 'terminal',
+    turnId,
+    terminalStatus: meta.status,
+    terminalReason: meta.terminalReason,
+    meta,
   })
 })
 
@@ -1171,7 +1583,18 @@ app.delete('/agent/plans/:filename', async (c) => {
   return c.json({ deleted: true })
 })
 
-// Stop/interrupt the current agent turn (and any active code agent task)
+// Stop/interrupt the current agent turn (and any active code agent task).
+//
+// Cancellation matrix (see Phase 2.6):
+//   - User-initiated stop (this endpoint):       ABORTS the turn
+//   - Client HTTP disconnect:                    turn continues in background
+//   - Runtime shutdown (SIGTERM):                graceful drain, then
+//                                                interrupted_recoverable
+//   - Provider error after tool calls:           DurableTurnRunner retries
+//
+// Here we record the user's explicit intent: finalize the turn ledger as
+// 'aborted' with terminalReason 'user_stop' so the client UI, reconciler,
+// and any future replay consumers all see a consistent terminal state.
 app.post('/agent/stop', async (c) => {
   if (!agentGateway) return c.json({ error: 'Gateway not ready' }, 503)
 
@@ -1179,14 +1602,33 @@ app.post('/agent/stop', async (c) => {
   const stopSessionKey = body.chatSessionId || 'chat'
   const aborted = agentGateway.abortCurrentTurn(stopSessionKey)
 
-  // Also cancel every running subagent spawned via AgentManager. The main turn
-  // signal does not reach these instances because each has its own AbortController.
   const cancelledSubagents = agentGateway.agentManager.cancelAll()
 
-  // Remove the buffer entirely so resume after stop returns 204 (not a replay)
+  // Capture the current turnId BEFORE aborting the buffer, so we can finalize
+  // the checkpoint ledger with the correct turn. Abort removes the buffer
+  // entry, so the query must come first.
+  const status = streamBufferStore.getStatus(stopSessionKey)
+  const abortedTurnId = status?.turnId
+
   streamBufferStore.abort(stopSessionKey)
 
-  return c.json({ stopped: aborted, cancelledSubagents })
+  if (abortedTurnId) {
+    try {
+      turnCheckpointLedger.finalize(abortedTurnId, 'aborted', 'user_stop')
+      pushTurnIngest('finalize', {
+        turnId: abortedTurnId,
+        status: 'aborted',
+        terminalReason: 'user_stop',
+      })
+    } catch (err: any) {
+      console.warn(
+        `[AgentRuntime] Failed to finalize aborted turn ${abortedTurnId}:`,
+        err?.message || err,
+      )
+    }
+  }
+
+  return c.json({ stopped: aborted, cancelledSubagents, turnId: abortedTurnId })
 })
 
 // Cancel a single running subagent by AgentManager instance id
@@ -3031,13 +3473,14 @@ function trackStreamEnd(): void { activeStreams = Math.max(0, activeStreams - 1)
 // Graceful Shutdown
 // =============================================================================
 
-const DRAIN_TIMEOUT_MS = 30_000
+const DRAIN_TIMEOUT_MS = Number(process.env.AGENT_DRAIN_TIMEOUT_MS || 30 * 60 * 1000)
 
 async function gracefulShutdown(signal: string): Promise<void> {
   if (isShuttingDown) return
   isShuttingDown = true
   console.log(`[agent-runtime] ${signal} received — draining ${activeStreams} active stream(s) (max ${DRAIN_TIMEOUT_MS / 1000}s)`)
 
+  let drainTimedOut = false
   if (activeStreams > 0) {
     const drainStart = Date.now()
     await new Promise<void>((resolve) => {
@@ -3045,6 +3488,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
         if (activeStreams <= 0 || Date.now() - drainStart > DRAIN_TIMEOUT_MS) {
           clearInterval(check)
           if (activeStreams > 0) {
+            drainTimedOut = true
             console.warn(`[agent-runtime] Drain timeout — ${activeStreams} stream(s) still active, proceeding with shutdown`)
           } else {
             console.log(`[agent-runtime] All streams drained in ${Date.now() - drainStart}ms`)
@@ -3055,7 +3499,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
     })
   }
 
-  streamBufferStore.dispose()
+  streamBufferStore.dispose({ interruptActive: drainTimedOut && activeStreams > 0 })
 
   try {
     if (s3SyncInstance) {

--- a/packages/agent-runtime/src/tool-idempotency.ts
+++ b/packages/agent-runtime/src/tool-idempotency.ts
@@ -1,3 +1,5 @@
+import type { AgentTool } from '@mariozechner/pi-agent-core'
+import type { TSchema } from '@sinclair/typebox'
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 /**
@@ -63,65 +65,67 @@ export interface ToolCallRecord {
  * tools as mutating since the only cost is a conservative "ask before
  * retry" in the continuation path.
  */
-const BUILTIN_TOOL_CLASSES: Record<string, ToolCallClass> = {
-  // Read-only (pure queries / safe to replay)
-  read_file: { readOnly: true, mutating: false },
-  search: { readOnly: true, mutating: false },
-  glob: { readOnly: true, mutating: false },
-  grep: { readOnly: true, mutating: false },
-  list_dir: { readOnly: true, mutating: false },
-  read_lints: { readOnly: true, mutating: false },
-  web: { readOnly: true, mutating: false },
-  memory_read: { readOnly: true, mutating: false },
-  memory_search: { readOnly: true, mutating: false },
-  read_guide: { readOnly: true, mutating: false },
-  impact_radius: { readOnly: true, mutating: false },
-  agent_list: { readOnly: true, mutating: false },
-  agent_status: { readOnly: true, mutating: false },
-  task_get: { readOnly: true, mutating: false },
-  task_list: { readOnly: true, mutating: false },
-  // Meta / UI-side-effect-only (safe to replay: UI reconciles by id)
-  todo_write: { readOnly: true, mutating: false },
-  notify_user_error: { readOnly: true, mutating: false },
-  quick_action: { readOnly: true, mutating: false },
-  ask_user: { readOnly: true, mutating: false },
-  // Mutating (filesystem, process, external APIs, team/agent state)
-  exec: { readOnly: false, mutating: true },
-  write_file: { readOnly: false, mutating: true },
-  edit_file: { readOnly: false, mutating: true },
-  create_file: { readOnly: false, mutating: true },
-  delete_file: { readOnly: false, mutating: true },
-  move_file: { readOnly: false, mutating: true },
-  send_message: { readOnly: false, mutating: true },
-  send_team_message: { readOnly: false, mutating: true },
-  channel_connect: { readOnly: false, mutating: true },
-  channel_disconnect: { readOnly: false, mutating: true },
-  agent_spawn: { readOnly: false, mutating: true },
-  agent_cancel: { readOnly: false, mutating: true },
-  agent_create: { readOnly: false, mutating: true },
-  team_create: { readOnly: false, mutating: true },
-  team_delete: { readOnly: false, mutating: true },
-  task_create: { readOnly: false, mutating: true },
-  task_update: { readOnly: false, mutating: true },
-  skill: { readOnly: false, mutating: true },
-  create_plan: { readOnly: false, mutating: true },
-  update_plan: { readOnly: false, mutating: true },
+/**
+ * Shogo's extension of pi-agent-core's AgentTool: every tool definition
+ * carries its own idempotency classification. Putting `cls` on the type
+ * as REQUIRED (not optional) means TypeScript enforces it at the
+ * definition site for every current and future tool — eliminating the
+ * drift hazard of a hardcoded name-to-class map (Russell review, PR #442).
+ */
+export interface ShogoAgentTool<TP extends TSchema = TSchema, TD = any>
+  extends AgentTool<TP, TD> {
+  /**
+   * Idempotency classification. Tools MUST declare whether they are
+   * safe to blind-replay (read-only) or have side effects that cannot
+   * be re-executed without risk of double-application (mutating).
+   */
+  cls: ToolCallClass
 }
 
-function classifyTool(toolName: string, explicit?: Partial<ToolCallClass>): ToolCallClass {
+/**
+ * Conservative default for dynamic / externally-sourced tools (MCP,
+ * composio, skill-server proxies) where static metadata isn't
+ * available at definition time. Assume mutating so the registry's
+ * safety gate is opt-out for replay rather than opt-in.
+ */
+export const DEFAULT_UNKNOWN_TOOL_CLASS: ToolCallClass = {
+  readOnly: false,
+  mutating: true,
+}
+
+/**
+ * Classify a tool. Prefer the explicit `cls` field on a `ShogoAgentTool`
+ * (single source of truth, type-enforced). Fall back to the conservative
+ * default for tools that don't carry metadata (dynamic / external).
+ *
+ * Accepts either a full tool object, or `(name, explicitCls)` for the
+ * legacy call pattern still used by ToolIdempotencyRegistry.start().
+ *
+ * The prior hardcoded name-to-class map was removed in response to
+ * review feedback — metadata belongs at the definition site so
+ * TypeScript enforces it on every future tool.
+ */
+export function classifyTool(
+  toolOrName: { cls?: ToolCallClass } | string,
+  explicit?: Partial<ToolCallClass>,
+): ToolCallClass {
   if (explicit) {
     return {
       readOnly: explicit.readOnly ?? !(explicit.mutating ?? true),
       mutating: explicit.mutating ?? !(explicit.readOnly ?? false),
     }
   }
-  const builtin = BUILTIN_TOOL_CLASSES[toolName]
-  if (builtin) return builtin
-  // Tools beginning with these prefixes are always read-only subagents/queries
-  if (toolName.startsWith('mcp_') && toolName.endsWith('_read')) {
-    return { readOnly: true, mutating: false }
+  if (typeof toolOrName === 'string') {
+    // Legacy / dynamic call site without a tool object. New code should
+    // pass the tool itself (ShogoAgentTool has a required `cls` field).
+    // For MCP proxies and external tools where we only have a string
+    // name, use naming conventions as a best-effort hint.
+    if (toolOrName.startsWith('mcp_') && toolOrName.endsWith('_read')) {
+      return { readOnly: true, mutating: false }
+    }
+    return { ...DEFAULT_UNKNOWN_TOOL_CLASS }
   }
-  return { readOnly: false, mutating: true }
+  return toolOrName.cls ?? { ...DEFAULT_UNKNOWN_TOOL_CLASS }
 }
 
 export class ToolIdempotencyRegistry {

--- a/packages/agent-runtime/src/tool-idempotency.ts
+++ b/packages/agent-runtime/src/tool-idempotency.ts
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Tool Idempotency Registry
+ *
+ * Tracks the lifecycle of each tool call across agent-loop attempts so that
+ * automatic continuations (see durable-turn-runner.ts) do not duplicate
+ * work when a turn is re-invoked.
+ *
+ * Lifecycle of a single tool call, keyed by the provider-assigned
+ * `toolCallId` (Anthropic `tool_use_id`):
+ *
+ *   planned  — the model emitted a tool_use block but the runtime has not
+ *              started executing it yet (tool input still streaming).
+ *   started  — onBeforeToolCall has fired but onAfterToolCall has not.
+ *   completed — onAfterToolCall fired with a recorded result.
+ *   failed   — onAfterToolCall fired with isError=true.
+ *
+ * When an attempt crashes / the provider stream terminates mid-turn, any
+ * tool that reached `started` but not `completed` is in a questionable
+ * state. For purely read-only tools the runner can safely re-execute; for
+ * mutating tools, the caller should either:
+ *   - consult a tool-specific verifier (e.g. "does this file already exist
+ *     with the expected contents?"), or
+ *   - surface an `ask_user` checkpoint ("I may have started <action>; should
+ *     I retry, skip, or abort?").
+ *
+ * This module intentionally does NOT attempt to persist results to disk.
+ * The durable-stream-ledger already captures the wire-level frames, and
+ * pi-agent-core's session history captures the semantic tool results. This
+ * registry is a lightweight in-memory index keyed by toolCallId that lets
+ * the gateway reason about what has/hasn't happened during a single turn
+ * run, even across auto-continuations.
+ */
+
+export type ToolCallState = 'planned' | 'started' | 'completed' | 'failed'
+
+export interface ToolCallClass {
+  /** Whether the tool is known to be purely read-only. */
+  readonly readOnly: boolean
+  /** Whether the tool mutates shared state (FS, external APIs, DB, etc.). */
+  readonly mutating: boolean
+}
+
+export interface ToolCallRecord {
+  toolCallId: string
+  toolName: string
+  state: ToolCallState
+  args?: any
+  result?: any
+  isError?: boolean
+  startedAt?: number
+  completedAt?: number
+  attempt: number
+  cls: ToolCallClass
+}
+
+/**
+ * Built-in classification of tool names. A tool not listed here defaults
+ * to `mutating: true` (pessimistic); callers can override per-invocation.
+ *
+ * Keep this list in sync with gateway-tools.ts — it's fine to leave unknown
+ * tools as mutating since the only cost is a conservative "ask before
+ * retry" in the continuation path.
+ */
+const BUILTIN_TOOL_CLASSES: Record<string, ToolCallClass> = {
+  // Read-only
+  read_file: { readOnly: true, mutating: false },
+  search: { readOnly: true, mutating: false },
+  glob: { readOnly: true, mutating: false },
+  grep: { readOnly: true, mutating: false },
+  list_dir: { readOnly: true, mutating: false },
+  read_lints: { readOnly: true, mutating: false },
+  web: { readOnly: true, mutating: false },
+  memory_read: { readOnly: true, mutating: false },
+  memory_search: { readOnly: true, mutating: false },
+  todo_write: { readOnly: true, mutating: false },
+  // Mutating
+  exec: { readOnly: false, mutating: true },
+  write_file: { readOnly: false, mutating: true },
+  edit_file: { readOnly: false, mutating: true },
+  create_file: { readOnly: false, mutating: true },
+  delete_file: { readOnly: false, mutating: true },
+  move_file: { readOnly: false, mutating: true },
+  send_message: { readOnly: false, mutating: true },
+  channel_connect: { readOnly: false, mutating: true },
+  channel_disconnect: { readOnly: false, mutating: true },
+}
+
+function classifyTool(toolName: string, explicit?: Partial<ToolCallClass>): ToolCallClass {
+  if (explicit) {
+    return {
+      readOnly: explicit.readOnly ?? !(explicit.mutating ?? true),
+      mutating: explicit.mutating ?? !(explicit.readOnly ?? false),
+    }
+  }
+  const builtin = BUILTIN_TOOL_CLASSES[toolName]
+  if (builtin) return builtin
+  // Tools beginning with these prefixes are always read-only subagents/queries
+  if (toolName.startsWith('mcp_') && toolName.endsWith('_read')) {
+    return { readOnly: true, mutating: false }
+  }
+  return { readOnly: false, mutating: true }
+}
+
+export class ToolIdempotencyRegistry {
+  private readonly byId = new Map<string, ToolCallRecord>()
+  private currentAttempt = 1
+
+  beginAttempt(attempt: number): void {
+    this.currentAttempt = attempt
+  }
+
+  plan(toolCallId: string, toolName: string, cls?: Partial<ToolCallClass>): ToolCallRecord {
+    const existing = this.byId.get(toolCallId)
+    if (existing) return existing
+    const rec: ToolCallRecord = {
+      toolCallId,
+      toolName,
+      state: 'planned',
+      attempt: this.currentAttempt,
+      cls: classifyTool(toolName, cls),
+    }
+    this.byId.set(toolCallId, rec)
+    return rec
+  }
+
+  start(toolCallId: string, toolName: string, args: any, cls?: Partial<ToolCallClass>): ToolCallRecord {
+    const rec = this.plan(toolCallId, toolName, cls)
+    rec.state = 'started'
+    rec.args = args
+    rec.startedAt = Date.now()
+    return rec
+  }
+
+  finish(toolCallId: string, result: any, isError: boolean): ToolCallRecord | null {
+    const rec = this.byId.get(toolCallId)
+    if (!rec) return null
+    rec.state = isError ? 'failed' : 'completed'
+    rec.result = result
+    rec.isError = isError
+    rec.completedAt = Date.now()
+    return rec
+  }
+
+  get(toolCallId: string): ToolCallRecord | null {
+    return this.byId.get(toolCallId) ?? null
+  }
+
+  isCompleted(toolCallId: string): boolean {
+    return this.byId.get(toolCallId)?.state === 'completed'
+  }
+
+  /**
+   * List tool calls that started in a previous attempt but never completed.
+   * These are the dangerous ones: mutating, started-but-unverified work.
+   */
+  listStartedButUnfinished(): ToolCallRecord[] {
+    return [...this.byId.values()].filter(r => r.state === 'started')
+  }
+
+  /**
+   * Clear entries from the registry so a caller can reset on a new user
+   * turn. The DurableTurnRunner keeps the registry across auto-continuations
+   * of the same turn, but a brand-new user message should start fresh.
+   */
+  reset(): void {
+    this.byId.clear()
+    this.currentAttempt = 1
+  }
+
+  snapshot(): ToolCallRecord[] {
+    return [...this.byId.values()].map(r => ({ ...r }))
+  }
+}

--- a/packages/agent-runtime/src/tool-idempotency.ts
+++ b/packages/agent-runtime/src/tool-idempotency.ts
@@ -64,7 +64,7 @@ export interface ToolCallRecord {
  * retry" in the continuation path.
  */
 const BUILTIN_TOOL_CLASSES: Record<string, ToolCallClass> = {
-  // Read-only
+  // Read-only (pure queries / safe to replay)
   read_file: { readOnly: true, mutating: false },
   search: { readOnly: true, mutating: false },
   glob: { readOnly: true, mutating: false },
@@ -74,8 +74,18 @@ const BUILTIN_TOOL_CLASSES: Record<string, ToolCallClass> = {
   web: { readOnly: true, mutating: false },
   memory_read: { readOnly: true, mutating: false },
   memory_search: { readOnly: true, mutating: false },
+  read_guide: { readOnly: true, mutating: false },
+  impact_radius: { readOnly: true, mutating: false },
+  agent_list: { readOnly: true, mutating: false },
+  agent_status: { readOnly: true, mutating: false },
+  task_get: { readOnly: true, mutating: false },
+  task_list: { readOnly: true, mutating: false },
+  // Meta / UI-side-effect-only (safe to replay: UI reconciles by id)
   todo_write: { readOnly: true, mutating: false },
-  // Mutating
+  notify_user_error: { readOnly: true, mutating: false },
+  quick_action: { readOnly: true, mutating: false },
+  ask_user: { readOnly: true, mutating: false },
+  // Mutating (filesystem, process, external APIs, team/agent state)
   exec: { readOnly: false, mutating: true },
   write_file: { readOnly: false, mutating: true },
   edit_file: { readOnly: false, mutating: true },
@@ -83,8 +93,19 @@ const BUILTIN_TOOL_CLASSES: Record<string, ToolCallClass> = {
   delete_file: { readOnly: false, mutating: true },
   move_file: { readOnly: false, mutating: true },
   send_message: { readOnly: false, mutating: true },
+  send_team_message: { readOnly: false, mutating: true },
   channel_connect: { readOnly: false, mutating: true },
   channel_disconnect: { readOnly: false, mutating: true },
+  agent_spawn: { readOnly: false, mutating: true },
+  agent_cancel: { readOnly: false, mutating: true },
+  agent_create: { readOnly: false, mutating: true },
+  team_create: { readOnly: false, mutating: true },
+  team_delete: { readOnly: false, mutating: true },
+  task_create: { readOnly: false, mutating: true },
+  task_update: { readOnly: false, mutating: true },
+  skill: { readOnly: false, mutating: true },
+  create_plan: { readOnly: false, mutating: true },
+  update_plan: { readOnly: false, mutating: true },
 }
 
 function classifyTool(toolName: string, explicit?: Partial<ToolCallClass>): ToolCallClass {

--- a/packages/agent-runtime/src/turn-telemetry.ts
+++ b/packages/agent-runtime/src/turn-telemetry.ts
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Turn-scoped telemetry.
+ *
+ * Phase 5.1 (structured turn-scoped logs) and 5.2 (metrics) of the durable
+ * turn work.
+ *
+ * This module keeps metrics/log plumbing out of the gateway hot path. We
+ * expose:
+ *
+ *   - `logTurnEvent(turnId, event, fields)` — a single-line JSON log for
+ *     downstream ingestion. Works whether or not an OTel pipeline is
+ *     configured.
+ *
+ *   - `recordTurnMetric(name, value, attrs)` — a no-op-friendly wrapper
+ *     around `@opentelemetry/api.metrics`. Falls back to structured logs
+ *     when OTel is unavailable so we never crash a turn over a missing
+ *     metrics SDK.
+ *
+ *   - `TurnTelemetry.start(turnId, attrs)` — returns a handle that records
+ *     attempt/continuation events and finalizes the span on terminal.
+ *
+ * The public surface is intentionally narrow: the gateway should treat
+ * telemetry as fire-and-forget side effects.
+ */
+
+type JSONFields = Record<string, unknown>
+
+let metrics: any = null
+let trace: any = null
+try {
+  // Soft import so builds without OTel installed still work.
+  const mod = require('@opentelemetry/api') as any
+  metrics = mod.metrics
+  trace = mod.trace
+} catch {
+  metrics = null
+  trace = null
+}
+
+const METER_NAME = 'shogo.agent.turn'
+const TRACER_NAME = 'shogo.agent.turn'
+
+let cachedMeter: any = null
+let cachedTracer: any = null
+function getMeter() {
+  if (cachedMeter) return cachedMeter
+  if (!metrics) return null
+  try {
+    cachedMeter = metrics.getMeter(METER_NAME)
+    return cachedMeter
+  } catch {
+    return null
+  }
+}
+function getTracer() {
+  if (cachedTracer) return cachedTracer
+  if (!trace) return null
+  try {
+    cachedTracer = trace.getTracer(TRACER_NAME)
+    return cachedTracer
+  } catch {
+    return null
+  }
+}
+
+const counters = new Map<string, any>()
+const histograms = new Map<string, any>()
+
+function getCounter(name: string) {
+  if (counters.has(name)) return counters.get(name)
+  const meter = getMeter()
+  if (!meter) return null
+  try {
+    const c = meter.createCounter(name)
+    counters.set(name, c)
+    return c
+  } catch {
+    return null
+  }
+}
+function getHistogram(name: string) {
+  if (histograms.has(name)) return histograms.get(name)
+  const meter = getMeter()
+  if (!meter) return null
+  try {
+    const h = meter.createHistogram(name)
+    histograms.set(name, h)
+    return h
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Single-line JSON log for turn events. Stable, machine-parseable.
+ *
+ * Example:
+ *   {"lvl":"info","kind":"turn","event":"checkpoint","turnId":"t-123",...}
+ */
+export function logTurnEvent(
+  turnId: string,
+  event: string,
+  fields: JSONFields = {},
+  level: 'info' | 'warn' | 'error' = 'info',
+): void {
+  try {
+    const line = JSON.stringify({
+      lvl: level,
+      kind: 'turn',
+      event,
+      turnId,
+      ts: Date.now(),
+      ...fields,
+    })
+    if (level === 'error') console.error(line)
+    else if (level === 'warn') console.warn(line)
+    else console.log(line)
+  } catch {
+    // Never let logging fail a turn
+  }
+}
+
+export function recordTurnCounter(
+  name: string,
+  value = 1,
+  attrs: Record<string, string | number | boolean> = {},
+): void {
+  try {
+    const c = getCounter(name)
+    if (c) c.add(value, attrs)
+    else logTurnEvent(String(attrs.turnId ?? 'unknown'), 'metric', { name, value, ...attrs })
+  } catch { /* telemetry must not throw */ }
+}
+
+export function recordTurnHistogram(
+  name: string,
+  value: number,
+  attrs: Record<string, string | number | boolean> = {},
+): void {
+  try {
+    const h = getHistogram(name)
+    if (h) h.record(value, attrs)
+    else logTurnEvent(String(attrs.turnId ?? 'unknown'), 'metric', { name, value, ...attrs })
+  } catch { /* telemetry must not throw */ }
+}
+
+/**
+ * A handle over a turn's OTel span + aggregated metrics. All methods are
+ * safe to call when OTel is not configured.
+ */
+export class TurnTelemetry {
+  private readonly startedAt = Date.now()
+  private ended = false
+  constructor(
+    public readonly turnId: string,
+    private readonly span: any,
+    private readonly baseAttrs: Record<string, string | number | boolean>,
+  ) {}
+
+  static start(
+    turnId: string,
+    attrs: Record<string, string | number | boolean> = {},
+  ): TurnTelemetry {
+    const tracer = getTracer()
+    let span: any = null
+    try {
+      if (tracer) {
+        span = tracer.startSpan('agent.turn', {
+          attributes: { 'turn.id': turnId, ...attrs },
+        })
+      }
+    } catch { /* best effort */ }
+
+    recordTurnCounter('agent_turn_started_total', 1, { turnId, ...attrs })
+    logTurnEvent(turnId, 'start', attrs)
+    return new TurnTelemetry(turnId, span, attrs)
+  }
+
+  attempt(cp: {
+    attempt: number
+    reason: string
+    willContinue: boolean
+    iterations: number
+    toolCallsThisAttempt: number
+    toolCallsTotal: number
+    outputTokensTotal: number
+    lastStopReason?: string
+    modelId?: string
+    error?: string
+  }): void {
+    logTurnEvent(this.turnId, 'checkpoint', cp)
+    recordTurnCounter('agent_turn_attempt_total', 1, {
+      turnId: this.turnId,
+      reason: cp.reason,
+      willContinue: cp.willContinue,
+      ...this.baseAttrs,
+    })
+    if (cp.error) {
+      recordTurnCounter('agent_turn_attempt_error_total', 1, {
+        turnId: this.turnId,
+        reason: cp.reason,
+        ...this.baseAttrs,
+      })
+    }
+    try {
+      this.span?.addEvent('attempt', {
+        'attempt.number': cp.attempt,
+        'attempt.reason': cp.reason,
+        'attempt.will_continue': cp.willContinue,
+        'attempt.iterations': cp.iterations,
+        'attempt.tool_calls_this_attempt': cp.toolCallsThisAttempt,
+        'attempt.tool_calls_total': cp.toolCallsTotal,
+        'attempt.output_tokens_total': cp.outputTokensTotal,
+        ...(cp.lastStopReason ? { 'attempt.stop_reason': cp.lastStopReason } : {}),
+        ...(cp.modelId ? { 'attempt.model_id': cp.modelId } : {}),
+      })
+    } catch {}
+  }
+
+  end(finalStatus: string, terminalReason?: string, fields: JSONFields = {}): void {
+    if (this.ended) return
+    this.ended = true
+    const durationMs = Date.now() - this.startedAt
+    logTurnEvent(this.turnId, 'end', {
+      status: finalStatus,
+      terminalReason,
+      durationMs,
+      ...fields,
+    })
+    recordTurnCounter('agent_turn_completed_total', 1, {
+      turnId: this.turnId,
+      status: finalStatus,
+      terminalReason: terminalReason ?? 'unspecified',
+      ...this.baseAttrs,
+    })
+    recordTurnHistogram('agent_turn_duration_ms', durationMs, {
+      turnId: this.turnId,
+      status: finalStatus,
+      ...this.baseAttrs,
+    })
+    try {
+      this.span?.setAttribute('turn.status', finalStatus)
+      if (terminalReason) this.span?.setAttribute('turn.terminal_reason', terminalReason)
+      this.span?.end()
+    } catch {}
+  }
+}

--- a/packages/shared-app/src/chat/index.ts
+++ b/packages/shared-app/src/chat/index.ts
@@ -21,3 +21,15 @@ export {
   buildRemoteChatApiUrl,
   type RemoteChatTransportOptions,
 } from './useRemoteChatTransport'
+
+export {
+  fetchActiveTurns,
+  fetchTurnStatus,
+  postTurnResume,
+  buildTurnStreamResumeUrl,
+  useActiveTurn,
+  type TurnMetaLike,
+  type TurnCheckpointLike,
+  type TurnStatusResult,
+  type ResumeDecision,
+} from './useTurnResume'

--- a/packages/shared-app/src/chat/useTurnResume.ts
+++ b/packages/shared-app/src/chat/useTurnResume.ts
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Turn-resume client helpers.
+ *
+ * Phase 4.1 of the durable-turn work: expose the API's semantic turn
+ * endpoints to the client so the UI can:
+ *   1. Discover an in-flight turn on mount (after a page reload / app
+ *      resume) via `fetchActiveTurns()`.
+ *   2. Poll a single turn's status (attempts, continuations, terminal
+ *      reason) via `fetchTurnStatus()` — used to drive the "continuing…"
+ *      and "paused" banners (Phase 4.2/3).
+ *   3. Ask the runtime to reconcile a turn via `postTurnResume()` — the
+ *      server decides whether a pure stream replay is enough or a fresh
+ *      chat request needs to be issued.
+ *
+ * These helpers are intentionally thin — no React state machinery here.
+ * UIs compose them with their own state management (React Query,
+ * useState, etc.). The `useActiveTurn` hook below is provided as a
+ * convenient React wrapper for the common "subscribe to active turn
+ * status" case.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+
+export interface TurnMetaLike {
+  turnId: string
+  status:
+    | 'active'
+    | 'completed'
+    | 'aborted'
+    | 'interrupted_recoverable'
+    | 'max_continuations'
+    | 'provider_fatal'
+    | 'loop_detected'
+  createdAt: number
+  updatedAt: number
+  terminalReason?: string
+  chatSessionId?: string
+  attempts?: number
+  toolCallsTotal?: number
+  outputTokensTotal?: number
+  lastStopReason?: string
+}
+
+export interface TurnCheckpointLike {
+  seq: number
+  at: number
+  attempt: number
+  reason: string
+  willContinue: boolean
+  iterations: number
+  toolCallsThisAttempt: number
+  toolCallsTotal: number
+  outputTokensTotal: number
+  lastStopReason?: string
+  modelId?: string
+  error?: string
+  extra?: Record<string, unknown>
+}
+
+export interface FetchOptions {
+  apiBaseUrl: string
+  projectId: string
+  fetch?: typeof globalThis.fetch
+  headers?: Record<string, string>
+  signal?: AbortSignal
+}
+
+export async function fetchActiveTurns(
+  opts: FetchOptions,
+): Promise<TurnMetaLike[]> {
+  const f = opts.fetch ?? globalThis.fetch
+  const res = await f(`${opts.apiBaseUrl}/api/projects/${opts.projectId}/turns/active`, {
+    headers: opts.headers,
+    signal: opts.signal,
+  })
+  if (!res.ok) return []
+  const body = (await res.json().catch(() => ({}))) as any
+  const list = body.active ?? []
+  return Array.isArray(list) ? (list as TurnMetaLike[]) : []
+}
+
+export interface TurnStatusResult {
+  meta: TurnMetaLike | null
+  checkpoints: TurnCheckpointLike[]
+}
+
+export async function fetchTurnStatus(
+  opts: FetchOptions & { turnId: string; fromSeq?: number },
+): Promise<TurnStatusResult | null> {
+  const f = opts.fetch ?? globalThis.fetch
+  const qs = opts.fromSeq ? `?fromSeq=${opts.fromSeq}` : ''
+  const url = `${opts.apiBaseUrl}/api/projects/${opts.projectId}/turns/${encodeURIComponent(opts.turnId)}/status${qs}`
+  const res = await f(url, { headers: opts.headers, signal: opts.signal })
+  if (!res.ok) return null
+  const body = (await res.json().catch(() => null)) as any
+  if (!body?.ok) return null
+  return {
+    meta: body.meta ?? null,
+    checkpoints: (body.checkpoints ?? []) as TurnCheckpointLike[],
+  }
+}
+
+export type ResumeDecision =
+  | { decision: 'replay'; turnId: string; chatSessionId?: string; replayPath?: string | null; meta: TurnMetaLike }
+  | { decision: 'interrupted_recoverable'; turnId: string; chatSessionId?: string; meta: TurnMetaLike; hint?: string }
+  | { decision: 'terminal'; turnId: string; terminalStatus: TurnMetaLike['status']; terminalReason?: string; meta: TurnMetaLike }
+  | { decision: 'not_found'; turnId: string }
+
+export async function postTurnResume(
+  opts: FetchOptions & { turnId: string },
+): Promise<ResumeDecision> {
+  const f = opts.fetch ?? globalThis.fetch
+  const url = `${opts.apiBaseUrl}/api/projects/${opts.projectId}/turns/${encodeURIComponent(opts.turnId)}/resume`
+  const res = await f(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...opts.headers },
+    signal: opts.signal,
+  })
+  if (res.status === 404) return { decision: 'not_found', turnId: opts.turnId }
+  const body = (await res.json().catch(() => null)) as any
+  if (!body?.ok) return { decision: 'not_found', turnId: opts.turnId }
+  return {
+    decision: body.decision,
+    turnId: opts.turnId,
+    chatSessionId: body.chatSessionId,
+    replayPath: body.replayPath,
+    meta: body.meta,
+    terminalStatus: body.terminalStatus,
+    terminalReason: body.terminalReason,
+    hint: body.hint,
+  } as ResumeDecision
+}
+
+/**
+ * Build a resume URL suitable for an SSE GET request, optionally with a
+ * `Last-Event-ID`-style `fromSeq`. This is the endpoint the AI SDK's
+ * DefaultChatTransport hits when reconnecting to an existing turn.
+ */
+export function buildTurnStreamResumeUrl(
+  apiBaseUrl: string,
+  projectId: string,
+  chatSessionId: string,
+  turnId: string,
+  fromSeq?: number,
+): string {
+  const qs = fromSeq ? `?fromSeq=${fromSeq}` : ''
+  return `${apiBaseUrl}/api/projects/${projectId}/chat/${encodeURIComponent(chatSessionId)}/turns/${encodeURIComponent(turnId)}/stream${qs}`
+}
+
+/**
+ * React hook: watch a single turn's status with configurable polling.
+ * Safe to call with a null turnId — it no-ops.
+ */
+export function useActiveTurn(
+  opts: Partial<FetchOptions> & { turnId: string | null; pollMs?: number; enabled?: boolean },
+): {
+  status: TurnMetaLike | null
+  checkpoints: TurnCheckpointLike[]
+  loading: boolean
+  error: Error | null
+} {
+  const { turnId, pollMs = 3_000, enabled = true } = opts
+  const [status, setStatus] = useState<TurnMetaLike | null>(null)
+  const [checkpoints, setCheckpoints] = useState<TurnCheckpointLike[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+  const lastSeqRef = useRef(0)
+
+  useEffect(() => {
+    if (!enabled || !turnId || !opts.apiBaseUrl || !opts.projectId) return
+    let cancelled = false
+    const controller = new AbortController()
+
+    const tick = async () => {
+      setLoading(true)
+      try {
+        const res = await fetchTurnStatus({
+          apiBaseUrl: opts.apiBaseUrl!,
+          projectId: opts.projectId!,
+          fetch: opts.fetch,
+          headers: opts.headers,
+          turnId,
+          fromSeq: lastSeqRef.current,
+          signal: controller.signal,
+        })
+        if (cancelled || !res) return
+        if (res.meta) setStatus(res.meta)
+        if (res.checkpoints.length > 0) {
+          setCheckpoints((prev) => [...prev, ...res.checkpoints])
+          lastSeqRef.current = res.checkpoints[res.checkpoints.length - 1].seq
+        }
+        setError(null)
+      } catch (err: any) {
+        if (!cancelled) setError(err instanceof Error ? err : new Error(String(err)))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    tick()
+    const timer = setInterval(() => {
+      // Only keep polling while the turn might still change.
+      if (status?.status && status.status !== 'active' && status.status !== 'interrupted_recoverable') {
+        return
+      }
+      tick()
+    }, pollMs)
+
+    return () => {
+      cancelled = true
+      controller.abort()
+      clearInterval(timer)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [turnId, opts.apiBaseUrl, opts.projectId, pollMs, enabled])
+
+  return { status, checkpoints, loading, error }
+}

--- a/packages/shared-runtime/src/__tests__/durable-stream-ledger.test.ts
+++ b/packages/shared-runtime/src/__tests__/durable-stream-ledger.test.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { DurableStreamLedger } from '../durable-stream-ledger'
+
+function encode(text: string): Uint8Array {
+  return new TextEncoder().encode(text)
+}
+
+async function collectStream(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let result = ''
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    result += decoder.decode(value, { stream: true })
+  }
+  return result
+}
+
+describe('DurableStreamLedger', () => {
+  let dir: string
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  })
+
+  test('persists chunks and replays them from a new instance', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'shogo-ledger-'))
+    const first = new DurableStreamLedger(dir)
+    const meta = first.start('chat-1', { turnId: 'turn-1', runtimeId: 'runtime-a' })
+    expect(meta.turnId).toBe('turn-1')
+
+    first.appendChunk('chat-1', encode('hello '))
+    first.appendChunk('chat-1', encode('world'))
+    first.complete('chat-1')
+
+    const second = new DurableStreamLedger(dir)
+    const replay = second.createReplayStream('chat-1')
+    expect(replay).not.toBeNull()
+    expect(await collectStream(replay!)).toBe('hello world')
+  })
+
+  test('replays only events after fromSeq', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'shogo-ledger-'))
+    const ledger = new DurableStreamLedger(dir)
+    ledger.start('chat-1', { turnId: 'turn-1' })
+    ledger.appendChunk('chat-1', encode('a'))
+    ledger.appendChunk('chat-1', encode('b'))
+    ledger.appendChunk('chat-1', encode('c'))
+
+    const replay = ledger.createReplayStream('chat-1', { fromSeq: 1 })
+    expect(replay).not.toBeNull()
+    expect(await collectStream(replay!)).toBe('bc')
+  })
+
+  test('rejects mismatched turn ids and aborted streams', () => {
+    dir = mkdtempSync(join(tmpdir(), 'shogo-ledger-'))
+    const ledger = new DurableStreamLedger(dir)
+    ledger.start('chat-1', { turnId: 'turn-1' })
+    ledger.appendChunk('chat-1', encode('a'))
+
+    expect(ledger.createReplayStream('chat-1', { turnId: 'turn-2' })).toBeNull()
+    ledger.abort('chat-1')
+    expect(ledger.createReplayStream('chat-1', { turnId: 'turn-1' })).toBeNull()
+  })
+
+  test('interrupted streams remain replayable with recoverable status', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'shogo-ledger-'))
+    const ledger = new DurableStreamLedger(dir)
+    ledger.start('chat-1', { turnId: 'turn-1' })
+    ledger.appendChunk('chat-1', encode('partial'))
+    ledger.interrupt('chat-1')
+
+    expect(ledger.getMeta('chat-1')?.status).toBe('interrupted_recoverable')
+    const replay = ledger.createReplayStream('chat-1', { turnId: 'turn-1' })
+    expect(replay).not.toBeNull()
+    expect(await collectStream(replay!)).toBe('partial')
+  })
+})

--- a/packages/shared-runtime/src/__tests__/stream-buffer.test.ts
+++ b/packages/shared-runtime/src/__tests__/stream-buffer.test.ts
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { describe, test, expect, afterEach } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
 import { StreamBufferStore, createBufferingTransform } from '../stream-buffer'
+import { DurableStreamLedger } from '../durable-stream-ledger'
 
 function encode(text: string): Uint8Array {
   return new TextEncoder().encode(text)
@@ -21,9 +25,14 @@ async function collectStream(stream: ReadableStream<Uint8Array>): Promise<string
 
 describe('StreamBufferStore', () => {
   let store: StreamBufferStore
+  let tempDir: string | null = null
 
   afterEach(() => {
     store?.dispose()
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true })
+      tempDir = null
+    }
   })
 
   test('create + append + replay returns chunks in order', async () => {
@@ -123,6 +132,36 @@ describe('StreamBufferStore', () => {
     const replay = store.createReplayStream('done')!
     const text = await collectStream(replay)
     expect(text).toBe('ab')
+  })
+
+  test('falls back to durable replay when memory buffer is gone', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'shogo-stream-buffer-'))
+    const ledger = new DurableStreamLedger(tempDir)
+    store = new StreamBufferStore({ durableLedger: ledger })
+    store.create('durable', { turnId: 'turn-1' })
+    store.append('durable', encode('persisted\n'))
+    store.complete('durable')
+    store.dispose()
+
+    store = new StreamBufferStore({ durableLedger: new DurableStreamLedger(tempDir) })
+    const replay = store.createReplayStream('durable', { turnId: 'turn-1' })
+    expect(replay).not.toBeNull()
+    expect(await collectStream(replay!)).toBe('persisted\n')
+  })
+
+  test('dispose can mark active durable streams as interrupted and replayable', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'shogo-stream-buffer-'))
+    const ledger = new DurableStreamLedger(tempDir)
+    store = new StreamBufferStore({ durableLedger: ledger })
+    store.create('durable', { turnId: 'turn-1' })
+    store.append('durable', encode('partial\n'))
+    store.dispose({ interruptActive: true })
+
+    expect(ledger.getMeta('durable')?.status).toBe('interrupted_recoverable')
+    store = new StreamBufferStore({ durableLedger: new DurableStreamLedger(tempDir) })
+    const replay = store.createReplayStream('durable', { turnId: 'turn-1' })
+    expect(replay).not.toBeNull()
+    expect(await collectStream(replay!)).toBe('partial\n')
   })
 
   test('isolation: two buffers do not cross-contaminate', async () => {

--- a/packages/shared-runtime/src/durable-stream-ledger.ts
+++ b/packages/shared-runtime/src/durable-stream-ledger.ts
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * File-backed stream ledger for resumable long-running agent responses.
+ *
+ * This intentionally stores the same bytes that the AI SDK client consumes.
+ * The hot in-memory StreamBufferStore still serves live subscribers, while the
+ * ledger lets a restarted runtime replay the last persisted stream frames.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'fs'
+import { randomUUID } from 'crypto'
+import { dirname, join } from 'path'
+
+const DEFAULT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000
+
+export type DurableStreamStatus = 'active' | 'completed' | 'aborted' | 'interrupted_recoverable'
+
+export interface DurableStreamStartOptions {
+  turnId?: string
+  runtimeId?: string
+}
+
+export interface DurableStreamMeta {
+  key: string
+  turnId: string
+  runtimeId?: string
+  status: DurableStreamStatus
+  createdAt: number
+  updatedAt: number
+  completedAt?: number
+  terminalReason?: string
+  lastSeq: number
+}
+
+export interface DurableStreamReplayOptions {
+  fromSeq?: number
+  turnId?: string
+}
+
+interface DurableStreamEvent {
+  seq: number
+  ts: number
+  type: 'chunk'
+  data: string
+}
+
+export class DurableStreamLedger {
+  private readonly dir: string
+  private readonly retentionMs: number
+  private metaCache = new Map<string, DurableStreamMeta>()
+
+  constructor(dir: string, options: { retentionMs?: number } = {}) {
+    this.dir = dir
+    this.retentionMs = options.retentionMs ?? DEFAULT_RETENTION_MS
+    mkdirSync(this.dir, { recursive: true })
+  }
+
+  start(key: string, options: DurableStreamStartOptions = {}): DurableStreamMeta {
+    mkdirSync(this.dir, { recursive: true })
+    const meta: DurableStreamMeta = {
+      key,
+      turnId: options.turnId || randomUUID(),
+      runtimeId: options.runtimeId,
+      status: 'active',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      lastSeq: 0,
+    }
+    writeFileSync(this.eventPath(key), '', 'utf-8')
+    this.writeMeta(meta)
+    return meta
+  }
+
+  appendChunk(key: string, chunk: Uint8Array): number {
+    const meta = this.getMeta(key) ?? this.start(key)
+    if (meta.status !== 'active') return meta.lastSeq
+
+    const seq = meta.lastSeq + 1
+    const event: DurableStreamEvent = {
+      seq,
+      ts: Date.now(),
+      type: 'chunk',
+      data: Buffer.from(chunk).toString('base64'),
+    }
+    appendFileSync(this.eventPath(key), `${JSON.stringify(event)}\n`, 'utf-8')
+    meta.lastSeq = seq
+    meta.updatedAt = event.ts
+    this.writeMeta(meta)
+    return seq
+  }
+
+  complete(key: string, terminalReason = 'completed'): void {
+    const meta = this.getMeta(key)
+    if (!meta || meta.status !== 'active') return
+    meta.status = 'completed'
+    meta.completedAt = Date.now()
+    meta.updatedAt = meta.completedAt
+    meta.terminalReason = terminalReason
+    this.writeMeta(meta)
+  }
+
+  abort(key: string, terminalReason = 'aborted'): void {
+    const meta = this.getMeta(key)
+    if (!meta) return
+    meta.status = 'aborted'
+    meta.completedAt = Date.now()
+    meta.updatedAt = meta.completedAt
+    meta.terminalReason = terminalReason
+    this.writeMeta(meta)
+  }
+
+  interrupt(key: string, terminalReason = 'interrupted_recoverable'): void {
+    const meta = this.getMeta(key)
+    if (!meta || meta.status !== 'active') return
+    meta.status = 'interrupted_recoverable'
+    meta.completedAt = Date.now()
+    meta.updatedAt = meta.completedAt
+    meta.terminalReason = terminalReason
+    this.writeMeta(meta)
+  }
+
+  has(key: string): boolean {
+    const meta = this.getMeta(key)
+    return !!meta && meta.status !== 'aborted' && existsSync(this.eventPath(key))
+  }
+
+  getMeta(key: string): DurableStreamMeta | null {
+    const cached = this.metaCache.get(key)
+    if (cached) return cached
+
+    const path = this.metaPath(key)
+    if (!existsSync(path)) return null
+    try {
+      const meta = JSON.parse(readFileSync(path, 'utf-8')) as DurableStreamMeta
+      this.metaCache.set(key, meta)
+      return meta
+    } catch {
+      return null
+    }
+  }
+
+  createReplayStream(key: string, options: DurableStreamReplayOptions = {}): ReadableStream<Uint8Array> | null {
+    const meta = this.getMeta(key)
+    if (!meta || meta.status === 'aborted') return null
+    if (options.turnId && meta.turnId !== options.turnId) return null
+
+    const path = this.eventPath(key)
+    if (!existsSync(path)) return null
+    const rawFromSeq = options.fromSeq ?? 0
+    const fromSeq = Number.isFinite(rawFromSeq) ? Math.max(0, rawFromSeq) : 0
+    const events = readFileSync(path, 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => {
+        try { return JSON.parse(line) as DurableStreamEvent } catch { return null }
+      })
+      .filter((event): event is DurableStreamEvent => !!event && event.seq > fromSeq)
+
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const event of events) {
+          controller.enqueue(Buffer.from(event.data, 'base64'))
+        }
+        controller.close()
+      },
+    })
+  }
+
+  cleanup(): void {
+    if (!existsSync(this.dir)) return
+    const cutoff = Date.now() - this.retentionMs
+    for (const entry of readdirSync(this.dir)) {
+      if (!entry.endsWith('.meta.json')) continue
+      const metaPath = join(this.dir, entry)
+      try {
+        const meta = JSON.parse(readFileSync(metaPath, 'utf-8')) as DurableStreamMeta
+        const lastTouched = meta.completedAt ?? meta.updatedAt ?? statSync(metaPath).mtimeMs
+        if (meta.status !== 'active' && lastTouched < cutoff) {
+          const encoded = entry.slice(0, -'.meta.json'.length)
+          rmSync(metaPath, { force: true })
+          rmSync(join(this.dir, `${encoded}.jsonl`), { force: true })
+          this.metaCache.delete(meta.key)
+        }
+      } catch {
+        // Leave malformed entries alone; runtime replay should be conservative.
+      }
+    }
+  }
+
+  private writeMeta(meta: DurableStreamMeta): void {
+    mkdirSync(dirname(this.metaPath(meta.key)), { recursive: true })
+    writeFileSync(this.metaPath(meta.key), JSON.stringify(meta), 'utf-8')
+    this.metaCache.set(meta.key, meta)
+  }
+
+  private metaPath(key: string): string {
+    return join(this.dir, `${this.encodeKey(key)}.meta.json`)
+  }
+
+  private eventPath(key: string): string {
+    return join(this.dir, `${this.encodeKey(key)}.jsonl`)
+  }
+
+  private encodeKey(key: string): string {
+    return Buffer.from(key).toString('base64url')
+  }
+}

--- a/packages/shared-runtime/src/durable-turn-env.ts
+++ b/packages/shared-runtime/src/durable-turn-env.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Unified durable-turn environment variables.
+ *
+ * Phase 6.1: single source of truth for the env vars that control the
+ * reliability behaviour of long-running agent sessions. Each runtime
+ * process (API, agent-runtime, watch scripts) calls `getDurableTurnEnv()`
+ * on boot and logs the resolved values, so operators can quickly verify
+ * what's actually in effect and so accidental drift between services is
+ * caught immediately.
+ *
+ * None of these variables are *required* — every one has a safe default.
+ * They are documented here in one place; individual modules should import
+ * the value from this module rather than reading `process.env` directly.
+ */
+
+export interface DurableTurnEnv {
+  /** Feature flag for the DurableTurnRunner auto-continuation layer. */
+  durableAgentTurns: boolean
+  /** Max continuation attempts after the first. */
+  agentMaxContinuations: number
+  /** Mid-stream provider retry budget per attempt. */
+  agentProviderRetries: number
+  /** SIGTERM → SIGKILL grace window for the agent process. */
+  agentKillGraceMs: number
+  /** Alias/fallback for `agentKillGraceMs`. */
+  agentDrainTimeoutMs: number
+  /** SIGTERM → SIGKILL grace window for Vite. */
+  viteKillGraceMs: number
+  /** SSE keep-alive interval (client heartbeat). */
+  streamKeepaliveMs: number
+  /** Retention of on-disk stream + turn ledger entries. */
+  agentStreamLedgerRetentionMs: number
+  /** Watch-script SIGKILL fallback timeout (dev only). */
+  watchApiKillTimeoutMs: number
+}
+
+function num(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const n = Number(raw)
+  return Number.isFinite(n) && n >= 0 ? n : fallback
+}
+
+function bool(name: string, fallback: boolean): boolean {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  return raw.toLowerCase() !== 'false' && raw !== '0'
+}
+
+export function getDurableTurnEnv(): DurableTurnEnv {
+  const agentKillGraceMs = num(
+    'AGENT_KILL_GRACE_MS',
+    num('AGENT_DRAIN_TIMEOUT_MS', 30 * 60_000),
+  )
+  return {
+    durableAgentTurns: bool('DURABLE_AGENT_TURNS', true),
+    agentMaxContinuations: num('AGENT_MAX_CONTINUATIONS', 5),
+    agentProviderRetries: num('AGENT_PROVIDER_RETRIES', 2),
+    agentKillGraceMs,
+    agentDrainTimeoutMs: num('AGENT_DRAIN_TIMEOUT_MS', agentKillGraceMs),
+    viteKillGraceMs: num('VITE_KILL_GRACE_MS', 10_000),
+    streamKeepaliveMs: num('STREAM_KEEPALIVE_MS', 15_000),
+    agentStreamLedgerRetentionMs: num(
+      'AGENT_STREAM_LEDGER_RETENTION_MS',
+      7 * 24 * 60 * 60 * 1000,
+    ),
+    watchApiKillTimeoutMs: num('WATCH_API_KILL_TIMEOUT_MS', 90_000),
+  }
+}
+
+/**
+ * Emit a single-line startup log summarizing the resolved durable-turn
+ * configuration so operators/developers can quickly verify what's in
+ * effect on each process.
+ */
+export function logDurableTurnStartup(component: string): DurableTurnEnv {
+  const env = getDurableTurnEnv()
+  try {
+    console.log(
+      `[${component}][durable-turn-env] ` +
+        `durableAgentTurns=${env.durableAgentTurns} ` +
+        `maxContinuations=${env.agentMaxContinuations} ` +
+        `providerRetries=${env.agentProviderRetries} ` +
+        `agentKillGraceMs=${env.agentKillGraceMs} ` +
+        `viteKillGraceMs=${env.viteKillGraceMs} ` +
+        `streamKeepaliveMs=${env.streamKeepaliveMs} ` +
+        `ledgerRetentionMs=${env.agentStreamLedgerRetentionMs} ` +
+        `watchApiKillMs=${env.watchApiKillTimeoutMs}`,
+    )
+  } catch { /* logging must never throw at startup */ }
+  return env
+}

--- a/packages/shared-runtime/src/index.ts
+++ b/packages/shared-runtime/src/index.ts
@@ -96,4 +96,27 @@ export {
   StreamBufferStore,
   createBufferingTransform,
   type StreamBufferWriter,
+  type StreamBufferStoreOptions,
 } from './stream-buffer'
+
+export {
+  DurableStreamLedger,
+  type DurableStreamMeta,
+  type DurableStreamReplayOptions,
+  type DurableStreamStartOptions,
+  type DurableStreamStatus,
+} from './durable-stream-ledger'
+
+export {
+  TurnCheckpointLedger,
+  type TurnMeta,
+  type TurnStatus,
+  type TurnCheckpointRecord,
+  type TurnStartOptions,
+} from './turn-checkpoint-ledger'
+
+export {
+  getDurableTurnEnv,
+  logDurableTurnStartup,
+  type DurableTurnEnv,
+} from './durable-turn-env'

--- a/packages/shared-runtime/src/server-framework.ts
+++ b/packages/shared-runtime/src/server-framework.ts
@@ -330,6 +330,7 @@ export async function createRuntimeApp(config: RuntimeAppConfig): Promise<Runtim
   }
 
   const publicPaths = new Set([
+    '/agent/health',
     '/agent/channels/webchat/widget.js',
     '/agent/channels/webchat/config',
     '/agent/channels/webchat/health',

--- a/packages/shared-runtime/src/stream-buffer.ts
+++ b/packages/shared-runtime/src/stream-buffer.ts
@@ -10,9 +10,16 @@
  * StreamBufferStore singleton — no shared state between processes.
  */
 
+import type {
+  DurableStreamLedger,
+  DurableStreamReplayOptions,
+  DurableStreamStartOptions,
+  DurableStreamMeta,
+} from './durable-stream-ledger'
+
 const CLEANUP_INTERVAL_MS = 60_000
-const MAX_BUFFER_AGE_MS = 30 * 60_000
-const COMPLETED_GRACE_MS = 30_000
+const MAX_BUFFER_AGE_MS = Number(process.env.STREAM_BUFFER_MAX_AGE_MS || 30 * 60_000)
+const COMPLETED_GRACE_MS = Number(process.env.STREAM_BUFFER_COMPLETED_GRACE_MS || 30_000)
 
 interface StreamBuffer {
   chunks: Uint8Array[]
@@ -20,6 +27,9 @@ interface StreamBuffer {
   status: 'active' | 'completed'
   createdAt: number
   completedAt: number | null
+  turnId?: string
+  runtimeId?: string
+  lastSeq: number
 }
 
 /**
@@ -30,13 +40,20 @@ interface StreamBuffer {
 export interface StreamBufferWriter {
   append(chunk: Uint8Array): void
   complete(): void
+  readonly turnId?: string
+}
+
+export interface StreamBufferStoreOptions {
+  durableLedger?: DurableStreamLedger
 }
 
 export class StreamBufferStore {
   private buffers = new Map<string, StreamBuffer>()
   private cleanupTimer: ReturnType<typeof setInterval> | null = null
+  private readonly durableLedger?: DurableStreamLedger
 
-  constructor() {
+  constructor(options: StreamBufferStoreOptions = {}) {
+    this.durableLedger = options.durableLedger
     this.cleanupTimer = setInterval(() => this.cleanup(), CLEANUP_INTERVAL_MS)
     if (this.cleanupTimer && typeof this.cleanupTimer === 'object' && 'unref' in this.cleanupTimer) {
       this.cleanupTimer.unref()
@@ -49,23 +66,31 @@ export class StreamBufferStore {
    *
    * Returns a writer bound to this specific buffer instance.
    */
-  create(key: string): StreamBufferWriter {
+  create(key: string, options: DurableStreamStartOptions = {}): StreamBufferWriter {
     const existing = this.buffers.get(key)
     if (existing && existing.status === 'active') {
       this.completeBuffer(existing)
     }
+    const durableMeta = this.durableLedger?.start(key, options)
     const buf: StreamBuffer = {
       chunks: [],
       subscribers: new Set(),
       status: 'active',
       createdAt: Date.now(),
       completedAt: null,
+      turnId: durableMeta?.turnId ?? options.turnId,
+      runtimeId: options.runtimeId,
+      lastSeq: 0,
     }
     this.buffers.set(key, buf)
 
     return {
+      get turnId() {
+        return buf.turnId
+      },
       append: (chunk: Uint8Array) => {
         if (buf.status !== 'active') return
+        buf.lastSeq = this.durableLedger?.appendChunk(key, chunk) ?? (buf.lastSeq + 1)
         buf.chunks.push(chunk)
         for (const ctrl of buf.subscribers) {
           try {
@@ -89,6 +114,7 @@ export class StreamBufferStore {
     const buf = this.buffers.get(key)
     if (!buf || buf.status !== 'active') return
 
+    buf.lastSeq = this.durableLedger?.appendChunk(key, chunk) ?? (buf.lastSeq + 1)
     buf.chunks.push(chunk)
     for (const ctrl of buf.subscribers) {
       try {
@@ -115,13 +141,40 @@ export class StreamBufferStore {
    */
   abort(key: string): void {
     const buf = this.buffers.get(key)
+    this.durableLedger?.abort(key)
     if (!buf) return
     this.completeBuffer(buf)
     this.buffers.delete(key)
   }
 
   has(key: string): boolean {
-    return this.buffers.has(key)
+    return this.buffers.has(key) || !!this.durableLedger?.has(key)
+  }
+
+  getStatus(key: string): DurableStreamMeta | {
+    key: string
+    turnId?: string
+    runtimeId?: string
+    status: 'active' | 'completed'
+    createdAt: number
+    updatedAt: number
+    completedAt?: number
+    lastSeq: number
+  } | null {
+    const buf = this.buffers.get(key)
+    if (buf) {
+      return {
+        key,
+        turnId: buf.turnId,
+        runtimeId: buf.runtimeId,
+        status: buf.status,
+        createdAt: buf.createdAt,
+        updatedAt: buf.completedAt ?? Date.now(),
+        completedAt: buf.completedAt ?? undefined,
+        lastSeq: buf.lastSeq,
+      }
+    }
+    return this.durableLedger?.getMeta(key) ?? null
   }
 
   /**
@@ -130,17 +183,20 @@ export class StreamBufferStore {
    *
    * Returns null if no buffer exists for the key.
    */
-  createReplayStream(key: string): ReadableStream<Uint8Array> | null {
+  createReplayStream(key: string, options: DurableStreamReplayOptions = {}): ReadableStream<Uint8Array> | null {
     const buf = this.buffers.get(key)
-    if (!buf) return null
+    if (!buf) return this.durableLedger?.createReplayStream(key, options) ?? null
+    if (options.turnId && buf.turnId && options.turnId !== buf.turnId) return null
 
     let subscribedController: ReadableStreamDefaultController<Uint8Array> | null = null
+    const rawFromSeq = options.fromSeq ?? 0
+    const fromSeq = Number.isFinite(rawFromSeq) ? Math.max(0, rawFromSeq) : 0
 
     return new ReadableStream<Uint8Array>({
       start(controller) {
-        for (const chunk of buf.chunks) {
+        for (let i = fromSeq; i < buf.chunks.length; i++) {
           try {
-            controller.enqueue(chunk)
+            controller.enqueue(buf.chunks[i])
           } catch {
             return
           }
@@ -165,6 +221,7 @@ export class StreamBufferStore {
 
   cleanup(): void {
     const now = Date.now()
+    this.durableLedger?.cleanup()
     for (const [key, buf] of this.buffers) {
       if (buf.status === 'completed' && buf.completedAt && now - buf.completedAt > COMPLETED_GRACE_MS) {
         this.buffers.delete(key)
@@ -175,13 +232,21 @@ export class StreamBufferStore {
     }
   }
 
-  dispose(): void {
+  dispose(options: { interruptActive?: boolean } = {}): void {
     if (this.cleanupTimer) {
       clearInterval(this.cleanupTimer)
       this.cleanupTimer = null
     }
-    for (const buf of this.buffers.values()) {
-      this.completeBuffer(buf)
+    for (const [key, buf] of this.buffers) {
+      if (options.interruptActive && buf.status === 'active') {
+        this.durableLedger?.interrupt(key)
+        for (const ctrl of buf.subscribers) {
+          try { ctrl.close() } catch { /* already closed */ }
+        }
+        buf.subscribers.clear()
+      } else {
+        this.completeBuffer(buf)
+      }
     }
     this.buffers.clear()
   }
@@ -190,6 +255,12 @@ export class StreamBufferStore {
     if (buf.status === 'completed') return
     buf.status = 'completed'
     buf.completedAt = Date.now()
+    for (const [key, candidate] of this.buffers) {
+      if (candidate === buf) {
+        this.durableLedger?.complete(key)
+        break
+      }
+    }
     for (const ctrl of buf.subscribers) {
       try { ctrl.close() } catch { /* already closed */ }
     }

--- a/packages/shared-runtime/src/turn-checkpoint-ledger.ts
+++ b/packages/shared-runtime/src/turn-checkpoint-ledger.ts
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * File-backed semantic turn-checkpoint ledger.
+ *
+ * The DurableStreamLedger persists raw SSE frames so clients can replay the
+ * wire-level protocol. This ledger persists the *semantic* lifecycle of a
+ * turn — attempt boundaries, continuation reasons, tool-call counts, token
+ * totals, termination — so the runtime can answer questions like:
+ *
+ *   - "Is turn T still active, paused, or terminally done?"
+ *   - "If the runtime crashes and restarts, what was the last checkpoint
+ *      so a reconciler can decide whether to resume, roll back, or ask?"
+ *   - "What continuations did we run for this turn and why?"
+ *
+ * Shape:
+ *   <dir>/<encodedTurnId>.meta.json  — single JSON blob for current state.
+ *   <dir>/<encodedTurnId>.jsonl      — append-only record of every checkpoint.
+ *
+ * The two together mirror the DurableStreamLedger layout so ops can reason
+ * about both at a glance.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'fs'
+import { dirname, join } from 'path'
+
+const DEFAULT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000
+
+export type TurnStatus =
+  | 'active'
+  | 'completed'
+  | 'aborted'
+  | 'interrupted_recoverable'
+  | 'max_continuations'
+  | 'provider_fatal'
+  | 'loop_detected'
+
+export interface TurnMeta {
+  turnId: string
+  sessionId?: string
+  chatSessionId?: string
+  runtimeId?: string
+  status: TurnStatus
+  createdAt: number
+  updatedAt: number
+  completedAt?: number
+  terminalReason?: string
+  attempts: number
+  iterationsTotal: number
+  toolCallsTotal: number
+  outputTokensTotal: number
+  lastStopReason?: string
+  lastAttemptModel?: string
+  lastSeq: number
+}
+
+export interface TurnCheckpointRecord {
+  seq: number
+  at: number
+  attempt: number
+  reason: string
+  willContinue: boolean
+  iterations: number
+  toolCallsThisAttempt: number
+  toolCallsTotal: number
+  outputTokensTotal: number
+  lastStopReason?: string
+  modelId?: string
+  error?: string
+  /** Arbitrary extras (e.g. unfinishedMutating tool ids). */
+  extra?: Record<string, unknown>
+}
+
+export interface TurnStartOptions {
+  sessionId?: string
+  chatSessionId?: string
+  runtimeId?: string
+}
+
+export class TurnCheckpointLedger {
+  private readonly dir: string
+  private readonly retentionMs: number
+  private metaCache = new Map<string, TurnMeta>()
+
+  constructor(dir: string, options: { retentionMs?: number } = {}) {
+    this.dir = dir
+    this.retentionMs = options.retentionMs ?? DEFAULT_RETENTION_MS
+    mkdirSync(this.dir, { recursive: true })
+  }
+
+  start(turnId: string, options: TurnStartOptions = {}): TurnMeta {
+    mkdirSync(this.dir, { recursive: true })
+    const now = Date.now()
+    const meta: TurnMeta = {
+      turnId,
+      sessionId: options.sessionId,
+      chatSessionId: options.chatSessionId,
+      runtimeId: options.runtimeId,
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+      attempts: 0,
+      iterationsTotal: 0,
+      toolCallsTotal: 0,
+      outputTokensTotal: 0,
+      lastSeq: 0,
+    }
+    writeFileSync(this.eventPath(turnId), '', 'utf-8')
+    this.writeMeta(meta)
+    return meta
+  }
+
+  /**
+   * Append a checkpoint and update the meta snapshot atomically (from a
+   * single process's perspective; we rely on OS-level write atomicity for
+   * small meta JSON blobs).
+   */
+  append(turnId: string, cp: Omit<TurnCheckpointRecord, 'seq' | 'at'>): TurnCheckpointRecord {
+    const meta = this.getMeta(turnId) ?? this.start(turnId)
+    const seq = meta.lastSeq + 1
+    const record: TurnCheckpointRecord = {
+      seq,
+      at: Date.now(),
+      ...cp,
+    }
+    appendFileSync(this.eventPath(turnId), `${JSON.stringify(record)}\n`, 'utf-8')
+
+    meta.lastSeq = seq
+    meta.updatedAt = record.at
+    meta.attempts = Math.max(meta.attempts, record.attempt)
+    meta.iterationsTotal += record.iterations
+    meta.toolCallsTotal = Math.max(meta.toolCallsTotal, record.toolCallsTotal)
+    meta.outputTokensTotal = Math.max(meta.outputTokensTotal, record.outputTokensTotal)
+    if (record.lastStopReason) meta.lastStopReason = record.lastStopReason
+    if (record.modelId) meta.lastAttemptModel = record.modelId
+    this.writeMeta(meta)
+    return record
+  }
+
+  finalize(turnId: string, status: TurnStatus, terminalReason?: string): TurnMeta | null {
+    const meta = this.getMeta(turnId)
+    if (!meta) return null
+    meta.status = status
+    meta.completedAt = Date.now()
+    meta.updatedAt = meta.completedAt
+    if (terminalReason) meta.terminalReason = terminalReason
+    this.writeMeta(meta)
+    return meta
+  }
+
+  getMeta(turnId: string): TurnMeta | null {
+    const cached = this.metaCache.get(turnId)
+    if (cached) return cached
+    const path = this.metaPath(turnId)
+    if (!existsSync(path)) return null
+    try {
+      const meta = JSON.parse(readFileSync(path, 'utf-8')) as TurnMeta
+      this.metaCache.set(turnId, meta)
+      return meta
+    } catch {
+      return null
+    }
+  }
+
+  readCheckpoints(turnId: string, fromSeq = 0): TurnCheckpointRecord[] {
+    const path = this.eventPath(turnId)
+    if (!existsSync(path)) return []
+    const out: TurnCheckpointRecord[] = []
+    for (const line of readFileSync(path, 'utf-8').split('\n')) {
+      if (!line) continue
+      try {
+        const rec = JSON.parse(line) as TurnCheckpointRecord
+        if (rec.seq > fromSeq) out.push(rec)
+      } catch {
+        // malformed line — skip
+      }
+    }
+    return out
+  }
+
+  /**
+   * Scan the ledger dir and return meta records for turns that are still
+   * marked `active`. Used by the runtime on boot to identify turns that
+   * should be reconciled (either resumed or marked interrupted).
+   */
+  listActive(): TurnMeta[] {
+    if (!existsSync(this.dir)) return []
+    const out: TurnMeta[] = []
+    for (const entry of readdirSync(this.dir)) {
+      if (!entry.endsWith('.meta.json')) continue
+      try {
+        const meta = JSON.parse(readFileSync(join(this.dir, entry), 'utf-8')) as TurnMeta
+        if (meta.status === 'active') out.push(meta)
+      } catch {}
+    }
+    return out
+  }
+
+  cleanup(): void {
+    if (!existsSync(this.dir)) return
+    const cutoff = Date.now() - this.retentionMs
+    for (const entry of readdirSync(this.dir)) {
+      if (!entry.endsWith('.meta.json')) continue
+      const metaPath = join(this.dir, entry)
+      try {
+        const meta = JSON.parse(readFileSync(metaPath, 'utf-8')) as TurnMeta
+        const lastTouched = meta.completedAt ?? meta.updatedAt ?? statSync(metaPath).mtimeMs
+        if (meta.status !== 'active' && lastTouched < cutoff) {
+          const encoded = entry.slice(0, -'.meta.json'.length)
+          rmSync(metaPath, { force: true })
+          rmSync(join(this.dir, `${encoded}.jsonl`), { force: true })
+          this.metaCache.delete(meta.turnId)
+        }
+      } catch {}
+    }
+  }
+
+  private writeMeta(meta: TurnMeta): void {
+    mkdirSync(dirname(this.metaPath(meta.turnId)), { recursive: true })
+    writeFileSync(this.metaPath(meta.turnId), JSON.stringify(meta), 'utf-8')
+    this.metaCache.set(meta.turnId, meta)
+  }
+
+  private metaPath(turnId: string): string {
+    return join(this.dir, `${this.encode(turnId)}.meta.json`)
+  }
+
+  private eventPath(turnId: string): string {
+    return join(this.dir, `${this.encode(turnId)}.jsonl`)
+  }
+
+  private encode(turnId: string): string {
+    return Buffer.from(turnId).toString('base64url')
+  }
+}

--- a/scripts/watch-api.ts
+++ b/scripts/watch-api.ts
@@ -26,8 +26,15 @@ const WATCH_DIRS = [
 ];
 
 const DEBOUNCE_MS = 800;
-const KILL_TIMEOUT_MS = 5_000;
-const PORT_WAIT_MS = 10_000;
+// How long we give the running API to gracefully shut down before SIGKILL.
+// The API's own gracefulShutdown waits for active agent turns to drain
+// (API_DRAIN_TIMEOUT_MS). In dev we don't want to block indefinitely on a
+// paused turn, but we must NOT kill the API in 5s while a legitimate long
+// chat is streaming — that's what was causing ConnectionRefused mid-turn
+// when a file save happened during a 10-tool response. Override via
+// WATCH_API_KILL_TIMEOUT_MS.
+const KILL_TIMEOUT_MS = Number(process.env.WATCH_API_KILL_TIMEOUT_MS || 90_000);
+const PORT_WAIT_MS = Number(process.env.WATCH_API_PORT_WAIT_MS || 30_000);
 const PORT_POLL_INTERVAL_MS = 300;
 
 let child: Subprocess | null = null;
@@ -71,7 +78,15 @@ async function startServer() {
     if (child) {
       const oldChild = child;
       child = null;
-      oldChild.kill();
+      // SIGTERM first — gives gracefulShutdown a chance to drain active
+      // agent turns. SIGKILL only after the grace period.
+      try { oldChild.kill("SIGTERM" as any); } catch { try { oldChild.kill(); } catch {} }
+
+      console.log(
+        `[watch-api] Sent SIGTERM to API; waiting up to ${Math.round(
+          KILL_TIMEOUT_MS / 1000,
+        )}s for graceful shutdown (drain active chat turns)...`,
+      );
 
       const killTimeout = setTimeout(() => {
         console.log(`[watch-api] Graceful exit timed out — sending SIGKILL`);


### PR DESCRIPTION
## Overview

This PR delivers **durable long-running agent sessions**: one user-visible chat turn can survive `max_tokens` exhaustion, iteration limits, recoverable provider interruptions, client disconnects (runtime keeps working), and API/runtime restarts—with **explicit semantics** instead of silent EOFs or vague “connection refused” failures.

**Fixes #441**

---

## Problem statement

- Long Anthropic turns with many tool calls could stop mid-response or appear blank.
- Proxies and load balancers could drop idle SSE lines; clients refreshing did not map cleanly to “turn still running vs truly dead.”
- API shutdown could tear down local runtimes while an agent turn was still executing because **proxy connection count ≠ active agent work**.
- After a runtime process restart, in-flight turns had no first-class **status** or **reconciliation** contract for the UI or API.

---

## Architecture (high level)

```mermaid
flowchart TB
  subgraph client["Client (mobile / shared-app)"]
    CP[ChatPanel + SSE]
    UR[useTurnResume helpers]
  end
  subgraph api["apps/api"]
    PC[project-chat routes]
    TS[TurnStore in-memory cache]
    RM[RuntimeManager + graceful shutdown]
  end
  subgraph runtime["packages/agent-runtime"]
    GW[Gateway: runDurableTurn / runAgentLoop]
    DTR[DurableTurnRunner]
    TIR[ToolIdempotencyRegistry]
    TEL[TurnTelemetry]
    SRV[server.ts: ledgers + HTTP]
  end
  subgraph disk["Workspace .shogo"]
    DSL[DurableStreamLedger]
    TCL[TurnCheckpointLedger]
  end
  CP -->|chat + resume SSE| PC
  UR -->|status / active / resume| PC
  PC -->|proxy| SRV
  PC --> TS
  SRV -->|ingest| PC
  SRV --> GW
  GW --> DTR
  DTR --> TIR
  GW --> TEL
  SRV --> DSL
  SRV --> TCL
  RM -->|drain activeTurns via health| SRV
```

---

## 1. `@shogo/shared-runtime`

### `DurableStreamLedger` (`durable-stream-ledger.ts`)

- File-backed persistence for **SSE stream chunks** and metadata under the project workspace (`.shogo/stream-ledger`).
- Enables **replay** after reconnect: clients can resume with `fromSeq` / `Last-Event-ID` style semantics without losing already-emitted frames.
- Configurable **retention** (default 7 days), aligned with turn ledger retention via unified env (see below).
- Unit tests in `__tests__/durable-stream-ledger.test.ts`.

### `TurnCheckpointLedger` (`turn-checkpoint-ledger.ts`)

- File-backed **semantic** ledger for a logical turn: `TurnMeta` (status, totals, terminal reason) plus ordered `TurnCheckpointRecord` entries.
- Status vocabulary includes **`active`**, **`completed`**, **`aborted`**, **`interrupted_recoverable`**, and terminal failure-style states—so operators and clients can distinguish “still streaming,” “done,” “user stopped,” and “restart happened; re-issue chat to continue.”
- APIs: `start`, `append`, `finalize`, `getMeta`, `readCheckpoints`, `listActive`, `cleanup`.

### `StreamBufferStore` + `server-framework` / `stream-buffer.ts`

- Write-through **in-memory buffer** to the durable ledger for live subscribers plus replay.
- Changes in this PR keep buffering, completion, abort, and replay paths consistent with ledger-backed durability (tests updated in `stream-buffer.test.ts`).

### `durable-turn-env.ts`

- **Single documented list** of env knobs for this feature area, with safe defaults:
  - `DURABLE_AGENT_TURNS` (default on)
  - `AGENT_MAX_CONTINUATIONS`, `AGENT_PROVIDER_RETRIES`
  - `AGENT_KILL_GRACE_MS` / `AGENT_DRAIN_TIMEOUT_MS`, `VITE_KILL_GRACE_MS`
  - `STREAM_KEEPALIVE_MS`
  - `AGENT_STREAM_LEDGER_RETENTION_MS`
  - `WATCH_API_KILL_TIMEOUT_MS` (dev watcher kill fallback)
- `logDurableTurnStartup(component)` prints one structured line at boot so **API vs agent-runtime** configs are easy to diff in logs.

---

## 2. `packages/agent-runtime`

### `DurableTurnRunner` (`durable-turn-runner.ts`)

- Wraps `runAgentLoop` in a **bounded** outer loop:
  - **Continuation reasons**: `max_tokens` (`lastStopReason === 'length'`), `iteration_limit`, `provider_error_after_tools` (when `maxIterationsExhausted` is set and tools already ran—mirrors prior gateway pain where the model “stopped” after partial tool work).
  - **Merge semantics**: text concatenated across attempts; tool calls unioned; token usage summed; **`newMessages` only from the last attempt** so the gateway’s session commit + `prepareNextHistory` path does not duplicate messages when intermediate attempts are already persisted.
- **Per-attempt provider retries**: if the inner loop returns an error with **no tool calls, no output tokens**, and the error is not billing/auth-shaped, the runner retries with exponential backoff up to `AGENT_PROVIDER_RETRIES` (default 2) before treating the attempt as failed.
- **`classifyAttempt`**: exported for tests; separates recoverable continuation vs **fatal** (loop break, billing/auth, context overflow, generic provider error without continuation path).
- **No-silent-EOF gate**: if the turn would “complete” with **zero** output tokens, **zero** tool calls, **no** text, and **no** error, the result is promoted to an explicit `Error` with `terminationReason: 'provider_fatal'` and a checkpoint reason `terminal_silent_empty` so the UI never shows a blank success.
- **Test hook**: `_runLoopForTests` injects a fake loop for fast unit tests (`__tests__/durable-turn-runner.test.ts`).

### `ToolIdempotencyRegistry` (`tool-idempotency.ts`)

- Tracks each `tool_use_id` through **`planned` → `started` → `completed` | `failed`**, with attempt number and **read-only vs mutating** classification (`BUILTIN_TOOL_CLASSES`, pessimistic default for unknown tools, `mcp_*_read` heuristic).
- **`listStartedButUnfinished()`** highlights mutating tools that may have **partial side effects** after a provider cut—surfaced in gateway checkpoints for banners / ops.

### `TurnTelemetry` (`turn-telemetry.ts`)

- Structured JSON logs and optional **OTel** span (`agent.turn`) with checkpoint events and terminal attributes for observability.

### `gateway.ts`

- **`DURABLE_AGENT_TURNS`** read **per turn** (not module load) so toggling env without full restart is meaningful; when `false`, logs an explicit **“DISABLED … falling back to single-shot runAgentLoop”** line.
- Wires **`runDurableTurn`** vs `runAgentLoop`, **`prepareNextHistory`** (session commit + compaction pipeline), **`onCheckpoint`** (tool registry unfinished mutating list, `data-turn-checkpoint` UI frames, ledger sinks, telemetry).
- **`turnSinksBySession`**: `turnCheckpointSink` / `turnTerminalSink` for ledger + ingest without exploding `processChatMessageStream` signatures.
- Tool callbacks: **`plan` / `start` / `finish`** on the idempotency registry aligned with tool lifecycle hooks.

### `server.ts` (agent HTTP server)

- Instantiates **`DurableStreamLedger`** + **`StreamBufferStore`** and **`TurnCheckpointLedger`** with retention from `getDurableTurnEnv()` / startup log.
- **`/agent/chat`**: assigns stable **`turnId`**, starts turn ledger, wires checkpoint + terminal sinks, **`pushTurnIngest`** to API (best-effort HTTP to cache turn state on the API).
- **Background stream reader `finally`**: if ledger still **`active`**, finalizes as **`completed`** with `terminalReason: 'stream_closed'` (safety net).
- **Boot reconciler**: any **`active`** turns from disk → **`interrupted_recoverable`** with `runtime_restart`; ledger/stream cleanup.
- **New routes**:
  - `GET /agent/turns/:turnId/status` — meta + checkpoints (`fromSeq` for incremental read).
  - `GET /agent/turns/active` — all active turn metas.
  - `POST /agent/turns/:turnId/resume` — **`ResumeDecision`**: `replay` | `interrupted_recoverable` | `terminal` | `not_found` (does **not** spawn work; documents how the client/API should proceed).
- **`/agent/stop`**: resolves **`turnId`** from stream buffer, finalizes ledger as **`aborted`** / `user_stop`, pushes ingest—**explicit user cancel** vs passive HTTP disconnect (turn may continue in background).

---

## 3. `apps/api`

### `lib/turns/turn-store.ts`

- Bounded **in-memory cache** of turn lifecycle (`start` / `checkpoint` / `finalize`) keyed by `turnId` for fast reads; **not** source of truth (runtime ledger is).

### `routes/project-chat.ts`

- Proxies with **cache-first** where appropriate:
  - `GET /projects/:projectId/turns/:turnId/status`
  - `GET /projects/:projectId/turns/active`
- `POST /projects/:projectId/turns/:turnId/resume` → runtime reconciler.
- `POST /projects/:projectId/turns/ingest` — **internal** ingestion from runtimes (auth pattern consistent with repo) to populate `turnStore`.

### `server.ts` (API)

- **`logDurableTurnStartup('api')`** on boot.
- **Graceful shutdown** refactored to **drain active agent turns first** by summing **`activeTurns`** (fallback `activeStreams`) from each local runtime’s **`/agent/health`**, then draining proxy connections, **then** stopping `runtimeManager` so long turns are not killed by API SIGTERM ordering.

### `lib/runtime/manager.ts` + `types.ts`

- **`AGENT_KILL_GRACE_MS`** / **`AGENT_DRAIN_TIMEOUT_MS`** alignment for SIGTERM→SIGKILL and cooperative drain windows so child agent processes match API shutdown expectations.

### `scripts/watch-api.ts`

- **`WATCH_API_KILL_TIMEOUT_MS`** aligned with API graceful drain so the dev watcher does not SIGKILL the API while turns are still draining.

---

## 4. `packages/shared-app`

### `chat/useTurnResume.ts` + `chat/index.ts` exports

- **`fetchTurnStatus`**, **`fetchActiveTurns`**, **`postTurnResume`**, **`buildTurnStreamResumeUrl`**, **`useActiveTurn`** (polling hook)—typed helpers for product code to integrate turn-aware UX without duplicating URL construction.

---

## 5. `apps/mobile`

### `components/chat/ChatPanel.tsx`

- Parses **`data-turn-checkpoint`** SSE frames into local state.
- **Continuation banner** (“Continuing…”) with attempt, reason, token/tool totals, and **warning** when **`unfinishedMutating`** tool IDs are present.
- Clears banner appropriately when a new stream starts or a clean end is detected.

---

## Cancellation semantics (matrix)

| Event | Turn on runtime | Ledger |
|------|------------------|--------|
| User **Stop** (`/agent/stop`) | Aborted | `aborted` / `user_stop` |
| Client **HTTP disconnect** | May **continue** (by design) | Stays **`active`** until completion or safety finalize |
| API **SIGTERM** after drain wait | Runtimes stopped after turns drain or timeout | Interrupted turns marked recoverable on **next** runtime boot |

---

## Environment variables (reference)

| Variable | Role | Default (see `getDurableTurnEnv`) |
|----------|------|-----------------------------------|
| `DURABLE_AGENT_TURNS` | Enable `runDurableTurn` | `true` |
| `AGENT_MAX_CONTINUATIONS` | Max auto-continuations after first attempt | `5` |
| `AGENT_PROVIDER_RETRIES` | Mid-attempt retries on empty failure | `2` |
| `AGENT_KILL_GRACE_MS` / `AGENT_DRAIN_TIMEOUT_MS` | Agent process graceful kill | `30m` |
| `VITE_KILL_GRACE_MS` | Vite child kill grace | `10s` |
| `STREAM_KEEPALIVE_MS` | SSE keep-alive interval | `15s` |
| `AGENT_STREAM_LEDGER_RETENTION_MS` | Disk retention for stream + turn ledgers | `7d` |
| `WATCH_API_KILL_TIMEOUT_MS` | Dev watcher API kill timeout | `90s` |
| `API_DRAIN_TIMEOUT_MS` | API shutdown poll budget | `30m` (API server, not in `DurableTurnEnv`) |

---

## Testing

```bash
bun test packages/agent-runtime/src/__tests__/durable-turn-runner.test.ts
bun test packages/shared-runtime/src/__tests__/durable-stream-ledger.test.ts
bun test packages/shared-runtime/src/__tests__/stream-buffer.test.ts
```

The durable-turn-runner tests cover: single completion, `max_tokens` continuation, iteration-limit continuation, transient provider retry, billing fatal path, `maxContinuations` cap, abort / host-cancel paths, silent-EOF promotion, default continuation prompt content, `classifyAttempt` branches, and **ToolIdempotencyRegistry** lifecycle + classification rules.

---

## Operational notes

- On startup, look for **`[api][durable-turn-env]`** and **`[agent-runtime][durable-turn-env]`** log lines to confirm both sides agree.
- After an unplanned runtime restart, **`interrupted_recoverable`** turns expect a **new chat send** with the same session so `DurableTurnRunner` can continue from persisted history—not magic auto-resume of the HTTP SSE from a dead process.

---

## Follow-ups (non-blocking)

- Wire **`useActiveTurn`** / resume flows everywhere the product wants “Codex-style” reconnect UX beyond the current `ChatPanel` banner.
- Optional: persist API `turnStore` for multi-instance API (today intentionally in-memory).
