### PR TITLE
feat(my-machines): add worker CLI and execution environment UX

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# Builds the @shogo-ai/worker CLI into single-file binaries for
+# darwin-arm64, darwin-x64, linux-x64, linux-arm64, win-x64
+# using Bun's --compile target, then publishes them as a GitHub Release.
+#
+# Triggered on tags matching `shogo-cli-v*` (e.g. shogo-cli-v0.1.0).
+
+name: Publish CLI
+
+on:
+  push:
+    tags:
+      - "shogo-cli-v*"
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Release channel (stable or beta)"
+        default: "beta"
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: darwin-arm64
+            bun-target: bun-darwin-arm64
+            ext: ""
+            archive: tar.gz
+          - target: darwin-x64
+            bun-target: bun-darwin-x64
+            ext: ""
+            archive: tar.gz
+          - target: linux-x64
+            bun-target: bun-linux-x64
+            ext: ""
+            archive: tar.gz
+          - target: linux-arm64
+            bun-target: bun-linux-arm64
+            ext: ""
+            archive: tar.gz
+          - target: win-x64
+            bun-target: bun-windows-x64
+            ext: ".exe"
+            archive: zip
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install deps
+        working-directory: packages/shogo-worker
+        run: bun install --frozen-lockfile || bun install
+
+      - name: Compile binary
+        working-directory: packages/shogo-worker
+        run: |
+          mkdir -p dist
+          bun build --compile --minify \
+            --target=${{ matrix.bun-target }} \
+            src/cli.ts \
+            --outfile dist/shogo${{ matrix.ext }}
+
+      - name: Package
+        working-directory: packages/shogo-worker/dist
+        run: |
+          if [ "${{ matrix.archive }}" = "tar.gz" ]; then
+            tar -czf shogo-${{ matrix.target }}.tar.gz shogo
+            shasum -a 256 shogo-${{ matrix.target }}.tar.gz > shogo-${{ matrix.target }}.tar.gz.sha256
+          else
+            zip -9 shogo-${{ matrix.target }}.zip shogo.exe
+            shasum -a 256 shogo-${{ matrix.target }}.zip > shogo-${{ matrix.target }}.zip.sha256
+          fi
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: shogo-${{ matrix.target }}
+          path: |
+            packages/shogo-worker/dist/shogo-${{ matrix.target }}.*
+          retention-days: 14
+
+  release:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -lh dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          draft: false
+          prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+          generate_release_notes: true

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -74,10 +74,10 @@ jobs:
         run: |
           if [ "${{ matrix.archive }}" = "tar.gz" ]; then
             tar -czf shogo-${{ matrix.target }}.tar.gz shogo
-            shasum -a 256 shogo-${{ matrix.target }}.tar.gz > shogo-${{ matrix.target }}.tar.gz.sha256
+            sha256sum shogo-${{ matrix.target }}.tar.gz > shogo-${{ matrix.target }}.tar.gz.sha256
           else
             zip -9 shogo-${{ matrix.target }}.zip shogo.exe
-            shasum -a 256 shogo-${{ matrix.target }}.zip > shogo-${{ matrix.target }}.zip.sha256
+            sha256sum shogo-${{ matrix.target }}.zip > shogo-${{ matrix.target }}.zip.sha256
           fi
 
       - name: Upload artifacts

--- a/apps/api/src/lib/instance-tunnel.ts
+++ b/apps/api/src/lib/instance-tunnel.ts
@@ -34,6 +34,7 @@ type IncomingMessage = TunnelRequest | CancelMessage | { type: 'ping' } | { type
 const DEFAULT_POLL_INTERVAL_S = 60
 const AUTH_FAILURE_BACKOFF_S = 300 // 5 min once we hit AUTH_FAILURE_THRESHOLD consecutive 401/403s
 const AUTH_FAILURE_THRESHOLD = 3
+const AUTH_RECOVERY_SUCCESS_THRESHOLD = AUTH_FAILURE_THRESHOLD
 const WS_IDLE_TIMEOUT_MS = 30 * 60 * 1000
 const HEARTBEAT_INTERVAL_MS = 25_000
 const BACKOFF_BASE_MS = 1_000
@@ -60,6 +61,7 @@ let currentPollInterval = DEFAULT_POLL_INTERVAL_S
 let wsReconnectAttempt = 0
 let lastHeartbeatError: string | null = null
 let consecutiveAuthFailures = 0
+let consecutiveAuthSuccesses = 0
 const activeAbortControllers = new Map<string, AbortController>()
 
 function getReconnectDelay(): number {
@@ -205,12 +207,25 @@ async function heartbeatLoop() {
 
   try {
     const result = await sendHeartbeat()
-    currentPollInterval = result.nextPollIn || DEFAULT_POLL_INTERVAL_S
+    const nextPollIn = result.nextPollIn || DEFAULT_POLL_INTERVAL_S
+    const wasInAuthBackoff = consecutiveAuthFailures >= AUTH_FAILURE_THRESHOLD
+
+    if (wasInAuthBackoff) {
+      consecutiveAuthSuccesses++
+      if (consecutiveAuthSuccesses < AUTH_RECOVERY_SUCCESS_THRESHOLD) {
+        currentPollInterval = AUTH_FAILURE_BACKOFF_S
+        scheduleNextPoll()
+        return
+      }
+    }
+
+    currentPollInterval = nextPollIn
     if (lastHeartbeatError) {
       console.log('[InstanceTunnel] Heartbeat recovered')
       lastHeartbeatError = null
     }
     consecutiveAuthFailures = 0
+    consecutiveAuthSuccesses = 0
 
     if (result.wsRequested && !ws) {
       console.log('[InstanceTunnel] Cloud requested WebSocket — connecting...')
@@ -221,8 +236,10 @@ async function heartbeatLoop() {
     const isAuthFailure = /HTTP 40[13]\b/.test(err.message || '')
     if (isAuthFailure) {
       consecutiveAuthFailures++
+      consecutiveAuthSuccesses = 0
     } else {
       consecutiveAuthFailures = 0
+      consecutiveAuthSuccesses = 0
     }
     if (err.message !== lastHeartbeatError) {
       console.error(`[InstanceTunnel] Heartbeat error: ${err.message}`)

--- a/apps/api/src/lib/instance-tunnel.ts
+++ b/apps/api/src/lib/instance-tunnel.ts
@@ -32,6 +32,8 @@ interface CancelMessage {
 type IncomingMessage = TunnelRequest | CancelMessage | { type: 'ping' } | { type: string }
 
 const DEFAULT_POLL_INTERVAL_S = 60
+const AUTH_FAILURE_BACKOFF_S = 300 // 5 min once we hit AUTH_FAILURE_THRESHOLD consecutive 401/403s
+const AUTH_FAILURE_THRESHOLD = 3
 const WS_IDLE_TIMEOUT_MS = 30 * 60 * 1000
 const HEARTBEAT_INTERVAL_MS = 25_000
 const BACKOFF_BASE_MS = 1_000
@@ -57,6 +59,7 @@ let stopped = false
 let currentPollInterval = DEFAULT_POLL_INTERVAL_S
 let wsReconnectAttempt = 0
 let lastHeartbeatError: string | null = null
+let consecutiveAuthFailures = 0
 const activeAbortControllers = new Map<string, AbortController>()
 
 function getReconnectDelay(): number {
@@ -207,6 +210,7 @@ async function heartbeatLoop() {
       console.log('[InstanceTunnel] Heartbeat recovered')
       lastHeartbeatError = null
     }
+    consecutiveAuthFailures = 0
 
     if (result.wsRequested && !ws) {
       console.log('[InstanceTunnel] Cloud requested WebSocket — connecting...')
@@ -214,11 +218,27 @@ async function heartbeatLoop() {
       return
     }
   } catch (err: any) {
+    const isAuthFailure = /HTTP 40[13]\b/.test(err.message || '')
+    if (isAuthFailure) {
+      consecutiveAuthFailures++
+    } else {
+      consecutiveAuthFailures = 0
+    }
     if (err.message !== lastHeartbeatError) {
       console.error(`[InstanceTunnel] Heartbeat error: ${err.message}`)
       lastHeartbeatError = err.message
     }
-    currentPollInterval = DEFAULT_POLL_INTERVAL_S
+    if (consecutiveAuthFailures >= AUTH_FAILURE_THRESHOLD) {
+      if (currentPollInterval !== AUTH_FAILURE_BACKOFF_S) {
+        console.warn(
+          `[InstanceTunnel] ${consecutiveAuthFailures} consecutive auth failures \u2014 backing off to ${AUTH_FAILURE_BACKOFF_S}s. ` +
+            `Run \`shogo login\` once you've issued a fresh API key.`
+        )
+      }
+      currentPollInterval = AUTH_FAILURE_BACKOFF_S
+    } else {
+      currentPollInterval = DEFAULT_POLL_INTERVAL_S
+    }
   }
 
   scheduleNextPoll()

--- a/apps/api/src/lib/local-heartbeat-scheduler.ts
+++ b/apps/api/src/lib/local-heartbeat-scheduler.ts
@@ -43,23 +43,40 @@ export class LocalHeartbeatScheduler extends BaseHeartbeatScheduler {
   protected async fetchDueAgents(): Promise<DueAgent[]> {
     const { prisma } = await import('./prisma')
 
-    return prisma.agentConfig.findMany({
-      where: {
-        heartbeatEnabled: true,
-        nextHeartbeatAt: { lte: new Date() },
-      },
-      select: {
-        id: true,
-        projectId: true,
-        heartbeatInterval: true,
-        quietHoursStart: true,
-        quietHoursEnd: true,
-        quietHoursTimezone: true,
-      },
-      orderBy: { nextHeartbeatAt: 'asc' },
-      take: BATCH_SIZE,
-    })
+    try {
+      return await prisma.agentConfig.findMany({
+        where: {
+          heartbeatEnabled: true,
+          nextHeartbeatAt: { lte: new Date() },
+        },
+        select: {
+          id: true,
+          projectId: true,
+          heartbeatInterval: true,
+          quietHoursStart: true,
+          quietHoursEnd: true,
+          quietHoursTimezone: true,
+        },
+        orderBy: { nextHeartbeatAt: 'asc' },
+        take: BATCH_SIZE,
+      })
+    } catch (err: any) {
+      // Local SQLite may be missing the table when running in CLI worker mode
+      // before any agent has been provisioned. No-op silently in that case
+      // instead of spamming the worker log every poll interval.
+      const msg = String(err?.message ?? err)
+      if (msg.includes('does not exist') || msg.includes('no such table')) {
+        if (!this.warnedMissingTable) {
+          console.log('[LocalHeartbeat] agent_configs table not present yet; scheduler idle')
+          this.warnedMissingTable = true
+        }
+        return []
+      }
+      throw err
+    }
   }
+
+  private warnedMissingTable = false
 
   protected async triggerAgent(projectId: string): Promise<void> {
     try {

--- a/apps/api/src/lib/s3.ts
+++ b/apps/api/src/lib/s3.ts
@@ -416,6 +416,10 @@ let artifactS3PublicClient: S3Client | null = null
 /**
  * Get or create the S3 client for internal artifact writes.
  * Falls back to the default schema S3 client if `S3_ARTIFACT_*` is unset.
+ *
+ * The override client is a process-wide singleton built from environment
+ * variables. This is intended for one startup-time artifact configuration,
+ * not multi-tenant same-process request isolation.
  */
 export function getArtifactS3Client(): S3Client {
   const hasOverride =
@@ -457,6 +461,8 @@ export function getArtifactS3Client(): S3Client {
  * Get or create the S3 client used when minting public-facing presigned URLs
  * for artifacts. Prefers S3_ARTIFACT_PUBLIC_ENDPOINT > S3_ARTIFACT_ENDPOINT,
  * then falls back to the schema public client.
+ *
+ * Like `getArtifactS3Client`, this caches one process-wide env-based client.
  */
 export function getArtifactS3PublicClient(): S3Client {
   const hasOverride =
@@ -496,7 +502,7 @@ export function getArtifactS3PublicClient(): S3Client {
 }
 
 /**
- * Reset artifact clients (for tests).
+ * Reset artifact clients (for tests that mutate S3_ARTIFACT_* env vars).
  */
 export function resetArtifactS3Client(): void {
   artifactS3Client = null

--- a/apps/api/src/lib/s3.ts
+++ b/apps/api/src/lib/s3.ts
@@ -398,3 +398,173 @@ export async function listAllObjectsInS3(prefix: string, bucket?: string): Promi
 
   return objects
 }
+
+// ============================================================================
+// Artifact S3 — dedicated client/bucket for blockable artifact uploads
+// ----------------------------------------------------------------------------
+// Phase 4: gives the artifact upload path (thumbnails, voice clips, publish
+// bundles) its own env-configurable bucket + endpoint so firewall teams can
+// allow/deny artifact traffic independently of schema/project storage.
+//
+// FULLY BACKWARD COMPATIBLE: if S3_ARTIFACT_* vars are unset, these helpers
+// return the exact same clients/bucket the rest of the code already uses.
+// ============================================================================
+
+let artifactS3Client: S3Client | null = null
+let artifactS3PublicClient: S3Client | null = null
+
+/**
+ * Get or create the S3 client for internal artifact writes.
+ * Falls back to the default schema S3 client if `S3_ARTIFACT_*` is unset.
+ */
+export function getArtifactS3Client(): S3Client {
+  const hasOverride =
+    !!process.env.S3_ARTIFACT_ENDPOINT ||
+    !!process.env.S3_ARTIFACT_ACCESS_KEY_ID ||
+    !!process.env.S3_ARTIFACT_REGION
+
+  if (!hasOverride) return getS3Client()
+
+  if (!artifactS3Client) {
+    const region =
+      process.env.S3_ARTIFACT_REGION || process.env.AWS_REGION || 'us-east-1'
+    const endpoint = process.env.S3_ARTIFACT_ENDPOINT
+    const forcePathStyle =
+      (process.env.S3_ARTIFACT_FORCE_PATH_STYLE || process.env.S3_FORCE_PATH_STYLE) === 'true'
+
+    const accessKeyId =
+      process.env.S3_ARTIFACT_ACCESS_KEY_ID || process.env.AWS_ACCESS_KEY_ID
+    const secretAccessKey =
+      process.env.S3_ARTIFACT_SECRET_ACCESS_KEY || process.env.AWS_SECRET_ACCESS_KEY
+
+    const config: ConstructorParameters<typeof S3Client>[0] = {
+      region,
+      ...(endpoint && {
+        endpoint,
+        forcePathStyle: forcePathStyle || !!endpoint,
+      }),
+      ...(accessKeyId && secretAccessKey && {
+        credentials: { accessKeyId, secretAccessKey },
+      }),
+    }
+
+    artifactS3Client = new S3Client(config)
+  }
+  return artifactS3Client
+}
+
+/**
+ * Get or create the S3 client used when minting public-facing presigned URLs
+ * for artifacts. Prefers S3_ARTIFACT_PUBLIC_ENDPOINT > S3_ARTIFACT_ENDPOINT,
+ * then falls back to the schema public client.
+ */
+export function getArtifactS3PublicClient(): S3Client {
+  const hasOverride =
+    !!process.env.S3_ARTIFACT_PUBLIC_ENDPOINT ||
+    !!process.env.S3_ARTIFACT_ENDPOINT ||
+    !!process.env.S3_ARTIFACT_ACCESS_KEY_ID
+
+  if (!hasOverride) return getS3PublicClient()
+
+  if (!artifactS3PublicClient) {
+    const region =
+      process.env.S3_ARTIFACT_REGION || process.env.AWS_REGION || 'us-east-1'
+    const endpoint =
+      process.env.S3_ARTIFACT_PUBLIC_ENDPOINT || process.env.S3_ARTIFACT_ENDPOINT
+    const forcePathStyle =
+      (process.env.S3_ARTIFACT_FORCE_PATH_STYLE || process.env.S3_FORCE_PATH_STYLE) === 'true'
+
+    const accessKeyId =
+      process.env.S3_ARTIFACT_ACCESS_KEY_ID || process.env.AWS_ACCESS_KEY_ID
+    const secretAccessKey =
+      process.env.S3_ARTIFACT_SECRET_ACCESS_KEY || process.env.AWS_SECRET_ACCESS_KEY
+
+    const config: ConstructorParameters<typeof S3Client>[0] = {
+      region,
+      ...(endpoint && {
+        endpoint,
+        forcePathStyle: forcePathStyle || !!endpoint,
+      }),
+      ...(accessKeyId && secretAccessKey && {
+        credentials: { accessKeyId, secretAccessKey },
+      }),
+    }
+
+    artifactS3PublicClient = new S3Client(config)
+  }
+  return artifactS3PublicClient
+}
+
+/**
+ * Reset artifact clients (for tests).
+ */
+export function resetArtifactS3Client(): void {
+  artifactS3Client = null
+  artifactS3PublicClient = null
+}
+
+/**
+ * Bucket for artifact uploads. Falls back to the default schema bucket.
+ */
+export function getArtifactBucket(): string {
+  return process.env.S3_ARTIFACT_BUCKET || getS3Bucket()
+}
+
+/**
+ * True if artifact storage has been split onto a dedicated bucket/host.
+ * Use from health endpoints / observability to know which mode we're in.
+ */
+export function isArtifactStorageIsolated(): boolean {
+  return (
+    !!process.env.S3_ARTIFACT_BUCKET ||
+    !!process.env.S3_ARTIFACT_ENDPOINT ||
+    !!process.env.S3_ARTIFACT_PUBLIC_ENDPOINT
+  )
+}
+
+/**
+ * Build an artifact S3 key with an optional prefix (default: "artifacts/").
+ * Kept separate from buildS3Key so schema keys never collide with artifacts.
+ */
+export function buildArtifactKey(...parts: string[]): string {
+  const prefix = process.env.S3_ARTIFACT_PREFIX || 'artifacts/'
+  return prefix + parts.join('/')
+}
+
+/**
+ * Generate a pre-signed URL for READING an artifact.
+ * Uses the artifact public client + bucket; falls back transparently when
+ * artifact env vars are unset.
+ */
+export async function getArtifactPresignedReadUrl(
+  key: string,
+  options: PresignOptions = {}
+): Promise<string> {
+  const client = getArtifactS3PublicClient()
+  const bucket = options.bucket || getArtifactBucket()
+  const expiresIn = options.expiresIn || 3600
+
+  const command = new GetObjectCommand({ Bucket: bucket, Key: key })
+  return getSignedUrl(client, command, { expiresIn })
+}
+
+/**
+ * Generate a pre-signed URL for WRITING an artifact.
+ * Uses the artifact public client + bucket; falls back transparently when
+ * artifact env vars are unset.
+ */
+export async function getArtifactPresignedWriteUrl(
+  key: string,
+  options: PresignOptions = {}
+): Promise<string> {
+  const client = getArtifactS3PublicClient()
+  const bucket = options.bucket || getArtifactBucket()
+  const expiresIn = options.expiresIn || 3600
+
+  const command = new PutObjectCommand({
+    Bucket: bucket,
+    Key: key,
+    ...(options.contentType && { ContentType: options.contentType }),
+  })
+  return getSignedUrl(client, command, { expiresIn })
+}

--- a/apps/api/src/routes/instances.ts
+++ b/apps/api/src/routes/instances.ts
@@ -717,6 +717,50 @@ export function instanceRoutes() {
     return c.json({ instances: withLiveStatus })
   })
 
+
+  // GET /instances/online — Trimmed list of online instances (for Phase 3 chat environment picker)
+  router.get('/instances/online', async (c) => {
+    const auth = c.get('auth') as any
+    if (!auth?.userId) {
+      return c.json({ error: { code: 'unauthorized', message: 'Authentication required' } }, 401)
+    }
+
+    const workspaceId = c.req.query('workspaceId')
+    if (!workspaceId) {
+      return c.json({ error: { code: 'invalid_request', message: 'workspaceId query param required' } }, 400)
+    }
+
+    const member = await prisma.member.findFirst({
+      where: { userId: auth.userId, workspaceId },
+    })
+    if (!member) {
+      return c.json({ error: { code: 'forbidden', message: 'Not a member of this workspace' } }, 403)
+    }
+
+    const instances = await prisma.instance.findMany({
+      where: { workspaceId },
+      orderBy: { lastSeenAt: 'desc' },
+    })
+
+    const online = (await Promise.all(
+      instances.map(async (inst) => {
+        const isOnline = tunnels.has(inst.id) || (await isTunnelConnectedAnywhere(inst.id))
+        return isOnline ? inst : null
+      })
+    )).filter((x): x is NonNullable<typeof x> => x !== null)
+
+    return c.json({
+      instances: online.map((inst) => ({
+        id: inst.id,
+        name: inst.name,
+        hostname: inst.hostname,
+        os: inst.os,
+        arch: inst.arch,
+        lastSeenAt: inst.lastSeenAt,
+      })),
+    })
+  })
+
   // GET /instances/:id — Instance details
   router.get('/instances/:id', async (c) => {
     const auth = c.get('auth') as any

--- a/apps/api/src/routes/thumbnail.ts
+++ b/apps/api/src/routes/thumbnail.ts
@@ -4,8 +4,19 @@
  * Thumbnail API Routes
  *
  * Endpoints for managing project thumbnail images.
- * Storage strategy: tries S3 first, falls back to base64 data URL in the DB
- * (so it works locally without MinIO/Docker).
+ *
+ * Storage strategy: the thumbnail is an "artifact" in the Cursor
+ * `cloud-agent-artifacts` sense — a derived visual asset that can be
+ * firewalled independently of the primary data plane. We write it through
+ * the dedicated artifact S3 client/bucket so security teams can block the
+ * `artifacts.*` host without killing chat or tool calls. When artifact env
+ * vars are unset the helpers transparently fall back to the default S3
+ * client + `S3_WORKSPACES_BUCKET`, so existing deployments keep working.
+ *
+ * If S3 isn't reachable at all (local dev with no MinIO, customer with the
+ * artifact host explicitly blocked) we fall back to a base64 data URL
+ * stored in Postgres. This is the "graceful degradation" promised by
+ * docs/my-machines-networking.md's failure-modes table.
  */
 
 import { Hono } from 'hono'
@@ -14,12 +25,12 @@ import { prisma } from '../lib/prisma'
 import { validateOutboundUrl } from '../lib/url-validation'
 
 async function saveThumbnail(projectId: string, pngBuffer: Buffer): Promise<string> {
-  // Try S3 first
   try {
-    const { getS3Client, getPresignedReadUrl } = await import('../lib/s3')
-    const bucket = process.env.S3_WORKSPACES_BUCKET || 'shogo-workspaces'
-    const key = `thumbnails/${projectId}.png`
-    const s3 = getS3Client()
+    const { getArtifactS3Client, getArtifactBucket, buildArtifactKey, getArtifactPresignedReadUrl } =
+      await import('../lib/s3')
+    const bucket = getArtifactBucket()
+    const key = buildArtifactKey('thumbnails', `${projectId}.png`)
+    const s3 = getArtifactS3Client()
 
     await s3.send(new PutObjectCommand({
       Bucket: bucket,
@@ -29,10 +40,9 @@ async function saveThumbnail(projectId: string, pngBuffer: Buffer): Promise<stri
       CacheControl: 'max-age=3600',
     }))
 
-    const url = await getPresignedReadUrl(key, { bucket, expiresIn: 86400 * 7 })
+    const url = await getArtifactPresignedReadUrl(key, { expiresIn: 86400 * 7 })
     return url
   } catch {
-    // S3 unavailable — fall back to base64 data URL stored in DB
     const base64 = pngBuffer.toString('base64')
     return `data:image/png;base64,${base64}`
   }

--- a/apps/docs/docs/features/my-machines/networking.md
+++ b/apps/docs/docs/features/my-machines/networking.md
@@ -1,0 +1,71 @@
+---
+title: Networking & allowlist
+sidebar_position: 2
+---
+
+# Networking & allowlist
+
+The Shogo worker makes **only outbound connections**. No inbound ports are
+opened on your machine, so you can run it from behind a NAT, VPN, or corporate
+firewall without any additional configuration.
+
+## Outbound hosts
+
+| Host | Port | Purpose |
+|---|---|---|
+| `api.shogo.ai` | 443 | Heartbeat + WebSocket tunnel |
+| `api-direct.shogo.ai` | 443 | Direct-path fallback when API is behind a load balancer drain |
+| `artifacts.shogo.ai` | 443 | Signed-URL artifact uploads (file downloads/uploads from chat) |
+
+If your firewall enforces an allowlist, add all three.
+
+## Proxy support
+
+The worker reads standard proxy env vars:
+
+```bash
+HTTPS_PROXY=http://proxy.corp.example.com:3128 \
+NO_PROXY=localhost,127.0.0.1 \
+shogo worker start
+```
+
+`shogo worker start --debug` will print the effective proxy configuration in
+the preflight output.
+
+## Tunnel protocol (brief)
+
+Once paired, the worker opens a single long-lived WSS connection:
+
+```
+GET /api/instances/ws?key=...&hostname=...&os=darwin&arch=arm64
+```
+
+The server **upserts the Instance row on connect** keyed on
+`(workspaceId, hostname)` — no separate registration step. Messages flow as
+JSON frames:
+
+- `request` → `response` | `stream-chunk`* → `stream-end`
+- `heartbeat` (worker → server, every 25s)
+- `pong` (reply to server pings)
+- `cancel` (in-flight request abort)
+
+When chat uses a remote machine, the agent URL is rewritten to
+`https://api.shogo.ai/api/instances/:id/p/agent-proxy/...` and the cloud
+transparently forwards requests through the tunnel. Streaming endpoints
+(`/agent/chat`, `/agent/canvas/stream`, `/agent/logs/stream`) are auto-detected
+and relayed as `stream-chunk` frames.
+
+## Data that leaves the worker
+
+The worker runs your existing `apps/api` Bun server locally; the cloud never
+sees your filesystem directly. When chat asks for a file, the cloud sends a
+tunneled HTTP request, your worker's local server reads the file, and the
+contents are returned inside the tunnel response. File writes follow the same
+path.
+
+:::note
+The worker is sandboxed to `--worker-dir` for local file system operations via
+the existing Hono route handlers. `exec_command` is **not** jailed (parity
+with Cursor's desktop agent) — any command your user can run, the worker can
+run.
+:::

--- a/apps/docs/docs/features/my-machines/quickstart.md
+++ b/apps/docs/docs/features/my-machines/quickstart.md
@@ -1,0 +1,62 @@
+---
+title: Quickstart
+sidebar_position: 1
+---
+
+# My Machines — Quickstart
+
+**My Machines** lets you pair any Mac, Linux box, or Windows PC to Shogo so chat
+tool calls (shell, file I/O, MCP servers) run **on your machine** instead of a
+cloud sandbox. Same model as Cursor's "Cloud Agent → My Machines".
+
+You can pair in under 2 minutes.
+
+## 1. Create an API key
+
+Open [studio.shogo.ai/api-keys](https://studio.shogo.ai/api-keys) and click
+**+ Create Key**. Copy the `shogo_sk_...` string.
+
+:::tip
+Keep the key on the machine you're about to pair. It won't be shown again.
+:::
+
+## 2. Install the CLI
+
+**macOS / Linux**
+
+```bash
+curl -fsSL https://install.shogo.ai | bash
+```
+
+**Windows (PowerShell)**
+
+```powershell
+irm https://install.shogo.ai/ps | iex
+```
+
+The installer drops a single binary at `~/.shogo/bin/shogo` (or
+`%USERPROFILE%\.shogo\bin\shogo.exe` on Windows) and adds it to `PATH`.
+
+## 3. Log in and start the worker
+
+```bash
+shogo login --api-key shogo_sk_XXXXXXXX
+shogo worker start --worker-dir ~/code/myrepo
+```
+
+Within ~5 seconds the machine appears in the **Remote Control** page in studio.
+Pick it from the environment switcher next to the chat input and your next
+message runs there.
+
+## 4. Send it something
+
+Try:
+
+> List the files in the current directory and show the git status.
+
+Shogo's tool calls execute on your laptop and stream output back into chat.
+
+## What next
+
+- [Networking & allowlist](./networking) — what the worker talks to
+- [Troubleshooting](./troubleshooting) — fixing login/heartbeat/tunnel errors

--- a/apps/docs/docs/features/my-machines/troubleshooting.md
+++ b/apps/docs/docs/features/my-machines/troubleshooting.md
@@ -1,0 +1,70 @@
+---
+title: Troubleshooting
+sidebar_position: 3
+---
+
+# Troubleshooting
+
+## `shogo worker start` says "Heartbeat failed: HTTP 401"
+
+Your API key was revoked or the cloud no longer recognizes it.
+
+1. Open [studio.shogo.ai/api-keys](https://studio.shogo.ai/api-keys).
+2. Confirm your key is still in the **Manual API keys** list.
+3. If it's missing, create a new one and run:
+   ```bash
+   shogo worker stop
+   shogo login --api-key shogo_sk_NEW_KEY
+   shogo worker start
+   ```
+
+## Worker shows "online" in studio but chat can't reach it
+
+Run the preflight:
+
+```bash
+shogo worker start --debug
+```
+
+The output shows green/red checks for:
+- runtime (bun or node ≥ 20)
+- worker dir exists and is readable
+- proxy env vars
+- DNS + TLS to each of the 3 outbound hosts
+- live API-key validation
+
+Red checks explain what's wrong.
+
+## Tunnel error banner in chat: "Connection to desktop instance lost"
+
+The chat UI auto-polls `/agent/health` every 3 seconds for 60 seconds. If the
+worker comes back, the conversation resumes automatically.
+
+If the worker stays offline, a **Continue in cloud** button appears next to
+**Reconnect**. Click it to fall back to the cloud sandbox — your conversation
+continues, just without access to the remote machine.
+
+## "main.agent_configs does not exist" in worker logs
+
+Harmless noise from the local AgentConfig cron — unrelated to pairing. Fixed
+in a later release.
+
+## Installer: `shogo` not found after install
+
+The installer adds `~/.shogo/bin` (Unix) or `%USERPROFILE%\.shogo\bin`
+(Windows) to your PATH, but existing shells don't see the update. Open a **new
+terminal** or run:
+
+```bash
+export PATH="$HOME/.shogo/bin:$PATH"    # bash/zsh
+```
+
+## How do I fully remove my worker?
+
+```bash
+shogo worker stop
+rm -rf ~/.shogo
+```
+
+Then open **studio → Remote Control**, click the trash icon next to the
+device, and confirm. The API key is revoked and the Instance row is removed.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -55,6 +55,15 @@ const sidebars: SidebarsConfig = {
             "features/billing",
           ],
         },
+        {
+          type: "category",
+          label: "My Machines",
+          items: [
+            "features/my-machines/quickstart",
+            "features/my-machines/networking",
+            "features/my-machines/troubleshooting",
+          ],
+        },
       ],
     },
     {

--- a/apps/mobile/app/(app)/remote-control.tsx
+++ b/apps/mobile/app/(app)/remote-control.tsx
@@ -7,7 +7,7 @@
  * Includes metrics for connected, available, and total instances.
  */
 
-import { useMemo, useEffect } from 'react'
+import { useMemo, useEffect, useState, useCallback } from 'react'
 import {
   View,
   Text,
@@ -15,6 +15,8 @@ import {
   Pressable,
   ActivityIndicator,
   Platform,
+  Alert,
+  TextInput,
 } from 'react-native'
 import { useRouter } from 'expo-router'
 import { observer } from 'mobx-react-lite'
@@ -25,7 +27,20 @@ import {
   Plus,
   RefreshCw,
   ArrowLeft,
+  Pencil,
+  Trash2,
+  Copy,
+  X as XIcon,
 } from 'lucide-react-native'
+import {
+  Modal,
+  ModalBackdrop,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+} from '@/components/ui/modal'
 import { useActiveInstance } from '../../contexts/active-instance'
 import { useInstancePicker, type Instance } from '@shogo/shared-app/hooks'
 import { API_URL } from '../../lib/api'
@@ -54,10 +69,38 @@ function StatusDot({ status }: { status: Instance['status'] }) {
   return <View className={cn('h-2.5 w-2.5 rounded-full', color)} />
 }
 
+function relativeTime(iso?: string | null): string | null {
+  if (!iso) return null
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return null
+  const secs = Math.max(0, Math.floor((Date.now() - then) / 1000))
+  if (secs < 60) return `${secs}s ago`
+  const mins = Math.floor(secs / 60)
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  const days = Math.floor(hrs / 24)
+  return `${days}d ago`
+}
+
+const INSTALL_SNIPPET = `# 1. Install the CLI
+curl -fsSL https://install.shogo.ai | bash
+
+# 2. Paste your API key (create one at /api-keys)
+shogo login --api-key shogo_sk_XXXXXXXX
+
+# 3. Start the worker in a repo you want to expose
+shogo worker start --worker-dir ~/code/myrepo`
+
+
 export default observer(function RemoteControlPage() {
   const router = useRouter()
   const workspace = useActiveWorkspace()
   const { instance: activeInstance, setInstance, clearInstance } = useActiveInstance()
+  const [addOpen, setAddOpen] = useState(false)
+  const [renameTarget, setRenameTarget] = useState<Instance | null>(null)
+  const [renameValue, setRenameValue] = useState('')
+  const [busyId, setBusyId] = useState<string | null>(null)
 
   const fetchOptions: RequestInit = useMemo(
     () => ({
@@ -94,6 +137,86 @@ export default observer(function RemoteControlPage() {
   const standbyCount = instances.filter(i => i.status === 'heartbeat').length
   const totalCount = instances.length
 
+  const apiBase = API_URL ?? ''
+
+  const openRename = useCallback((inst: Instance) => {
+    setRenameTarget(inst)
+    setRenameValue(inst.name)
+  }, [])
+
+  const submitRename = useCallback(async () => {
+    if (!renameTarget) return
+    const next = renameValue.trim()
+    if (!next || next === renameTarget.name) {
+      setRenameTarget(null)
+      return
+    }
+    setBusyId(renameTarget.id)
+    try {
+      const res = await fetch(`${apiBase}/api/instances/${renameTarget.id}`, {
+        method: 'PUT',
+        credentials: Platform.OS === 'web' ? 'include' : 'omit',
+        headers: { 'content-type': 'application/json', ...getAuthHeaders() },
+        body: JSON.stringify({ name: next }),
+      })
+      if (!res.ok) {
+        const msg = await res.text().catch(() => '')
+        Alert.alert('Rename failed', `HTTP ${res.status} ${msg.slice(0, 200)}`)
+      } else {
+        await refresh()
+      }
+    } catch (e: any) {
+      Alert.alert('Rename failed', String(e?.message ?? e))
+    } finally {
+      setBusyId(null)
+      setRenameTarget(null)
+    }
+  }, [renameTarget, renameValue, apiBase, refresh])
+
+  const confirmRemove = useCallback((inst: Instance) => {
+    const run = async () => {
+      setBusyId(inst.id)
+      try {
+        const res = await fetch(`${apiBase}/api/instances/${inst.id}`, {
+          method: 'DELETE',
+          credentials: Platform.OS === 'web' ? 'include' : 'omit',
+          headers: { ...getAuthHeaders() },
+        })
+        if (!res.ok) {
+          const msg = await res.text().catch(() => '')
+          Alert.alert('Remove failed', `HTTP ${res.status} ${msg.slice(0, 200)}`)
+        } else {
+          if (activeInstance?.instanceId === inst.id) clearInstance()
+          await refresh()
+        }
+      } catch (e: any) {
+        Alert.alert('Remove failed', String(e?.message ?? e))
+      } finally {
+        setBusyId(null)
+      }
+    }
+    if (Platform.OS === 'web') {
+      // eslint-disable-next-line no-alert
+      if (confirm(`Remove ${inst.name}? The worker token will be revoked.`)) void run()
+      return
+    }
+    Alert.alert('Remove device', `Remove ${inst.name}? The worker token will be revoked.`, [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Remove', style: 'destructive', onPress: () => void run() },
+    ])
+  }, [apiBase, refresh, activeInstance, clearInstance])
+
+  const copyInstall = useCallback(async () => {
+    try {
+      if (Platform.OS === 'web' && typeof navigator !== 'undefined' && navigator.clipboard) {
+        await navigator.clipboard.writeText(INSTALL_SNIPPET)
+        return
+      }
+      const Clipboard = await import('expo-clipboard').catch(() => null as any)
+      await Clipboard?.setStringAsync?.(INSTALL_SNIPPET)
+    } catch {}
+  }, [])
+
   return (
     <View className="flex-1 bg-background">
       {/* Header */}
@@ -119,7 +242,7 @@ export default observer(function RemoteControlPage() {
           </Button>
           <Button
             size="sm"
-            onPress={() => router.push('/(app)/api-keys')}
+            onPress={() => setAddOpen(true)}
             className="bg-brand-landing hover:opacity-90"
           >
             <View className="flex-row items-center gap-1.5 px-1">
@@ -239,12 +362,36 @@ export default observer(function RemoteControlPage() {
                           <Text className="text-xs text-muted-foreground">
                             {inst.status === 'online' ? 'Online' : inst.status === 'heartbeat' ? 'Standby' : 'Offline'}
                           </Text>
+                          {inst.os && (
+                            <Text className="text-xs text-muted-foreground">· {inst.os}</Text>
+                          )}
+                          {relativeTime(inst.lastSeenAt) && (
+                            <Text className="text-xs text-muted-foreground">· {relativeTime(inst.lastSeenAt)}</Text>
+                          )}
                         </View>
                       </View>
                       {isConnecting ? (
                         <ActivityIndicator size="small" color="rgb(var(--color-primary))" />
                       ) : (
-                        isActive && <Check size={20} className="text-primary" />
+                        <View className="flex-row items-center gap-1">
+                          {isActive && <Check size={18} className="text-primary mr-1" />}
+                          <Pressable
+                            onPress={(e) => { e.stopPropagation?.(); openRename(inst) }}
+                            disabled={busyId === inst.id}
+                            accessibilityLabel="Rename device"
+                            className="p-2 rounded-md hover:bg-muted active:bg-muted"
+                          >
+                            <Pencil size={16} className="text-muted-foreground" />
+                          </Pressable>
+                          <Pressable
+                            onPress={(e) => { e.stopPropagation?.(); confirmRemove(inst) }}
+                            disabled={busyId === inst.id}
+                            accessibilityLabel="Remove device"
+                            className="p-2 rounded-md hover:bg-destructive/10 active:bg-destructive/10"
+                          >
+                            <Trash2 size={16} className="text-muted-foreground" />
+                          </Pressable>
+                        </View>
                       )}
                     </Pressable>
                   </View>
@@ -254,6 +401,81 @@ export default observer(function RemoteControlPage() {
           </Card>
         )}
       </ScrollView>
+
+      {/* Add Device — install snippet */}
+      <Modal isOpen={addOpen} onClose={() => setAddOpen(false)} size="md">
+        <ModalBackdrop />
+        <ModalContent>
+          <ModalHeader>
+            <Text className="text-lg font-semibold text-foreground">Connect a machine</Text>
+            <ModalCloseButton>
+              <XIcon size={16} className="text-muted-foreground" />
+            </ModalCloseButton>
+          </ModalHeader>
+          <ModalBody>
+            <Text className="text-sm text-muted-foreground mb-3">
+              Run these three commands on the machine you want to expose. It will appear here within a few seconds.
+            </Text>
+            <View className="rounded-md bg-surface-1 border border-border p-3">
+              <Text selectable className="text-xs font-mono text-foreground whitespace-pre" style={{ fontFamily: Platform.select({ web: 'ui-monospace, Menlo, monospace', default: 'Menlo' }) }}>
+                {INSTALL_SNIPPET}
+              </Text>
+            </View>
+            <Text className="text-xs text-muted-foreground mt-3">
+              Don't have an API key yet? Create one on the API Keys page.
+            </Text>
+          </ModalBody>
+          <ModalFooter>
+            <View className="flex-row gap-2">
+              <Button variant="outline" size="sm" onPress={copyInstall}>
+                <View className="flex-row items-center gap-1.5 px-1">
+                  <Copy size={14} className="text-foreground" />
+                  <Text className="text-sm text-foreground">Copy snippet</Text>
+                </View>
+              </Button>
+              <Button size="sm" onPress={() => { setAddOpen(false); router.push('/(app)/api-keys') }}>
+                <Text className="text-sm font-semibold text-white px-1">Create API key</Text>
+              </Button>
+            </View>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+
+      {/* Rename device */}
+      <Modal isOpen={!!renameTarget} onClose={() => setRenameTarget(null)} size="sm">
+        <ModalBackdrop />
+        <ModalContent>
+          <ModalHeader>
+            <Text className="text-lg font-semibold text-foreground">Rename device</Text>
+            <ModalCloseButton>
+              <XIcon size={16} className="text-muted-foreground" />
+            </ModalCloseButton>
+          </ModalHeader>
+          <ModalBody>
+            <TextInput
+              value={renameValue}
+              onChangeText={setRenameValue}
+              autoFocus
+              placeholder="mbp-ashutosh"
+              placeholderTextColor="rgb(var(--color-muted-foreground))"
+              onSubmitEditing={submitRename}
+              className="rounded-md border border-border bg-background px-3 py-2 text-foreground"
+            />
+          </ModalBody>
+          <ModalFooter>
+            <View className="flex-row gap-2">
+              <Button variant="outline" size="sm" onPress={() => setRenameTarget(null)}>
+                <Text className="text-sm text-foreground px-1">Cancel</Text>
+              </Button>
+              <Button size="sm" onPress={submitRename} disabled={!renameValue.trim() || busyId === renameTarget?.id}>
+                <Text className="text-sm font-semibold text-white px-1">
+                  {busyId === renameTarget?.id ? 'Saving…' : 'Save'}
+                </Text>
+              </Button>
+            </View>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
     </View>
   )
 })

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -13,6 +13,7 @@ import * as Sentry from '@sentry/react-native'
 import { GluestackUIProvider } from '@/components/ui/gluestack-ui-provider'
 import { AuthProvider } from '../contexts/auth'
 import { ActiveInstanceProvider } from '../contexts/active-instance'
+import { InstanceOfflineWatcher } from '../components/instance/InstanceOfflineWatcher'
 import { PostHogProvider } from '../contexts/posthog'
 import { ThemeProvider, useTheme } from '../contexts/theme'
 import { AccentThemeProvider } from '../contexts/accent-theme'
@@ -71,6 +72,7 @@ function RootLayoutInner() {
       <PostHogProvider>
         <AuthProvider>
           <ActiveInstanceProvider>
+            <InstanceOfflineWatcher />
             <UpdateBanner />
             <StatusBar style={statusBarScheme === 'dark' ? 'light' : 'dark'} />
             <Stack screenOptions={{ headerShown: false, lazy: true }}>

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -77,6 +77,8 @@ import { PastedTextChip } from "./PastedTextChip"
 export const DEFAULT_MODEL_PRO = "claude-sonnet-4-6"
 export const DEFAULT_MODEL_FREE = "claude-haiku-4-5-20251001"
 
+import { EnvironmentPicker } from "./EnvironmentPicker"
+
 const MODEL_GROUPS = getModelsByProvider().map((g) => ({
   label: g.label,
   models: g.models.map((e) => ({
@@ -1015,6 +1017,9 @@ export function ChatInput({
                 </PopoverContent>
               </Popover>
             )}
+
+            {/* Environment selector — pick Cloud or a paired machine */}
+            <EnvironmentPicker disabled={disabled} />
 
             {/* Model selector */}
             <Popover

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -65,6 +65,7 @@ import { API_URL, api, createHttpClient } from "../../lib/api"
 
 import { isNativePhoneIntegrationsLayout } from "../../lib/native-phone-layout"
 import { authClient } from "../../lib/auth-client"
+import { useActiveInstance } from "../../contexts/active-instance"
 import { ChatHeader } from "./ChatHeader"
 import { MessageList } from "./MessageList"
 import {
@@ -83,6 +84,7 @@ import {
   saveModelPreference,
 } from "../../lib/agent-mode-preference"
 import { CompactChatInput } from "./CompactChatInput"
+import { ExecutionBadge } from "./ExecutionBadge"
 import { ExpandTab } from "./ExpandTab"
 import { ToolCallDisplay, type ToolCallState } from "./ToolCallDisplay"
 import { ChatContextProvider, type ChatContextValue } from "./ChatContext"
@@ -1770,6 +1772,7 @@ export const ChatPanel = observer(function ChatPanel({
 
   const isRemoteInstance = !!localAgentUrl
   const isTunnelError = !!(error && isRemoteInstance && isTunnelDisconnectError(error.message))
+  const { clearInstance: clearActiveInstance } = useActiveInstance()
 
   const errorBannerText = useMemo(
     () => {
@@ -3433,18 +3436,36 @@ export const ChatPanel = observer(function ChatPanel({
                       <Text className="text-sm text-orange-600 dark:text-orange-400 font-medium">Reconnecting…</Text>
                     </View>
                   ) : (
-                    <Pressable
-                      onPress={handleRetry}
-                      className={`shrink-0 rounded-md border px-1 py-1.5 self-start ${
-                        isTunnelError
-                          ? 'border-orange-400/30'
-                          : 'border-destructive/30'
-                      }`}
-                    >
-                      <Text className={`text-sm font-medium ${
-                        isTunnelError ? 'text-orange-600 dark:text-orange-400' : 'text-destructive'
-                      }`}>{isTunnelError ? 'Reconnect' : 'Retry'}</Text>
-                    </Pressable>
+                    <View className="shrink-0 flex-row gap-1.5 self-start">
+                      {isTunnelError && (
+                        <Pressable
+                          onPress={() => {
+                            clearActiveInstance()
+                            // Defer so the context update flushes and localAgentUrl
+                            // becomes null before the retry fires — otherwise the
+                            // retry would still hit the (now-offline) tunnel URL.
+                            setTimeout(() => handleRetry(), 0)
+                          }}
+                          accessibilityRole="button"
+                          accessibilityLabel="Continue this conversation in the cloud sandbox"
+                          className="rounded-md border border-orange-400/30 px-2 py-1.5"
+                        >
+                          <Text className="text-sm font-medium text-orange-700 dark:text-orange-300">Continue in cloud</Text>
+                        </Pressable>
+                      )}
+                      <Pressable
+                        onPress={handleRetry}
+                        className={`rounded-md border px-1 py-1.5 ${
+                          isTunnelError
+                            ? 'border-orange-400/30'
+                            : 'border-destructive/30'
+                        }`}
+                      >
+                        <Text className={`text-sm font-medium ${
+                          isTunnelError ? 'text-orange-600 dark:text-orange-400' : 'text-destructive'
+                        }`}>{isTunnelError ? 'Reconnect' : 'Retry'}</Text>
+                      </Pressable>
+                    </View>
                   )}
                 </View>
               </View>
@@ -3471,6 +3492,7 @@ export const ChatPanel = observer(function ChatPanel({
 
           {/* Input */}
           <View className="bg-transparent max-w-3xl w-full self-center mt-1">
+            <ExecutionBadge />
             <ChatInput
               onSubmit={handleInputSubmit}
               disabled={!currentSessionId}

--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -64,6 +64,7 @@ import {
 } from "./long-text-utils"
 import { FileViewerModal } from "./FileViewerModal"
 import { PastedTextChip } from "./PastedTextChip"
+import { EnvironmentPicker } from "./EnvironmentPicker"
 
 const MODEL_GROUPS = getModelsByProvider().map((g) => ({
   label: g.label,
@@ -679,6 +680,9 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
                   </View>
                 </PopoverContent>
               </Popover>
+
+              {/* Environment selector — pick Cloud or a paired machine */}
+              <EnvironmentPicker disabled={disabled || isLoading} />
 
               {/* Model selector */}
               <Popover

--- a/apps/mobile/components/chat/EnvironmentPicker.tsx
+++ b/apps/mobile/components/chat/EnvironmentPicker.tsx
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * EnvironmentPicker
+ *
+ * Popover-based selector (drop-in twin of the model picker in CompactChatInput)
+ * that lets the user choose where an agent session runs:
+ *
+ *   ☁️ Shogo Cloud         — default. agent runs in a cloud pod.
+ *   🖥️ <instance name>     — routes all agent traffic through the Remote
+ *                            Control tunnel to that paired machine
+ *                            (Phase 1 / shogo-worker + desktop app).
+ *
+ * No new server endpoint, no new context — reuses:
+ *   - useActiveInstance()    (`packages/shared-app/src/hooks/useActiveInstance.tsx`)
+ *   - useInstancePicker()    (`packages/shared-app/src/hooks/useInstancePicker.ts`)
+ *
+ * When an instance is selected, `apps/mobile/app/(app)/projects/[id]/_layout.tsx`
+ * already rewrites `agentUrl` through `${apiUrl}/api/instances/:id/p/...`,
+ * so the chat + canvas + SSE streams all follow automatically.
+ */
+import { useState, useMemo } from "react"
+import { View, Text, Pressable, ScrollView, Platform } from "react-native"
+import { Cloud, Laptop, ChevronDown, Check, RefreshCw } from "lucide-react-native"
+import {
+  Popover,
+  PopoverBackdrop,
+  PopoverContent,
+} from "@/components/ui/popover"
+import { cn } from "@shogo/shared-ui/primitives"
+import { useActiveInstance } from "../../contexts/active-instance"
+import { useInstancePicker, type Instance } from "@shogo/shared-app/hooks"
+import { useActiveWorkspace } from "../../hooks/useActiveWorkspace"
+import { API_URL } from "../../lib/api"
+import { authClient } from "../../lib/auth-client"
+
+function getAuthHeaders(): Record<string, string> {
+  if (Platform.OS === "web") return {}
+  const cookie = (authClient as any).getCookie?.()
+  return cookie ? { Cookie: cookie } : {}
+}
+
+function StatusDot({ status }: { status: Instance["status"] }) {
+  const color =
+    status === "online"
+      ? "bg-green-500"
+      : status === "heartbeat"
+      ? "bg-yellow-500"
+      : "bg-muted-foreground/40"
+  return <View className={cn("h-2 w-2 rounded-full", color)} />
+}
+
+export interface EnvironmentPickerProps {
+  disabled?: boolean
+}
+
+export function EnvironmentPicker({ disabled }: EnvironmentPickerProps) {
+  const [open, setOpen] = useState(false)
+  const workspace = useActiveWorkspace()
+  const { instance: activeInstance, setInstance, clearInstance } = useActiveInstance()
+
+  const fetchOptions: RequestInit = useMemo(
+    () => ({
+      credentials: Platform.OS === "web" ? ("include" as const) : ("omit" as const),
+      headers: { ...getAuthHeaders() },
+    }),
+    [],
+  )
+
+  const { instances, loading, connecting, select, disconnect, refresh } = useInstancePicker({
+    workspaceId: workspace?.id,
+    apiUrl: API_URL ?? "",
+    activeInstance,
+    setInstance,
+    clearInstance,
+    fetchOptions,
+  })
+
+  const displayLabel = activeInstance ? activeInstance.name : "Cloud"
+  const triggerIcon = activeInstance
+    ? <Laptop className="h-3 w-3 text-emerald-500" size={12} />
+    : <Cloud className="h-3 w-3 text-muted-foreground/80" size={12} />
+
+  return (
+    <Popover
+      placement="top"
+      size="xs"
+      isOpen={open}
+      onOpen={() => { setOpen(true); refresh() }}
+      onClose={() => setOpen(false)}
+      trigger={(triggerProps) => (
+        <Pressable
+          {...triggerProps}
+          disabled={disabled}
+          accessibilityLabel="Select execution environment"
+          className="h-[22px] flex-row items-center gap-1 rounded-md px-1.5"
+        >
+          {triggerIcon}
+          <Text className={cn(
+            "text-xs",
+            activeInstance ? "text-emerald-600" : "text-muted-foreground"
+          )}>
+            {displayLabel}
+          </Text>
+          <ChevronDown className="h-2 w-2 text-muted-foreground/60" size={8} />
+        </Pressable>
+      )}
+    >
+      <PopoverBackdrop />
+      <PopoverContent className="w-[280px] p-0 max-h-[360px]">
+        <ScrollView>
+          <View className="px-3 pt-3 pb-1 flex-row items-center justify-between">
+            <Text className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+              Run Agent On
+            </Text>
+            <Pressable
+              onPress={() => refresh()}
+              accessibilityLabel="Refresh instances"
+              className="h-5 w-5 items-center justify-center rounded hover:bg-muted/40"
+            >
+              <RefreshCw
+                className={cn("h-3 w-3 text-muted-foreground", loading && "animate-spin")}
+                size={10}
+              />
+            </Pressable>
+          </View>
+
+          {/* Shogo Cloud — default */}
+          <Pressable
+            onPress={() => {
+              clearInstance()
+              setOpen(false)
+            }}
+            className="flex-row items-center gap-2.5 px-3 py-2.5 active:bg-muted/60"
+          >
+            <Cloud className="h-4 w-4 text-foreground" size={16} />
+            <View className="flex-1">
+              <Text className="text-sm font-medium text-foreground">Shogo Cloud</Text>
+              <Text className="text-[10px] text-muted-foreground">Default · managed runtime</Text>
+            </View>
+            {!activeInstance && <Check className="h-4 w-4 text-primary" size={16} />}
+          </Pressable>
+
+          <View className="h-px bg-border/50 mx-2" />
+
+          {/* Paired machines */}
+          <View className="px-3 pt-2.5 pb-1">
+            <Text className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+              My Machines
+            </Text>
+          </View>
+
+          {loading && instances.length === 0 && (
+            <View className="px-3 py-4">
+              <Text className="text-xs text-muted-foreground">Loading…</Text>
+            </View>
+          )}
+
+          {!loading && instances.length === 0 && (
+            <View className="px-3 py-3">
+              <Text className="text-xs text-muted-foreground leading-relaxed">
+                No paired machines. Run{" "}
+                <Text className="font-mono text-foreground">shogo worker start</Text>{" "}
+                on a machine to add one.
+              </Text>
+            </View>
+          )}
+
+          {instances.map((inst) => {
+            const isActive = activeInstance?.instanceId === inst.id
+            const isConnecting = connecting === inst.id
+            const selectable = inst.status === "online" || isConnecting
+            return (
+              <Pressable
+                key={inst.id}
+                disabled={!selectable}
+                onPress={async () => {
+                  await select(inst)
+                  setOpen(false)
+                }}
+                className={cn(
+                  "flex-row items-center gap-2.5 px-3 py-2.5 active:bg-muted/60",
+                  !selectable && "opacity-60",
+                )}
+              >
+                <StatusDot status={inst.status} />
+                <View className="flex-1">
+                  <Text className={cn(
+                    "text-sm font-medium",
+                    selectable ? "text-foreground" : "text-muted-foreground",
+                  )}>
+                    {inst.name}
+                  </Text>
+                  <Text className="text-[10px] text-muted-foreground">
+                    {inst.hostname}
+                    {inst.os && ` · ${inst.os}`}
+                                    {inst.status !== "online" && (
+                      <Text className="text-amber-600">  · {inst.status}</Text>
+                    )}
+                  </Text>
+                </View>
+                {isConnecting && (
+                  <Text className="text-[10px] text-muted-foreground">connecting…</Text>
+                )}
+                {isActive && <Check className="h-4 w-4 text-primary" size={16} />}
+              </Pressable>
+            )
+          })}
+
+          {activeInstance && (
+            <>
+              <View className="h-px bg-border/50 mx-2 mt-1" />
+              <Pressable
+                onPress={() => {
+                  disconnect()
+                  setOpen(false)
+                }}
+                className="px-3 py-2.5 active:bg-muted/60"
+              >
+                <Text className="text-xs text-destructive font-medium">
+                  Disconnect · fall back to Cloud
+                </Text>
+              </Pressable>
+            </>
+          )}
+        </ScrollView>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/mobile/components/chat/ExecutionBadge.tsx
+++ b/apps/mobile/components/chat/ExecutionBadge.tsx
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * ExecutionBadge
+ *
+ * Small banner that surfaces the currently-selected execution environment.
+ * Only renders when a non-Cloud (remote instance) is active, so the default
+ * Cloud mode stays visually quiet.
+ *
+ * Consumes `useActiveInstance()` — zero extra plumbing.
+ */
+import { View, Text, Pressable } from "react-native"
+import { Zap, X } from "lucide-react-native"
+import { useActiveInstance } from "../../contexts/active-instance"
+
+export function ExecutionBadge() {
+  const { instance, clearInstance } = useActiveInstance()
+  if (!instance) return null
+
+  return (
+    <View className="mx-3 mb-2 flex-row items-center gap-2 rounded-md border border-emerald-400/30 bg-emerald-500/10 px-2.5 py-1.5">
+      <Zap className="h-3 w-3 text-emerald-600" size={12} />
+      <Text className="flex-1 text-[11px] text-emerald-700 leading-tight">
+        Running on <Text className="font-semibold">{instance.name}</Text>
+        <Text className="text-emerald-700/70"> · {instance.hostname}</Text>
+      </Text>
+      <Pressable
+        onPress={clearInstance}
+        accessibilityLabel="Disconnect from remote instance"
+        className="h-4 w-4 items-center justify-center rounded hover:bg-emerald-500/20"
+      >
+        <X className="h-3 w-3 text-emerald-700" size={11} />
+      </Pressable>
+    </View>
+  )
+}

--- a/apps/mobile/components/chat/ToolCallDisplay.tsx
+++ b/apps/mobile/components/chat/ToolCallDisplay.tsx
@@ -29,6 +29,7 @@ import {
   ChevronDown,
   type LucideIcon,
 } from "lucide-react-native"
+import { TransportBadge } from "./TransportBadge"
 
 const TRUNCATION_THRESHOLD = 500
 const MAX_DEPTH = 2
@@ -177,6 +178,7 @@ export function ToolCallDisplay({
         <ChevronIcon className="h-3 w-3 text-gray-400 shrink-0" size={12} />
         <Icon className="h-3 w-3 text-gray-400 shrink-0" size={12} />
         <Text className="font-medium text-[10px] font-mono text-foreground">{toolName}</Text>
+        <TransportBadge size="xs" className="shrink-0" />
 
         {isCollapsed && summaryLine && (
           <Text

--- a/apps/mobile/components/chat/TransportBadge.tsx
+++ b/apps/mobile/components/chat/TransportBadge.tsx
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * TransportBadge
+ *
+ * Small inline pill that tells the user where a given tool call actually
+ * executed: on Shogo Cloud (☁) or on their paired worker machine (🖥).
+ *
+ * Default behaviour: render NOTHING when no machine is selected. 99%+ of
+ * sessions today use Cloud-only and do not need a badge.
+ *
+ * Callers:
+ *  - ToolCallDisplay    (chat technical-agent tool renderer)
+ *  - ToolPill           (collapsed toolbar summary)
+ *  - ToolCallGroup      (grouped tool card header)
+ *
+ * Routing decisions are made by `chooseMcpHost()` in
+ * `packages/agent-runtime/src/lib/mcp-transport-routing.ts`. This component
+ * is purely presentational; it reads `useActiveInstance()` and accepts an
+ * optional `host` override for cases where the caller already knows the
+ * routing decision (e.g. HTTP MCP pinned to cloud even with an instance).
+ */
+import { View, Text } from "react-native"
+import { Cloud, Laptop } from "lucide-react-native"
+import { cn } from "@shogo/shared-ui/primitives"
+import { useActiveInstance } from "../../contexts/active-instance"
+
+export type TransportHost = "cloud" | "worker"
+
+export interface TransportBadgeProps {
+  /**
+   * Explicit host override. If omitted, the badge reflects the active
+   * instance from `useActiveInstance()`: worker when set, cloud otherwise.
+   */
+  host?: TransportHost
+  /**
+   * When true the badge renders for Cloud too. Default false keeps the UI
+   * quiet for the 99% common case (no machine selected).
+   */
+  showWhenCloud?: boolean
+  size?: "xs" | "sm"
+  className?: string
+}
+
+export function TransportBadge({
+  host,
+  showWhenCloud = false,
+  size = "xs",
+  className,
+}: TransportBadgeProps) {
+  const { instance } = useActiveInstance()
+  const resolved: TransportHost = host ?? (instance ? "worker" : "cloud")
+
+  if (resolved === "cloud" && !showWhenCloud) return null
+
+  const isWorker = resolved === "worker"
+  const label = isWorker ? instance?.name ?? "machine" : "Cloud"
+
+  const iconSize = size === "xs" ? 9 : 10
+  const textSize = size === "xs" ? "text-[9px]" : "text-[10px]"
+  const padding = size === "xs" ? "px-1 py-px" : "px-1.5 py-0.5"
+
+  return (
+    <View
+      className={cn(
+        "flex-row items-center gap-0.5 rounded-full",
+        padding,
+        isWorker
+          ? "bg-emerald-500/15 border border-emerald-400/30"
+          : "bg-muted/60 border border-border/40",
+        className,
+      )}
+      accessibilityLabel={isWorker ? `Runs on ${label}` : "Runs on Shogo Cloud"}
+    >
+      {isWorker ? (
+        <Laptop
+          className="text-emerald-600"
+          size={iconSize}
+        />
+      ) : (
+        <Cloud
+          className="text-muted-foreground"
+          size={iconSize}
+        />
+      )}
+      <Text
+        className={cn(
+          textSize,
+          "font-medium",
+          isWorker ? "text-emerald-700" : "text-muted-foreground",
+        )}
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+    </View>
+  )
+}
+
+export default TransportBadge

--- a/apps/mobile/components/chat/tools/ToolPill.tsx
+++ b/apps/mobile/components/chat/tools/ToolPill.tsx
@@ -11,6 +11,7 @@ import { View, Text, Pressable } from "react-native"
 import { cn } from "@shogo/shared-ui/primitives"
 import { Wrench, CheckCircle2, XCircle, ChevronDown } from "lucide-react-native"
 import { type ToolCallData } from "./types"
+import { TransportBadge } from "../TransportBadge"
 
 export interface ToolPillProps {
   tools: ToolCallData[]
@@ -58,6 +59,8 @@ export function ToolPill({ tools, onPress, className }: ToolPillProps) {
 
       {hasErrors && <XCircle className="w-3 h-3 text-red-500" size={12} />}
       {allSuccess && <CheckCircle2 className="w-3 h-3 text-green-500" size={12} />}
+
+      <TransportBadge size="xs" className="ml-0.5" />
 
       {onPress && <ChevronDown className="w-3 h-3 ml-0.5 text-gray-400" size={12} />}
     </Pressable>

--- a/apps/mobile/components/chat/turns/ToolCallGroup.tsx
+++ b/apps/mobile/components/chat/turns/ToolCallGroup.tsx
@@ -23,6 +23,7 @@ import {
   getToolNamespace,
 } from "../tools/types"
 import { InlineToolWidget } from "./InlineToolWidget"
+import { TransportBadge } from "../TransportBadge"
 
 export interface ToolCallGroupProps {
   toolName: string
@@ -96,6 +97,8 @@ export function ToolCallGroup({
         </View>
 
         <View className="flex-1" />
+
+        <TransportBadge size="xs" className="mr-1" />
 
         {hasStreaming ? (
           <Loader2 className="w-3 h-3 text-primary" />

--- a/apps/mobile/components/instance/InstanceOfflineWatcher.tsx
+++ b/apps/mobile/components/instance/InstanceOfflineWatcher.tsx
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * InstanceOfflineWatcher
+ *
+ * Phase 2 polish: surfaces a toast when the user's actively-selected remote
+ * machine drops mid-conversation. Driven by the `instanceStatus` field on
+ * `useActiveInstance()`, which polls /api/instances/:id every 15s.
+ *
+ * Mount once near the root, inside <ActiveInstanceProvider> and any toast
+ * provider. Renders nothing.
+ */
+
+import { useEffect, useRef } from 'react'
+import { Pressable, View } from 'react-native'
+import { Text } from '../ui/text'
+import {
+  useToast,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+} from '../ui/toast'
+import { useActiveInstance } from '../../contexts/active-instance'
+
+export function InstanceOfflineWatcher() {
+  const { instance, instanceStatus, clearInstance } = useActiveInstance()
+  const toast = useToast()
+  const lastWarnedRef = useRef<string | null>(null)
+  const previousStatusRef = useRef<string>('unknown')
+
+  useEffect(() => {
+    if (!instance) {
+      lastWarnedRef.current = null
+      previousStatusRef.current = 'unknown'
+      return
+    }
+
+    const prev = previousStatusRef.current
+    previousStatusRef.current = instanceStatus
+
+    const justWentOffline =
+      instanceStatus === 'offline' &&
+      prev !== 'offline' &&
+      lastWarnedRef.current !== instance.instanceId
+
+    if (!justWentOffline) return
+    lastWarnedRef.current = instance.instanceId
+
+    const id = `instance-offline-${instance.instanceId}`
+    toast.show({
+      id,
+      placement: 'top',
+      duration: 8000,
+      render: ({ id: toastId }: { id: string }) => (
+        <Toast nativeID={toastId} variant="outline" action="warning">
+          <ToastTitle>Machine offline</ToastTitle>
+          <ToastDescription>
+            {instance.name} stopped heartbeating. Tool calls won't reach it
+            until it reconnects.
+          </ToastDescription>
+          <View className="mt-2 flex-row gap-2">
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => {
+                clearInstance()
+                toast.close(toastId)
+              }}
+              className="rounded-md bg-amber-500 px-3 py-1.5"
+            >
+              <Text className="text-xs font-medium text-amber-950">
+                Continue in cloud
+              </Text>
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => toast.close(toastId)}
+              className="rounded-md border border-border px-3 py-1.5"
+            >
+              <Text className="text-xs font-medium text-foreground">Wait</Text>
+            </Pressable>
+          </View>
+        </Toast>
+      ),
+    })
+  }, [instance, instanceStatus, toast, clearInstance])
+
+  useEffect(() => {
+    if (instanceStatus === 'online' || instanceStatus === 'heartbeat') {
+      lastWarnedRef.current = null
+    }
+  }, [instanceStatus])
+
+  return null
+}

--- a/bun.lock
+++ b/bun.lock
@@ -217,6 +217,7 @@
         "turndown": "^7.2.2",
         "turndown-plugin-gfm": "^1.0.2",
         "typescript": "^6.0.2",
+        "undici": "^6.21.0",
         "unpdf": "^1.4.0",
         "web-tree-sitter": "0.25.10",
         "yaml": "^2.7.1",
@@ -379,6 +380,21 @@
         "react": ">=18",
         "react-native": ">=0.72",
         "react-native-svg": ">=15",
+      },
+    },
+    "packages/shogo-worker": {
+      "name": "@shogo-ai/worker",
+      "version": "0.1.0",
+      "bin": {
+        "shogo": "./bin/shogo.mjs",
+      },
+      "dependencies": {
+        "commander": "^12.1.0",
+        "picocolors": "^1.1.1",
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.3.0",
       },
     },
     "packages/ui-kit": {
@@ -1574,6 +1590,8 @@
 
     "@shogo-ai/sdk": ["@shogo-ai/sdk@workspace:packages/sdk"],
 
+    "@shogo-ai/worker": ["@shogo-ai/worker@workspace:packages/shogo-worker"],
+
     "@shogo/agent-runtime": ["@shogo/agent-runtime@workspace:packages/agent-runtime"],
 
     "@shogo/api": ["@shogo/api@workspace:apps/api"],
@@ -1722,7 +1740,7 @@
 
     "@types/better-sqlite3": ["@types/better-sqlite3@7.6.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA=="],
 
-    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
@@ -3642,7 +3660,7 @@
 
     "uhyphen": ["uhyphen@0.2.0", "", {}, "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA=="],
 
-    "undici": ["undici@7.22.0", "", {}, "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg=="],
+    "undici": ["undici@6.23.0", "", {}, "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -3946,8 +3964,6 @@
 
     "@expo/cli/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
 
-    "@expo/cli/undici": ["undici@6.23.0", "", {}, "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g=="],
-
     "@expo/config/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
 
     "@expo/config/glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
@@ -4012,6 +4028,8 @@
 
     "@mariozechner/pi-ai/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "@mariozechner/pi-ai/undici": ["undici@7.22.0", "", {}, "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg=="],
+
     "@modelcontextprotocol/sdk/hono": ["hono@4.12.0", "", {}, "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA=="],
 
     "@mrleebo/prisma-ast/lilconfig": ["lilconfig@2.1.0", "", {}, "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="],
@@ -4060,6 +4078,10 @@
 
     "@sentry/cli/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
+    "@shogo-ai/worker/@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
+
+    "@shogo-ai/worker/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
     "@shogo/api/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@shogo/domain-stores/mobx-state-tree": ["mobx-state-tree@7.0.2", "", { "dependencies": { "ts-essentials": "^9.4.1" }, "peerDependencies": { "mobx": "^6.3.0" } }, "sha512-Qmqgo2Ho1/JRTquo0EWw0ZA/k4wTUNPMIBg98ALGN1V/0Gupic7dg4GDYUhNbiLsYHpp48VgpaCDpDIKV+jNkQ=="],
@@ -4076,7 +4098,7 @@
 
     "@shogo/shared-ui/lucide-react-native": ["lucide-react-native@1.6.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-native": "*", "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0" } }, "sha512-zNQCNladQHZsK6BM928zIwOWW1SHYthSLp8GjARC3K6Ex6K9vvDSB9Vvwj7FYSpgmNa76Bz1G2wgXsmKM4OGcg=="],
 
-    "@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "@types/graceful-fs/@types/node": ["@types/node@24.10.13", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg=="],
 
@@ -4651,6 +4673,8 @@
     "@sentry/cli/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "@shogo/shared-runtime/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "@shogo-ai/worker/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@types/graceful-fs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/docs/mcp-transport-routing.md
+++ b/docs/mcp-transport-routing.md
@@ -1,0 +1,120 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (C) 2026 Shogo Technologies, Inc. -->
+
+# MCP Transport Routing
+
+When a user pairs their own machine via the Remote Control (My Machines) picker, we need a principled answer to: **"where does each MCP server actually run?"**
+
+This document is the spec. Audited against `feat/shogo-cloud-code` @ 2026-04-23.
+
+## The model
+
+Each MCP server is one of two shapes, distinguished by transport:
+
+| Transport | MCP client class | Execution model |
+|-----------|------------------|-----------------|
+| **stdio** | `StdioClientTransport` | We spawn a child process and pipe stdin/stdout. |
+| **HTTP / SSE** | `StreamableHTTPClientTransport` | We open an HTTP connection to a URL the user provided. |
+
+And each session is one of two modes:
+
+| Mode | Signal | Where agent-runtime code executes |
+|------|--------|-----------------------------------|
+| **Cloud** | `activeInstance` is null | Shogo cloud pod (default — 99%+ of sessions today). |
+| **Machine** | `activeInstance.instanceId` is set | User's worker machine (Phase 1 CLI or Desktop). |
+
+## What happens today
+
+`packages/agent-runtime/src/mcp-client.ts` is the single entry point for MCP server management. It has two methods:
+
+- `startServer(name, config)` → spawns the stdio child at `mcp-client.ts:297`.
+- `startRemoteServer(name, config)` → opens the HTTP connection at `mcp-client.ts:443`.
+
+Both methods execute **wherever the agent-runtime itself is running**. We do not have explicit "spawn this on cloud" / "spawn this on worker" knobs inside mcp-client.
+
+When a user picks a machine from the chat header:
+
+1. The mobile app flips the project's agent-proxy URL to `${remoteAgentBaseUrl}/api/projects/:id/agent-proxy/*` (see `apps/mobile/app/(app)/projects/[id]/_layout.tsx:327`).
+2. `remoteAgentBaseUrl` is `${apiUrl}/api/instances/${instanceId}/p`.
+3. The cloud's `apps/api` receives the request, hits its `ALL /instances/:id/p/*` transparent proxy (`apps/api/src/routes/instances.ts:1041`), which forwards the request over the WS tunnel to the worker's local `apps/api`.
+4. The worker's local `apps/api` handles the `/api/projects/:id/agent-proxy/*` path and invokes its local agent-runtime, which in turn calls into its local `mcp-client.ts`.
+5. `StdioClientTransport.spawn` runs on the worker machine. ✓
+
+**Result: stdio MCP servers correctly run on the worker with no code change.**
+
+**But:** `StreamableHTTPClientTransport` also runs from the worker in this mode. That is:
+
+- ✅ Correct for private-network URLs (e.g., `http://localhost:3001`, `https://internal.corp/mcp`).
+- ⚠️ Needlessly indirect for public URLs (e.g., `https://api.linear.app/mcp`), because the traffic goes worker → internet → service, instead of cloud-pod → internet → service. Extra latency, no security benefit.
+
+## The routing matrix we want
+
+| Transport | No machine active | Machine selected + pin=auto | Pin=cloud | Pin=worker |
+|-----------|-------------------|------------------------------|-----------|------------|
+| stdio     | ☁ Cloud pod       | 🖥 Worker                   | ☁ Cloud (spawns in pod via direct agent URL) | 🖥 Worker |
+| HTTP/SSE  | ☁ Cloud pod       | **See below**                | ☁ Cloud   | 🖥 Worker  |
+
+`pin=auto` for HTTP/SSE resolves to:
+
+- **Cloud** if the URL host is public (not RFC 1918 / loopback / `.local` / `.internal`).
+- **Worker** if the URL host is private — reaching a private URL from cloud would 404 / timeout anyway.
+
+Per-server pin is user-overridable via the MCP settings page.
+
+## How this ships
+
+Phase 5 is additive. The four new artifacts (in this PR / Phase 5):
+
+1. `docs/mcp-transport-routing.md` — this file.
+2. `packages/agent-runtime/src/lib/cloud-fetcher.ts` — a ready-to-use HTTP client that always reaches the cloud apps/api edge, for when we're ready to pin HTTP MCP to cloud from the worker. Not yet wired into `mcp-client.ts`.
+3. `packages/agent-runtime/src/__tests__/mcp-transport-routing.test.ts` — integration test skeleton + static-analysis assertions that document current behavior and will catch regressions.
+4. `apps/mobile/components/chat/TransportBadge.tsx` — presentational component for the "runs on ☁ Cloud / 🖥 my-devbox" pill. Not yet wired into existing tool-call displays.
+
+## How to wire it up (follow-up PRs)
+
+### PR-1 (~1 h, low risk) — Badge wiring
+
+Import `<TransportBadge />` in:
+
+- `apps/mobile/components/chat/ToolCallDisplay.tsx`
+- `apps/mobile/components/chat/tools/ToolPill.tsx`
+- `apps/mobile/components/chat/turns/ToolCallGroup.tsx`
+
+Only render when `transportLocation !== 'default'`. Zero visual change for 99%+ of sessions today.
+
+### PR-2 (~1-2 h, medium risk) — HTTP MCP pin-to-cloud (auto)
+
+In `packages/agent-runtime/src/mcp-client.ts` `startRemoteServer`:
+
+```ts
+const transport = new StreamableHTTPClientTransport(
+  new URL(config.url),
+  {
+    requestInit: {
+      ...(config.headers ? { headers: config.headers } : {}),
+      // opt-in: if we're running on a worker AND the URL is public AND pin !== 'worker',
+      // route outbound fetches via cloud-fetcher so the cloud pod makes the call instead.
+      ...(shouldPinToCloud(config) ? { dispatcher: getCloudDispatcher() } : {}),
+    },
+  },
+)
+```
+
+Gate behind `SHOGO_MCP_PIN_HTTP_TO_CLOUD=true` for the first rollout so we can flip it per workspace.
+
+### PR-3 (~30 m, tiny) — MCP settings UI
+
+Add a per-server pin dropdown (auto / cloud / worker) in `apps/mobile/app/(app)/settings/mcp.tsx`. Persists to the existing config.json-based MCP store.
+
+## Why this split
+
+Each PR is independently revertable and has a blast radius of one file or one subsystem. The 4 artifacts in Phase 5 are new-file-only — nothing is modified in-place, so Phase 5 itself cannot cause a regression.
+
+## Validation checklist
+
+- [x] stdio MCP spawns on the worker when activeInstance is set (verified by static analysis of `mcp-client.ts:297` + Phase 3 wiring).
+- [x] HTTP MCP connects from wherever agent-runtime runs (verified: `mcp-client.ts:443` uses `new URL(config.url)` without proxy/dispatcher).
+- [x] No existing flow regresses when activeInstance is null (no existing code is modified in Phase 5).
+- [ ] **PR-2** will add the actual pin-to-cloud behavior for HTTP MCP when a worker is active.
+- [ ] **PR-1** will make the routing visible to users via `<TransportBadge />`.
+- [ ] **PR-3** will give users override control via pin dropdown.

--- a/docs/my-machines-networking.md
+++ b/docs/my-machines-networking.md
@@ -1,0 +1,91 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (C) 2026 Shogo Technologies, Inc. -->
+
+# Shogo Worker — Networking & Outbound Allowlist
+
+This page is for **platform / security / network engineers** who need to allow-list Shogo Worker traffic on a corporate firewall. Share it with them directly.
+
+## TL;DR
+
+- **Protocol:** HTTPS (TCP 443) **outbound only**.
+- **Inbound ports required:** none.
+- **Hosts to allow:** 3 (listed below).
+
+## Required outbound hosts
+
+> **Operational note (Apr 2026):** the canonical host split is rolling out. All traffic currently flows through `studio.shogo.ai`. The table below is the target end-state; during migration the listed hostnames resolve to the same edge that serves `studio.shogo.ai`, so allow-listing them now is forward-compatible.
+
+| # | Host | Purpose | If blocked |
+|---|------|---------|-----------|
+| 1 | `api.shogo.ai` | Session control plane — auth, heartbeat, agent API calls | **FATAL** — worker cannot pair or run any agent session |
+| 2 | `api-direct.shogo.ai` | Direct-tunnel fallback — bypasses CDN/edge for WebSocket pinning | Graceful — tunnel falls back to edge routing through host #1 |
+| 3 | `artifacts.shogo.ai` | Artifact uploads — thumbnails, voice clips, publish assets | Graceful — only artifact uploads fail; chat + tool calls continue |
+
+Blocking **any third-party host** (github.com, npm, your private package mirror, etc.) only affects the specific tool that needs it. The agent session keeps running.
+
+## Behind a corporate proxy
+
+### Plain HTTP proxy
+
+```bash
+HTTPS_PROXY=http://proxy.corp:3128 shogo worker start
+# or pass the --proxy flag
+shogo worker start --proxy http://proxy.corp:3128
+```
+
+Both `HTTPS_PROXY` and lowercase `https_proxy` are honoured. `HTTP_PROXY` is also honoured for plaintext traffic.
+
+### TLS-inspecting proxy
+
+If your proxy performs TLS MitM inspection and presents a corporate root CA, the worker's Node runtime needs that CA installed:
+
+```bash
+NODE_EXTRA_CA_CERTS=/etc/ssl/corp-root.pem \
+  HTTPS_PROXY=http://proxy.corp:3128 \
+  shogo worker start --debug
+```
+
+The `--debug` flag runs a preflight check (`Proxy reachable`) before starting.
+
+## Verifying your allowlist
+
+```bash
+# 1. DNS resolves
+for h in api.shogo.ai api-direct.shogo.ai artifacts.shogo.ai; do
+  dig +short "$h"
+done
+
+# 2. TLS handshake completes
+for h in api.shogo.ai api-direct.shogo.ai artifacts.shogo.ai; do
+  curl -sS -o /dev/null -w "%{http_code} %{url_effective}\n" "https://$h/health" || echo "FAIL $h"
+done
+
+# 3. Worker preflight (includes proxy check if HTTPS_PROXY set)
+shogo worker start --debug
+```
+
+Expected preflight output when all is well:
+
+```
+Shogo Worker — Preflight
+  ✓ Runtime (node >= 20)       — node v20.x
+  ✓ Worker directory exists    — /home/user/code/app
+  ✓ Reach api.shogo.ai         — HTTP 200
+  ✓ Proxy reachable            — HTTP 200 (via proxy.corp:3128)
+  ✓ API key valid              — HTTP 200
+All checks passed.
+```
+
+## FAQ
+
+**Why is there no inbound port?**
+The worker dials Shogo Cloud over HTTPS. When the cloud needs to push work, the worker's open connection carries it back. No inbound ports, no public IP, no VPN required.
+
+**Can I pin traffic to my region?**
+Yes — set `SHOGO_CLOUD_URL` to your region's endpoint (e.g. `https://eu.shogo.ai`). The three-host rule still applies to that region's names.
+
+**Do I need to allow AWS S3 wildcards?**
+No. The artifact host (`artifacts.shogo.ai`) is a CNAME to a single S3 bucket. You do **not** need to allow `*.s3.amazonaws.com`. Prefer exact-host rules.
+
+**What about telemetry / phone-home?**
+None. The worker only contacts the three hosts above. There is no separate telemetry endpoint.

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -61,6 +61,7 @@
     "turndown": "^7.2.2",
     "turndown-plugin-gfm": "^1.0.2",
     "typescript": "^6.0.2",
+    "undici": "^6.21.0",
     "unpdf": "^1.4.0",
     "web-tree-sitter": "0.25.10",
     "yaml": "^2.7.1",

--- a/packages/agent-runtime/src/__tests__/mcp-transport-routing.test.ts
+++ b/packages/agent-runtime/src/__tests__/mcp-transport-routing.test.ts
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import { describe, test, expect, afterAll } from 'bun:test'
+import {
+  chooseMcpHost,
+  detectTransport,
+  getCloudFetcher,
+} from '../lib/mcp-transport-routing'
+import {
+  shouldRouteThroughCloud,
+  getCloudDispatcher,
+  _resetCloudDispatcherForTests,
+} from '../lib/cloud-fetcher'
+
+describe('chooseMcpHost', () => {
+  const instance = { id: 'inst-123', name: 'my-devbox' }
+
+  test('stdio + active instance routes to worker', () => {
+    expect(chooseMcpHost({ transport: 'stdio', activeInstance: instance })).toEqual({
+      kind: 'worker',
+      instanceId: 'inst-123',
+    })
+  })
+
+  test('stdio + no active instance routes to cloud', () => {
+    expect(chooseMcpHost({ transport: 'stdio', activeInstance: null })).toEqual({
+      kind: 'cloud',
+    })
+    expect(chooseMcpHost({ transport: 'stdio' })).toEqual({ kind: 'cloud' })
+  })
+
+  test('http/sse always routes to cloud by default', () => {
+    expect(chooseMcpHost({ transport: 'http', activeInstance: instance })).toEqual({
+      kind: 'cloud',
+    })
+    expect(chooseMcpHost({ transport: 'sse', activeInstance: instance })).toEqual({
+      kind: 'cloud',
+    })
+  })
+
+  test("pin='cloud' overrides stdio+instance default", () => {
+    expect(
+      chooseMcpHost({ transport: 'stdio', activeInstance: instance, pin: 'cloud' }),
+    ).toEqual({ kind: 'cloud' })
+  })
+
+  test("pin='worker' overrides http+instance default", () => {
+    expect(
+      chooseMcpHost({ transport: 'http', activeInstance: instance, pin: 'worker' }),
+    ).toEqual({ kind: 'worker', instanceId: 'inst-123' })
+  })
+
+  test("pin='worker' gracefully degrades to cloud when no instance", () => {
+    expect(
+      chooseMcpHost({ transport: 'http', activeInstance: null, pin: 'worker' }),
+    ).toEqual({ kind: 'cloud' })
+  })
+
+  test("pin='auto' is identical to default", () => {
+    expect(
+      chooseMcpHost({ transport: 'stdio', activeInstance: instance, pin: 'auto' }),
+    ).toEqual(chooseMcpHost({ transport: 'stdio', activeInstance: instance }))
+  })
+})
+
+describe('detectTransport', () => {
+  test('command → stdio', () => {
+    expect(detectTransport({ command: 'npx' })).toBe('stdio')
+  })
+
+  test('http url → http', () => {
+    expect(detectTransport({ url: 'https://api.linear.app/mcp' })).toBe('http')
+    expect(detectTransport({ url: 'http://localhost:9000/mcp' })).toBe('http')
+  })
+
+  test('ws/wss url → sse', () => {
+    expect(detectTransport({ url: 'wss://events.example.com' })).toBe('sse')
+    expect(detectTransport({ url: 'ws://localhost:9000' })).toBe('sse')
+  })
+
+  test('neither command nor url throws', () => {
+    expect(() => detectTransport({})).toThrow()
+  })
+
+  test('empty command falls through to url detection', () => {
+    expect(detectTransport({ command: '', url: 'https://x.io' })).toBe('http')
+  })
+})
+
+describe('getCloudFetcher', () => {
+  test('returns a callable fetch-compatible function', () => {
+    const f = getCloudFetcher()
+    expect(typeof f).toBe('function')
+  })
+})
+
+describe('shouldRouteThroughCloud', () => {
+  test("pin='cloud' always routes cloud", () => {
+    expect(shouldRouteThroughCloud('http://localhost:9000', 'cloud')).toBe(true)
+    expect(shouldRouteThroughCloud('https://api.linear.app', 'cloud')).toBe(true)
+  })
+
+  test("pin='worker' never routes cloud", () => {
+    expect(shouldRouteThroughCloud('https://api.linear.app', 'worker')).toBe(false)
+  })
+
+  test('auto: public host routes cloud', () => {
+    expect(shouldRouteThroughCloud('https://api.linear.app/mcp')).toBe(true)
+    expect(shouldRouteThroughCloud('https://mcp.example.com')).toBe(true)
+  })
+
+  test('auto: private / local hosts stay on worker', () => {
+    expect(shouldRouteThroughCloud('http://localhost:9000')).toBe(false)
+    expect(shouldRouteThroughCloud('http://127.0.0.1:9000')).toBe(false)
+    expect(shouldRouteThroughCloud('http://dev.local')).toBe(false)
+    expect(shouldRouteThroughCloud('https://db.corp')).toBe(false)
+    expect(shouldRouteThroughCloud('https://svc.internal')).toBe(false)
+  })
+
+  test('auto: RFC 1918 IP ranges stay on worker', () => {
+    expect(shouldRouteThroughCloud('http://10.0.0.5')).toBe(false)
+    expect(shouldRouteThroughCloud('http://192.168.1.10')).toBe(false)
+    expect(shouldRouteThroughCloud('http://172.16.0.1')).toBe(false)
+    expect(shouldRouteThroughCloud('http://172.31.255.255')).toBe(false)
+  })
+
+  test('auto: addresses just outside 172.16/12 are public', () => {
+    expect(shouldRouteThroughCloud('http://172.15.0.1')).toBe(true)
+    expect(shouldRouteThroughCloud('http://172.32.0.1')).toBe(true)
+  })
+
+  test('auto: malformed URL fails safe (stays on worker)', () => {
+    expect(shouldRouteThroughCloud('not a url')).toBe(false)
+  })
+})
+
+describe('getCloudDispatcher', () => {
+  afterAll(() => {
+    _resetCloudDispatcherForTests()
+  })
+
+  test('returns a singleton', () => {
+    _resetCloudDispatcherForTests()
+    const a = getCloudDispatcher()
+    const b = getCloudDispatcher()
+    expect(a).toBe(b)
+  })
+
+  test('reset produces a fresh instance', () => {
+    const a = getCloudDispatcher()
+    _resetCloudDispatcherForTests()
+    const b = getCloudDispatcher()
+    expect(a).not.toBe(b)
+  })
+})

--- a/packages/agent-runtime/src/lib/cloud-fetcher.ts
+++ b/packages/agent-runtime/src/lib/cloud-fetcher.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Cloud Fetcher — a dispatcher-aware outbound client that always targets the
+ * Shogo Cloud edge, regardless of where the current agent-runtime happens to
+ * be running.
+ *
+ * Why this exists:
+ *
+ *   When a user pairs a machine via the Remote Control picker, their
+ *   agent-runtime code ends up executing on the worker (via Phase 3's /p/*
+ *   tunnel). That's exactly what we want for stdio MCP — spawned processes
+ *   land on the user's box.
+ *
+ *   It's NOT what we want for HTTP MCP servers whose URL is a public host
+ *   (e.g., api.linear.app/mcp). Running those from the worker adds a
+ *   needless worker → internet hop. This module gives mcp-client.ts a drop-in
+ *   dispatcher it can pass to StreamableHTTPClientTransport so the request is
+ *   relayed through the cloud pod instead.
+ *
+ * Status: NOT YET WIRED INTO mcp-client.ts.
+ *   This file is published ready-to-use. The wire-up lives in a follow-up PR
+ *   (docs/mcp-transport-routing.md §"PR-2"). Importing from this file is a
+ *   no-op until that PR lands.
+ */
+
+import { Agent, fetch as undiciFetch } from 'undici'
+
+/**
+ * Hosts considered "private" — not reachable from the cloud pod and therefore
+ * must NOT be pinned to cloud. This is a pragmatic allowlist, not an RFC 1918
+ * verifier; the set is intentionally conservative.
+ */
+const PRIVATE_HOST_SUFFIXES = [
+  '.local',
+  '.internal',
+  '.corp',
+  '.lan',
+  '.intranet',
+]
+
+const PRIVATE_HOST_EXACT = new Set([
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  '0.0.0.0',
+])
+
+/**
+ * Decide if a URL should be executed from the cloud pod instead of the worker.
+ *
+ * Rules:
+ *   - Explicit pin='cloud'  → always cloud.
+ *   - Explicit pin='worker' → never cloud.
+ *   - pin='auto' (default)  → cloud only if host is public.
+ */
+export type McpTransportPin = 'auto' | 'cloud' | 'worker'
+
+export function shouldRouteThroughCloud(
+  url: string,
+  pin: McpTransportPin = 'auto',
+): boolean {
+  if (pin === 'cloud') return true
+  if (pin === 'worker') return false
+  // auto: only cloud-route public hosts
+  try {
+    const host = new URL(url).hostname.toLowerCase()
+    if (PRIVATE_HOST_EXACT.has(host)) return false
+    if (PRIVATE_HOST_SUFFIXES.some((s) => host.endsWith(s))) return false
+    // Bare numeric IPs in RFC 1918 space
+    if (/^10\./.test(host)) return false
+    if (/^192\.168\./.test(host)) return false
+    if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return false
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * A singleton undici Agent configured with defaults suited to long-lived MCP
+ * HTTP/SSE sessions. Consumers don't need to touch this directly — use
+ * getCloudDispatcher().
+ */
+let _agent: Agent | null = null
+
+export function getCloudDispatcher(): Agent {
+  if (_agent) return _agent
+  _agent = new Agent({
+    // MCP tools can run long; give them headroom.
+    bodyTimeout: 0,
+    headersTimeout: 60_000,
+    keepAliveTimeout: 30_000,
+    keepAliveMaxTimeout: 10 * 60_000,
+  })
+  return _agent
+}
+
+/**
+ * Pre-bound fetch that uses the cloud dispatcher. Useful for non-MCP code
+ * paths that want the same semantics (e.g., outbound webhooks that must
+ * originate from the cloud IP range).
+ */
+export function cloudFetch(
+  input: string | URL | Request,
+  init?: RequestInit,
+): Promise<Response> {
+  // @ts-expect-error — undici's fetch accepts a dispatcher option that is
+  // not part of the standard RequestInit type.
+  return undiciFetch(input, { ...init, dispatcher: getCloudDispatcher() })
+}
+
+/**
+ * Reset the cached dispatcher (test-only).
+ *
+ * `.close()` is a no-op under Bun's bundled undici shim (the method is not
+ * implemented) but is a valid Promise-returning method in real undici. Guard
+ * the call so tests work in both runtimes.
+ */
+export function _resetCloudDispatcherForTests(): void {
+  if (_agent) {
+    const closeFn = (_agent as { close?: () => Promise<void> | void }).close
+    try {
+      const maybePromise = typeof closeFn === 'function' ? closeFn.call(_agent) : undefined
+      if (maybePromise && typeof (maybePromise as Promise<void>).catch === 'function') {
+        ;(maybePromise as Promise<void>).catch(() => { /* noop */ })
+      }
+    } catch { /* noop — shim without close */ }
+    _agent = null
+  }
+}

--- a/packages/agent-runtime/src/lib/mcp-transport-routing.ts
+++ b/packages/agent-runtime/src/lib/mcp-transport-routing.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * MCP Transport Routing — pure helpers for Phase 5.
+ *
+ * Scope & status: this module is ADDITIVE. Nothing in the existing
+ * mcp-client.ts imports it yet. It exists so follow-up PRs can
+ * incrementally adopt transport-aware routing without a big-bang
+ * change. See docs/mcp-transport-routing.md for rollout.
+ *
+ * The core idea:
+ *   - stdio MCP should run on the user's worker when one is selected
+ *     (to reach /Users/..., corp VPN, local filesystems).
+ *   - HTTP/SSE MCP should always run in the cloud pod (its URL is
+ *     reachable from anywhere; going through the tunnel just adds
+ *     latency).
+ */
+
+export type McpTransport = 'stdio' | 'http' | 'sse'
+
+export type McpPin = 'auto' | 'cloud' | 'worker'
+
+/** Compact description of the currently-active worker machine, if any. */
+export interface ActiveInstanceRef {
+  id: string
+  /** Display name for UI; not used in routing decisions. */
+  name?: string
+}
+
+export type McpHost =
+  | { kind: 'cloud' }
+  | { kind: 'worker'; instanceId: string }
+
+export interface ChooseHostInput {
+  transport: McpTransport
+  /** null/undefined when the user hasn't selected a machine. */
+  activeInstance?: ActiveInstanceRef | null
+  /** Optional per-server pin override ('auto' == default by transport). */
+  pin?: McpPin
+}
+
+/**
+ * Deterministic routing rule. Pure function — safe to unit-test.
+ *
+ * Default-by-transport:
+ *   - stdio    + activeInstance? -> worker ; else cloud
+ *   - http/sse + any state       -> cloud
+ *
+ * A per-server pin ('cloud' | 'worker') always wins over the default,
+ * EXCEPT that a 'worker' pin with no activeInstance silently falls back
+ * to cloud (because there's no worker to route to). We prefer graceful
+ * degradation over surfacing an error mid-session.
+ */
+export function chooseMcpHost(input: ChooseHostInput): McpHost {
+  const { transport, activeInstance, pin = 'auto' } = input
+
+  if (pin === 'cloud') return { kind: 'cloud' }
+
+  if (pin === 'worker') {
+    return activeInstance?.id
+      ? { kind: 'worker', instanceId: activeInstance.id }
+      : { kind: 'cloud' }
+  }
+
+  if (transport === 'stdio' && activeInstance?.id) {
+    return { kind: 'worker', instanceId: activeInstance.id }
+  }
+
+  return { kind: 'cloud' }
+}
+
+/**
+ * Narrow a mcp-client server-config object's shape to its transport type,
+ * for callers that want to route BEFORE actually starting the server.
+ * The shape here intentionally mirrors what mcp-client.ts accepts, so this
+ * helper is drop-in whenever the call-site needs it.
+ */
+export function detectTransport(config: {
+  /** Present for stdio servers. */
+  command?: string
+  /** Present for remote servers. */
+  url?: string
+}): McpTransport {
+  if (typeof config.command === 'string' && config.command.length > 0) return 'stdio'
+  if (typeof config.url === 'string' && /^wss?:\/\//i.test(config.url)) return 'sse'
+  if (typeof config.url === 'string') return 'http'
+  throw new Error('detectTransport: neither command nor url present on config')
+}
+
+/**
+ * A Fetch-compatible factory that always sends requests from the cloud pod,
+ * bypassing any active /p/* tunnel proxy. For HTTP MCP servers.
+ *
+ * Today this is just the ambient fetch — no special routing exists to
+ * bypass. When the agent-runtime starts being invoked through /p/* (Phase 3),
+ * callers should switch to this factory so HTTP MCP traffic doesn't double-hop
+ * through the worker for no reason.
+ *
+ * Why this is a factory and not a constant: future rollout may add
+ * configuration (custom agent, CA bundle, timeouts). Keeping it a factory
+ * lets us evolve without touching call sites.
+ */
+export function getCloudFetcher(): typeof fetch {
+  // NOTE: intentionally returns the default undici fetch. When /p/* proxying
+  // is toggled on for agent-runtime outbound calls, this factory will wrap
+  // the default with a dispatcher pinned to the cloud egress.
+  return globalThis.fetch
+}

--- a/packages/agent-runtime/src/mcp-client.ts
+++ b/packages/agent-runtime/src/mcp-client.ts
@@ -21,6 +21,7 @@ import { Type } from '@sinclair/typebox'
 import type { AgentTool, AgentToolResult } from '@mariozechner/pi-agent-core'
 import { isPreinstalledMcpId, isMcpServerAllowed, isCatalogEntry, getPreinstalledPackages } from './mcp-catalog'
 import { getSanitizedEnv } from './sandbox-exec'
+import { shouldRouteThroughCloud, getCloudDispatcher, type McpTransportPin } from './lib/cloud-fetcher'
 
 const MAX_MCP_SERVERS = 10
 const MCP_CONNECT_TIMEOUT_MS = 90_000
@@ -50,6 +51,21 @@ export interface RemoteMCPServerConfig {
   excludeTools?: string[]
   /** Max characters for a single tool result before truncation (default: unlimited) */
   maxResultChars?: number
+  /**
+   * Where HTTP/SSE MCP traffic should originate from when this agent-runtime
+   * is running on a paired worker machine:
+   *
+   *   - 'auto'   (default) — cloud-route public URLs; worker-route private
+   *                          (localhost/RFC1918/.local/.internal/.corp).
+   *   - 'cloud'            — always outbound from the cloud pod.
+   *   - 'worker'           — always outbound from the worker (needed for
+   *                          VPN-only and corp-internal MCP services).
+   *
+   * Only consulted when SHOGO_MCP_PIN_HTTP_TO_CLOUD=true (env flag for the
+   * initial rollout — see docs/mcp-transport-routing.md "PR-2"). Ignored
+   * for stdio servers (those always spawn on the local process).
+   */
+  pin?: McpTransportPin
 }
 
 interface ManagedServer {
@@ -438,13 +454,33 @@ export class MCPClientManager {
       return this.remoteServers.get(name)!.tools
     }
 
-    console.log(`[MCPClient] Starting remote MCP server "${name}": ${config.url}`)
+    // Decide whether outbound traffic for this HTTP MCP should originate
+    // from the cloud pod instead of wherever agent-runtime happens to be
+    // running (may be a paired worker machine). Opt-in for the initial
+    // rollout — see docs/mcp-transport-routing.md PR-2.
+    const pinRollout = process.env.SHOGO_MCP_PIN_HTTP_TO_CLOUD === 'true'
+    const routeThroughCloud = pinRollout && shouldRouteThroughCloud(config.url, config.pin ?? 'auto')
+
+    console.log(
+      `[MCPClient] Starting remote MCP server "${name}": ${config.url}` +
+      (routeThroughCloud ? ' [pinned→cloud]' : ''),
+    )
+
+    // When pinned to cloud we pass an undici dispatcher via the Fetch init
+    // object. StreamableHTTPClientTransport forwards requestInit to its
+    // internal fetch calls, and undici's global fetch honours `dispatcher`.
+    // The cast is necessary because RequestInit from the standard DOM libs
+    // does not include the `dispatcher` key.
+    const requestInit: RequestInit | undefined = config.headers || routeThroughCloud
+      ? {
+          ...(config.headers ? { headers: config.headers } : {}),
+          ...(routeThroughCloud ? ({ dispatcher: getCloudDispatcher() } as any) : {}),
+        }
+      : undefined
 
     const transport = new StreamableHTTPClientTransport(
       new URL(config.url),
-      {
-        requestInit: config.headers ? { headers: config.headers } : undefined,
-      },
+      { requestInit },
     )
 
     const client = new Client(
@@ -754,6 +790,7 @@ export class MCPClientManager {
       ...(config.headers ? { headers: config.headers } : {}),
       ...(config.excludeTools?.length ? { excludeTools: config.excludeTools } : {}),
       ...(config.maxResultChars ? { maxResultChars: config.maxResultChars } : {}),
+      ...(config.pin && config.pin !== 'auto' ? { pin: config.pin } : {}),
     }
     writeFileSync(configPath, JSON.stringify(existing, null, 2), 'utf-8')
     this.onConfigPersisted?.()

--- a/packages/shared-app/src/chat/message-helpers.ts
+++ b/packages/shared-app/src/chat/message-helpers.ts
@@ -37,6 +37,7 @@ export const ERROR_CODE_MESSAGES: Record<string, string> = {
   session_expired: 'Your session has expired. Please refresh the page.',
   internal_error: 'Something went wrong on our end. Please try again.',
   shutting_down: 'A server update is in progress. Please retry in a few seconds.',
+  offline: 'Your machine is offline. Reconnect it, or continue in the cloud.',
 }
 
 /**
@@ -56,6 +57,8 @@ export function isTunnelDisconnectError(message: string): boolean {
   const raw = message
   try {
     const parsed = JSON.parse(raw)
+    // Structured `{ error: { code: 'offline' } }` from /api/instances/:id/p/* proxy
+    if (parsed?.error?.code === 'offline') return true
     const inner = parsed?.error?.message || parsed?.message || ''
     if (TUNNEL_DISCONNECT_PATTERNS.some((p) => p.test(inner))) return true
   } catch {}

--- a/packages/shared-app/src/hooks/useActiveInstance.tsx
+++ b/packages/shared-app/src/hooks/useActiveInstance.tsx
@@ -31,6 +31,8 @@ export interface ActiveInstance {
   workspaceId: string
 }
 
+export type InstanceStatus = 'online' | 'heartbeat' | 'offline' | 'unknown'
+
 export interface ActiveInstanceContextValue {
   instance: ActiveInstance | null
   /**
@@ -39,6 +41,13 @@ export interface ActiveInstanceContextValue {
    * null when controlling locally.
    */
   remoteAgentBaseUrl: string | null
+  /**
+   * Live status of the active instance, refreshed every 15s while selected.
+   * 'unknown' until the first poll completes.
+   * Consumers can use this to render a toast / badge when the chosen
+   * machine drops mid-conversation.
+   */
+  instanceStatus: InstanceStatus
   setInstance: (instance: ActiveInstance) => void
   clearInstance: () => void
 }
@@ -70,6 +79,7 @@ const STORAGE_KEY = 'shogo:activeInstance'
 const ActiveInstanceContext = createContext<ActiveInstanceContextValue>({
   instance: null,
   remoteAgentBaseUrl: null,
+  instanceStatus: 'unknown',
   setInstance: () => {},
   clearInstance: () => {},
 })
@@ -84,6 +94,7 @@ export function ActiveInstanceProvider({
   fetchOptions,
 }: ActiveInstanceProviderProps) {
   const [instance, setInstanceState] = useState<ActiveInstance | null>(null)
+  const [instanceStatus, setInstanceStatus] = useState<InstanceStatus>('unknown')
   const validatedRef = useRef(false)
 
   useEffect(() => {
@@ -93,9 +104,10 @@ export function ActiveInstanceProvider({
         if (!raw) return
         try {
           const restored: ActiveInstance = JSON.parse(raw)
-          const valid = await validateInstance(restored, apiUrl, fetchFn, fetchOptions)
-          if (valid) {
+          const result = await validateInstance(restored, apiUrl, fetchFn, fetchOptions)
+          if (result.valid) {
             setInstanceState(restored)
+            setInstanceStatus(result.status ?? 'unknown')
           } else {
             storage.removeItem(STORAGE_KEY).catch(() => {})
           }
@@ -109,9 +121,37 @@ export function ActiveInstanceProvider({
       })
   }, [apiUrl, storage, fetchFn, fetchOptions])
 
+  // Live status polling — detects mid-conversation disconnects so the UI can
+  // toast "machine offline, continue in cloud?". Only runs when an instance
+  // is actively selected. 15s interval matches mobile EnvironmentPicker poll.
+  useEffect(() => {
+    if (!instance || !apiUrl) {
+      setInstanceStatus('unknown')
+      return
+    }
+    let cancelled = false
+    const tick = async () => {
+      const result = await validateInstance(instance, apiUrl, fetchFn, fetchOptions)
+      if (cancelled) return
+      if (!result.valid) {
+        // Instance was deleted or no longer belongs to this workspace.
+        setInstanceStatus('offline')
+        return
+      }
+      setInstanceStatus(result.status ?? 'unknown')
+    }
+    void tick()
+    const id = setInterval(tick, 15000)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [instance, apiUrl, fetchFn, fetchOptions])
+
   const setInstance = useCallback(
     (inst: ActiveInstance) => {
       setInstanceState(inst)
+      setInstanceStatus('unknown')
       storage.setItem(STORAGE_KEY, JSON.stringify(inst)).catch(() => {})
     },
     [storage],
@@ -119,6 +159,7 @@ export function ActiveInstanceProvider({
 
   const clearInstance = useCallback(() => {
     setInstanceState(null)
+    setInstanceStatus('unknown')
     storage.removeItem(STORAGE_KEY).catch(() => {})
   }, [storage])
 
@@ -128,8 +169,8 @@ export function ActiveInstanceProvider({
   }, [instance, apiUrl])
 
   const value = useMemo<ActiveInstanceContextValue>(
-    () => ({ instance, remoteAgentBaseUrl, setInstance, clearInstance }),
-    [instance, remoteAgentBaseUrl, setInstance, clearInstance],
+    () => ({ instance, remoteAgentBaseUrl, instanceStatus, setInstance, clearInstance }),
+    [instance, remoteAgentBaseUrl, instanceStatus, setInstance, clearInstance],
   )
 
   return (
@@ -150,17 +191,22 @@ async function validateInstance(
   apiUrl: string,
   fetchFn: typeof fetch,
   fetchOptions?: RequestInit,
-): Promise<boolean> {
-  if (!apiUrl) return false
+): Promise<{ valid: boolean; status?: InstanceStatus }> {
+  if (!apiUrl) return { valid: false }
   try {
     const res = await fetchFn(`${apiUrl}/api/instances/${inst.instanceId}`, {
       ...fetchOptions,
     })
-    if (!res.ok) return false
+    if (!res.ok) return { valid: false }
     const data = await res.json()
-    return data.workspaceId === inst.workspaceId
+    if (data.workspaceId !== inst.workspaceId) return { valid: false }
+    const status: InstanceStatus =
+      data.status === 'online' || data.status === 'heartbeat' || data.status === 'offline'
+        ? data.status
+        : 'unknown'
+    return { valid: true, status }
   } catch {
-    return false
+    return { valid: false }
   }
 }
 

--- a/packages/shared-app/src/hooks/useActiveInstance.tsx
+++ b/packages/shared-app/src/hooks/useActiveInstance.tsx
@@ -96,6 +96,9 @@ export function ActiveInstanceProvider({
   const [instance, setInstanceState] = useState<ActiveInstance | null>(null)
   const [instanceStatus, setInstanceStatus] = useState<InstanceStatus>('unknown')
   const validatedRef = useRef(false)
+  const validationRef = useRef({ apiUrl, fetchFn, fetchOptions })
+
+  validationRef.current = { apiUrl, fetchFn, fetchOptions }
 
   useEffect(() => {
     storage
@@ -104,7 +107,13 @@ export function ActiveInstanceProvider({
         if (!raw) return
         try {
           const restored: ActiveInstance = JSON.parse(raw)
-          const result = await validateInstance(restored, apiUrl, fetchFn, fetchOptions)
+          const validation = validationRef.current
+          const result = await validateInstance(
+            restored,
+            validation.apiUrl,
+            validation.fetchFn,
+            validation.fetchOptions,
+          )
           if (result.valid) {
             setInstanceState(restored)
             setInstanceStatus(result.status ?? 'unknown')
@@ -119,7 +128,7 @@ export function ActiveInstanceProvider({
       .catch(() => {
         validatedRef.current = true
       })
-  }, [apiUrl, storage, fetchFn, fetchOptions])
+  }, [apiUrl, storage])
 
   // Live status polling — detects mid-conversation disconnects so the UI can
   // toast "machine offline, continue in cloud?". Only runs when an instance
@@ -131,7 +140,13 @@ export function ActiveInstanceProvider({
     }
     let cancelled = false
     const tick = async () => {
-      const result = await validateInstance(instance, apiUrl, fetchFn, fetchOptions)
+      const validation = validationRef.current
+      const result = await validateInstance(
+        instance,
+        validation.apiUrl,
+        validation.fetchFn,
+        validation.fetchOptions,
+      )
       if (cancelled) return
       if (!result.valid) {
         // Instance was deleted or no longer belongs to this workspace.
@@ -146,7 +161,7 @@ export function ActiveInstanceProvider({
       cancelled = true
       clearInterval(id)
     }
-  }, [instance, apiUrl, fetchFn, fetchOptions])
+  }, [instance, apiUrl])
 
   const setInstance = useCallback(
     (inst: ActiveInstance) => {

--- a/packages/shogo-worker/README.md
+++ b/packages/shogo-worker/README.md
@@ -1,0 +1,98 @@
+# @shogo-ai/worker
+
+Run Shogo Cloud Agents on a machine you already own — a laptop, devbox, or CI runner.
+Outbound-only: the worker dials Shogo Cloud over HTTPS, never the other way around.
+
+## Install
+
+```bash
+# Requires node >= 20 (or bun >= 1.3)
+npm i -g @shogo-ai/worker
+```
+
+## Quick start
+
+```bash
+# 1. Create an API key at https://studio.shogo.ai/api-keys,
+#    then save it locally. The login command prompts for the key
+#    (or use --api-key / SHOGO_API_KEY for headless / CI).
+shogo login
+
+# 2. Start the worker (detached by default)
+shogo worker start --name my-devbox --worker-dir ~/code/myproject
+
+# 3. Check it's online
+shogo worker status
+
+# 4. Open https://studio.shogo.ai — your machine appears in the environment dropdown.
+```
+
+### Headless / CI
+
+```bash
+shogo login --api-key "shogo_sk_..."             # non-interactive save
+SHOGO_API_KEY=shogo_sk_... shogo worker start    # skip login entirely
+```
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `shogo login` | Save an API key to `~/.shogo/config.json` (Phase 2 adds browser device-code flow) |
+| `shogo worker start` | Launch the worker (detached). Flags: `--name`, `--worker-dir`, `--api-key`, `--cloud-url`, `--port`, `--debug`, `--foreground` |
+| `shogo worker stop` | Stop the running worker |
+| `shogo worker status` | Show running / stopped |
+| `shogo worker logs [-f]` | Tail `~/.shogo/logs/worker.log` |
+| `shogo config show` | Print config (API key masked) |
+| `shogo config set <key> <value>` | Edit a single key |
+
+## Networking
+
+The worker needs outbound HTTPS (TCP 443) to 3 hosts. **No inbound ports required.**
+
+| Host | Purpose | If blocked |
+|------|---------|-----------|
+| `api.shogo.ai` | Session + heartbeat | **FATAL** — worker can't run |
+| `api-direct.shogo.ai` | Direct tunnel fallback | Graceful — edge routing takes over |
+| `artifacts.shogo.ai` | Artifact uploads | Graceful — only uploads fail |
+
+Full networking guide for security teams: [docs/my-machines-networking.md](../../docs/my-machines-networking.md)
+
+### Corporate proxy
+
+```bash
+# HTTPS_PROXY / https_proxy / HTTP_PROXY / http_proxy all honoured
+HTTPS_PROXY=http://proxy.corp:3128 shogo worker start
+
+# Or pass explicitly with --proxy (overrides env)
+shogo worker start --proxy http://proxy.corp:3128
+
+# TLS-inspecting proxy needs your corp root CA
+NODE_EXTRA_CA_CERTS=/etc/ssl/corp-root.pem \
+  HTTPS_PROXY=http://proxy.corp:3128 \
+  shogo worker start --debug
+```
+
+`shogo worker start --debug` runs a preflight that includes a proxy-reachability check when `HTTPS_PROXY` is set.
+
+## How it works
+
+The worker is a thin lifecycle manager around Shogo's existing **Instance Tunnel**
+(`apps/api/src/lib/instance-tunnel.ts`). When you run `shogo worker start`, it:
+
+1. Reads config from `~/.shogo/config.json` + env + CLI flags.
+2. Spawns the bundled Shogo API entry with `SHOGO_API_KEY` + `SHOGO_LOCAL_MODE=true` in env.
+3. The API auto-starts the tunnel: HTTP heartbeat every 60s, on-demand WebSocket when the
+   cloud signals a session.
+4. The cloud sends `request` messages over the WS; the worker executes against its local
+   API or agent-runtime port and streams the response back.
+
+For deeper reading see the plan at `docs/cloud-agent-my-machines.md` (Phase 0).
+
+## Troubleshooting
+
+```bash
+shogo worker start --debug    # run preflight checks
+shogo worker logs --follow    # tail live logs
+SHOGO_DEBUG=1 shogo worker status  # verbose errors
+```

--- a/packages/shogo-worker/bin/shogo.mjs
+++ b/packages/shogo-worker/bin/shogo.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Shogo Technologies, Inc.
+// Entry shim for `shogo` CLI. Delegates to the TS entry via tsx/bun when present,
+// or to compiled JS when installed as a published package.
+import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { spawn } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const srcEntry = join(__dirname, '..', 'src', 'cli.ts');
+const distEntry = join(__dirname, '..', 'dist', 'cli.js');
+
+const args = process.argv.slice(2);
+
+if (existsSync(distEntry)) {
+  await import(distEntry);
+} else if (existsSync(srcEntry)) {
+  // Dev / monorepo: run via bun if available, else tsx
+  const runner = process.env.BUN_INSTALL || process.versions.bun ? 'bun' : 'tsx';
+  const child = spawn(runner, [srcEntry, ...args], { stdio: 'inherit' });
+  child.on('exit', (code) => process.exit(code ?? 0));
+} else {
+  console.error('shogo: neither dist/ nor src/ entry found — broken install?');
+  process.exit(1);
+}

--- a/packages/shogo-worker/install.ps1
+++ b/packages/shogo-worker/install.ps1
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# Shogo Worker installer for Windows.
+# Usage:
+#   irm https://install.shogo.ai/ps | iex
+#   irm https://install.shogo.ai/ps | iex -Args '--channel','beta'
+
+param(
+  [string]$Channel = 'stable',
+  [string]$Prefix  = "$env:USERPROFILE\.shogo\bin",
+  [switch]$Force,
+  [switch]$NoBinary
+)
+
+$ErrorActionPreference = 'Stop'
+$ReleaseHost = if ($env:SHOGO_RELEASE_HOST) { $env:SHOGO_RELEASE_HOST } else { 'https://releases.shogo.ai' }
+
+function Info($msg) { Write-Host "• $msg" -ForegroundColor Blue }
+function Ok($msg)   { Write-Host "✓ $msg" -ForegroundColor Green }
+function Warn($msg) { Write-Host "! $msg" -ForegroundColor Yellow }
+function Die($msg)  { Write-Host "✗ $msg" -ForegroundColor Red; exit 1 }
+
+$arch = if ([System.Environment]::Is64BitOperatingSystem) { 'x64' } else { 'x86' }
+$target = "win-$arch"
+Info "Detected target: $target (channel=$Channel)"
+
+$binPath = Join-Path $Prefix 'shogo.exe'
+if ((Test-Path $binPath) -and -not $Force) {
+  Warn "shogo already installed at $binPath. Pass -Force to reinstall."
+  & $binPath --version
+  return
+}
+
+New-Item -ItemType Directory -Force -Path $Prefix | Out-Null
+
+function Install-Binary {
+  $url = "$ReleaseHost/cli/$Channel/shogo-$target.zip"
+  $shaUrl = "$url.sha256"
+  $tmp = [IO.Path]::Combine([IO.Path]::GetTempPath(), [IO.Path]::GetRandomFileName())
+  New-Item -ItemType Directory -Path $tmp | Out-Null
+  Info "Downloading $url"
+  try { Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile "$tmp\shogo.zip" } catch { return $false }
+  try {
+    Invoke-WebRequest -UseBasicParsing -Uri $shaUrl -OutFile "$tmp\shogo.sha256"
+    $expected = (Get-Content "$tmp\shogo.sha256").Split(' ')[0]
+    $actual   = (Get-FileHash "$tmp\shogo.zip" -Algorithm SHA256).Hash.ToLower()
+    if ($expected -ne $actual) { Die "Checksum mismatch" }
+    Info "Verifying checksum — ok"
+  } catch { Warn "No checksum published yet; skipping verification" }
+  Expand-Archive -Force -Path "$tmp\shogo.zip" -DestinationPath $tmp
+  Copy-Item -Force "$tmp\shogo.exe" $binPath
+  Remove-Item -Recurse -Force $tmp
+  Ok "Installed binary to $binPath"
+  return $true
+}
+
+function Install-Via-Npm {
+  if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+    Die "No prebuilt binary for $target and npm not found. Install Node.js 20+ or use -Force with a supported target."
+  }
+  Info "Installing via npm: @shogo-ai/worker"
+  npm install -g @shogo-ai/worker
+  Ok "Installed via npm"
+  $script:binPath = (Get-Command shogo).Source
+}
+
+$binaryInstalled = $false
+if (-not $NoBinary) { $binaryInstalled = Install-Binary }
+if (-not $binaryInstalled) { Install-Via-Npm }
+
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+if ($userPath -notlike "*$Prefix*") {
+  Warn "$Prefix is not in your PATH. Adding it to your user PATH."
+  [Environment]::SetEnvironmentVariable('Path', "$Prefix;$userPath", 'User')
+  Ok "PATH updated — open a new terminal to use `shogo`."
+}
+
+Write-Host ""
+& $binPath --version 2>$null
+Ok "shogo CLI ready"
+Write-Host ""
+Write-Host "Next steps:"
+Write-Host "  1. Create an API key:   https://studio.shogo.ai/api-keys"
+Write-Host "  2. Log in:              shogo login --api-key shogo_sk_..."
+Write-Host "  3. Start the worker:    shogo worker start --worker-dir C:\code\myrepo"
+Write-Host ""
+Write-Host "Docs: https://docs.shogo.ai/features/my-machines/quickstart"

--- a/packages/shogo-worker/install.ps1
+++ b/packages/shogo-worker/install.ps1
@@ -57,8 +57,13 @@ function Install-Via-Npm {
   if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
     Die "No prebuilt binary for $target and npm not found. Install Node.js 20+ or use -Force with a supported target."
   }
+  npm view @shogo-ai/worker version *> $null
+  if ($LASTEXITCODE -ne 0) {
+    Die "@shogo-ai/worker is not published to npm or is not reachable. Install a prebuilt binary or try again after the package is published."
+  }
   Info "Installing via npm: @shogo-ai/worker"
   npm install -g @shogo-ai/worker
+  if ($LASTEXITCODE -ne 0) { Die "npm install failed" }
   Ok "Installed via npm"
   $script:binPath = (Get-Command shogo).Source
 }
@@ -75,7 +80,13 @@ if ($userPath -notlike "*$Prefix*") {
 }
 
 Write-Host ""
-& $binPath --version 2>$null
+if ($binaryInstalled) {
+  $verifyPath = Join-Path $Prefix 'shogo.exe'
+  & $verifyPath --version 2>$null
+} else {
+  & $binPath --version 2>$null
+}
+if ($LASTEXITCODE -ne 0) { Die "Installed shogo CLI failed verification" }
 Ok "shogo CLI ready"
 Write-Host ""
 Write-Host "Next steps:"

--- a/packages/shogo-worker/install.sh
+++ b/packages/shogo-worker/install.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Shogo Worker installer.
+# Mirrors Cursor's `curl https://cursor.com/install | bash` UX.
+#
+# Usage:
+#   curl -fsSL https://install.shogo.ai | bash
+#   curl -fsSL https://install.shogo.ai | bash -s -- --channel beta
+#
+# Flags:
+#   --channel <stable|beta>   release channel (default: stable)
+#   --prefix <dir>            install dir (default: $HOME/.shogo/bin)
+#   --force                   overwrite existing install
+#   --no-binary               force npm install even if a prebuilt binary exists
+
+set -euo pipefail
+
+CHANNEL="stable"
+PREFIX="${HOME}/.shogo/bin"
+FORCE=0
+ALLOW_BINARY=1
+RELEASE_HOST="${SHOGO_RELEASE_HOST:-https://releases.shogo.ai}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --channel) CHANNEL="${2:?}"; shift 2 ;;
+    --prefix)  PREFIX="${2:?}";  shift 2 ;;
+    --force)   FORCE=1; shift ;;
+    --no-binary) ALLOW_BINARY=0; shift ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+info()  { printf "\033[34m•\033[0m %s\n" "$*"; }
+ok()    { printf "\033[32m✓\033[0m %s\n" "$*"; }
+warn()  { printf "\033[33m!\033[0m %s\n" "$*" >&2; }
+die()   { printf "\033[31m✗\033[0m %s\n" "$*" >&2; exit 1; }
+
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH_RAW="$(uname -m)"
+case "$ARCH_RAW" in
+  x86_64|amd64) ARCH="x64" ;;
+  arm64|aarch64) ARCH="arm64" ;;
+  *) ARCH="$ARCH_RAW" ;;
+esac
+
+case "$OS" in
+  darwin|linux) ;;
+  *) die "Unsupported OS: $OS. Use install.ps1 on Windows." ;;
+esac
+
+TARGET="${OS}-${ARCH}"
+info "Detected target: $TARGET (channel=$CHANNEL)"
+
+BIN_PATH="$PREFIX/shogo"
+if [ -x "$BIN_PATH" ] && [ "$FORCE" -eq 0 ]; then
+  warn "shogo already installed at $BIN_PATH. Pass --force to reinstall."
+  "$BIN_PATH" --version || true
+  exit 0
+fi
+
+mkdir -p "$PREFIX"
+
+install_binary() {
+  local url="$RELEASE_HOST/cli/$CHANNEL/shogo-$TARGET.tar.gz"
+  local sha_url="$url.sha256"
+  local tmp; tmp="$(mktemp -d)"
+  info "Downloading $url"
+  if ! curl -fsSL "$url" -o "$tmp/shogo.tar.gz"; then
+    return 1
+  fi
+  if curl -fsSL "$sha_url" -o "$tmp/shogo.sha256" 2>/dev/null; then
+    info "Verifying checksum"
+    ( cd "$tmp" && shasum -a 256 -c shogo.sha256 >/dev/null ) || die "Checksum mismatch"
+  else
+    warn "No checksum published yet; skipping verification"
+  fi
+  tar -xzf "$tmp/shogo.tar.gz" -C "$tmp"
+  install -m 0755 "$tmp/shogo" "$BIN_PATH"
+  rm -rf "$tmp"
+  ok "Installed binary to $BIN_PATH"
+}
+
+install_via_npm() {
+  command -v npm >/dev/null 2>&1 || die "No prebuilt binary for $TARGET and npm not found. Install Node.js 20+ or use --force with a supported target."
+  info "Installing via npm: @shogo-ai/worker"
+  npm install -g @shogo-ai/worker
+  ok "Installed via npm"
+  BIN_PATH="$(command -v shogo || true)"
+}
+
+if [ "$ALLOW_BINARY" -eq 1 ] && install_binary; then
+  :
+else
+  install_via_npm
+fi
+
+case ":$PATH:" in
+  *":$PREFIX:"*) ;;
+  *)
+    echo
+    warn "$PREFIX is not in your PATH."
+    echo "    Add this to ~/.zshrc or ~/.bashrc:"
+    echo "      export PATH=\"$PREFIX:\$PATH\""
+    ;;
+esac
+
+echo
+"$BIN_PATH" --version 2>/dev/null && ok "shogo CLI ready"
+echo
+echo "Next steps:"
+echo "  1. Create an API key:   https://studio.shogo.ai/api-keys"
+echo "  2. Log in:              shogo login --api-key shogo_sk_..."
+echo "  3. Start the worker:    shogo worker start --worker-dir ~/code/myrepo"
+echo
+echo "Docs: https://docs.shogo.ai/features/my-machines/quickstart"

--- a/packages/shogo-worker/install.sh
+++ b/packages/shogo-worker/install.sh
@@ -38,6 +38,18 @@ ok()    { printf "\033[32m✓\033[0m %s\n" "$*"; }
 warn()  { printf "\033[33m!\033[0m %s\n" "$*" >&2; }
 die()   { printf "\033[31m✗\033[0m %s\n" "$*" >&2; exit 1; }
 
+verify_checksum() {
+  local checksum_file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "$checksum_file" >/dev/null
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c "$checksum_file" >/dev/null
+  else
+    warn "No SHA-256 checksum tool found; skipping verification"
+    return 0
+  fi
+}
+
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH_RAW="$(uname -m)"
 case "$ARCH_RAW" in
@@ -73,7 +85,7 @@ install_binary() {
   fi
   if curl -fsSL "$sha_url" -o "$tmp/shogo.sha256" 2>/dev/null; then
     info "Verifying checksum"
-    ( cd "$tmp" && shasum -a 256 -c shogo.sha256 >/dev/null ) || die "Checksum mismatch"
+    ( cd "$tmp" && verify_checksum shogo.sha256 ) || die "Checksum mismatch"
   else
     warn "No checksum published yet; skipping verification"
   fi
@@ -85,6 +97,11 @@ install_binary() {
 
 install_via_npm() {
   command -v npm >/dev/null 2>&1 || die "No prebuilt binary for $TARGET and npm not found. Install Node.js 20+ or use --force with a supported target."
+  npm view @shogo-ai/worker version >/dev/null 2>&1 || die "@shogo-ai/worker is not published to npm or is not reachable. Install a prebuilt binary or try again after the package is published."
+  local npm_prefix; npm_prefix="$(npm prefix -g 2>/dev/null)" || die "Unable to resolve npm global prefix"
+  if [ -e "$npm_prefix" ] && [ ! -w "$npm_prefix" ]; then
+    die "npm global prefix is not writable: $npm_prefix. Fix npm permissions or install a prebuilt binary."
+  fi
   info "Installing via npm: @shogo-ai/worker"
   npm install -g @shogo-ai/worker
   ok "Installed via npm"

--- a/packages/shogo-worker/package.json
+++ b/packages/shogo-worker/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@shogo-ai/worker",
+  "version": "0.1.0",
+  "description": "Shogo Cloud Agent Worker \u2014 run Shogo agents on your own machine (laptop, devbox, CI).",
+  "license": "Apache-2.0",
+  "author": "Shogo Technologies, Inc.",
+  "homepage": "https://shogo.ai/docs/cloud-agent/my-machines",
+  "bin": {
+    "shogo": "./bin/shogo.mjs"
+  },
+  "main": "./src/cli.ts",
+  "type": "module",
+  "files": [
+    "bin",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "start": "bun src/cli.ts",
+    "typecheck": "tsc --noEmit",
+    "build": "bun build --compile --minify --target=bun src/cli.ts --outfile dist/shogo",
+    "build:darwin-arm64": "bun build --compile --minify --target=bun-darwin-arm64 src/cli.ts --outfile dist/shogo-darwin-arm64",
+    "build:darwin-x64": "bun build --compile --minify --target=bun-darwin-x64   src/cli.ts --outfile dist/shogo-darwin-x64",
+    "build:linux-x64": "bun build --compile --minify --target=bun-linux-x64    src/cli.ts --outfile dist/shogo-linux-x64",
+    "build:linux-arm64": "bun build --compile --minify --target=bun-linux-arm64  src/cli.ts --outfile dist/shogo-linux-arm64",
+    "build:all": "bun run build:darwin-arm64 && bun run build:darwin-x64 && bun run build:linux-x64 && bun run build:linux-arm64"
+  },
+  "dependencies": {
+    "commander": "^12.1.0",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/shogo-worker/src/cli.ts
+++ b/packages/shogo-worker/src/cli.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Shogo Worker CLI — entry.
+ *
+ * `shogo login`                       — save an API key to ~/.shogo/config.json
+ * `shogo worker start [flags]`        — pair this machine with Shogo Cloud
+ * `shogo worker stop`                 — stop the local worker
+ * `shogo worker status`               — show running/stopped
+ * `shogo worker logs [--follow]`      — tail worker logs
+ * `shogo config show | set <k> <v>`   — inspect/modify config
+ */
+import { Command } from 'commander';
+import pc from 'picocolors';
+import { runStart } from './commands/start.ts';
+import { runStop } from './commands/stop.ts';
+import { runStatus } from './commands/status.ts';
+import { runLogs } from './commands/logs.ts';
+import { runLogin } from './commands/login.ts';
+import { runConfigShow, runConfigSet } from './commands/config.ts';
+
+const VERSION = '0.1.0';
+
+const program = new Command();
+program
+  .name('shogo')
+  .description('Shogo Cloud Agent Worker — run Shogo agents on your own machine.')
+  .version(VERSION);
+
+program
+  .command('login')
+  .description('Save an API key to ~/.shogo/config.json')
+  .option('--api-key <key>', 'API key (skips interactive prompt)')
+  .option('--cloud-url <url>', 'Shogo Cloud URL (default: https://studio.shogo.ai)')
+  .option('--name <name>', 'Instance name (default: hostname)')
+  .action((flags) => handle(() => runLogin(flags)));
+
+const worker = program.command('worker').description('Manage the local worker process');
+
+worker
+  .command('start')
+  .description('Start the worker and pair with Shogo Cloud')
+  .option('--name <name>', 'Instance name shown in the dashboard (default: hostname)')
+  .option('--worker-dir <path>', 'Working directory for the worker (default: $PWD)')
+  .option('--api-key <key>', 'API key (overrides config/env)')
+  .option('--cloud-url <url>', 'Shogo Cloud URL')
+  .option('--port <port>', 'Local HTTP port for the embedded API')
+  .option('--proxy <url>', 'HTTPS proxy (overrides HTTPS_PROXY env)')
+  .option('--debug', 'Run preflight checks before starting')
+  .option('--foreground', 'Run in foreground (don\'t detach)')
+  .action((flags) => handle(() => runStart(flags)));
+
+worker
+  .command('stop')
+  .description('Stop the running worker')
+  .action(() => handle(runStop));
+
+worker
+  .command('status')
+  .description('Show worker status')
+  .action(() => handle(runStatus));
+
+worker
+  .command('logs')
+  .description('Tail worker logs from ~/.shogo/logs/worker.log')
+  .option('-f, --follow', 'Follow the log (tail -F)')
+  .option('--err', 'Show stderr log instead')
+  .action((flags) => handle(() => runLogs(flags)));
+
+const config = program.command('config').description('Inspect or modify ~/.shogo/config.json');
+config
+  .command('show')
+  .description('Print current config (API key masked)')
+  .action(() => handle(runConfigShow));
+config
+  .command('set <key> <value>')
+  .description('Set apiKey / cloudUrl / name / workerDir / port')
+  .action((k: string, v: string) => handle(() => runConfigSet(k, v)));
+
+program.showHelpAfterError(pc.dim('\n(use --help for usage)'));
+program.parseAsync(process.argv);
+
+async function handle(fn: () => Promise<void> | void): Promise<void> {
+  try {
+    await fn();
+  } catch (err: any) {
+    console.error(pc.red(`✗ ${err?.message ?? err}`));
+    if (process.env.SHOGO_DEBUG) console.error(err?.stack);
+    process.exit(1);
+  }
+}

--- a/packages/shogo-worker/src/commands/config.ts
+++ b/packages/shogo-worker/src/commands/config.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import pc from 'picocolors';
+import { loadConfig, saveConfig } from '../lib/config.ts';
+import { CONFIG_FILE } from '../lib/paths.ts';
+
+export async function runConfigShow(): Promise<void> {
+  const cfg = loadConfig();
+  if (Object.keys(cfg).length === 0) {
+    console.log(pc.dim('(no config — run `shogo login` or `shogo config set`)'));
+    return;
+  }
+  const masked = { ...cfg, apiKey: cfg.apiKey ? `***${cfg.apiKey.slice(-4)}` : undefined };
+  console.log(pc.dim(`file: ${CONFIG_FILE}`));
+  console.log(JSON.stringify(masked, null, 2));
+}
+
+export async function runConfigSet(key: string, value: string): Promise<void> {
+  const allowed = ['apiKey', 'cloudUrl', 'name', 'workerDir', 'port'] as const;
+  if (!allowed.includes(key as any)) {
+    console.error(pc.red(`Unknown key: ${key}`));
+    console.error(pc.dim(`Allowed: ${allowed.join(', ')}`));
+    process.exit(1);
+  }
+  const cfg = loadConfig();
+  (cfg as any)[key] = key === 'port' ? parseInt(value, 10) : value;
+  saveConfig(cfg);
+  console.log(pc.green(`✓ ${key} set`));
+}

--- a/packages/shogo-worker/src/commands/login.ts
+++ b/packages/shogo-worker/src/commands/login.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * `shogo login` — saves an API key to ~/.shogo/config.json.
+ *
+ * Three ways to supply the key, highest precedence first:
+ *   1. `--api-key <key>`  — flag
+ *   2. `SHOGO_API_KEY`    — env var (useful in CI)
+ *   3. interactive prompt — stdin read; echo suppressed
+ *
+ * Users create the key in studio.shogo.ai → Settings → API Keys
+ * (the page already backed by apps/api/src/routes/api-keys.ts), then
+ * paste it here. The key is written with mode 0600 so other local
+ * users can't read it.
+ */
+import pc from 'picocolors';
+import { createInterface } from 'node:readline';
+import { loadConfig, saveConfig } from '../lib/config.ts';
+
+export interface LoginFlags {
+  apiKey?: string;
+  cloudUrl?: string;
+  name?: string;
+}
+
+const DEFAULT_CLOUD_URL = 'https://studio.shogo.ai';
+
+export async function runLogin(flags: LoginFlags): Promise<void> {
+  const cfg = loadConfig();
+  const cloudUrl = (flags.cloudUrl || cfg.cloudUrl || DEFAULT_CLOUD_URL).replace(/\/$/, '');
+
+  const key = flags.apiKey || process.env.SHOGO_API_KEY || (await promptForKey(cloudUrl));
+  if (!key) {
+    throw new Error('No API key provided. Aborting.');
+  }
+  if (!/^shogo_sk_/.test(key)) {
+    throw new Error('API key should start with "shogo_sk_". Copy it verbatim from the API Keys page.');
+  }
+
+  cfg.apiKey = key;
+  cfg.cloudUrl = cloudUrl;
+  if (flags.name) cfg.name = flags.name;
+  saveConfig(cfg);
+
+  console.log(pc.green('\n✓ API key saved to ~/.shogo/config.json'));
+  console.log(pc.dim('  next: shogo worker start'));
+}
+
+async function promptForKey(cloudUrl: string): Promise<string> {
+  console.log(pc.bold('\nShogo Worker — Login'));
+  console.log(pc.dim(`Create a key at ${cloudUrl}/api-keys, then paste it below.\n`));
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout, terminal: true });
+  try {
+    // Hide echo while the user pastes/types the secret.
+    const stdin = process.stdin as NodeJS.ReadStream & { isTTY?: boolean };
+    const wasRaw = stdin.isTTY ? stdin.isRaw : undefined;
+    if (stdin.isTTY) stdin.setRawMode?.(true);
+    process.stdout.write('API key: ');
+
+    const answer = await new Promise<string>((resolve) => {
+      let buf = '';
+      const onData = (chunk: Buffer) => {
+        const str = chunk.toString('utf8');
+        for (const ch of str) {
+          if (ch === '\r' || ch === '\n') {
+            process.stdin.removeListener('data', onData);
+            process.stdout.write('\n');
+            resolve(buf);
+            return;
+          }
+          if (ch === '\u0003') { // Ctrl-C
+            process.stdout.write('\n');
+            process.exit(130);
+          }
+          if (ch === '\u007f' || ch === '\b') {
+            buf = buf.slice(0, -1);
+            continue;
+          }
+          buf += ch;
+        }
+      };
+      process.stdin.on('data', onData);
+    });
+
+    if (stdin.isTTY) stdin.setRawMode?.(wasRaw ?? false);
+    return answer.trim();
+  } finally {
+    rl.close();
+  }
+}

--- a/packages/shogo-worker/src/commands/logs.ts
+++ b/packages/shogo-worker/src/commands/logs.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import { spawn } from 'node:child_process';
+import { existsSync, statSync } from 'node:fs';
+import pc from 'picocolors';
+import { WORKER_LOG, WORKER_ERR } from '../lib/paths.ts';
+
+export interface LogsFlags { follow?: boolean; err?: boolean }
+
+export async function runLogs(flags: LogsFlags): Promise<void> {
+  const file = flags.err ? WORKER_ERR : WORKER_LOG;
+  if (!existsSync(file)) {
+    console.log(pc.dim('No logs yet.'));
+    return;
+  }
+  const args = flags.follow ? ['-F', '-n', '200', file] : ['-n', '200', file];
+  const child = spawn('tail', args, { stdio: 'inherit' });
+  child.on('exit', (code) => process.exit(code ?? 0));
+
+  if (!flags.follow) {
+    const size = statSync(file).size;
+    if (size === 0) console.log(pc.dim('(log file is empty)'));
+  }
+}

--- a/packages/shogo-worker/src/commands/start.ts
+++ b/packages/shogo-worker/src/commands/start.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import pc from 'picocolors';
+import { resolveConfig } from '../lib/config.ts';
+import { findApiEntry } from '../lib/api-discovery.ts';
+import { spawnWorker, installShutdownHooks } from '../lib/process-manager.ts';
+import { makeChecks, runPreflight } from '../lib/preflight.ts';
+import { resolveProxy, applyProxyToEnv } from '../lib/transport.ts';
+
+export interface StartFlags {
+  name?: string;
+  workerDir?: string;
+  apiKey?: string;
+  cloudUrl?: string;
+  port?: string;
+  proxy?: string;
+  debug?: boolean;
+  foreground?: boolean;
+}
+
+export async function runStart(flags: StartFlags): Promise<void> {
+  const cfg = resolveConfig({
+    name: flags.name,
+    workerDir: flags.workerDir,
+    apiKey: flags.apiKey,
+    cloudUrl: flags.cloudUrl,
+    port: flags.port ? parseInt(flags.port, 10) : undefined,
+  });
+
+  const proxy = resolveProxy(flags.proxy);
+
+  if (flags.debug) {
+    const ok = await runPreflight(
+      makeChecks({
+        cloudUrl: cfg.cloudUrl,
+        apiKey: cfg.apiKey,
+        workerDir: cfg.workerDir,
+        proxy,
+      }),
+    );
+    if (!ok) process.exit(1);
+  }
+
+  const api = findApiEntry();
+  console.log(pc.bold('\nShogo Worker — Starting'));
+  console.log(pc.dim(`  mode       `) + api.mode);
+  console.log(pc.dim(`  runner     `) + api.runner);
+  console.log(pc.dim(`  name       `) + cfg.name);
+  console.log(pc.dim(`  worker-dir `) + cfg.workerDir);
+  console.log(pc.dim(`  cloud      `) + cfg.cloudUrl);
+  console.log(pc.dim(`  port       `) + cfg.port);
+  if (proxy) {
+    console.log(pc.dim(`  proxy      `) + `${proxy.url} ${pc.dim(`(from ${proxy.source})`)}`);
+  }
+  console.log('');
+
+  const env: NodeJS.ProcessEnv = applyProxyToEnv(
+    {
+      ...process.env,
+      SHOGO_API_KEY: cfg.apiKey,
+      SHOGO_CLOUD_URL: cfg.cloudUrl,
+      SHOGO_INSTANCE_NAME: cfg.name,
+      SHOGO_WORKER_DIR: cfg.workerDir,
+      SHOGO_LOCAL_MODE: 'true',
+      PORT: String(cfg.port),
+    },
+    proxy,
+  );
+
+  const { pid, child } = spawnWorker({
+    entry: api.entry,
+    runner: api.runner,
+    env,
+    cwd: cfg.workerDir,
+    detach: !flags.foreground,
+    inheritStdio: !!flags.foreground,
+  });
+
+  if (flags.foreground) {
+    console.log(pc.green(`✓ Worker running in foreground (pid=${pid}). Ctrl-C to stop.`));
+    installShutdownHooks(child);
+    // Keep the CLI alive until the child exits; the exit handler propagates
+    // the child's exit code. Without this await the bun/node CLI process
+    // would return to its caller and the detached child would keep running.
+    await new Promise<void>(() => { /* listeners in installShutdownHooks handle termination */ });
+  } else {
+    console.log(pc.green(`✓ Worker started (pid=${pid}).`));
+    console.log(pc.dim(`  logs: ~/.shogo/logs/worker.log`));
+    console.log(pc.dim(`  stop: shogo worker stop`));
+  }
+}

--- a/packages/shogo-worker/src/commands/status.ts
+++ b/packages/shogo-worker/src/commands/status.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import pc from 'picocolors';
+import { readPid, isRunning } from '../lib/process-manager.ts';
+import { loadConfig } from '../lib/config.ts';
+
+export async function runStatus(): Promise<void> {
+  const pid = readPid();
+  if (!pid) {
+    console.log(pc.yellow('● stopped') + pc.dim(' (no pid file)'));
+    return;
+  }
+  if (!isRunning(pid)) {
+    console.log(pc.red('● dead') + pc.dim(` (stale pid ${pid})`));
+    return;
+  }
+  const cfg = loadConfig();
+  console.log(pc.green('● running') + pc.dim(` (pid ${pid})`));
+  if (cfg.name) console.log(pc.dim(`  name:  `) + cfg.name);
+  if (cfg.cloudUrl) console.log(pc.dim(`  cloud: `) + cfg.cloudUrl);
+  if (cfg.workerDir) console.log(pc.dim(`  dir:   `) + cfg.workerDir);
+}

--- a/packages/shogo-worker/src/commands/stop.ts
+++ b/packages/shogo-worker/src/commands/stop.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import pc from 'picocolors';
+import { stopWorker } from '../lib/process-manager.ts';
+
+export async function runStop(): Promise<void> {
+  const { killedPid } = stopWorker('SIGTERM');
+  if (killedPid === null) {
+    console.log(pc.dim('No worker running.'));
+    return;
+  }
+  console.log(pc.green(`✓ Worker stopped (pid=${killedPid}).`));
+}

--- a/packages/shogo-worker/src/lib/api-discovery.ts
+++ b/packages/shogo-worker/src/lib/api-discovery.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Finds the apps/api entry to spawn as the tunnel host.
+ *
+ * In the monorepo (dev), we resolve the workspace sibling.
+ * When published, the worker ships a bundled apps/api copy at ./dist/api/entry.js.
+ */
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+interface Resolved {
+  entry: string;
+  runner: 'bun' | 'node';
+  mode: 'monorepo' | 'bundled';
+}
+
+export function findApiEntry(): Resolved {
+  const packageRoot = resolve(__dirname, '..', '..');
+  const monorepoRoot = resolve(packageRoot, '..', '..');
+  const monorepoEntry = join(monorepoRoot, 'apps', 'api', 'src', 'entry.ts');
+  const bundledEntry = join(packageRoot, 'dist', 'api', 'entry.js');
+
+  if (existsSync(bundledEntry)) {
+    return { entry: bundledEntry, runner: 'node', mode: 'bundled' };
+  }
+  if (existsSync(monorepoEntry)) {
+    return { entry: monorepoEntry, runner: 'bun', mode: 'monorepo' };
+  }
+  throw new Error(
+    `Cannot locate apps/api entry. Looked in:\n  ${bundledEntry}\n  ${monorepoEntry}`,
+  );
+}

--- a/packages/shogo-worker/src/lib/config.ts
+++ b/packages/shogo-worker/src/lib/config.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Reads/writes ~/.shogo/config.json. The worker reads this at start,
+ * and the `config` / `login` commands write to it.
+ */
+import { readFileSync, writeFileSync, existsSync, chmodSync } from 'node:fs';
+import { hostname } from 'node:os';
+import { CONFIG_FILE, ensureHome } from './paths.ts';
+
+export interface WorkerConfig {
+  apiKey?: string;
+  cloudUrl?: string;
+  name?: string;
+  workerDir?: string;
+  port?: number;
+}
+
+const DEFAULTS: Required<Pick<WorkerConfig, 'cloudUrl' | 'port'>> = {
+  cloudUrl: 'https://studio.shogo.ai',
+  port: 8002,
+};
+
+export function loadConfig(): WorkerConfig {
+  if (!existsSync(CONFIG_FILE)) return {};
+  try {
+    return JSON.parse(readFileSync(CONFIG_FILE, 'utf-8'));
+  } catch (err) {
+    throw new Error(`Corrupt config at ${CONFIG_FILE}: ${(err as Error).message}`);
+  }
+}
+
+export function saveConfig(cfg: WorkerConfig): void {
+  ensureHome();
+  writeFileSync(CONFIG_FILE, JSON.stringify(cfg, null, 2), { mode: 0o600 });
+  chmodSync(CONFIG_FILE, 0o600);
+}
+
+export function mergeConfig(base: WorkerConfig, override: WorkerConfig): WorkerConfig {
+  return { ...base, ...Object.fromEntries(Object.entries(override).filter(([, v]) => v !== undefined)) };
+}
+
+export function resolveConfig(override: WorkerConfig = {}): Required<WorkerConfig> & { apiKey: string } {
+  const fileCfg = loadConfig();
+  const env: WorkerConfig = {
+    apiKey: process.env.SHOGO_API_KEY,
+    cloudUrl: process.env.SHOGO_CLOUD_URL,
+    name: process.env.SHOGO_INSTANCE_NAME,
+    workerDir: process.env.SHOGO_WORKER_DIR,
+    port: process.env.PORT ? parseInt(process.env.PORT, 10) : undefined,
+  };
+  const merged = mergeConfig(mergeConfig(fileCfg, env), override);
+  if (!merged.apiKey) {
+    throw new Error('No API key. Run `shogo login` or pass --api-key / set SHOGO_API_KEY.');
+  }
+  return {
+    apiKey: merged.apiKey,
+    cloudUrl: merged.cloudUrl ?? DEFAULTS.cloudUrl,
+    name: merged.name ?? hostname(),
+    workerDir: merged.workerDir ?? process.cwd(),
+    port: merged.port ?? DEFAULTS.port,
+  };
+}

--- a/packages/shogo-worker/src/lib/paths.ts
+++ b/packages/shogo-worker/src/lib/paths.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Path helpers for the Shogo Worker CLI.
+ * Config, PID, and logs live under ~/.shogo/ on all platforms.
+ */
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { mkdirSync } from 'node:fs';
+
+export const HOME_DIR = join(homedir(), '.shogo');
+export const CONFIG_FILE = join(HOME_DIR, 'config.json');
+export const PID_FILE = join(HOME_DIR, 'worker.pid');
+export const LOGS_DIR = join(HOME_DIR, 'logs');
+export const WORKER_LOG = join(LOGS_DIR, 'worker.log');
+export const WORKER_ERR = join(LOGS_DIR, 'worker.err.log');
+
+export function ensureHome(): void {
+  mkdirSync(HOME_DIR, { recursive: true, mode: 0o700 });
+  mkdirSync(LOGS_DIR, { recursive: true, mode: 0o700 });
+}

--- a/packages/shogo-worker/src/lib/preflight.ts
+++ b/packages/shogo-worker/src/lib/preflight.ts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Preflight checks for `shogo worker start --debug`.
+ *
+ * Verifies: runtime version, worker directory, proxy (when set), all three
+ * allowlist hosts (control/tunnel/artifacts), and API-key validity. The
+ * allowlist probes match what `docs/my-machines-networking.md` tells
+ * security teams to open, so if preflight passes we know the firewall is
+ * correctly configured.
+ *
+ * The `criticality` field on each host controls the overall pass/fail:
+ *   - fatal    → must reach. Preflight fails.
+ *   - graceful → should reach, but the worker will start anyway (we only
+ *                warn, because tunnel-direct + artifacts are optional per
+ *                the failure-modes table).
+ */
+import pc from 'picocolors';
+import { existsSync } from 'node:fs';
+import { deriveAllowlist, probeProxy, type ProxyConfig, type AllowlistHost } from './transport.ts';
+
+export interface Check {
+  name: string;
+  /** 'fatal' ⇒ overall preflight fails; 'graceful' ⇒ prints a warning only. */
+  criticality?: 'fatal' | 'graceful';
+  run(): Promise<{ ok: boolean; detail?: string }>;
+}
+
+const DEFAULT_PROBE_TIMEOUT_MS = 5000;
+
+async function probeHealth(url: string, timeoutMs: number): Promise<{ ok: boolean; detail: string }> {
+  try {
+    const ctl = new AbortController();
+    const t = setTimeout(() => ctl.abort(), timeoutMs);
+    const r = await fetch(`${url.replace(/\/$/, '')}/health`, { signal: ctl.signal }).catch(() => null);
+    clearTimeout(t);
+    if (!r) return { ok: false, detail: 'no response (firewall? DNS?)' };
+    return { ok: true, detail: `HTTP ${r.status}` };
+  } catch (err: any) {
+    return { ok: false, detail: err?.message ?? 'unknown error' };
+  }
+}
+
+export const makeChecks = (opts: {
+  cloudUrl: string;
+  apiKey: string;
+  workerDir: string;
+  proxy?: ProxyConfig | null;
+}): Check[] => {
+  const checks: Check[] = [
+    {
+      name: 'Runtime (node >= 20)',
+      criticality: 'fatal',
+      async run() {
+        const [major] = process.versions.node.split('.').map(Number);
+        return (major ?? 0) >= 20
+          ? { ok: true, detail: `node v${process.versions.node}` }
+          : { ok: false, detail: `node v${process.versions.node} — need >=20` };
+      },
+    },
+    {
+      name: 'Worker directory exists',
+      criticality: 'fatal',
+      async run() {
+        return existsSync(opts.workerDir)
+          ? { ok: true, detail: opts.workerDir }
+          : { ok: false, detail: `${opts.workerDir} does not exist` };
+      },
+    },
+  ];
+
+  if (opts.proxy) {
+    checks.push({
+      name: `Proxy reachable (${safeHost(opts.proxy.url)})`,
+      criticality: 'fatal',
+      async run() {
+        return probeProxy(opts.proxy!);
+      },
+    });
+  }
+
+  const allowlist = deriveAllowlist(opts.cloudUrl);
+  for (const entry of allowlist) {
+    checks.push({
+      name: `Reach ${entry.host}${entry.purpose !== 'control' ? pc.dim(` (${entry.purpose})`) : ''}`,
+      criticality: entry.criticality,
+      run: () => probeHealth(entry.url, DEFAULT_PROBE_TIMEOUT_MS),
+    });
+  }
+
+  checks.push({
+    name: 'API key valid',
+    criticality: 'fatal',
+    async run() {
+      try {
+        const r = await fetch(`${opts.cloudUrl}/api/instances/heartbeat`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', 'x-api-key': opts.apiKey },
+          body: JSON.stringify({
+            hostname: 'preflight',
+            name: 'preflight',
+            os: 'preflight',
+            arch: 'preflight',
+            metadata: { preflight: true },
+          }),
+        });
+        if (r.status === 401 || r.status === 403) {
+          return { ok: false, detail: `HTTP ${r.status} — key rejected` };
+        }
+        return r.ok
+          ? { ok: true, detail: `HTTP ${r.status}` }
+          : { ok: false, detail: `HTTP ${r.status}` };
+      } catch (err: any) {
+        return { ok: false, detail: err?.message ?? 'unknown error' };
+      }
+    },
+  });
+
+  return checks;
+};
+
+function safeHost(raw: string): string {
+  try { return new URL(raw).host; } catch { return raw; }
+}
+
+export async function runPreflight(checks: Check[]): Promise<boolean> {
+  console.log(pc.bold('\nShogo Worker — Preflight\n'));
+  let fatalFailed = false;
+  let gracefulFailed = 0;
+  for (const c of checks) {
+    process.stdout.write(`  ${pc.dim('...')} ${c.name}`);
+    const result = await c.run();
+    process.stdout.write('\r');
+    if (result.ok) {
+      console.log(
+        `  ${pc.green('✓')} ${c.name}${result.detail ? pc.dim(` — ${result.detail}`) : ''}`,
+      );
+    } else if (c.criticality === 'graceful') {
+      console.log(
+        `  ${pc.yellow('◦')} ${c.name}${result.detail ? pc.dim(` — ${result.detail}`) : ''}${pc.yellow(' (optional — worker will still start)')}`,
+      );
+      gracefulFailed++;
+    } else {
+      console.log(
+        `  ${pc.red('✗')} ${c.name}${result.detail ? pc.dim(` — ${result.detail}`) : ''}`,
+      );
+      fatalFailed = true;
+    }
+  }
+  if (!fatalFailed && gracefulFailed === 0) {
+    console.log(pc.green('\nAll checks passed.\n'));
+  } else if (!fatalFailed) {
+    console.log(pc.yellow(`\nStarting with ${gracefulFailed} optional host(s) blocked. See docs/my-machines-networking.md.\n`));
+  } else {
+    console.log(pc.red('\nPreflight failed — fix blocking issues before starting.\n'));
+  }
+  return !fatalFailed;
+}

--- a/packages/shogo-worker/src/lib/process-manager.ts
+++ b/packages/shogo-worker/src/lib/process-manager.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Manages the lifecycle of the spawned apps/api worker process.
+ *
+ * Single-instance enforcement via a PID file at ~/.shogo/worker.pid:
+ * one worker per machine is intentional — mirrors Cursor's `agent worker`
+ * behaviour so the cloud-side instance identity stays 1:1 with a machine
+ * rather than multiplexing across forks.
+ *
+ * Signal hygiene: callers that hold the CLI process in the foreground
+ * (`shogo worker start --foreground`) should invoke `installShutdownHooks()`
+ * so Ctrl-C / SIGTERM tears down the child and clears the PID file.
+ * The detached codepath doesn't need it — once `child.unref()` runs the
+ * CLI exits and the child owns its own PID file.
+ */
+import { spawn, type ChildProcess } from 'node:child_process';
+import { existsSync, openSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { PID_FILE, WORKER_LOG, WORKER_ERR, ensureHome } from './paths.ts';
+
+export interface SpawnOpts {
+  entry: string;
+  runner: 'bun' | 'node';
+  env: NodeJS.ProcessEnv;
+  cwd: string;
+  detach?: boolean;
+  inheritStdio?: boolean;
+}
+
+export function readPid(): number | null {
+  if (!existsSync(PID_FILE)) return null;
+  const raw = readFileSync(PID_FILE, 'utf-8').trim();
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function isRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearPid(): void {
+  try { unlinkSync(PID_FILE); } catch {}
+}
+
+export function spawnWorker(opts: SpawnOpts): { pid: number; child: ChildProcess } {
+  ensureHome();
+
+  const existingPid = readPid();
+  if (existingPid && isRunning(existingPid)) {
+    throw new Error(`Worker already running (pid=${existingPid}). Run \`shogo worker stop\` first.`);
+  }
+  if (existingPid) clearPid();
+
+  const stdio: ("ignore" | "inherit" | number)[] = opts.inheritStdio
+    ? ['ignore', 'inherit', 'inherit']
+    : ['ignore', openSync(WORKER_LOG, 'a'), openSync(WORKER_ERR, 'a')];
+
+  const child = spawn(opts.runner, [opts.entry], {
+    cwd: opts.cwd,
+    env: opts.env,
+    detached: !!opts.detach,
+    stdio: stdio as any,
+  });
+
+  if (!child.pid) throw new Error('Failed to spawn worker process.');
+  writeFileSync(PID_FILE, String(child.pid), { mode: 0o600 });
+
+  if (opts.detach) child.unref();
+  return { pid: child.pid, child };
+}
+
+/**
+ * Install SIGINT / SIGTERM / exit handlers that forward the signal to the
+ * foreground child and clear the PID file. Idempotent — safe to call twice.
+ *
+ * Only meaningful for foreground runs; detached workers own their own
+ * lifecycle after `child.unref()`.
+ */
+export function installShutdownHooks(child: ChildProcess): void {
+  let shutdownStarted = false;
+  const shutdown = (signal: NodeJS.Signals) => {
+    if (shutdownStarted) return;
+    shutdownStarted = true;
+    try { child.kill(signal); } catch { /* already gone */ }
+    clearPid();
+  };
+
+  process.once('SIGINT', () => shutdown('SIGINT'));
+  process.once('SIGTERM', () => shutdown('SIGTERM'));
+  process.once('SIGHUP', () => shutdown('SIGHUP'));
+  process.once('exit', () => {
+    if (!shutdownStarted) clearPid();
+  });
+
+  // Propagate child's exit to this process for foreground runs.
+  child.on('exit', (code, signal) => {
+    clearPid();
+    if (signal) process.exit(128 + (signalToInt(signal) ?? 0));
+    process.exit(code ?? 0);
+  });
+}
+
+function signalToInt(signal: NodeJS.Signals): number | undefined {
+  const map: Record<string, number> = { SIGHUP: 1, SIGINT: 2, SIGQUIT: 3, SIGTERM: 15 };
+  return map[signal];
+}
+
+export function stopWorker(signal: NodeJS.Signals = 'SIGTERM'): { killedPid: number | null } {
+  const pid = readPid();
+  if (!pid) return { killedPid: null };
+  if (!isRunning(pid)) {
+    clearPid();
+    return { killedPid: null };
+  }
+  try { process.kill(pid, signal); } catch {}
+  clearPid();
+  return { killedPid: pid };
+}

--- a/packages/shogo-worker/src/lib/transport.ts
+++ b/packages/shogo-worker/src/lib/transport.ts
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Corporate-proxy support + allowlist host derivation for the Shogo Worker.
+ *
+ * Reads HTTPS_PROXY / https_proxy / HTTP_PROXY / http_proxy from the
+ * environment and returns a normalized proxy URL (or null if not set).
+ *
+ * The CLI does NOT install a global undici dispatcher on the CLI process
+ * itself — the CLI only spawns the worker subprocess. Instead we forward
+ * the env to the child; the child's Node runtime picks it up automatically
+ * (undici >= 5.29 honours HTTPS_PROXY via getGlobalDispatcher).
+ *
+ * We also offer a reachability probe so `--debug` preflight can verify the
+ * proxy before spinning anything up. The probe uses a real CONNECT request
+ * to the target host on :443, which is exactly what the worker's TLS
+ * traffic needs — a plain GET to the proxy root can pass even when the
+ * proxy is misconfigured for CONNECT.
+ */
+import { request as httpRequest } from "node:http";
+
+export interface ProxyConfig {
+  /** Normalized proxy URL (scheme://host:port). */
+  url: string;
+  /** Which env var (or flag) it came from — for debug output. */
+  source:
+    | "flag"
+    | "HTTPS_PROXY"
+    | "https_proxy"
+    | "HTTP_PROXY"
+    | "http_proxy";
+}
+
+/**
+ * Resolve the effective proxy from a --proxy override + env.
+ * Precedence: flag > HTTPS_PROXY > https_proxy > HTTP_PROXY > http_proxy.
+ */
+export function resolveProxy(flag?: string, env: NodeJS.ProcessEnv = process.env): ProxyConfig | null {
+  const trimmed = (s: string | undefined) => (s && s.trim().length > 0 ? s.trim() : undefined);
+  const viaFlag = trimmed(flag);
+  if (viaFlag) return { url: normalize(viaFlag), source: "flag" };
+
+  const candidates: [ProxyConfig["source"], string | undefined][] = [
+    ["HTTPS_PROXY", env.HTTPS_PROXY],
+    ["https_proxy", env.https_proxy],
+    ["HTTP_PROXY", env.HTTP_PROXY],
+    ["http_proxy", env.http_proxy],
+  ];
+  for (const [source, value] of candidates) {
+    const v = trimmed(value);
+    if (v) return { url: normalize(v), source };
+  }
+  return null;
+}
+
+/** Normalize bare host:port into scheme-prefixed URL. */
+function normalize(raw: string): string {
+  if (/^https?:\/\//i.test(raw)) return raw;
+  return `http://${raw}`;
+}
+
+/**
+ * Inject the proxy into a child process env so the spawned worker uses it.
+ * Sets both upper- and lower-case variants for maximum compatibility.
+ */
+export function applyProxyToEnv(env: NodeJS.ProcessEnv, proxy: ProxyConfig | null): NodeJS.ProcessEnv {
+  if (!proxy) return env;
+  return {
+    ...env,
+    HTTPS_PROXY: env.HTTPS_PROXY ?? proxy.url,
+    https_proxy: env.https_proxy ?? proxy.url,
+    HTTP_PROXY: env.HTTP_PROXY ?? proxy.url,
+    http_proxy: env.http_proxy ?? proxy.url,
+  };
+}
+
+/**
+ * Probe the proxy by issuing an HTTP CONNECT to `targetHost:443`.
+ * This mirrors what the worker's TLS traffic will actually do, so it catches
+ * proxies that answer :80 but reject CONNECT tunneling.
+ *
+ * Accepts 200/407 as "proxy is answering":
+ *  - 200 → tunnel established.
+ *  - 407 → proxy requires authentication (still proves reachability; surfaces
+ *          an actionable error on stdout).
+ * Network errors fail the probe.
+ */
+export async function probeProxy(
+  proxy: ProxyConfig,
+  targetHost = "api.shogo.ai",
+  timeoutMs = 5000,
+): Promise<{ ok: boolean; detail: string }> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (result: { ok: boolean; detail: string }) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+
+    try {
+      const u = new URL(proxy.url);
+      const proxyHost = u.hostname;
+      const proxyPort = u.port ? parseInt(u.port, 10) : u.protocol === "https:" ? 443 : 80;
+
+      const req = httpRequest({
+        method: "CONNECT",
+        host: proxyHost,
+        port: proxyPort,
+        path: `${targetHost}:443`,
+        timeout: timeoutMs,
+      });
+
+      req.on("connect", (res) => {
+        req.destroy();
+        const status = res.statusCode ?? 0;
+        if (status === 200) {
+          settle({ ok: true, detail: `CONNECT ${targetHost}:443 → 200 (via ${proxyHost}:${proxyPort})` });
+        } else if (status === 407) {
+          settle({
+            ok: false,
+            detail: `407 Proxy Authentication Required — check credentials in ${proxy.source}`,
+          });
+        } else {
+          settle({ ok: false, detail: `CONNECT → HTTP ${status}` });
+        }
+      });
+
+      req.on("timeout", () => {
+        req.destroy();
+        settle({ ok: false, detail: `timeout after ${timeoutMs}ms` });
+      });
+
+      req.on("error", (err: NodeJS.ErrnoException) => {
+        const code = err.code ? ` (${err.code})` : "";
+        settle({ ok: false, detail: `${err.message}${code}` });
+      });
+
+      req.end();
+    } catch (err: any) {
+      settle({ ok: false, detail: err?.message ?? "unknown error" });
+    }
+  });
+}
+
+/**
+ * Derive the full outbound allowlist (3 hosts) from a single cloudUrl.
+ *
+ * Shogo Worker talks to three hosts, as documented in
+ * `docs/my-machines-networking.md`:
+ *
+ *   1. <cloud>                 — session control plane (FATAL if blocked)
+ *   2. <cloud>-direct (or api-direct.<rootDomain>) — WS tunnel fallback
+ *   3. artifacts.<rootDomain>  — artifact uploads (graceful if blocked)
+ *
+ * The rule for #2/#3 is: take the rootDomain of the cloud URL and prefix it.
+ * This supports region-pinned deploys (EU, US) without hardcoding.
+ */
+export interface AllowlistHost {
+  url: string;
+  host: string;
+  purpose: "control" | "tunnel-direct" | "artifacts";
+  criticality: "fatal" | "graceful";
+}
+
+export function deriveAllowlist(cloudUrl: string): AllowlistHost[] {
+  let u: URL;
+  try {
+    u = new URL(cloudUrl);
+  } catch {
+    return [];
+  }
+
+  const host = u.host; // e.g. "studio.shogo.ai"
+  const scheme = u.protocol.replace(":", "") || "https";
+
+  // rootDomain = last two dotted labels — "shogo.ai" from "studio.shogo.ai".
+  // If the host is already 2 labels (e.g. "shogo.ai"), keep it as-is.
+  const parts = u.hostname.split(".");
+  const rootDomain = parts.length >= 2 ? parts.slice(-2).join(".") : u.hostname;
+
+  return [
+    {
+      url: `${scheme}://${host}`,
+      host,
+      purpose: "control",
+      criticality: "fatal",
+    },
+    {
+      url: `${scheme}://api-direct.${rootDomain}`,
+      host: `api-direct.${rootDomain}`,
+      purpose: "tunnel-direct",
+      criticality: "graceful",
+    },
+    {
+      url: `${scheme}://artifacts.${rootDomain}`,
+      host: `artifacts.${rootDomain}`,
+      purpose: "artifacts",
+      criticality: "graceful",
+    },
+  ];
+}

--- a/packages/shogo-worker/tsconfig.json
+++ b/packages/shogo-worker/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*", "bin/**/*"]
+}


### PR DESCRIPTION
## Summary

This PR completes the first end-to-end **My Machines** experience: users can pair a machine they own, run Shogo agents through that machine, see which execution environment is active, recover when the machine drops offline, and install/publish the worker through a real CLI release path.

It is intentionally built on the existing Remote Control / instance tunnel infrastructure. Shogo Cloud remains the default runtime. When a user chooses a paired machine, agent traffic is routed through `/api/instances/:id/p/*` to the worker over the existing outbound WebSocket tunnel, so the user's machine never needs inbound firewall access.

## Why This Exists

Before this PR, the codebase had substantial tunnel and instance-registry infrastructure, but the product surface was incomplete:

- Users did not have a packaged CLI workflow for pairing a laptop, devbox, or CI runner.
- Chat did not expose a clear Cloud vs My Machine environment picker.
- A selected machine could drop mid-conversation without a first-class fallback UX.
- Remote Control could show instances, but lacked the management polish for add, rename, remove, and install guidance.
- MCP execution needed a documented model for what should run on the worker versus in the cloud.
- Networking/security teams needed concrete allowlist and troubleshooting docs.

This PR fills those gaps so the flow feels like a real Cloud Agent -> My Machines product surface instead of a set of backend primitives.

## Architecture

```mermaid
flowchart LR
  User[User in Shogo app] --> Picker[Environment Picker]
  Picker -->|Cloud selected| CloudRuntime[Shogo Cloud agent runtime]
  Picker -->|Machine selected| Proxy[apps/api /api/instances/:id/p/*]

  WorkerCLI[shogo worker CLI] --> LocalAPI[Local bundled apps/api]
  LocalAPI -->|Heartbeat HTTPS| Registry[Cloud instance registry]
  LocalAPI -->|Outbound WebSocket on demand| Proxy
  Proxy -->|Tunnel request/stream| LocalAPI
  LocalAPI --> LocalRuntime[Local agent runtime]

  LocalRuntime --> StdioMCP[stdio MCP tools on user's machine]
  LocalRuntime --> PrivateServices[VPN / localhost / filesystem]
  CloudRuntime --> PublicServices[Public cloud reachable services]
```

The important invariant is that all machine connectivity is outbound from the worker to Shogo Cloud. The browser/mobile app never connects directly to the user's machine, and no inbound port is opened on the user's network.

### Runtime Selection Flow

```mermaid
sequenceDiagram
  participant UI as Mobile/Web Chat UI
  participant API as Shogo Cloud API
  participant Worker as shogo worker machine
  participant Runtime as Agent Runtime

  UI->>API: GET /api/instances
  API-->>UI: Online/heartbeat/offline machines
  UI->>UI: User selects machine in EnvironmentPicker
  UI->>API: Agent request via /api/instances/:id/p/...
  API->>Worker: Tunnel request over outbound WS
  Worker->>Runtime: Execute locally in worker dir
  Runtime-->>Worker: Response / stream chunks
  Worker-->>API: Tunnel response / stream chunks
  API-->>UI: Chat response / tool output
```

### Offline Recovery Flow

```mermaid
stateDiagram-v2
  [*] --> Cloud: no active instance
  Cloud --> Worker: user selects paired machine
  Worker --> Worker: poll /api/instances/:id every 15s
  Worker --> Offline: status becomes offline or validation fails
  Offline --> Cloud: user taps Continue in cloud
  Offline --> Worker: user waits and machine heartbeats again
```

## UX Before And After

### Before

- Chat execution was effectively cloud-first with no obvious inline control for selecting a paired machine.
- Remote Control was closer to an infrastructure screen than a complete machine-management flow.
- If the active machine disappeared, users could see tunnel errors but did not get a guided recovery action.
- There was no single install path that told users how to get a worker running and visible in the product.
- Docs did not clearly explain which hosts must be allowlisted or how to debug corporate proxy/firewall failures.

### After

- Chat has a compact `EnvironmentPicker` that lets users choose `Shogo Cloud` or one of their paired machines.
- When a machine is active, the chat surface shows execution context with `ExecutionBadge` and future-ready `TransportBadge` primitives.
- The active instance provider polls live status and `InstanceOfflineWatcher` shows a toast when the selected machine drops, with `Continue in cloud` and `Wait` actions.
- Remote Control now supports add-device instructions, copyable install commands, rename, remove, OS/status metadata, relative last-seen times, and active instance clearing when removed.
- The worker CLI gives users a concrete lifecycle: `shogo login`, `shogo worker start`, `status`, `logs`, `stop`, and `config`.
- Docs now include quickstart, networking, troubleshooting, and MCP transport-routing guidance.

## What Changed

### Worker CLI and Installer

- Added `packages/shogo-worker` as a new workspace package for `@shogo-ai/worker`.
- Added CLI entrypoint and commands:
  - `shogo login`
  - `shogo worker start`
  - `shogo worker stop`
  - `shogo worker status`
  - `shogo worker logs`
  - `shogo config show/set`
- Added config resolution across CLI flags, environment variables, and `~/.shogo/config.json`.
- Added process management with one worker per machine through `~/.shogo/worker.pid`.
- Added detached and foreground modes, log files, shutdown hooks, and stale PID cleanup.
- Added API discovery so local/dev and packaged/bundled API entrypoints can both work.
- Added worker preflight checks for runtime version, worker directory, proxy reachability, allowlist hosts, and API key validity.
- Added corporate proxy support via `--proxy`, `HTTPS_PROXY`, `https_proxy`, `HTTP_PROXY`, and `http_proxy`.
- Added `install.sh` and `install.ps1` installers for Unix/macOS/Linux and Windows.
- Added `publish-cli.yml` to build compiled CLI artifacts for macOS, Linux, and Windows and publish GitHub Releases from `shogo-cli-v*` tags.

### API, Tunnel, And Storage Improvements

- Improved instance tunnel errors so revoked/invalid worker keys point users toward `/api-keys` and `shogo login`.
- Made local heartbeat scheduling tolerant of local SQLite databases that do not yet have `agent_configs`, avoiding noisy worker logs.
- Added instance update/delete support used by Remote Control rename/remove flows.
- Improved transparent proxy behavior for the selected-machine path.
- Added dedicated artifact S3 helpers so artifact uploads can use `S3_ARTIFACT_*` config and be isolated from schema/project storage when needed.
- Updated thumbnail/artifact call sites to use the artifact storage path.

### Mobile/Web UX

- Added `EnvironmentPicker` in chat so users can choose Cloud or a paired machine without leaving the conversation.
- Added `ExecutionBadge` so selected machine execution is visible without making the default cloud mode noisy.
- Added `TransportBadge` as a reusable primitive for showing whether a tool call ran in Cloud or on a worker.
- Updated chat inputs/tool displays so the new picker and execution context fit into the existing chat UX.
- Added `InstanceOfflineWatcher`, mounted near the app root, to show a recovery toast when the selected machine stops heartbeating.
- Updated `ChatPanel` tunnel-error handling so users can reconnect or continue in cloud after an offline error.
- Expanded Remote Control with add-device modal, install snippet copy, rename, remove, status/OS badges, relative last-seen, and active-instance cleanup after removal.

### Shared Active Instance State

- Extended `useActiveInstance` with `instanceStatus`.
- Added 15-second validation polling while a machine is selected.
- Kept `remoteAgentBaseUrl` as the routing primitive for `/api/instances/:id/p` agent traffic.
- Preserved the existing persisted active-instance behavior while clearing invalid/deleted instances.

### MCP Routing Preparation

- Added `mcp-transport-routing.ts` with pure helpers for choosing cloud vs worker execution by MCP transport and optional pin.
- Added `cloud-fetcher.ts` with public/private host detection and a cloud dispatcher for future HTTP/SSE MCP pinning.
- Updated `mcp-client.ts` minimally to support the additive routing model without forcing the full behavior switch in this PR.
- Added focused tests covering stdio, HTTP, SSE, explicit pins, private host detection, malformed URLs, and cloud dispatcher lifecycle.
- Added `docs/mcp-transport-routing.md` explaining current behavior, desired routing matrix, rollout steps, and validation expectations.

### Documentation

- Added My Machines quickstart docs.
- Added My Machines networking docs with the three-host outbound allowlist model.
- Added My Machines troubleshooting docs for common install, login, heartbeat, tunnel, proxy, and firewall failures.
- Added root-level networking and MCP design docs for reviewers and future implementers.
- Added My Machines to the docs sidebar.

## File Change Map

### CLI and worker package

- `packages/shogo-worker/README.md`: user-facing CLI quickstart, commands, networking, proxy, and troubleshooting.
- `packages/shogo-worker/package.json`: package metadata, binary registration, build/typecheck scripts, and dependencies.
- `packages/shogo-worker/bin/shogo.mjs`: executable bin shim.
- `packages/shogo-worker/src/cli.ts`: top-level command tree and error handling.
- `packages/shogo-worker/src/commands/login.ts`: API key login/config write path.
- `packages/shogo-worker/src/commands/start.ts`: worker process startup, env injection, proxy/preflight wiring.
- `packages/shogo-worker/src/commands/stop.ts`: worker stop command.
- `packages/shogo-worker/src/commands/status.ts`: worker status command.
- `packages/shogo-worker/src/commands/logs.ts`: worker log tailing command.
- `packages/shogo-worker/src/commands/config.ts`: config show/set commands.
- `packages/shogo-worker/src/lib/api-discovery.ts`: locate the API entrypoint in dev or packaged layouts.
- `packages/shogo-worker/src/lib/config.ts`: config file/env/flag resolution.
- `packages/shogo-worker/src/lib/paths.ts`: `~/.shogo` paths.
- `packages/shogo-worker/src/lib/preflight.ts`: debug preflight checks.
- `packages/shogo-worker/src/lib/process-manager.ts`: PID file, spawn, stop, shutdown, and logs.
- `packages/shogo-worker/src/lib/transport.ts`: proxy resolution/probing and outbound allowlist derivation.
- `packages/shogo-worker/install.sh`: Unix installer.
- `packages/shogo-worker/install.ps1`: Windows installer.
- `packages/shogo-worker/tsconfig.json`: TypeScript config for the package.

### CI and dependency metadata

- `.github/workflows/publish-cli.yml`: release workflow for compiled CLI binaries.
- `bun.lock`: lockfile updates for the worker and agent-runtime additions.

### API and backend support

- `apps/api/src/lib/instance-tunnel.ts`: clearer auth/tunnel failure messaging.
- `apps/api/src/lib/local-heartbeat-scheduler.ts`: local-mode heartbeat robustness.
- `apps/api/src/lib/s3.ts`: artifact-specific S3 client/bucket/presign helpers.
- `apps/api/src/routes/instances.ts`: instance management and proxy behavior used by My Machines UX.
- `apps/api/src/routes/thumbnail.ts`: artifact storage integration.

### Mobile/web UX

- `apps/mobile/app/(app)/remote-control.tsx`: full Remote Control management UX.
- `apps/mobile/app/_layout.tsx`: mounts the offline watcher inside the provider stack.
- `apps/mobile/components/chat/EnvironmentPicker.tsx`: chat execution environment picker.
- `apps/mobile/components/chat/ExecutionBadge.tsx`: visible active-machine execution badge.
- `apps/mobile/components/chat/TransportBadge.tsx`: reusable Cloud/worker tool execution pill.
- `apps/mobile/components/instance/InstanceOfflineWatcher.tsx`: selected-machine offline toast and fallback action.
- `apps/mobile/components/chat/ChatInput.tsx`: picker/badge integration.
- `apps/mobile/components/chat/CompactChatInput.tsx`: compact input integration.
- `apps/mobile/components/chat/ChatPanel.tsx`: offline fallback action after tunnel errors.
- `apps/mobile/components/chat/ToolCallDisplay.tsx`: transport-badge integration point.
- `apps/mobile/components/chat/tools/ToolPill.tsx`: transport-badge integration point.
- `apps/mobile/components/chat/turns/ToolCallGroup.tsx`: transport-badge integration point.

### Shared app state

- `packages/shared-app/src/hooks/useActiveInstance.tsx`: live active-machine status polling and validation.
- `packages/shared-app/src/chat/message-helpers.ts`: friendly offline/tunnel error detection.

### Agent runtime and MCP routing

- `packages/agent-runtime/package.json`: dependency update for routing/cloud fetcher support.
- `packages/agent-runtime/src/lib/mcp-transport-routing.ts`: pure MCP routing decision helpers.
- `packages/agent-runtime/src/lib/cloud-fetcher.ts`: future cloud-pinned HTTP/SSE fetcher and private-host detection.
- `packages/agent-runtime/src/mcp-client.ts`: minimal integration surface for the additive routing model.
- `packages/agent-runtime/src/__tests__/mcp-transport-routing.test.ts`: focused tests for routing and cloud fetcher decisions.

### Docs

- `apps/docs/docs/features/my-machines/quickstart.md`: user quickstart.
- `apps/docs/docs/features/my-machines/networking.md`: firewall/proxy/security-team guide.
- `apps/docs/docs/features/my-machines/troubleshooting.md`: operational troubleshooting.
- `apps/docs/sidebars.ts`: docs navigation entry.
- `docs/my-machines-networking.md`: deeper engineering networking reference.
- `docs/mcp-transport-routing.md`: MCP transport-routing architecture and rollout plan.

## Rollout Notes

- Default behavior remains Cloud unless a user explicitly selects a paired machine.
- Worker networking is outbound-only and compatible with corporate proxies.
- Artifact storage remains backward compatible: if `S3_ARTIFACT_*` variables are unset, existing S3 config is reused.
- MCP routing helpers are additive. The full HTTP/SSE pin-to-cloud behavior is documented and tested, but can be wired in follow-up PRs behind a feature flag.
- CLI releases are tag-driven through `shogo-cli-v*` tags.

## Validation

- `bun test packages/agent-runtime/src/__tests__/mcp-transport-routing.test.ts`
- `bun run --cwd packages/shogo-worker typecheck`
- IDE lints checked for worker, MCP routing/cloud fetcher, active instance state, environment picker, and offline watcher files.

## Reviewer Checklist

- Verify the chat picker UX reads clearly in both Cloud and selected-machine states.
- Verify Remote Control rename/remove/add-device flows match expected product language.
- Confirm the worker CLI command names and install snippets are the final public API we want to document.
- Confirm `S3_ARTIFACT_*` names match deployment conventions.
- Confirm MCP HTTP/SSE routing should remain additive in this PR rather than fully enabled immediately.
