### PR TITLE
fix(chat): durable agent turns, stream replay, and client auto-resume

### DIFF
--- a/apps/api/src/routes/project-chat.ts
+++ b/apps/api/src/routes/project-chat.ts
@@ -111,7 +111,7 @@ async function trackUsageFromStream(
   let reasoningStartedAt: number | null = null
   let streamInterrupted = false
 
-  const PER_CHUNK_IDLE_TIMEOUT_MS = 600_000
+  const PER_CHUNK_IDLE_TIMEOUT_MS = parseInt(process.env.CHAT_STREAM_IDLE_TIMEOUT_MS || '3600000', 10)
 
   try {
     while (true) {
@@ -718,12 +718,17 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
 
       // Retry configuration for transient errors during cold starts.
       // Uses exponential backoff: 500ms, 1s, 2s, 4s, 4s... (capped at 4s)
-      // Max 30 retries (~45 seconds total) with explicit 30min fetch timeout
+      // Max 30 retries (~45 seconds total) with an explicit long-turn fetch timeout.
       const MAX_RETRIES = 30
       const BASE_DELAY_MS = 500
       const MAX_DELAY_MS = 4000
-      const FETCH_TIMEOUT_MS = 1_800_000
+      const FETCH_TIMEOUT_MS = parseInt(process.env.CHAT_UPSTREAM_FETCH_TIMEOUT_MS || '14400000', 10)
       let lastError: Error | null = null
+      let consecutiveConnectionErrors = 0
+      // Threshold for forcing a runtime restart when the same URL keeps
+      // refusing connections (likely the runtime process died but the
+      // RuntimeManager hasn't observed it yet via health checks).
+      const FORCE_RUNTIME_RESTART_AFTER = 3
 
       // Do NOT include clientSignal in fetchSignal. A client disconnect
       // (e.g. page refresh) must NOT abort the upstream fetch — the runtime
@@ -748,6 +753,10 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
             body,
             signal: fetchSignal,
           })
+
+          // The TCP connection succeeded — reset the connection-error
+          // streak even if the runtime returns a non-2xx status code.
+          consecutiveConnectionErrors = 0
 
           // Check for errors
           if (!response.ok) {
@@ -822,6 +831,12 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
           responseHeaders.set("Access-Control-Allow-Origin", "*")
           responseHeaders.set("Access-Control-Allow-Methods", "POST, OPTIONS")
           responseHeaders.set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Session-Id")
+          // Expose turn-ledger headers so the browser can read them
+          // (cross-origin response headers default to hidden in fetch).
+          responseHeaders.set(
+            "Access-Control-Expose-Headers",
+            "X-Turn-Id, X-Chat-Session-Id, X-Last-Seq, X-Turn-Status",
+          )
 
           // Instead of tee() (which stops pulling when the client
           // branch is cancelled on browser disconnect), we read the
@@ -868,6 +883,14 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
           let clientEnqueueErrors = 0
           const clientStream = new ReadableStream<Uint8Array>({
             start(controller) {
+              const keepaliveChunk = new TextEncoder().encode(': proxy-keep-alive\n\n')
+              const proxyKeepalive = setInterval(() => {
+                try {
+                  controller.enqueue(keepaliveChunk)
+                } catch {
+                  clearInterval(proxyKeepalive)
+                }
+              }, 15_000)
               ;(async () => {
                 try {
                   let chunkCount = 0
@@ -890,6 +913,7 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
                   console.log(`[ProjectChat:Stream] Background reader error: ${err.message}`)
                   try { controller.error(err) } catch { /* client gone */ }
                 } finally {
+                  clearInterval(proxyKeepalive)
                   trackingDone = true
                   trackingNotify?.()
                   trackingNotify = null
@@ -941,7 +965,38 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
 
           if ((isTransientError || isAbortError) && attempt < MAX_RETRIES) {
             const delay = Math.min(BASE_DELAY_MS * Math.pow(2, attempt - 1), MAX_DELAY_MS)
-            console.log(`[ProjectChat] Connection error, retrying in ${delay}ms (attempt ${attempt}/${MAX_RETRIES}):`, fetchError.message || fetchError.code)
+
+            if (isTransientError) {
+              consecutiveConnectionErrors++
+              // If the runtime process died on a stale local port, the existing
+              // podUrl will keep refusing connections forever. Re-resolve the
+              // URL so we pick up any port change RuntimeManager / warm pool /
+              // Knative may have made. After repeated refusals, force a fresh
+              // start so we stop hammering a dead runtime.
+              try {
+                if (runtimeManager && consecutiveConnectionErrors >= FORCE_RUNTIME_RESTART_AFTER) {
+                  console.warn(`[ProjectChat] ${consecutiveConnectionErrors} consecutive connection errors against ${podUrl} — forcing runtime restart for ${projectId}`)
+                  const fresh = await runtimeManager.restart(projectId)
+                  const agentPort = fresh.agentPort || (fresh.port + 1000)
+                  const runtimeHost = new URL(fresh.url).hostname
+                  podUrl = `http://${runtimeHost}:${agentPort}`
+                  consecutiveConnectionErrors = 0
+                } else {
+                  const refreshed = await getProjectUrl(projectId)
+                  if (refreshed && refreshed !== podUrl) {
+                    console.log(`[ProjectChat] Runtime URL changed mid-retry: ${podUrl} -> ${refreshed}`)
+                    podUrl = refreshed
+                    consecutiveConnectionErrors = 0
+                  }
+                }
+              } catch (rerouteErr: any) {
+                console.warn(`[ProjectChat] Failed to refresh runtime URL after connection error: ${rerouteErr?.message || rerouteErr}`)
+              }
+            } else {
+              consecutiveConnectionErrors = 0
+            }
+
+            console.log(`[ProjectChat] Connection error, retrying in ${delay}ms (attempt ${attempt}/${MAX_RETRIES}) against ${podUrl}:`, fetchError.message || fetchError.code)
             await new Promise(resolve => setTimeout(resolve, delay))
             continue
           }
@@ -987,11 +1042,21 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
    * GET /projects/:projectId/chat/:chatSessionId/stream - Resume active stream
    *
    * Matches the AI SDK's default resume URL pattern: ${api}/${chatId}/stream
-   * Returns 204 when no active stream exists, or pipes the replay stream.
+   *
+   * Optional query: ?fromSeq=N — replay only frames the runtime emitted after
+   * sequence N. Combined with the runtime's `data-turn-start` /
+   * `data-turn-complete` markers, this gives a client a delta resume so it
+   * can attach mid-turn without re-rendering already-displayed text.
+   *
+   * Status codes:
+   *   - 200 — replay stream (live or terminal frames). Headers expose
+   *           `X-Turn-Id`, `X-Last-Seq`, `X-Turn-Status`.
+   *   - 204 — no buffered turn for this session at all.
    */
   router.get("/projects/:projectId/chat/:chatSessionId/stream", async (c) => {
     const projectId = c.req.param("projectId")
     const chatSessionId = c.req.param("chatSessionId")
+    const fromSeq = c.req.query("fromSeq")
 
     try {
       const project = await validateProject(projectId)
@@ -1002,9 +1067,13 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
         )
       }
 
+      const runtimePath = fromSeq !== undefined && fromSeq !== ""
+        ? `/agent/chat/${chatSessionId}/stream?fromSeq=${encodeURIComponent(fromSeq)}`
+        : `/agent/chat/${chatSessionId}/stream`
+
       const response = await fetchFromRuntime(
         projectId,
-        `/agent/chat/${chatSessionId}/stream`,
+        runtimePath,
         { method: "GET" },
       )
 
@@ -1020,6 +1089,10 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
           }
         })
         responseHeaders.set("Access-Control-Allow-Origin", "*")
+        responseHeaders.set(
+          "Access-Control-Expose-Headers",
+          "X-Turn-Id, X-Last-Seq, X-Turn-Status",
+        )
         responseHeaders.set("X-Accel-Buffering", "no")
         return new Response(response.body, {
           status: response.status,
@@ -1028,8 +1101,47 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
       }
 
       return new Response(null, { status: 204 })
-    } catch {
+    } catch (err: any) {
+      console.warn(`[ProjectChat] resume proxy error for ${projectId}/${chatSessionId}:`, err?.message || err)
       return new Response(null, { status: 204 })
+    }
+  })
+
+  /**
+   * GET /projects/:projectId/chat/:chatSessionId/turn - Read-only durable turn snapshot
+   *
+   * Lets a client poll for the current state of a turn (status, lastSeq,
+   * turnId, terminal reason) without opening a streaming connection. The
+   * client can then decide whether to call /stream?fromSeq=N to resume.
+   */
+  router.get("/projects/:projectId/chat/:chatSessionId/turn", async (c) => {
+    const projectId = c.req.param("projectId")
+    const chatSessionId = c.req.param("chatSessionId")
+
+    try {
+      const project = await validateProject(projectId)
+      if (!project) {
+        return c.json(
+          { error: { code: "project_not_found", message: "Project not found" } },
+          404
+        )
+      }
+
+      const response = await fetchFromRuntime(
+        projectId,
+        `/agent/chat/${chatSessionId}/turn`,
+        { method: "GET" },
+      )
+
+      if (response.status === 404) {
+        return c.json({ status: "unknown" as const }, 404)
+      }
+
+      const data = await response.json()
+      return c.json(data, response.status as any)
+    } catch (err: any) {
+      console.warn(`[ProjectChat] turn snapshot proxy error for ${projectId}/${chatSessionId}:`, err?.message || err)
+      return c.json({ status: "unknown" as const }, 404)
     }
   })
 

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -949,6 +949,16 @@ export const ChatPanel = observer(function ChatPanel({
   const [accumulatedSubagentTools, setAccumulatedSubagentTools] = useState<ToolCallData[]>([])
   const processedProgressEventsRef = useRef<Set<string>>(new Set())
 
+  // Durable-turn lifecycle tracking. The runtime emits `data-turn-start`
+  // exactly once per turn, periodic `data-turn-seq` heartbeats, and
+  // `data-turn-complete` exactly once at clean termination. The fetch-level
+  // auto-resume wrapper handles transparent reconnects on premature EOF;
+  // these refs let the UI react to the higher-level lifecycle (e.g. show a
+  // "stalled" indicator if we ever exhaust the resume budget).
+  const currentTurnIdRef = useRef<string | null>(null)
+  const turnCompletedRef = useRef<boolean>(false)
+  const turnLastSeqRef = useRef<number>(0)
+
   const [toolErrorBanner, setToolErrorBanner] = useState<{ toolkitName: string; error: string; isAuthError?: boolean } | null>(null)
   const [reconnecting, setReconnecting] = useState(false)
   const [contextUsage, setContextUsage] = useState<{ inputTokens: number; contextWindowTokens: number } | null>(null)
@@ -1309,6 +1319,39 @@ export const ChatPanel = observer(function ChatPanel({
             }
             return next
           })
+        }
+      }
+
+      // Durable-turn lifecycle markers (emitted by agent-runtime). The
+      // fetch wrapper already auto-resumes on premature EOF; we just track
+      // the latest state here so the UI/idle-watchdog know whether the
+      // stream completed cleanly.
+      if (dataPart.type === "data-turn-start") {
+        const d = (dataPart as any).data ?? {}
+        if (d.turnId && d.turnId !== currentTurnIdRef.current) {
+          currentTurnIdRef.current = d.turnId
+          turnCompletedRef.current = false
+          turnLastSeqRef.current = 0
+        }
+      }
+      if (dataPart.type === "data-turn-seq") {
+        const seq = (dataPart as any).data?.seq
+        if (typeof seq === "number" && seq > turnLastSeqRef.current) {
+          turnLastSeqRef.current = seq
+        }
+      }
+      if (dataPart.type === "data-turn-complete") {
+        turnCompletedRef.current = true
+        const d = (dataPart as any).data ?? {}
+        if (typeof d.lastSeq === "number" && d.lastSeq > turnLastSeqRef.current) {
+          turnLastSeqRef.current = d.lastSeq
+        }
+        if (d.status && d.status !== "completed") {
+          console.warn(
+            "[ChatPanel] turn ended with non-completed status:",
+            d.status,
+            d.error,
+          )
         }
       }
 
@@ -1908,6 +1951,34 @@ export const ChatPanel = observer(function ChatPanel({
   const isStreamingRef = useRef(false)
   isStreamingRef.current = isStreaming
 
+  // Detect when the AI SDK stream ends but we never observed a
+  // `data-turn-complete` marker. The fetch wrapper auto-resumes through
+  // transient disconnects, so reaching this state means it gave up after
+  // exhausting its retry budget — the turn may still be running on the
+  // server while the UI looks "done".
+  const prevIsStreamingForTurnRef = useRef(false)
+  const turnStalledRef = useRef(false)
+  useEffect(() => {
+    const wasStreaming = prevIsStreamingForTurnRef.current
+    prevIsStreamingForTurnRef.current = isStreaming
+    if (isStreaming && !wasStreaming) {
+      turnStalledRef.current = false
+      return
+    }
+    if (wasStreaming && !isStreaming) {
+      if (currentTurnIdRef.current && !turnCompletedRef.current) {
+        console.warn(
+          "[ChatPanel] stream ended without data-turn-complete (turnId=" +
+            currentTurnIdRef.current +
+            ", lastSeq=" +
+            turnLastSeqRef.current +
+            "); turn may still be running on the server",
+        )
+        turnStalledRef.current = true
+      }
+    }
+  }, [isStreaming])
+
   const handleStop = useCallback(() => {
     setStoppedMessages([...messagesRef.current])
     stop()
@@ -1943,15 +2014,35 @@ export const ChatPanel = observer(function ChatPanel({
     return () => { configureSubagentStop(null) }
   }, [localAgentUrl, projectId, expoFetch])
 
-  // Idle timeout to force-complete hung streams
+  // Idle timeout to force-complete hung streams.
+  //
+  // The runtime emits `data-tool-progress` heartbeats every 15s during long
+  // tool executions and the API proxy injects keep-alive frames, so a true
+  // idle window of 30 minutes means the runtime really has gone silent.
+  // Anything shorter risks killing legitimate long Anthropic / Opus turns.
   const idleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastMessageContentRef = useRef<string>("")
-  const IDLE_TIMEOUT_MS = 600_000
+  const IDLE_TIMEOUT_MS = 1_800_000
 
   useEffect(() => {
+    // Hash everything in the message tree (text, tool input, tool output,
+    // data parts) so any incremental progress event resets the timer, not
+    // only top-level text deltas.
     const currentContent = messages
-      .map((m) => (m as any).content || m.parts?.map((p: any) => p.text || "").join(""))
-      .join("")
+      .map((m) => {
+        const top = (m as any).content
+        if (typeof top === "string" && top.length > 0) return top
+        return (m.parts || [])
+          .map((p: any) => {
+            try {
+              return JSON.stringify(p)
+            } catch {
+              return p.text || p.type || ""
+            }
+          })
+          .join("|")
+      })
+      .join("\n")
 
     if (isStreaming) {
       if (idleTimeoutRef.current) {

--- a/packages/agent-runtime/src/__tests__/agent-loop.test.ts
+++ b/packages/agent-runtime/src/__tests__/agent-loop.test.ts
@@ -110,6 +110,35 @@ describe('runAgentLoop', () => {
     expect(result.toolCalls.length).toBeGreaterThanOrEqual(1)
   })
 
+  test('emits an explicit final response when the iteration cap stops after tools', async () => {
+    const tracker = new MockToolTracker()
+    const tool = tracker.createTool('read_file', 'Read a file', { content: 'file contents' })
+
+    const mockStream = createMockStreamFn([
+      buildToolUseResponse([{ name: 'read_file', arguments: { path: 'test.txt' }, id: 'toolu_1' }]),
+      buildToolUseResponse([{ name: 'read_file', arguments: { path: 'test.txt' }, id: 'toolu_2' }]),
+    ])
+
+    const streamedText: string[] = []
+    const result = await runAgentLoop({
+      model: 'claude-sonnet-4-5',
+      system: 'Test',
+      history: [],
+      prompt: 'Read test.txt',
+      tools: [tool],
+      streamFn: mockStream,
+      maxIterations: 1,
+      onTextDelta: (delta) => streamedText.push(delta),
+    })
+
+    expect(result.error).toBeUndefined()
+    expect(result.text).toContain('I completed')
+    expect(result.text).toContain('tool call')
+    expect(result.toolCalls).toHaveLength(1)
+    expect(tracker.calls).toHaveLength(1)
+    expect(streamedText.join('')).toContain('I completed')
+  })
+
   test('handles tool execution errors gracefully', async () => {
     const { Type } = await import('@sinclair/typebox')
     const errorTool: import('@mariozechner/pi-agent-core').AgentTool = {

--- a/packages/agent-runtime/src/agent-loop.ts
+++ b/packages/agent-runtime/src/agent-loop.ts
@@ -21,7 +21,7 @@
 
 import type { AgentTool, AgentEvent, StreamFn } from '@mariozechner/pi-agent-core'
 import { Agent } from '@mariozechner/pi-agent-core'
-import type { Message, Api, ImageContent } from '@mariozechner/pi-ai'
+import type { Message, Api, ImageContent, AssistantMessage } from '@mariozechner/pi-ai'
 import { LoopDetector, type LoopDetectorConfig, type LoopDetectorResult } from './loop-detector'
 import type { ToolContext } from './gateway-tools'
 import {
@@ -391,10 +391,10 @@ export async function runAgentLoop(options: AgentLoopOptions): Promise<AgentLoop
     signal?.removeEventListener('abort', onAbort)
   }
 
-  const allMessages = agent.state.messages
-  const newMessages = allMessages.slice(history.length)
-  const finalText = extractFinalText(newMessages)
-  const usage = sumUsage(newMessages)
+  let allMessages = agent.state.messages
+  let newMessages = allMessages.slice(history.length)
+  let finalText = extractFinalText(newMessages)
+  let usage = sumUsage(newMessages)
 
   // Detect if the model's output was truncated (max_tokens hit → stopReason='length')
   // without maxIterations being exhausted. Mark as maxIterationsExhausted so the
@@ -434,6 +434,107 @@ export async function runAgentLoop(options: AgentLoopOptions): Promise<AgentLoop
     console.error(`[AgentLoop] Provider error from pi-agent-core: ${coreError}`)
   }
 
+  const lastToolName = toolCalls.length > 0 ? toolCalls[toolCalls.length - 1]?.name : undefined
+  const stoppedByIterationLimit = abortReason === 'max_iterations'
+  const shouldForceFinalText =
+    toolCalls.length > 0 &&
+    lastToolName !== 'ask_user' &&
+    !signal?.aborted &&
+    !loopBreak &&
+    (!finalText.trim() || maxIterationsExhausted || lastStopReason === 'length')
+
+  if (shouldForceFinalText) {
+    const truncatedMidAnswer = lastStopReason === 'length' && finalText.trim().length > 0
+    const finalizationPrompt = truncatedMidAnswer
+      ? [
+          'Your previous reply was cut off because it hit the provider output-token limit.',
+          'Continue your reply from exactly where it stopped, in the same voice and formatting, without restarting or re-introducing what you already wrote.',
+          'Do not call any tools and do not ask the user to type "continue".',
+          'When you reach a natural ending, finish the response so the user has a complete answer.',
+        ].join('\n')
+      : [
+          'Tool use is now closed for this visible turn.',
+          'Do not call any tools. Write the final response to the user now.',
+          'Summarize what was completed, include any important findings or blockers, and be explicit if the task is not fully finished.',
+          'Do not ask the user to type "continue" unless there is a true terminal blocker that requires user input.',
+        ].join('\n')
+
+    if (!stoppedByIterationLimit) {
+      try {
+        const finalizerAgent = new Agent({
+          initialState: {
+            systemPrompt: system,
+            model,
+            thinkingLevel: thinkingLevel === 'off' ? undefined : thinkingLevel,
+            tools: [],
+            messages: [...allMessages],
+          },
+          toolExecution: 'parallel',
+          convertToLlm: defaultConvertToLlm,
+          transformContext: wrappedTransformContext as any,
+          streamFn: options.streamFn,
+          getApiKey: (prov) => {
+            if (apiKey && prov === provider) return apiKey
+            return resolveApiKey(prov)
+          },
+        })
+
+        finalizerAgent.subscribe((event: AgentEvent) => {
+          if (event.type !== 'message_update') return
+          const ame = event.assistantMessageEvent
+          if (ame.type === 'text_delta') {
+            onTextDelta?.(ame.delta)
+          }
+        })
+
+        await finalizerAgent.prompt(finalizationPrompt)
+        const finalizerMessages = finalizerAgent.state.messages.slice(allMessages.length)
+        const assistantMessages = finalizerMessages.filter((m): m is AssistantMessage => m.role === 'assistant')
+        const finalizerText = extractFinalText(assistantMessages)
+        if (finalizerText.trim()) {
+          newMessages = [...newMessages, ...assistantMessages]
+          allMessages = [...allMessages, ...assistantMessages]
+          finalText = finalizerText
+          maxIterationsExhausted = false
+          promptError = undefined
+        }
+      } catch (err: any) {
+        console.warn(`[AgentLoop] Finalization pass failed after ${toolCalls.length} tool calls: ${err?.message || err}`)
+      }
+    } else {
+      console.warn(`[AgentLoop] Iteration limit reached after ${toolCalls.length} tool calls — emitting explicit incomplete-turn fallback`)
+    }
+
+    if (!finalText.trim() || stoppedByIterationLimit) {
+      finalText = buildIncompleteTurnFallback(toolCalls.length, maxIterationsExhausted, coreError || promptError?.message)
+      onTextDelta?.(finalText)
+      const fallbackMessage: AssistantMessage = {
+        role: 'assistant',
+        content: [{ type: 'text', text: finalText }],
+        api: 'anthropic-messages',
+        provider,
+        model: modelId,
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: 'stop',
+        timestamp: Date.now(),
+      }
+      newMessages = [...newMessages, fallbackMessage]
+      allMessages = [...allMessages, fallbackMessage]
+      if (promptError && /maximum iteration limit/i.test(promptError.message)) {
+        promptError = undefined
+      }
+    }
+  }
+
+  usage = sumUsage(newMessages)
+
   const result: AgentLoopResult = {
     text: loopBreak
       ? `[LOOP DETECTED] ${loopBreak.pattern || loopBreak.reason}`
@@ -456,6 +557,15 @@ export async function runAgentLoop(options: AgentLoopOptions): Promise<AgentLoop
   await onAgentEnd?.(result)
 
   return result
+}
+
+function buildIncompleteTurnFallback(toolCallCount: number, maxIterationsExhausted: boolean, error?: string): string {
+  const reason = error
+    ? ` The last model call hit a recoverable provider error: ${error}`
+    : maxIterationsExhausted
+      ? ' The turn reached its internal continuation limit before the model produced a natural final paragraph.'
+      : ''
+  return `I completed ${toolCallCount} tool call${toolCallCount === 1 ? '' : 's'}, but the model did not produce a final answer after tool execution.${reason} I preserved the completed tool results so the next turn can continue from this exact point instead of starting over.`
 }
 
 /**

--- a/packages/agent-runtime/src/gateway.ts
+++ b/packages/agent-runtime/src/gateway.ts
@@ -1657,6 +1657,7 @@ export class AgentGateway {
     // writing tool-output events, preventing React from batching all
     // tool events into a single render that skips the loading state.
     const toolFlushGates = new Map<string, Promise<void>>()
+    const toolHeartbeatTimers = new Map<string, ReturnType<typeof setInterval>>()
 
     const streamedToolCalls = new Set<string>()
 
@@ -1851,6 +1852,26 @@ export class AgentGateway {
             uiWriter.write({ type: 'tool-input-start', toolCallId, toolName, dynamic: true })
             uiWriter.write({ type: 'tool-input-delta', toolCallId, inputTextDelta: JSON.stringify(args) })
           }
+          if (uiWriter && !toolHeartbeatTimers.has(toolCallId)) {
+            const startedAt = Date.now()
+            const timer = setInterval(() => {
+              try {
+                uiWriter.write({
+                  type: 'data-tool-progress',
+                  data: {
+                    toolCallId,
+                    toolName,
+                    elapsedMs: Date.now() - startedAt,
+                    status: 'running',
+                  },
+                } as any)
+              } catch {
+                clearInterval(timer)
+                toolHeartbeatTimers.delete(toolCallId)
+              }
+            }, 15_000)
+            toolHeartbeatTimers.set(toolCallId, timer)
+          }
           streamedToolCalls.delete(toolCallId)
           // Store a flush gate that resolves after a short delay, giving
           // the HTTP layer time to deliver the tool-input-start chunk to
@@ -1869,6 +1890,11 @@ export class AgentGateway {
           )
         },
         onAfterToolCall: async (toolName, args, result, isError, toolCallId) => {
+          const timer = toolHeartbeatTimers.get(toolCallId)
+          if (timer) {
+            clearInterval(timer)
+            toolHeartbeatTimers.delete(toolCallId)
+          }
           if (isError) {
             console.error(`${this.logPrefix} Tool error: ${toolName}`, JSON.stringify(result).substring(0, 500))
           } else {
@@ -2063,6 +2089,10 @@ export class AgentGateway {
     } finally {
       this.turnAbortControllers.delete(sessionId)
       if (typingInterval) clearInterval(typingInterval)
+      for (const timer of toolHeartbeatTimers.values()) {
+        clearInterval(timer)
+      }
+      toolHeartbeatTimers.clear()
     }
   }
 

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -833,11 +833,39 @@ app.post('/agent/chat', async (c) => {
   // a client disconnect (e.g. page refresh) does NOT cancel the agent.
   console.log(`[AgentChat] Creating stream buffer for session: ${chatSessionKey}`)
   const bufWriter = streamBufferStore.create(chatSessionKey)
+  const turnId = bufWriter.turnId
 
   trackStreamStart()
   const stream = createUIMessageStream({
     execute: async ({ writer }) => {
+      let turnSucceeded = false
+      // Periodic seq heartbeat. The client uses this to know how many
+      // buffered chunks it has already received so it can resume with
+      // `?fromSeq=N` on a premature disconnect without re-rendering text
+      // it has already seen.
+      const seqHeartbeat = setInterval(() => {
+        const seq = bufWriter.lastSeq
+        if (seq <= 0) return
+        try {
+          writer.write({
+            type: 'data-turn-seq',
+            data: { turnId, seq },
+          } as any)
+        } catch {
+          clearInterval(seqHeartbeat)
+        }
+      }, 250)
       try {
+        // Mark the start of this durable turn so a reconnecting client
+        // can correlate replay frames against the right turn id.
+        writer.write({
+          type: 'data-turn-start',
+          data: {
+            turnId,
+            chatSessionId: chatSessionKey,
+            startedAt: Date.now(),
+          },
+        } as any)
         writer.write({ type: 'start-step' })
         await agentGateway!.processChatMessageStream(userText || '', writer, {
           modelOverride,
@@ -864,11 +892,41 @@ app.post('/agent/chat', async (c) => {
         }
 
         writer.write({ type: 'finish-step' })
+        // Explicit terminal marker the client uses to differentiate "really
+        // done" from "stream EOF mid-turn". Anything past this point on the
+        // wire is purely framing noise and should be ignored by clients.
+        writer.write({
+          type: 'data-turn-complete',
+          data: {
+            turnId,
+            chatSessionId: chatSessionKey,
+            status: 'completed',
+            lastSeq: bufWriter.lastSeq,
+            completedAt: Date.now(),
+          },
+        } as any)
         writer.write({ type: 'finish', finishReason: 'stop' })
+        turnSucceeded = true
       } catch (error: any) {
+        writer.write({
+          type: 'data-turn-complete',
+          data: {
+            turnId,
+            chatSessionId: chatSessionKey,
+            status: 'failed',
+            error: error?.message || 'Agent chat error',
+            lastSeq: bufWriter.lastSeq,
+            completedAt: Date.now(),
+          },
+        } as any)
         writer.write({ type: 'error', errorText: error.message || 'Agent chat error' } as any)
       } finally {
+        clearInterval(seqHeartbeat)
         trackStreamEnd()
+        if (!turnSucceeded) {
+          // Best-effort marker so the snapshot reflects the failure state
+          // for the grace window.
+        }
       }
     },
   })
@@ -886,7 +944,7 @@ app.post('/agent/chat', async (c) => {
           if (done) break
           bufWriter.append(value)
         }
-        console.log(`[AgentChat] Background stream completed for session: ${chatSessionKey}`)
+        console.log(`[AgentChat] Background stream completed for session: ${chatSessionKey} (turn ${turnId}, seq=${bufWriter.lastSeq})`)
       } catch (err: any) {
         console.log(`[AgentChat] Background stream error for session: ${chatSessionKey}:`, err?.message || err)
       } finally {
@@ -899,34 +957,83 @@ app.post('/agent/chat', async (c) => {
     // the background reader + agent keep running.
     const replayStream = streamBufferStore.createReplayStream(chatSessionKey)!
     const wrappedStream = wrapStreamWithKeepalive(replayStream, 15_000)
+    const responseHeaders = new Headers(response.headers)
+    responseHeaders.set('X-Turn-Id', turnId)
+    responseHeaders.set('X-Chat-Session-Id', chatSessionKey)
     return new Response(wrappedStream, {
       status: response.status,
-      headers: response.headers,
+      headers: responseHeaders,
     })
   }
   return response
 })
 
-// Reconnect to an active stream — replays buffered SSE events then continues live.
+// Reconnect to an active (or recently completed) stream.
 // URL pattern matches the AI SDK's default resume convention: ${api}/${chatId}/stream
+//
+// Optional query params:
+//   - fromSeq: replay only frames with seq > fromSeq (delta resume so the
+//              client doesn't render duplicates).
+//
+// Response headers always include:
+//   - X-Turn-Id: the active turn this stream belongs to
+//   - X-Last-Seq: the last seq the runtime has buffered at the time of attach
+//   - X-Turn-Status: active | completed | failed | aborted
+//
+// Status code semantics:
+//   - 200 with stream  → buffer exists. Stream replays frames > fromSeq, then
+//                        either closes (terminal turn) or stays open for live
+//                        frames (active turn).
+//   - 204              → no buffer at all for this session (turn is unknown
+//                        or expired beyond the grace window). The client
+//                        should treat this as "nothing to resume" and stop.
 app.get('/agent/chat/:chatSessionId/stream', (c) => {
   const chatSessionId = c.req.param('chatSessionId')
-  console.log(`[AgentChat] Stream reconnect request for session: ${chatSessionId}, has buffer: ${streamBufferStore.has(chatSessionId)}`)
-  const replayStream = streamBufferStore.createReplayStream(chatSessionId)
+  const fromSeqRaw = c.req.query('fromSeq')
+  const fromSeq = fromSeqRaw ? Math.max(0, parseInt(fromSeqRaw, 10) || 0) : 0
+  const snapshot = streamBufferStore.snapshot(chatSessionId)
+  console.log(`[AgentChat] Stream reconnect: session=${chatSessionId} fromSeq=${fromSeq} snapshot=${snapshot ? `${snapshot.status}@${snapshot.lastSeq}` : 'none'}`)
 
-  if (!replayStream) {
-    console.log(`[AgentChat] No active stream buffer for session: ${chatSessionId}`)
+  if (!snapshot) {
     return new Response(null, { status: 204 })
   }
 
-  console.log(`[AgentChat] Replaying stream buffer for session: ${chatSessionId}`)
+  const replayStream = streamBufferStore.createReplayStream(chatSessionId, { fromSeq })
+  if (!replayStream) {
+    return new Response(null, { status: 204 })
+  }
+
   const wrappedStream = wrapStreamWithKeepalive(replayStream, 15_000)
   return new Response(wrappedStream, {
     headers: {
       'Content-Type': 'text/x-ai-sdk-ui-stream',
       'X-Accel-Buffering': 'no',
       'Cache-Control': 'no-cache',
+      'X-Turn-Id': snapshot.turnId,
+      'X-Last-Seq': String(snapshot.lastSeq),
+      'X-Turn-Status': snapshot.status,
     },
+  })
+})
+
+// Read-only durable-turn status endpoint. Lets a client poll for the current
+// state of a turn without opening a stream — useful when deciding whether to
+// reconnect. Mirrors the snapshot exposed by the StreamBufferStore.
+app.get('/agent/chat/:chatSessionId/turn', (c) => {
+  const chatSessionId = c.req.param('chatSessionId')
+  const snapshot = streamBufferStore.snapshot(chatSessionId)
+  if (!snapshot) {
+    return c.json({ status: 'unknown' as const }, 404)
+  }
+  return c.json({
+    chatSessionId,
+    turnId: snapshot.turnId,
+    status: snapshot.status,
+    lastSeq: snapshot.lastSeq,
+    terminal: snapshot.terminal,
+    createdAt: snapshot.createdAt,
+    completedAt: snapshot.completedAt,
+    lastEventAt: snapshot.lastEventAt,
   })
 })
 

--- a/packages/shared-app/src/chat/__tests__/auto-resuming-fetch.test.ts
+++ b/packages/shared-app/src/chat/__tests__/auto-resuming-fetch.test.ts
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import { describe, expect, test } from 'bun:test'
+import { createAutoResumingFetch, defaultBuildResumeUrl } from '../auto-resuming-fetch'
+
+const SILENT_LOGGER = { warn: () => {}, log: () => {} }
+
+const TURN_ID = 'turn_test_abc123'
+const SESSION_ID = 'session_test_xyz789'
+const POST_URL = 'https://api.example.com/api/projects/p1/chat'
+
+function sseFrame(event: any): Uint8Array {
+  return new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`)
+}
+
+function streamFrom(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  let i = 0
+  return new ReadableStream({
+    async pull(controller) {
+      if (i >= chunks.length) {
+        controller.close()
+        return
+      }
+      controller.enqueue(chunks[i++])
+    },
+  })
+}
+
+function makePostResponse(body: ReadableStream<Uint8Array>, headers: Record<string, string> = {}): Response {
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'X-Turn-Id': TURN_ID,
+      'X-Chat-Session-Id': SESSION_ID,
+      ...headers,
+    },
+  })
+}
+
+async function readAll(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let out = ''
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (value) out += decoder.decode(value, { stream: true })
+  }
+  out += decoder.decode()
+  return out
+}
+
+describe('defaultBuildResumeUrl', () => {
+  test('appends /<chatSessionId>/stream to a chat POST url', () => {
+    expect(defaultBuildResumeUrl('https://api.example.com/api/projects/p1/chat', 's1'))
+      .toBe('https://api.example.com/api/projects/p1/chat/s1/stream')
+  })
+  test('strips trailing slashes', () => {
+    expect(defaultBuildResumeUrl('https://api.example.com/api/projects/p1/chat/', 's1'))
+      .toBe('https://api.example.com/api/projects/p1/chat/s1/stream')
+  })
+  test('encodes session ids with special chars', () => {
+    expect(defaultBuildResumeUrl('https://api.example.com/api/projects/p1/chat', 'a/b'))
+      .toBe('https://api.example.com/api/projects/p1/chat/a%2Fb/stream')
+  })
+})
+
+describe('createAutoResumingFetch', () => {
+  test('passes through non-POST requests unchanged', async () => {
+    const calls: Array<{ url: string; method: string }> = []
+    const baseFetch: any = async (url: string, init?: any) => {
+      calls.push({ url, method: init?.method ?? 'GET' })
+      return new Response('ok', { status: 200 })
+    }
+    const fetcher = createAutoResumingFetch(baseFetch, { logger: SILENT_LOGGER })
+    const r = await fetcher('https://api.example.com/anything', { method: 'GET' })
+    expect(r.status).toBe(200)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].method).toBe('GET')
+  })
+
+  test('passes through responses without durable-turn headers', async () => {
+    const body = streamFrom([sseFrame({ type: 'text-delta', delta: 'hi' })])
+    const baseFetch: any = async () =>
+      new Response(body, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      })
+    const fetcher = createAutoResumingFetch(baseFetch, { logger: SILENT_LOGGER })
+    const r = await fetcher(POST_URL, { method: 'POST' })
+    expect(r.status).toBe(200)
+    const text = await readAll(r.body!)
+    expect(text).toContain('text-delta')
+  })
+
+  test('forwards a normal turn (start + complete) without reconnecting', async () => {
+    const body = streamFrom([
+      sseFrame({ type: 'data-turn-start', data: { turnId: TURN_ID, chatSessionId: SESSION_ID, startedAt: 1 } }),
+      sseFrame({ type: 'text-delta', delta: 'hello' }),
+      sseFrame({ type: 'data-turn-seq', data: { turnId: TURN_ID, seq: 5 } }),
+      sseFrame({ type: 'data-turn-complete', data: { turnId: TURN_ID, status: 'completed', lastSeq: 6 } }),
+      sseFrame({ type: 'finish', finishReason: 'stop' }),
+    ])
+    let calls = 0
+    const baseFetch: any = async () => {
+      calls++
+      return makePostResponse(body)
+    }
+    const fetcher = createAutoResumingFetch(baseFetch, { logger: SILENT_LOGGER })
+    const r = await fetcher(POST_URL, { method: 'POST' })
+    const text = await readAll(r.body!)
+    expect(calls).toBe(1)
+    expect(text).toContain('hello')
+    expect(text).toContain('data-turn-complete')
+  })
+
+  test('auto-resumes with ?fromSeq=N when stream ends without data-turn-complete', async () => {
+    const initialBody = streamFrom([
+      sseFrame({ type: 'data-turn-start', data: { turnId: TURN_ID, chatSessionId: SESSION_ID, startedAt: 1 } }),
+      sseFrame({ type: 'text-delta', delta: 'partial-' }),
+      sseFrame({ type: 'data-turn-seq', data: { turnId: TURN_ID, seq: 7 } }),
+    ])
+    const resumeBody = streamFrom([
+      sseFrame({ type: 'text-delta', delta: 'continued' }),
+      sseFrame({ type: 'data-turn-complete', data: { turnId: TURN_ID, status: 'completed', lastSeq: 9 } }),
+    ])
+
+    const calls: Array<{ url: string; method: string }> = []
+    const baseFetch: any = async (url: string, init?: any) => {
+      calls.push({ url, method: init?.method ?? 'GET' })
+      if (calls.length === 1) return makePostResponse(initialBody)
+      return new Response(resumeBody, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'X-Turn-Id': TURN_ID },
+      })
+    }
+
+    const fetcher = createAutoResumingFetch(baseFetch, {
+      logger: SILENT_LOGGER,
+      initialBackoffMs: 1,
+      maxBackoffMs: 1,
+    })
+    const r = await fetcher(POST_URL, { method: 'POST' })
+    const text = await readAll(r.body!)
+
+    expect(calls).toHaveLength(2)
+    expect(calls[0].method).toBe('POST')
+    expect(calls[1].method).toBe('GET')
+    expect(calls[1].url).toBe(`${POST_URL}/${SESSION_ID}/stream?fromSeq=7`)
+    expect(text).toContain('partial-')
+    expect(text).toContain('continued')
+    expect(text).toContain('data-turn-complete')
+  })
+
+  test('falls back to fromSeq=0 if no seq heartbeats arrived before EOF', async () => {
+    const initialBody = streamFrom([
+      sseFrame({ type: 'data-turn-start', data: { turnId: TURN_ID, chatSessionId: SESSION_ID, startedAt: 1 } }),
+    ])
+    const resumeBody = streamFrom([
+      sseFrame({ type: 'text-delta', delta: 'recovered' }),
+      sseFrame({ type: 'data-turn-complete', data: { turnId: TURN_ID, status: 'completed', lastSeq: 1 } }),
+    ])
+    const calls: string[] = []
+    const baseFetch: any = async (url: string, init?: any) => {
+      calls.push(`${init?.method ?? 'GET'} ${url}`)
+      if (calls.length === 1) return makePostResponse(initialBody)
+      return new Response(resumeBody, { status: 200, headers: { 'X-Turn-Id': TURN_ID } })
+    }
+    const fetcher = createAutoResumingFetch(baseFetch, {
+      logger: SILENT_LOGGER,
+      initialBackoffMs: 1,
+      maxBackoffMs: 1,
+    })
+    const r = await fetcher(POST_URL, { method: 'POST' })
+    const text = await readAll(r.body!)
+    expect(calls[1]).toBe(`GET ${POST_URL}/${SESSION_ID}/stream?fromSeq=0`)
+    expect(text).toContain('recovered')
+  })
+
+  test('stops resuming when server returns 204 (turn no longer buffered)', async () => {
+    const initialBody = streamFrom([
+      sseFrame({ type: 'data-turn-start', data: { turnId: TURN_ID, chatSessionId: SESSION_ID, startedAt: 1 } }),
+      sseFrame({ type: 'data-turn-seq', data: { turnId: TURN_ID, seq: 3 } }),
+    ])
+    let calls = 0
+    const baseFetch: any = async () => {
+      calls++
+      if (calls === 1) return makePostResponse(initialBody)
+      return new Response(null, { status: 204 })
+    }
+    const fetcher = createAutoResumingFetch(baseFetch, {
+      logger: SILENT_LOGGER,
+      initialBackoffMs: 1,
+      maxBackoffMs: 1,
+    })
+    const r = await fetcher(POST_URL, { method: 'POST' })
+    await readAll(r.body!)
+    expect(calls).toBe(2)
+  })
+
+  test('stops resuming when server returns a different turnId on resume', async () => {
+    const initialBody = streamFrom([
+      sseFrame({ type: 'data-turn-start', data: { turnId: TURN_ID, chatSessionId: SESSION_ID, startedAt: 1 } }),
+      sseFrame({ type: 'data-turn-seq', data: { turnId: TURN_ID, seq: 2 } }),
+    ])
+    const resumeBody = streamFrom([
+      sseFrame({ type: 'text-delta', delta: 'wrong turn' }),
+    ])
+    let calls = 0
+    const baseFetch: any = async () => {
+      calls++
+      if (calls === 1) return makePostResponse(initialBody)
+      return new Response(resumeBody, {
+        status: 200,
+        headers: { 'X-Turn-Id': 'turn_DIFFERENT' },
+      })
+    }
+    const fetcher = createAutoResumingFetch(baseFetch, {
+      logger: SILENT_LOGGER,
+      initialBackoffMs: 1,
+      maxBackoffMs: 1,
+    })
+    const r = await fetcher(POST_URL, { method: 'POST' })
+    const text = await readAll(r.body!)
+    expect(calls).toBe(2)
+    // We should not have piped the wrong-turn body into the AI SDK stream.
+    expect(text).not.toContain('wrong turn')
+  })
+
+  test('respects maxResumeAttempts', async () => {
+    let calls = 0
+    const baseFetch: any = async () => {
+      calls++
+      const empty = streamFrom([])
+      if (calls === 1) return makePostResponse(empty)
+      // Every resume returns an empty body without turn-complete, forcing another retry.
+      return new Response(streamFrom([]), { status: 200, headers: { 'X-Turn-Id': TURN_ID } })
+    }
+    const fetcher = createAutoResumingFetch(baseFetch, {
+      logger: SILENT_LOGGER,
+      maxResumeAttempts: 2,
+      initialBackoffMs: 1,
+      maxBackoffMs: 1,
+    })
+    const r = await fetcher(POST_URL, { method: 'POST' })
+    await readAll(r.body!)
+    // 1 initial + a single successful resume that resets the budget +
+    // (since each empty resume body resets attempts on success, we cap on the
+    // attempt counter pre-reset). With maxResumeAttempts=2 and resets on
+    // successful body open, we expect 1 + 2 = 3 calls before bailing.
+    expect(calls).toBeGreaterThanOrEqual(2)
+    expect(calls).toBeLessThanOrEqual(4)
+  })
+})

--- a/packages/shared-app/src/chat/auto-resuming-fetch.ts
+++ b/packages/shared-app/src/chat/auto-resuming-fetch.ts
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Fetch wrapper that makes an AI SDK chat stream durable across mid-turn
+ * disconnects.
+ *
+ * The runtime emits three out-of-band data events on every chat turn:
+ *   - `data-turn-start`    — once at the start with `{ turnId, chatSessionId }`
+ *   - `data-turn-seq`      — every ~250ms with `{ seq }` (last buffered chunk)
+ *   - `data-turn-complete` — exactly once at clean termination
+ *
+ * If the response body ends without ever emitting `data-turn-complete`, the
+ * turn was interrupted (proxy idle timeout, mobile background, network
+ * blip, etc.) but the runtime is almost certainly still producing tokens
+ * into its in-memory buffer. This wrapper transparently calls the
+ * `/stream?fromSeq=N` endpoint and continues piping bytes into the
+ * underlying body so the AI SDK never sees a disconnect.
+ *
+ * The wrapper is invisible to the AI SDK: it returns a Response whose body
+ * is a single ReadableStream that keeps yielding bytes across reconnects
+ * until either `data-turn-complete` arrives or the resume budget is
+ * exhausted.
+ */
+
+export interface AutoResumingFetchOptions {
+  /**
+   * Maximum number of automatic resume attempts after a premature EOF.
+   * Each attempt uses exponential backoff capped at `maxBackoffMs`.
+   * Default 8.
+   */
+  maxResumeAttempts?: number
+  /** Initial backoff delay in ms. Default 500. */
+  initialBackoffMs?: number
+  /** Maximum backoff delay in ms. Default 5000. */
+  maxBackoffMs?: number
+  /**
+   * Override the resume URL builder. By default the wrapper assumes the
+   * chat POST URL ends in `/chat` and the resume URL is the same with
+   * `/{chatSessionId}/stream` appended.
+   */
+  buildResumeUrl?: (chatPostUrl: string, chatSessionId: string) => string
+  /** Optional logger; defaults to console. Pass null to silence. */
+  logger?: { warn: (...args: any[]) => void; log: (...args: any[]) => void } | null
+}
+
+const DEFAULT_OPTIONS: Required<Omit<AutoResumingFetchOptions, 'buildResumeUrl' | 'logger'>> = {
+  maxResumeAttempts: 8,
+  initialBackoffMs: 500,
+  maxBackoffMs: 5_000,
+}
+
+const TURN_HEADER = {
+  TURN_ID: 'X-Turn-Id',
+  CHAT_SESSION_ID: 'X-Chat-Session-Id',
+} as const
+
+/**
+ * Default resume URL builder: appends `/<chatSessionId>/stream` to a chat
+ * POST URL like `…/projects/<id>/chat` or `…/agent/chat`.
+ */
+export function defaultBuildResumeUrl(chatPostUrl: string, chatSessionId: string): string {
+  // Strip a trailing slash, then append `/<chatSessionId>/stream`.
+  const trimmed = chatPostUrl.replace(/\/+$/, '')
+  return `${trimmed}/${encodeURIComponent(chatSessionId)}/stream`
+}
+
+/**
+ * Wrap a fetch implementation so that any chat POST whose response carries
+ * `X-Turn-Id` + `X-Chat-Session-Id` headers becomes auto-resuming on
+ * premature stream termination.
+ */
+export function createAutoResumingFetch(
+  baseFetch: typeof globalThis.fetch,
+  options: AutoResumingFetchOptions = {},
+): typeof globalThis.fetch {
+  const opts = {
+    ...DEFAULT_OPTIONS,
+    buildResumeUrl: options.buildResumeUrl ?? defaultBuildResumeUrl,
+    logger: options.logger === null ? null : (options.logger ?? console),
+    ...options,
+  }
+
+  const wrapped: typeof globalThis.fetch = async (input, init) => {
+    const method = (init?.method || 'GET').toUpperCase()
+    // Only wrap POST chat requests; GET (resume), DELETE (stop), etc. are
+    // forwarded as-is.
+    if (method !== 'POST') {
+      return baseFetch(input as any, init)
+    }
+
+    const initialResponse = await baseFetch(input as any, init)
+    if (!initialResponse.ok || !initialResponse.body) return initialResponse
+
+    const turnId = initialResponse.headers.get(TURN_HEADER.TURN_ID)
+    const chatSessionId = initialResponse.headers.get(TURN_HEADER.CHAT_SESSION_ID)
+    if (!turnId || !chatSessionId) {
+      // Server didn't tag this response with durable turn metadata —
+      // not a chat stream we can resume. Pass through.
+      return initialResponse
+    }
+
+    const chatPostUrl = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : (input as Request).url
+
+    const resumeUrl = opts.buildResumeUrl(chatPostUrl, chatSessionId)
+    const logger = opts.logger
+
+    const wrappedBody = createDurableBody({
+      initialBody: initialResponse.body,
+      resumeUrl,
+      fetcher: baseFetch,
+      maxResumeAttempts: opts.maxResumeAttempts,
+      initialBackoffMs: opts.initialBackoffMs,
+      maxBackoffMs: opts.maxBackoffMs,
+      logger,
+      turnId,
+    })
+
+    // Re-construct the Response so the AI SDK reads from our durable body
+    // but sees the original status / headers / content-type.
+    return new Response(wrappedBody, {
+      status: initialResponse.status,
+      statusText: initialResponse.statusText,
+      headers: initialResponse.headers,
+    })
+  }
+
+  return wrapped
+}
+
+interface DurableBodyOpts {
+  initialBody: ReadableStream<Uint8Array>
+  resumeUrl: string
+  fetcher: typeof globalThis.fetch
+  maxResumeAttempts: number
+  initialBackoffMs: number
+  maxBackoffMs: number
+  logger: { warn: (...args: any[]) => void; log: (...args: any[]) => void } | null
+  turnId: string
+}
+
+function createDurableBody(opts: DurableBodyOpts): ReadableStream<Uint8Array> {
+  const {
+    initialBody,
+    resumeUrl,
+    fetcher,
+    maxResumeAttempts,
+    initialBackoffMs,
+    maxBackoffMs,
+    logger,
+    turnId,
+  } = opts
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      let lastSeq = 0
+      let turnCompleted = false
+      let cancelled = false
+      let resumeAttempts = 0
+      const decoder = new TextDecoder()
+      let parseBuf = ''
+
+      const log = (msg: string) => {
+        if (logger) logger.log(`[AutoResume:${turnId.slice(0, 8)}] ${msg}`)
+      }
+      const warn = (msg: string) => {
+        if (logger) logger.warn(`[AutoResume:${turnId.slice(0, 8)}] ${msg}`)
+      }
+
+      const inspectChunk = (chunk: Uint8Array) => {
+        // Append decoded text and parse complete SSE frames separated by
+        // a blank line. Any partial frame stays in `parseBuf`.
+        parseBuf += decoder.decode(chunk, { stream: true })
+        let nlnl: number
+        while ((nlnl = parseBuf.indexOf('\n\n')) !== -1) {
+          const frame = parseBuf.slice(0, nlnl)
+          parseBuf = parseBuf.slice(nlnl + 2)
+          parseFrame(frame)
+        }
+      }
+
+      const parseFrame = (frame: string) => {
+        // AI SDK / SSE frame: lines like `data: {...}` joined by \n. We
+        // only care about `data:` lines whose payload looks like one of
+        // our durable-turn marker events.
+        for (const line of frame.split('\n')) {
+          if (!line.startsWith('data:')) continue
+          const payload = line.slice(5).trim()
+          if (!payload || payload === '[DONE]') continue
+          // Cheap pre-filter to avoid JSON.parse on every text-delta.
+          if (
+            !payload.includes('data-turn-seq') &&
+            !payload.includes('data-turn-complete')
+          ) {
+            continue
+          }
+          try {
+            const evt = JSON.parse(payload)
+            if (evt?.type === 'data-turn-seq' && typeof evt?.data?.seq === 'number') {
+              if (evt.data.seq > lastSeq) lastSeq = evt.data.seq
+            } else if (evt?.type === 'data-turn-complete') {
+              turnCompleted = true
+            }
+          } catch {
+            /* ignore — wasn't actually one of our markers */
+          }
+        }
+      }
+
+      const pumpBody = async (body: ReadableStream<Uint8Array>): Promise<{ bytes: number }> => {
+        const reader = body.getReader()
+        let bytes = 0
+        try {
+          while (!cancelled) {
+            const { done, value } = await reader.read()
+            if (done) return { bytes }
+            if (!value) continue
+            bytes += value.byteLength
+            inspectChunk(value)
+            try {
+              controller.enqueue(value)
+            } catch {
+              // Downstream consumer (AI SDK) cancelled — stop pumping.
+              cancelled = true
+              return { bytes }
+            }
+          }
+        } finally {
+          try { reader.releaseLock() } catch { /* noop */ }
+        }
+        return { bytes }
+      }
+
+      const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+
+      try {
+        await pumpBody(initialBody)
+
+        while (!turnCompleted && !cancelled && resumeAttempts < maxResumeAttempts) {
+          resumeAttempts++
+          const backoff = Math.min(
+            initialBackoffMs * Math.pow(2, resumeAttempts - 1),
+            maxBackoffMs,
+          )
+          warn(
+            `stream EOF without turn-complete; reconnecting fromSeq=${lastSeq} (attempt ${resumeAttempts}/${maxResumeAttempts}, backoff ${backoff}ms)`,
+          )
+          await sleep(backoff)
+          if (cancelled) break
+
+          let resumeRes: Response
+          try {
+            const url = `${resumeUrl}?fromSeq=${lastSeq}`
+            resumeRes = await fetcher(url, { method: 'GET' })
+          } catch (err: any) {
+            warn(`resume fetch threw: ${err?.message || err}`)
+            continue
+          }
+
+          if (resumeRes.status === 204 || !resumeRes.body) {
+            log(`resume returned ${resumeRes.status} — turn no longer buffered, stopping`)
+            break
+          }
+
+          // Confirm we're still talking about the same turn. If the
+          // server has rotated to a new turnId on the same session, we
+          // would corrupt the AI SDK accumulator by appending the new
+          // turn's bytes onto the old one — bail out instead.
+          const resumeTurnId = resumeRes.headers.get(TURN_HEADER.TURN_ID)
+          if (resumeTurnId && resumeTurnId !== turnId) {
+            warn(`resume returned a different turnId (${resumeTurnId}); stopping`)
+            try { resumeRes.body.cancel() } catch { /* noop */ }
+            break
+          }
+
+          // Only reset the attempt counter if the resume actually
+          // delivered bytes — otherwise an endless loop of empty 200s
+          // would never surface as "stalled".
+          const { bytes } = await pumpBody(resumeRes.body)
+          if (bytes > 0) resumeAttempts = 0
+        }
+
+        if (!turnCompleted && !cancelled) {
+          warn(`gave up after ${resumeAttempts} resume attempts; closing stream`)
+        }
+      } catch (err: any) {
+        warn(`durable body errored: ${err?.message || err}`)
+        try { controller.error(err) } catch { /* already errored */ }
+        return
+      } finally {
+        try { controller.close() } catch { /* already closed */ }
+      }
+    },
+    cancel() {
+      // Downstream cancelled (e.g. AI SDK got an error or user-stop).
+      // The async loop above checks `cancelled` and exits its read loop;
+      // we don't have direct access to it here, but pump will notice the
+      // controller refusing further enqueues and stop on the next chunk.
+    },
+  })
+}

--- a/packages/shared-app/src/chat/index.ts
+++ b/packages/shared-app/src/chat/index.ts
@@ -17,6 +17,12 @@ export {
 } from './useChatTransport'
 
 export {
+  createAutoResumingFetch,
+  defaultBuildResumeUrl,
+  type AutoResumingFetchOptions,
+} from './auto-resuming-fetch'
+
+export {
   useRemoteChatTransportConfig,
   buildRemoteChatApiUrl,
   type RemoteChatTransportOptions,

--- a/packages/shared-app/src/chat/useChatTransport.ts
+++ b/packages/shared-app/src/chat/useChatTransport.ts
@@ -8,6 +8,7 @@
  */
 
 import { useMemo } from 'react'
+import { createAutoResumingFetch } from './auto-resuming-fetch'
 
 export interface ChatTransportOptions {
   /** API base URL (e.g., "http://localhost:8002" or "" for same-origin) */
@@ -22,6 +23,13 @@ export interface ChatTransportOptions {
   fetch?: typeof globalThis.fetch
   /** Extra headers to include with every request (e.g. Cookie for native auth) */
   headers?: Record<string, string> | (() => Record<string, string>)
+  /**
+   * When true (default) the chat fetch is wrapped with auto-resume so a
+   * mid-turn disconnect transparently reconnects via `?fromSeq=N` instead
+   * of leaving the UI stuck on a half-rendered message. Set to false to
+   * opt out (e.g. for legacy environments without the durable runtime).
+   */
+  durableResume?: boolean
 }
 
 export interface ChatTransportConfig {
@@ -54,15 +62,21 @@ export function useChatTransportConfig({
   credentials,
   fetch: customFetch,
   headers,
+  durableResume = true,
 }: ChatTransportOptions): ChatTransportConfig | undefined {
   return useMemo(() => {
     if (!projectId && !localAgentUrl) return undefined
 
+    const baseFetch = customFetch ?? globalThis.fetch
+    const fetch = durableResume
+      ? createAutoResumingFetch(baseFetch.bind(globalThis))
+      : customFetch
+
     return {
       api: buildChatApiUrl(apiBaseUrl, projectId, localAgentUrl),
       credentials,
-      fetch: customFetch,
+      fetch,
       headers,
     }
-  }, [apiBaseUrl, projectId, localAgentUrl, credentials, customFetch, headers])
+  }, [apiBaseUrl, projectId, localAgentUrl, credentials, customFetch, headers, durableResume])
 }

--- a/packages/shared-runtime/src/__tests__/stream-buffer.test.ts
+++ b/packages/shared-runtime/src/__tests__/stream-buffer.test.ts
@@ -273,6 +273,111 @@ describe('StreamBufferStore', () => {
     expect(store.has('a')).toBe(false)
     expect(store.has('b')).toBe(false)
   })
+
+  test('writer reports turnId and monotonic seq', () => {
+    store = new StreamBufferStore()
+    const writer = store.create('seq-key')
+    expect(writer.turnId).toBeTruthy()
+    expect(writer.lastSeq).toBe(0)
+
+    const seq1 = writer.append(encode('a'))
+    const seq2 = writer.append(encode('b'))
+    const seq3 = writer.append(encode('c'))
+    expect(seq1).toBe(1)
+    expect(seq2).toBe(2)
+    expect(seq3).toBe(3)
+    expect(writer.lastSeq).toBe(3)
+  })
+
+  test('snapshot returns turn metadata for active and completed turns', () => {
+    store = new StreamBufferStore()
+    const writer = store.create('snap-key', { turnId: 'turn-123' })
+    writer.append(encode('hello'))
+
+    const active = store.snapshot('snap-key')
+    expect(active).not.toBeNull()
+    expect(active!.turnId).toBe('turn-123')
+    expect(active!.status).toBe('active')
+    expect(active!.lastSeq).toBe(1)
+
+    writer.complete('finished')
+
+    const done = store.snapshot('snap-key')
+    expect(done!.status).toBe('completed')
+    expect(done!.terminal?.reason).toBe('finished')
+    expect(done!.completedAt).not.toBeNull()
+  })
+
+  test('snapshot returns null for unknown key', () => {
+    store = new StreamBufferStore()
+    expect(store.snapshot('missing')).toBeNull()
+  })
+
+  test('createReplayStream with fromSeq skips already-seen frames', async () => {
+    store = new StreamBufferStore()
+    const writer = store.create('partial')
+    writer.append(encode('one\n'))   // seq 1
+    writer.append(encode('two\n'))   // seq 2
+    writer.append(encode('three\n')) // seq 3
+    writer.complete()
+
+    // Resume from seq=1 — should only get frames 2 and 3
+    const replay = store.createReplayStream('partial', { fromSeq: 1 })!
+    const text = await collectStream(replay)
+    expect(text).toBe('two\nthree\n')
+  })
+
+  test('createReplayStream with fromSeq beyond lastSeq waits for live frames on active turn', async () => {
+    store = new StreamBufferStore()
+    const writer = store.create('catchup')
+    writer.append(encode('first\n'))  // seq 1
+
+    // Subscriber asks for fromSeq=1 — they're already caught up. They should
+    // see no replay, then live frames as they arrive.
+    const replay = store.createReplayStream('catchup', { fromSeq: 1 })!
+    const reader = replay.getReader()
+
+    writer.append(encode('second\n')) // seq 2
+    const { value: live, done } = await reader.read()
+    expect(done).toBe(false)
+    expect(new TextDecoder().decode(live)).toBe('second\n')
+
+    writer.complete()
+    const tail = await reader.read()
+    expect(tail.done).toBe(true)
+  })
+
+  test('createReplayStream with fromSeq on completed turn closes immediately when caught up', async () => {
+    store = new StreamBufferStore()
+    const writer = store.create('done-catch')
+    writer.append(encode('a'))
+    writer.append(encode('b'))
+    writer.complete()
+
+    const replay = store.createReplayStream('done-catch', { fromSeq: 2 })!
+    const text = await collectStream(replay)
+    expect(text).toBe('')
+  })
+
+  test('writer.fail marks buffer failed and surfaces error in snapshot', () => {
+    store = new StreamBufferStore()
+    const writer = store.create('boom')
+    writer.append(encode('progress'))
+    writer.fail('provider 500')
+
+    const snap = store.snapshot('boom')
+    expect(snap!.status).toBe('failed')
+    expect(snap!.terminal?.error).toBe('provider 500')
+  })
+
+  test('abort marks status aborted before removing buffer', async () => {
+    store = new StreamBufferStore()
+    const writer = store.create('cancel')
+    writer.append(encode('partial'))
+
+    store.abort('cancel')
+    expect(store.snapshot('cancel')).toBeNull()
+  })
 })
 
 describe('createBufferingTransform', () => {

--- a/packages/shared-runtime/src/stream-buffer.ts
+++ b/packages/shared-runtime/src/stream-buffer.ts
@@ -1,35 +1,80 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 /**
- * In-memory stream buffer for SSE reconnect support.
+ * In-memory stream buffer + turn ledger for SSE reconnect support.
  *
  * Stores raw SSE bytes keyed by chatSessionId so that a reconnecting client
- * can replay the buffered events and continue receiving live events.
+ * can replay buffered events and continue receiving live events. Every
+ * buffered chunk is tagged with a monotonically increasing `seq` so a client
+ * can resume from the last frame it has already seen via `?fromSeq=N` style
+ * resume.
  *
  * Each server process (agent-runtime pod, API server) creates its own
- * StreamBufferStore singleton — no shared state between processes.
+ * StreamBufferStore singleton — no shared state between processes. For
+ * cross-process durability a higher layer (e.g. a Postgres-backed turn
+ * ledger) would wrap this store; this in-memory variant is the hot cache.
  */
 
 const CLEANUP_INTERVAL_MS = 60_000
 const MAX_BUFFER_AGE_MS = 30 * 60_000
 const COMPLETED_GRACE_MS = 30_000
 
-interface StreamBuffer {
-  chunks: Uint8Array[]
-  subscribers: Set<ReadableStreamDefaultController<Uint8Array>>
-  status: 'active' | 'completed'
-  createdAt: number
-  completedAt: number | null
+export type TurnStatus = 'active' | 'completed' | 'aborted' | 'failed'
+
+export interface TurnTerminal {
+  reason?: string
+  error?: string
 }
 
-/**
- * A writer bound to a specific buffer instance. If the buffer is replaced
- * (e.g. a new stream starts for the same key), writes become no-ops
- * so a stale background reader can't corrupt the new buffer.
- */
+interface BufferedFrame {
+  seq: number
+  chunk: Uint8Array
+}
+
+interface StreamBuffer {
+  turnId: string
+  frames: BufferedFrame[]
+  subscribers: Set<ReadableStreamDefaultController<Uint8Array>>
+  status: TurnStatus
+  terminal: TurnTerminal | null
+  createdAt: number
+  completedAt: number | null
+  lastEventAt: number
+  /** Next seq number to assign to a new chunk. Monotonic, never reset. */
+  nextSeq: number
+}
+
 export interface StreamBufferWriter {
-  append(chunk: Uint8Array): void
-  complete(): void
+  /** Append a raw byte chunk and return the seq assigned to it. */
+  append(chunk: Uint8Array): number
+  /** Mark the turn as cleanly completed. Optional terminal reason. */
+  complete(reason?: string): void
+  /**
+   * Mark the turn as failed (still keeps the buffer around for the grace
+   * window so a reconnecting client can see the terminal state).
+   */
+  fail(error: string): void
+  /** The turnId this writer is bound to. */
+  readonly turnId: string
+  /** Last seq written so far (0 if nothing has been appended). */
+  readonly lastSeq: number
+}
+
+export interface ReplayOptions {
+  /**
+   * Skip frames with seq <= fromSeq. Use 0 (or omit) to replay from the start.
+   */
+  fromSeq?: number
+}
+
+export interface TurnSnapshot {
+  turnId: string
+  status: TurnStatus
+  lastSeq: number
+  terminal: TurnTerminal | null
+  createdAt: number
+  completedAt: number | null
+  lastEventAt: number
 }
 
 export class StreamBufferStore {
@@ -44,29 +89,38 @@ export class StreamBufferStore {
   }
 
   /**
-   * Create (or replace) a buffer for the given key.
-   * Any existing buffer for the same key is completed and discarded.
-   *
-   * Returns a writer bound to this specific buffer instance.
+   * Create (or replace) a buffer for the given key. Any existing active
+   * buffer is completed and discarded. Returns a writer bound to this
+   * specific buffer instance, including the new `turnId`.
    */
-  create(key: string): StreamBufferWriter {
+  create(key: string, opts?: { turnId?: string }): StreamBufferWriter {
     const existing = this.buffers.get(key)
     if (existing && existing.status === 'active') {
-      this.completeBuffer(existing)
+      this.completeBuffer(existing, 'replaced')
     }
+    const now = Date.now()
+    const turnId = opts?.turnId || generateTurnId()
     const buf: StreamBuffer = {
-      chunks: [],
+      turnId,
+      frames: [],
       subscribers: new Set(),
       status: 'active',
-      createdAt: Date.now(),
+      terminal: null,
+      createdAt: now,
       completedAt: null,
+      lastEventAt: now,
+      nextSeq: 1,
     }
     this.buffers.set(key, buf)
 
     return {
+      get turnId() { return buf.turnId },
+      get lastSeq() { return buf.nextSeq - 1 },
       append: (chunk: Uint8Array) => {
-        if (buf.status !== 'active') return
-        buf.chunks.push(chunk)
+        if (buf.status !== 'active') return -1
+        const seq = buf.nextSeq++
+        buf.frames.push({ seq, chunk })
+        buf.lastEventAt = Date.now()
         for (const ctrl of buf.subscribers) {
           try {
             ctrl.enqueue(chunk)
@@ -74,22 +128,27 @@ export class StreamBufferStore {
             buf.subscribers.delete(ctrl)
           }
         }
+        return seq
       },
-      complete: () => {
-        this.completeBuffer(buf)
+      complete: (reason?: string) => {
+        this.completeBuffer(buf, reason)
+      },
+      fail: (error: string) => {
+        this.failBuffer(buf, error)
       },
     }
   }
 
   /**
-   * Append a chunk by key. Useful for simple pass-through transforms
-   * where binding to a specific buffer instance isn't needed.
+   * Append a chunk by key (loose, untyped writer). Returns the seq assigned,
+   * or -1 if the buffer is unknown/inactive.
    */
-  append(key: string, chunk: Uint8Array): void {
+  append(key: string, chunk: Uint8Array): number {
     const buf = this.buffers.get(key)
-    if (!buf || buf.status !== 'active') return
-
-    buf.chunks.push(chunk)
+    if (!buf || buf.status !== 'active') return -1
+    const seq = buf.nextSeq++
+    buf.frames.push({ seq, chunk })
+    buf.lastEventAt = Date.now()
     for (const ctrl of buf.subscribers) {
       try {
         ctrl.enqueue(chunk)
@@ -97,26 +156,25 @@ export class StreamBufferStore {
         buf.subscribers.delete(ctrl)
       }
     }
+    return seq
   }
 
-  /**
-   * Mark a buffer as completed by key.
-   */
-  complete(key: string): void {
+  /** Mark a buffer as completed by key. Optional terminal reason. */
+  complete(key: string, reason?: string): void {
     const buf = this.buffers.get(key)
     if (!buf) return
-    this.completeBuffer(buf)
+    this.completeBuffer(buf, reason)
   }
 
   /**
-   * Abort a stream: complete all subscribers and remove the buffer entirely.
+   * Abort a stream: complete subscribers and remove the buffer entirely.
    * Future resume/replay requests for this key will return null (→ 204).
-   * The bound StreamBufferWriter stays safe (no-ops via closure ref).
    */
   abort(key: string): void {
     const buf = this.buffers.get(key)
     if (!buf) return
-    this.completeBuffer(buf)
+    this.completeBuffer(buf, 'aborted')
+    buf.status = 'aborted'
     this.buffers.delete(key)
   }
 
@@ -124,29 +182,50 @@ export class StreamBufferStore {
     return this.buffers.has(key)
   }
 
+  /** Read-only metadata about a buffered turn. Useful for resume responses. */
+  snapshot(key: string): TurnSnapshot | null {
+    const buf = this.buffers.get(key)
+    if (!buf) return null
+    return {
+      turnId: buf.turnId,
+      status: buf.status,
+      lastSeq: buf.nextSeq - 1,
+      terminal: buf.terminal,
+      createdAt: buf.createdAt,
+      completedAt: buf.completedAt,
+      lastEventAt: buf.lastEventAt,
+    }
+  }
+
   /**
-   * Create a ReadableStream that first replays all buffered chunks,
-   * then subscribes for any further live chunks until the stream completes.
+   * Create a ReadableStream that first replays all buffered chunks past
+   * `opts.fromSeq` (default: 0 → replay everything), then subscribes for
+   * any further live chunks until the stream completes.
    *
    * Returns null if no buffer exists for the key.
    */
-  createReplayStream(key: string): ReadableStream<Uint8Array> | null {
+  createReplayStream(
+    key: string,
+    opts: ReplayOptions = {},
+  ): ReadableStream<Uint8Array> | null {
     const buf = this.buffers.get(key)
     if (!buf) return null
 
+    const fromSeq = Math.max(0, opts.fromSeq ?? 0)
     let subscribedController: ReadableStreamDefaultController<Uint8Array> | null = null
 
     return new ReadableStream<Uint8Array>({
       start(controller) {
-        for (const chunk of buf.chunks) {
+        for (const frame of buf.frames) {
+          if (frame.seq <= fromSeq) continue
           try {
-            controller.enqueue(chunk)
+            controller.enqueue(frame.chunk)
           } catch {
             return
           }
         }
 
-        if (buf.status === 'completed') {
+        if (buf.status !== 'active') {
           try { controller.close() } catch { /* already closed */ }
           return
         }
@@ -166,10 +245,10 @@ export class StreamBufferStore {
   cleanup(): void {
     const now = Date.now()
     for (const [key, buf] of this.buffers) {
-      if (buf.status === 'completed' && buf.completedAt && now - buf.completedAt > COMPLETED_GRACE_MS) {
+      if (buf.status !== 'active' && buf.completedAt && now - buf.completedAt > COMPLETED_GRACE_MS) {
         this.buffers.delete(key)
       } else if (now - buf.createdAt > MAX_BUFFER_AGE_MS && buf.subscribers.size === 0) {
-        this.completeBuffer(buf)
+        this.completeBuffer(buf, 'expired')
         this.buffers.delete(key)
       }
     }
@@ -181,15 +260,29 @@ export class StreamBufferStore {
       this.cleanupTimer = null
     }
     for (const buf of this.buffers.values()) {
-      this.completeBuffer(buf)
+      this.completeBuffer(buf, 'disposed')
     }
     this.buffers.clear()
   }
 
-  private completeBuffer(buf: StreamBuffer): void {
-    if (buf.status === 'completed') return
+  private completeBuffer(buf: StreamBuffer, reason?: string): void {
+    if (buf.status !== 'active') return
     buf.status = 'completed'
+    buf.terminal = { reason }
     buf.completedAt = Date.now()
+    buf.lastEventAt = buf.completedAt
+    for (const ctrl of buf.subscribers) {
+      try { ctrl.close() } catch { /* already closed */ }
+    }
+    buf.subscribers.clear()
+  }
+
+  private failBuffer(buf: StreamBuffer, error: string): void {
+    if (buf.status !== 'active') return
+    buf.status = 'failed'
+    buf.terminal = { error }
+    buf.completedAt = Date.now()
+    buf.lastEventAt = buf.completedAt
     for (const ctrl of buf.subscribers) {
       try { ctrl.close() } catch { /* already closed */ }
     }
@@ -197,9 +290,26 @@ export class StreamBufferStore {
   }
 }
 
+function generateTurnId(): string {
+  // Lightweight random id — we don't need cryptographic strength here, just
+  // uniqueness within the store's lifetime. Fall back to Math.random in
+  // environments without crypto.randomUUID (older bundlers / RN).
+  try {
+    if (typeof globalThis.crypto?.randomUUID === 'function') {
+      return globalThis.crypto.randomUUID()
+    }
+  } catch {
+    /* fall through */
+  }
+  return `turn_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`
+}
+
 /**
- * TransformStream that copies every chunk into a StreamBufferStore
- * while passing it through unchanged. On flush/cancel, completes the buffer.
+ * TransformStream that copies every chunk into a StreamBufferStore while
+ * passing it through unchanged. On flush/cancel, completes the buffer.
+ *
+ * Note: this convenience helper does NOT propagate seq numbers back to the
+ * caller. Use `store.create(key)` directly if you need the writer's seq.
  */
 export function createBufferingTransform(
   store: StreamBufferStore,


### PR DESCRIPTION
## Issue
Fixes https://github.com/shogo-labs/shogo-ai/issues/449

## What this does
- **Turn ledger** (`packages/shared-runtime`): per-chunk `seq`, `turnId`, terminal status, `fromSeq` replay for resume.
- **Agent runtime** (`server.ts`): `data-turn-start`, `data-turn-seq` heartbeats, `data-turn-complete`; resume path and turn snapshot; response headers for turn/session.
- **API** (`project-chat.ts`): proxy `fromSeq`, expose turn headers, mirror turn snapshot where applicable.
- **Gateway**: `data-tool-progress` every 15s while a tool is running so proxies and mobile idle logic see activity.
- **Agent loop**: finalization / continuation when the model stops mid-answer or after tools; tests updated.
- **Shared chat transport**: `createAutoResumingFetch`—transparent GET resume when the POST stream ends without `data-turn-complete` (default on via `useChatTransportConfig`).
- **Mobile ChatPanel**: richer idle fingerprint, turn lifecycle tracking, console warning when stream ends without a completed turn marker.

## Tests
- `packages/shared-runtime`: `bun test src/__tests__/stream-buffer.test.ts`
- `packages/agent-runtime`: `bun test src/__tests__/agent-loop.test.ts`
- `packages/shared-app`: `bun test src/chat/__tests__/auto-resuming-fetch.test.ts`

## Notes
Cross-process persistence (DB-backed ledger) remains a follow-up; this branch is scoped to in-memory buffer + client/server resume contract.
