### PR TITLE
fix(staging): bypass DomainMapping for desktop tunnel WebSocket

### DIFF
--- a/apps/api/src/__tests__/instances-heartbeat.test.ts
+++ b/apps/api/src/__tests__/instances-heartbeat.test.ts
@@ -47,12 +47,16 @@ const mockPrisma = {
 // instances.ts (which transitively imports tunnel-redis).
 process.env.SHOGO_LOCAL_MODE = 'true'
 
+const mockResolveApiKey = mock(async (key: string) => {
+  if (key === 'shogo_valid_key' || key === 'shogo_bearer_key' || key === 'shogo_x_api_key' || key === 'shogo_legacy_key') {
+    return { workspaceId: 'ws-1', userId: 'user-1' }
+  }
+  return null
+})
+
 mock.module('../lib/prisma', () => ({ prisma: mockPrisma }))
 mock.module('../routes/api-keys', () => ({
-  resolveApiKey: mock(async (key: string) => {
-    if (key === 'shogo_valid_key') return { workspaceId: 'ws-1', userId: 'user-1' }
-    return null
-  }),
+  resolveApiKey: mockResolveApiKey,
 }))
 mock.module('../lib/push-notifications', () => ({
   sendPushToInstance: mock(async () => {}),
@@ -63,7 +67,7 @@ let currentUser: any = adminUser
 
 // ─── Import after mocks ─────────────────────────────────────────────────────
 
-const { instanceRoutes, _testing } = await import('../routes/instances')
+const { instanceRoutes, authenticateInstanceWs, _testing } = await import('../routes/instances')
 
 function createTestApp() {
   const app = new Hono()
@@ -178,6 +182,113 @@ describe('POST /api/instances/heartbeat', () => {
     const data = await res.json()
     expect(data.wsRequested).toBe(false)
     expect(data.nextPollIn).toBe(_testing.POLL_INTERVAL_IDLE_S)
+  })
+})
+
+describe('authenticateInstanceWs', () => {
+  beforeEach(() => {
+    mockPrisma.instance.upsert.mockReset()
+    mockPrisma.instance.upsert.mockImplementation(() =>
+      Promise.resolve({ ...mockInstance }),
+    )
+    mockResolveApiKey.mockReset()
+    mockResolveApiKey.mockImplementation(async (key: string) => {
+      if (key === 'shogo_valid_key' || key === 'shogo_bearer_key' || key === 'shogo_x_api_key' || key === 'shogo_legacy_key') {
+        return { workspaceId: 'ws-1', userId: 'user-1' }
+      }
+      return null
+    })
+  })
+
+  test('prefers Authorization bearer over x-api-key and legacy query key', async () => {
+    const result = await authenticateInstanceWs(new Request(
+      'https://tunnel.test.shogo.ai/api/instances/ws?key=shogo_legacy_key&hostname=query-host',
+      {
+        headers: {
+          authorization: 'Bearer shogo_bearer_key',
+          'x-api-key': 'shogo_x_api_key',
+        },
+      },
+    ))
+
+    expect(result).toEqual({ instanceId: 'inst-1', workspaceId: 'ws-1' })
+    expect(mockResolveApiKey).toHaveBeenCalledTimes(1)
+    expect(mockResolveApiKey).toHaveBeenCalledWith('shogo_bearer_key')
+  })
+
+  test('prefers x-api-key over legacy query key when bearer is absent', async () => {
+    await authenticateInstanceWs(new Request(
+      'https://tunnel.test.shogo.ai/api/instances/ws?key=shogo_legacy_key&hostname=query-host',
+      {
+        headers: {
+          'x-api-key': 'shogo_x_api_key',
+        },
+      },
+    ))
+
+    expect(mockResolveApiKey).toHaveBeenCalledTimes(1)
+    expect(mockResolveApiKey).toHaveBeenCalledWith('shogo_x_api_key')
+  })
+
+  test('legacy query key emits one warning per upgrade', async () => {
+    const originalWarn = console.warn
+    const warn = mock(() => {})
+    console.warn = warn as any
+
+    try {
+      await authenticateInstanceWs(new Request(
+        'https://tunnel.test.shogo.ai/api/instances/ws?key=shogo_legacy_key&hostname=query-host',
+      ))
+    } finally {
+      console.warn = originalWarn
+    }
+
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(String(warn.mock.calls[0][0])).toContain('legacy ?key= query param')
+  })
+
+  test('header identity overrides query identity in instance upsert', async () => {
+    await authenticateInstanceWs(new Request(
+      'https://tunnel.test.shogo.ai/api/instances/ws?hostname=query-host&name=Query%20Name&os=linux&arch=x64',
+      {
+        headers: {
+          authorization: 'Bearer shogo_valid_key',
+          'x-shogo-hostname': 'header-host',
+          'x-shogo-name': 'Header Name',
+          'x-shogo-os': 'darwin',
+          'x-shogo-arch': 'arm64',
+        },
+      },
+    ))
+
+    expect(mockPrisma.instance.upsert).toHaveBeenCalledTimes(1)
+    const args = mockPrisma.instance.upsert.mock.calls[0][0] as any
+    expect(args.where.workspaceId_hostname).toEqual({
+      workspaceId: 'ws-1',
+      hostname: 'header-host',
+    })
+    expect(args.update).toMatchObject({
+      name: 'Header Name',
+      os: 'darwin',
+      arch: 'arm64',
+    })
+    expect(args.create).toMatchObject({
+      workspaceId: 'ws-1',
+      hostname: 'header-host',
+      name: 'Header Name',
+      os: 'darwin',
+      arch: 'arm64',
+    })
+  })
+
+  test('missing key returns null without resolving key or touching DB', async () => {
+    const result = await authenticateInstanceWs(new Request(
+      'https://tunnel.test.shogo.ai/api/instances/ws?hostname=query-host',
+    ))
+
+    expect(result).toBeNull()
+    expect(mockResolveApiKey).not.toHaveBeenCalled()
+    expect(mockPrisma.instance.upsert).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/api/src/lib/__tests__/instance-tunnel.test.ts
+++ b/apps/api/src/lib/__tests__/instance-tunnel.test.ts
@@ -71,14 +71,44 @@ describe('Instance Tunnel Client', () => {
     expect(mod._testing.getCloudUrl()).toBe('https://studio.shogo.ai')
   })
 
-  test('buildWsUrl converts http to ws and includes params', async () => {
+  test('buildWsUrl converts http to ws and is path-only (no secrets in query)', async () => {
     const mod = await import('../instance-tunnel')
     const url = mod._testing.buildWsUrl()
-    expect(url).toMatch(/^wss:\/\/studio\.test\.shogo\.ai\/api\/instances\/ws\?/)
-    expect(url).toContain('key=shogo_test_key')
-    expect(url).toContain('hostname=')
-    expect(url).toContain('os=')
-    expect(url).toContain('arch=')
+    expect(url).toBe('wss://studio.test.shogo.ai/api/instances/ws')
+    // Credentials must NOT live in the URL (Cloudflare / Kourier access
+    // logs would capture them). They travel as request headers in
+    // connectWs().
+    expect(url).not.toContain('key=')
+    expect(url).not.toContain('hostname=')
+    expect(url).not.toContain('os=')
+  })
+
+  test('SHOGO_TUNNEL_WS_URL env overrides the cloud-derived base', async () => {
+    process.env.SHOGO_TUNNEL_WS_URL = 'wss://tunnel.test.shogo.ai'
+    const mod = await import('../instance-tunnel')
+    expect(mod._testing.buildWsUrl()).toBe('wss://tunnel.test.shogo.ai/api/instances/ws')
+    expect(mod._testing.getWsBaseUrl()).toBe('wss://tunnel.test.shogo.ai')
+    delete process.env.SHOGO_TUNNEL_WS_URL
+  })
+
+  test('cloud-published wsUrl from heartbeat overrides the cloud-derived base', async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response(JSON.stringify({
+        instanceId: 'inst-1',
+        nextPollIn: 60,
+        wsRequested: false,
+        wsUrl: 'wss://tunnel.test.shogo.ai',
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })),
+    )
+
+    const mod = await import('../instance-tunnel')
+    mod._testing.serverPublishedWsUrl = null
+    await mod._testing.sendHeartbeat()
+    expect(mod._testing.serverPublishedWsUrl).toBe('wss://tunnel.test.shogo.ai')
+    expect(mod._testing.buildWsUrl()).toBe('wss://tunnel.test.shogo.ai/api/instances/ws')
   })
 
   test('sendHeartbeat calls fetch with correct URL and headers', async () => {

--- a/apps/api/src/lib/__tests__/instance-tunnel.test.ts
+++ b/apps/api/src/lib/__tests__/instance-tunnel.test.ts
@@ -91,6 +91,17 @@ describe('Instance Tunnel Client', () => {
     delete process.env.SHOGO_TUNNEL_WS_URL
   })
 
+  test('fails loudly when runtime does not advertise WebSocket header support', async () => {
+    const mod = await import('../instance-tunnel')
+    const nonBunRuntime = {}
+    expect(mod._testing.supportsWebSocketConstructorHeaders(nonBunRuntime as any)).toBe(false)
+    expect(() =>
+      mod._testing.createTunnelWebSocket('wss://tunnel.test.shogo.ai/api/instances/ws', {
+        headers: { Authorization: 'Bearer shogo_test_key' },
+      }, nonBunRuntime as any),
+    ).toThrow(mod.TunnelWebSocketHeaderSupportError)
+  })
+
   test('cloud-published wsUrl from heartbeat overrides the cloud-derived base', async () => {
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response(JSON.stringify({
@@ -107,7 +118,7 @@ describe('Instance Tunnel Client', () => {
     const mod = await import('../instance-tunnel')
     mod._testing.serverPublishedWsUrl = null
     await mod._testing.sendHeartbeat()
-    expect(mod._testing.serverPublishedWsUrl).toBe('wss://tunnel.test.shogo.ai')
+    expect(mod._testing.serverPublishedWsUrl as string | null).toBe('wss://tunnel.test.shogo.ai')
     expect(mod._testing.buildWsUrl()).toBe('wss://tunnel.test.shogo.ai/api/instances/ws')
   })
 

--- a/apps/api/src/lib/instance-tunnel.ts
+++ b/apps/api/src/lib/instance-tunnel.ts
@@ -31,6 +31,40 @@ interface CancelMessage {
 
 type IncomingMessage = TunnelRequest | CancelMessage | { type: 'ping' } | { type: string }
 
+type TunnelWebSocketInit = {
+  headers: Record<string, string>
+}
+
+type TunnelWebSocketConstructor = new (url: string, init: TunnelWebSocketInit) => WebSocket
+
+type RuntimeWithBunWebSocketHeaders = typeof globalThis & {
+  Bun?: unknown
+  process?: {
+    versions?: {
+      bun?: string
+    }
+  }
+}
+
+type HeartbeatResponse = {
+  instanceId?: string
+  nextPollIn: number
+  wsRequested: boolean
+  wsUrl?: string
+}
+
+export class TunnelWebSocketHeaderSupportError extends Error {
+  code = 'TUNNEL_WS_HEADERS_UNSUPPORTED' as const
+
+  constructor() {
+    super(
+      'Tunnel WebSocket auth requires Bun WebSocket header support. ' +
+        'This runtime does not advertise Bun, so Authorization headers may be dropped.'
+    )
+    this.name = 'TunnelWebSocketHeaderSupportError'
+  }
+}
+
 const DEFAULT_POLL_INTERVAL_S = 60
 const AUTH_FAILURE_BACKOFF_S = 300 // 5 min once we hit AUTH_FAILURE_THRESHOLD consecutive 401/403s
 const AUTH_FAILURE_THRESHOLD = 3
@@ -126,6 +160,25 @@ function getCloudUrl(): string {
   return (process.env.SHOGO_CLOUD_URL || 'https://studio.shogo.ai').replace(/\/$/, '')
 }
 
+function supportsWebSocketConstructorHeaders(
+  runtime: RuntimeWithBunWebSocketHeaders = globalThis as RuntimeWithBunWebSocketHeaders,
+): boolean {
+  return typeof runtime.Bun !== 'undefined' || typeof runtime.process?.versions?.bun === 'string'
+}
+
+function createTunnelWebSocket(
+  url: string,
+  init: TunnelWebSocketInit,
+  runtime: RuntimeWithBunWebSocketHeaders = globalThis as RuntimeWithBunWebSocketHeaders,
+): WebSocket {
+  if (!supportsWebSocketConstructorHeaders(runtime)) {
+    throw new TunnelWebSocketHeaderSupportError()
+  }
+
+  const WebSocketCtor = WebSocket as unknown as TunnelWebSocketConstructor
+  return new WebSocketCtor(url, init)
+}
+
 /**
  * Resolve the base URL to use for the on-demand tunnel WebSocket.
  *
@@ -185,7 +238,7 @@ async function collectMetadata(): Promise<Record<string, unknown>> {
 
 // ─── HTTP Heartbeat Loop ────────────────────────────────────────────────────
 
-async function sendHeartbeat(): Promise<{ nextPollIn: number; wsRequested: boolean; wsUrl?: string }> {
+async function sendHeartbeat(): Promise<HeartbeatResponse> {
   const cloudUrl = getCloudUrl()
   const key = process.env.SHOGO_API_KEY!
   const metadata = await collectMetadata()
@@ -209,7 +262,7 @@ async function sendHeartbeat(): Promise<{ nextPollIn: number; wsRequested: boole
     throw new Error(`Heartbeat failed: HTTP ${resp.status}`)
   }
 
-  const data = await resp.json() as { nextPollIn: number; wsRequested: boolean; wsUrl?: string }
+  const data = await resp.json() as HeartbeatResponse
 
   // Cache the server-published tunnel WS URL so connectWs() picks it up
   // without a second round-trip. Treat empty / falsy as "no override".
@@ -445,8 +498,7 @@ function connectWs() {
 
   let socket: WebSocket
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    socket = new (WebSocket as any)(url, wsInit) as WebSocket
+    socket = createTunnelWebSocket(url, wsInit)
   } catch (err: any) {
     console.error(`[InstanceTunnel] WebSocket creation failed: ${err.message}`)
     ws = null
@@ -572,6 +624,8 @@ export const _testing = {
   connectWs,
   cleanupWs,
   getCloudUrl,
+  supportsWebSocketConstructorHeaders,
+  createTunnelWebSocket,
   getWsBaseUrl,
   buildWsUrl,
   getReconnectDelay,

--- a/apps/api/src/lib/instance-tunnel.ts
+++ b/apps/api/src/lib/instance-tunnel.ts
@@ -62,6 +62,13 @@ let wsReconnectAttempt = 0
 let lastHeartbeatError: string | null = null
 let consecutiveAuthFailures = 0
 let consecutiveAuthSuccesses = 0
+// Public WS endpoint published by the cloud `heartbeat` response.
+// In staging / prod this is a non-DomainMapping host
+// (`wss://tunnel.staging.shogo.ai` / `wss://tunnel.shogo.ai`) that
+// supports WebSocket Upgrade end-to-end. When the cloud doesn't supply
+// a value (older API or self-hosted), we fall back to deriving it from
+// SHOGO_CLOUD_URL.
+let serverPublishedWsUrl: string | null = null
 const activeAbortControllers = new Map<string, AbortController>()
 
 function getReconnectDelay(): number {
@@ -119,16 +126,30 @@ function getCloudUrl(): string {
   return (process.env.SHOGO_CLOUD_URL || 'https://studio.shogo.ai').replace(/\/$/, '')
 }
 
-function buildWsUrl(): string {
-  const cloudUrl = getCloudUrl()
-  const wsBase = cloudUrl.replace(/^http/, 'ws')
-  const key = process.env.SHOGO_API_KEY!
-  const hn = osHostname()
-  const os = platform()
-  const arch = osArch()
-  const name = process.env.SHOGO_INSTANCE_NAME || hn
+/**
+ * Resolve the base URL to use for the on-demand tunnel WebSocket.
+ *
+ * Priority:
+ *   1. `SHOGO_TUNNEL_WS_URL` env (explicit override; for ops / debugging)
+ *   2. `wsUrl` field from the most recent heartbeat response (the
+ *      canonical signal from the cloud — points at a non-DomainMapping
+ *      host like `wss://tunnel.staging.shogo.ai`)
+ *   3. Derived from `SHOGO_CLOUD_URL` (legacy / self-hosted path; this
+ *      is what currently fails on Knative DomainMapping clusters and
+ *      is the reason this fallback exists at all)
+ */
+function getWsBaseUrl(): string {
+  const explicit = (process.env.SHOGO_TUNNEL_WS_URL || '').trim()
+  if (explicit) return explicit.replace(/\/$/, '')
+  if (serverPublishedWsUrl) return serverPublishedWsUrl.replace(/\/$/, '')
+  return getCloudUrl().replace(/^http/, 'ws')
+}
 
-  return `${wsBase}/api/instances/ws?key=${encodeURIComponent(key)}&hostname=${encodeURIComponent(hn)}&os=${encodeURIComponent(os)}&arch=${encodeURIComponent(arch)}&name=${encodeURIComponent(name)}`
+function buildWsUrl(): string {
+  // Path-only URL — credentials and identity now travel as request
+  // headers (see connectWs), so they do NOT end up in Cloudflare /
+  // Kourier access logs.
+  return `${getWsBaseUrl()}/api/instances/ws`
 }
 
 async function collectMetadata(): Promise<Record<string, unknown>> {
@@ -164,7 +185,7 @@ async function collectMetadata(): Promise<Record<string, unknown>> {
 
 // ─── HTTP Heartbeat Loop ────────────────────────────────────────────────────
 
-async function sendHeartbeat(): Promise<{ nextPollIn: number; wsRequested: boolean }> {
+async function sendHeartbeat(): Promise<{ nextPollIn: number; wsRequested: boolean; wsUrl?: string }> {
   const cloudUrl = getCloudUrl()
   const key = process.env.SHOGO_API_KEY!
   const metadata = await collectMetadata()
@@ -188,7 +209,18 @@ async function sendHeartbeat(): Promise<{ nextPollIn: number; wsRequested: boole
     throw new Error(`Heartbeat failed: HTTP ${resp.status}`)
   }
 
-  return resp.json()
+  const data = await resp.json() as { nextPollIn: number; wsRequested: boolean; wsUrl?: string }
+
+  // Cache the server-published tunnel WS URL so connectWs() picks it up
+  // without a second round-trip. Treat empty / falsy as "no override".
+  if (typeof data.wsUrl === 'string' && data.wsUrl.length > 0) {
+    if (data.wsUrl !== serverPublishedWsUrl) {
+      console.log(`[InstanceTunnel] Cloud advertised tunnel WS URL: ${data.wsUrl}`)
+    }
+    serverPublishedWsUrl = data.wsUrl
+  }
+
+  return data
 }
 
 function scheduleNextPoll(intervalS?: number) {
@@ -385,16 +417,43 @@ function connectWs() {
   if (stopped || ws) return
 
   const url = buildWsUrl()
-  console.log(`[InstanceTunnel] Opening WebSocket to ${url.replace(/key=[^&]+/, 'key=***')}`)
+  const key = process.env.SHOGO_API_KEY!
+  const hn = osHostname()
+  const os = platform()
+  const arch = osArch()
+  const name = process.env.SHOGO_INSTANCE_NAME || hn
 
+  console.log(`[InstanceTunnel] Opening WebSocket to ${url} (hostname=${hn})`)
+
+  // Bun's WebSocket constructor accepts a `headers` option; this lets us
+  // ship the API key and identity in request headers rather than the
+  // query string, so Cloudflare / Kourier access logs never capture
+  // the secret.
+  //
+  // The fallback `key=` query path on the server side stays in place
+  // for older desktops that don't run on Bun yet; once everyone is
+  // migrated we can drop it.
+  const wsInit = {
+    headers: {
+      'Authorization': `Bearer ${key}`,
+      'x-shogo-hostname': hn,
+      'x-shogo-name': name,
+      'x-shogo-os': os,
+      'x-shogo-arch': arch,
+    },
+  }
+
+  let socket: WebSocket
   try {
-    ws = new WebSocket(url)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    socket = new (WebSocket as any)(url, wsInit) as WebSocket
   } catch (err: any) {
     console.error(`[InstanceTunnel] WebSocket creation failed: ${err.message}`)
     ws = null
     scheduleNextPoll(5)
     return
   }
+  ws = socket
 
   ws.onopen = () => {
     console.log('[InstanceTunnel] WebSocket connected — session active')
@@ -513,6 +572,7 @@ export const _testing = {
   connectWs,
   cleanupWs,
   getCloudUrl,
+  getWsBaseUrl,
   buildWsUrl,
   getReconnectDelay,
   DEFAULT_POLL_INTERVAL_S,
@@ -525,4 +585,6 @@ export const _testing = {
   set wsReconnectAttempt(v: number) { wsReconnectAttempt = v },
   get ws() { return ws },
   get stopped() { return stopped },
+  get serverPublishedWsUrl() { return serverPublishedWsUrl },
+  set serverPublishedWsUrl(v: string | null) { serverPublishedWsUrl = v },
 }

--- a/apps/api/src/routes/instances.ts
+++ b/apps/api/src/routes/instances.ts
@@ -369,6 +369,31 @@ export function handleInstanceWsClose(ws: WebSocket & { data?: any }) {
 }
 
 /**
+ * Read the tunnel API key out of a WebSocket upgrade request.
+ *
+ * Preferred order (header-only — keeps secrets out of access logs and
+ * Cloudflare logging):
+ *   1. `Authorization: Bearer <key>`
+ *   2. `x-api-key: <key>`
+ *
+ * Legacy fallback for older desktop builds:
+ *   3. `?key=<key>` query parameter
+ *
+ * The legacy path is deprecated; once all deployed desktops have rolled
+ * to the new tunnel client we can drop the query-string branch.
+ */
+function extractInstanceWsKey(url: URL, headers: Headers): { key: string; legacy: boolean } {
+  const auth = headers.get('authorization') || ''
+  const bearer = auth.match(/^Bearer\s+(.+)$/i)?.[1]?.trim()
+  if (bearer) return { key: bearer, legacy: false }
+  const xKey = headers.get('x-api-key')
+  if (xKey) return { key: xKey, legacy: false }
+  const queryKey = url.searchParams.get('key')
+  if (queryKey) return { key: queryKey, legacy: true }
+  return { key: '', legacy: false }
+}
+
+/**
  * Authenticate a WebSocket upgrade request.
  * Returns { instanceId, workspaceId } or null.
  */
@@ -377,30 +402,40 @@ export async function authenticateInstanceWs(
 ): Promise<{ instanceId: string; workspaceId: string } | null> {
   try {
     const url = new URL(req.url)
-    const key = url.searchParams.get('key') || req.headers.get('x-api-key') || ''
+    const { key, legacy } = extractInstanceWsKey(url, req.headers)
     if (!key) return null
 
     const resolved = await resolveApiKey(key)
     if (!resolved) return null
 
-  const hostname = url.searchParams.get('hostname') || 'unknown'
-  const name = url.searchParams.get('name') || hostname
-  const os = url.searchParams.get('os') || null
-  const arch = url.searchParams.get('arch') || null
+    if (legacy) {
+      console.warn('[RemoteControl] WS auth used legacy ?key= query param — desktop should upgrade to header-based auth')
+    }
 
-  const instance = await prisma.instance.upsert({
-    where: { workspaceId_hostname: { workspaceId: resolved.workspaceId, hostname } },
-    update: { name, os, arch, status: 'online', lastSeenAt: new Date(), wsRequestedAt: null },
-    create: {
-      workspaceId: resolved.workspaceId,
-      name,
-      hostname,
-      os,
-      arch,
-      status: 'online',
-      lastSeenAt: new Date(),
-    },
-  })
+    // Identity (used to upsert the Instance row) — read from headers
+    // first, fall back to query for legacy clients.
+    const headerHostname = req.headers.get('x-shogo-hostname')
+    const hostname = headerHostname || url.searchParams.get('hostname') || 'unknown'
+    const headerName = req.headers.get('x-shogo-name')
+    const name = headerName || url.searchParams.get('name') || hostname
+    const headerOs = req.headers.get('x-shogo-os')
+    const os = headerOs || url.searchParams.get('os') || null
+    const headerArch = req.headers.get('x-shogo-arch')
+    const arch = headerArch || url.searchParams.get('arch') || null
+
+    const instance = await prisma.instance.upsert({
+      where: { workspaceId_hostname: { workspaceId: resolved.workspaceId, hostname } },
+      update: { name, os, arch, status: 'online', lastSeenAt: new Date(), wsRequestedAt: null },
+      create: {
+        workspaceId: resolved.workspaceId,
+        name,
+        hostname,
+        os,
+        arch,
+        status: 'online',
+        lastSeenAt: new Date(),
+      },
+    })
 
     return { instanceId: instance.id, workspaceId: resolved.workspaceId }
   } catch (err) {
@@ -617,11 +652,20 @@ export function instanceRoutes() {
     const nextPollIn = await computeNextPollIn(instance.id, resolved.workspaceId, instance.wsRequestedAt)
     const hasTunnel = tunnels.has(instance.id) || await isTunnelConnectedAnywhere(instance.id)
 
+    // Where the desktop should open its on-demand WebSocket. In staging
+    // / production this points at a non-DomainMapping host
+    // (`tunnel.staging.shogo.ai` / `tunnel.shogo.ai`) that bypasses the
+    // Knative DomainMapping rewriteHost loopback that breaks the WS
+    // Upgrade handshake. When unset, the desktop falls back to deriving
+    // the URL from its existing cloud URL (the dev / self-hosted path).
+    const tunnelWsUrl = (process.env.SHOGO_TUNNEL_WS_URL || '').trim() || undefined
+
     return c.json({
       instanceId: instance.id,
       nextPollIn,
       wsRequested,
       tunnelStatus: hasTunnel ? 'connected' : 'polling',
+      wsUrl: tunnelWsUrl,
     })
   })
 

--- a/k8s/overlays/staging/api-service.yaml
+++ b/k8s/overlays/staging/api-service.yaml
@@ -84,12 +84,19 @@ spec:
         autoscaling.knative.dev/min-scale: "1"
         autoscaling.knative.dev/max-scale: "5"
         # ─── Long-lived WebSocket support for desktop tunnel ───────────────
-        # Without these, Knative's activator / autoscaler can terminate
-        # pods holding active desktop WS sessions, causing intermittent
-        # "instance offline" 503s even when Redis is healthy.
+        # The desktop tunnel WebSocket no longer flows through the
+        # Knative DomainMapping path (see api-tunnel-ingress.yaml — it
+        # uses a label-selector Service that bypasses the
+        # `rewriteHost` + ExternalName loopback that breaks WS Upgrade).
+        # The remaining annotations make sure pods that are mid-WS-session
+        # are not yanked under us when an autoscaler or revision rollout
+        # decides to recycle them.
         #
-        # target-burst-capacity=-1  keep the activator on the data path so
-        #                           WS upgrades survive scale transitions
+        # target-burst-capacity=-1  keep the activator on the HTTP data
+        #                           path so heartbeat HTTP/2 traffic
+        #                           survives scale transitions cleanly
+        #                           (the tunnel WS bypasses the activator
+        #                           entirely via api-tunnel-direct → 8012)
         # scale-down-delay=5m       don't reap pods immediately on idle;
         #                           gives desktops time to reconnect gracefully
         # window=60s                standard smoothing
@@ -144,6 +151,13 @@ spec:
               value: "https://studio.staging.shogo.ai"
             - name: ALLOWED_ORIGINS
               value: "https://studio.staging.shogo.ai"
+            # Public hostname the desktop should use for the on-demand
+            # tunnel WebSocket. Routed by api-tunnel-ingress.yaml directly
+            # to the api revision pod (no DomainMapping → no broken WS
+            # Upgrade hop). Heartbeat traffic stays on
+            # SHOGO_PUBLIC_API_URL above.
+            - name: SHOGO_TUNNEL_WS_URL
+              value: "wss://tunnel.staging.shogo.ai"
             - name: REDIS_URL
               value: "redis://redis-master.shogo-staging-system:6379"
             - name: DATABASE_URL

--- a/k8s/overlays/staging/api-tunnel-ingress.yaml
+++ b/k8s/overlays/staging/api-tunnel-ingress.yaml
@@ -1,0 +1,89 @@
+# =============================================================================
+# Desktop Tunnel WebSocket Ingress — Staging
+# =============================================================================
+# Why this exists:
+#
+# Knative DomainMapping (e.g. studio.staging.shogo.ai → studio ksvc)
+# implements its underlying KIngress as a `rewriteHost` + ExternalName
+# loopback through `kourier-internal`. That extra Envoy→Envoy hop is wired
+# with HTTP/2 cleartext on the upstream cluster and does not enable
+# `extended-CONNECT` (RFC 8441), so it silently drops `Upgrade: websocket`
+# requests with `503 UC` after ~1s. Plain HTTP through the same path
+# works fine, which is why the desktop heartbeat is healthy while the
+# remote-control WebSocket upgrade gets stuck in "standby".
+#
+# Workaround: this manifest creates a non-DomainMapping public route
+# specifically for the desktop tunnel WS endpoint (`tunnel.staging.shogo.ai`).
+# It points a Knative Ingress (KIngress) directly at a regular ClusterIP
+# Service whose label-selector tracks the live api ksvc revision pods on
+# their queue-proxy port. There is no `rewriteHost` and no ExternalName
+# loopback, so Kourier produces a normal Envoy upstream cluster that
+# happily passes the WS Upgrade.
+#
+# Routing chain after this is applied:
+#   Cloudflare (TLS, *.staging.shogo.ai cert)
+#     → OCI LoadBalancer (kourier:80/443)
+#     → Kourier external listener
+#     → Knative Ingress `api-tunnel`     (no DomainMapping, no rewriteHost)
+#     → Service `api-tunnel-direct`      (selector: serving.knative.dev/service=api)
+#     → api revision Pod  port 8012      (queue-proxy, then user container)
+#
+# The Service's label selector is on `serving.knative.dev/service=api`, not
+# on a specific revision name. Knative scales old revisions to zero, so in
+# steady state the Service's endpoints contain only pods of the current
+# ready revision. No external controller is needed to keep this in sync
+# with `kn service apply`.
+#
+# Heartbeat traffic (HTTP) continues to flow through the existing
+# studio.staging.shogo.ai DomainMapping unchanged — only the WS path is
+# moved.
+# =============================================================================
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-tunnel-direct
+  namespace: shogo-staging-system
+  labels:
+    app.kubernetes.io/part-of: shogo
+    app.kubernetes.io/component: instance-tunnel
+    environment: staging
+spec:
+  type: ClusterIP
+  # Match every running api revision pod via the standard Knative service
+  # label. With min-scale=1 + scale-to-zero on older revisions, the
+  # endpoint set converges on the latest ready revision automatically.
+  selector:
+    serving.knative.dev/service: api
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8012  # queue-proxy ingress port (preserves Knative concurrency tracking)
+      protocol: TCP
+---
+apiVersion: networking.internal.knative.dev/v1alpha1
+kind: Ingress
+metadata:
+  name: api-tunnel
+  namespace: shogo-staging-system
+  annotations:
+    networking.knative.dev/ingress.class: kourier.ingress.networking.knative.dev
+  labels:
+    app.kubernetes.io/part-of: shogo
+    app.kubernetes.io/component: instance-tunnel
+    environment: staging
+spec:
+  httpOption: Enabled
+  rules:
+    - hosts:
+        - tunnel.staging.shogo.ai
+      visibility: ExternalIP
+      http:
+        paths:
+          # Single direct split — no rewriteHost — so Kourier emits a normal
+          # Envoy upstream cluster that handles WebSocket Upgrade.
+          - splits:
+              - serviceName: api-tunnel-direct
+                serviceNamespace: shogo-staging-system
+                servicePort: 80
+                percent: 100

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -9,6 +9,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - api-service.yaml
+  - api-tunnel-ingress.yaml
   - web-service.yaml
   - docs-service.yaml
 


### PR DESCRIPTION
Closes #452

## Summary
- routes desktop tunnel WebSocket traffic to a dedicated non-DomainMapping host (`tunnel.staging.shogo.ai`) via a direct Knative Ingress path (`api-tunnel`) and selector Service (`api-tunnel-direct`)
- updates tunnel auth from query-string-first to header-first (`Authorization` / `x-api-key`) with legacy `?key=` fallback for backward compatibility
- adds cloud-published WS endpoint discovery (`wsUrl` in heartbeat + desktop resolver) so desktop can use the dedicated tunnel host while heartbeat remains on existing studio HTTP origin

## Detailed RCA
Remote control in staging could heartbeat but never transition to online session because `/api/instances/ws` failed only on public DomainMapping hosts with `503 UC`.

Validated behavior:
- internal/direct WS upgrade path reached API and returned app-level auth responses (`401`) as expected
- DomainMapping-backed public hosts (`studio.staging.shogo.ai`, `api.141.148.27.1.sslip.io`) consistently returned `503 UC`
- HTTP on the same hosts remained healthy

Root cause:
- DomainMapping-generated KIngress uses `rewriteHost` + split target to `ExternalName` services, which loops external kourier traffic back through `kourier-internal`
- in this cluster path, that extra Envoy->Envoy hop drops WS upgrade and surfaces `503 UC`

This PR avoids that broken hop by introducing a dedicated ingress path for tunnel WS traffic.

## Fix Details
- **Infra (staging overlay)**
  - add `k8s/overlays/staging/api-tunnel-ingress.yaml`
    - `Service api-tunnel-direct` with selector `serving.knative.dev/service=api`, target `8012`
    - Knative `Ingress api-tunnel` exposing `tunnel.staging.shogo.ai` directly to `api-tunnel-direct`
  - include new manifest in `k8s/overlays/staging/kustomization.yaml`
  - add `SHOGO_TUNNEL_WS_URL=wss://tunnel.staging.shogo.ai` to staging API env
- **API tunnel auth + discovery**
  - `authenticateInstanceWs()` now reads key header-first, legacy query fallback
  - instance identity fields for WS upsert now support headers (`x-shogo-*`) with query fallback
  - heartbeat response now includes optional `wsUrl` from `SHOGO_TUNNEL_WS_URL`
- **Desktop tunnel client**
  - WS base URL resolution priority: `SHOGO_TUNNEL_WS_URL` env -> heartbeat `wsUrl` -> legacy derived cloud URL
  - WS URL is now path-only (`/api/instances/ws`), key/identity moved to headers

## Security Notes
- mitigates key leakage in ingress/access logs by no longer placing API keys in WS query strings for upgraded clients
- preserves temporary query fallback to avoid breaking older desktops immediately

## Validation
- `bun test apps/api/src/lib/__tests__/instance-tunnel.test.ts apps/api/src/lib/__tests__/instance-tunnel-backoff.test.ts`
- `bun test apps/api/src/__tests__/cloud-login-e2e.test.ts`
- manual staging validation:
  - `https://tunnel.staging.shogo.ai/api/instances/ws` reaches API auth path (returns `401` for invalid creds)
  - old DomainMapping WS path still reproduces `503`, confirming RCA and necessity of bypass
  - existing studio HTTP path remains healthy

## Rollout Notes
- this PR is intentionally scoped to the staging tunnel WS outage theme only
- after merge/deploy, desktop clients need the new tunnel client build to fully consume heartbeat `wsUrl` + header auth path

Made with [Cursor](https://cursor.com)
## New Runtime Flow (Post-fix)

1. Desktop signs in to SHOGO Cloud as before.
2. Desktop keeps sending heartbeat HTTP requests to `studio.staging.shogo.ai`.
3. API heartbeat response now tells desktop: for WebSocket tunnel, use `wss://tunnel.staging.shogo.ai`.
4. When user clicks the desktop instance in Remote Control, cloud marks `wsRequested`.
5. Desktop sees `wsRequested` on heartbeat and opens WebSocket to `tunnel.staging.shogo.ai`, not `studio.staging.shogo.ai`.
6. That tunnel host bypasses the broken Knative DomainMapping path and reaches the API directly.
7. API registers the tunnel in Redis/Postgres.
8. Studio sees the instance as online and remote control connects instead of staying in standby.