### PR TITLE
fix(chat): durable long-running stream completion on staging

### DIFF
--- a/apps/api/src/lib/warm-pool-controller.ts
+++ b/apps/api/src/lib/warm-pool-controller.ts
@@ -1808,6 +1808,8 @@ export class WarmPoolController {
             },
           },
           spec: {
+            // Requires knative-serving/config-defaults max-revision-timeout-seconds
+            // to be at least this value; see k8s/knative/config-defaults.yaml.
             timeoutSeconds: 3600,
             responseStartTimeoutSeconds: 600,
             securityContext: { fsGroup: 999 },

--- a/apps/api/src/lib/warm-pool-controller.ts
+++ b/apps/api/src/lib/warm-pool-controller.ts
@@ -1808,7 +1808,7 @@ export class WarmPoolController {
             },
           },
           spec: {
-            timeoutSeconds: 1800,
+            timeoutSeconds: 3600,
             responseStartTimeoutSeconds: 600,
             securityContext: { fsGroup: 999 },
             containers: [

--- a/apps/api/src/routes/project-chat.ts
+++ b/apps/api/src/routes/project-chat.ts
@@ -45,6 +45,10 @@ export interface ProjectChatRoutesConfig {
 
 const PROJECT_ROOT = resolve(import.meta.dir, '../../../..')
 const WORKSPACES_DIR = process.env.WORKSPACES_DIR || resolve(PROJECT_ROOT, 'workspaces')
+const AGENT_TURN_STALE_AFTER_MS = parseInt(
+  process.env.AGENT_TURN_STALE_AFTER_MS || String(2 * 60 * 60_000),
+  10,
+)
 
 export const FILE_MODIFYING_TOOLS = new Set([
   'write_file', 'edit_file', 'delete_file',
@@ -113,6 +117,10 @@ async function trackUsageFromStream(
   let streamInterrupted = false
   let turnCompleteReceived = false
   let turnCompleteStatus: string | null = null
+  let turnCompleteError: string | null = null
+  let streamTurnId: string | null = opts?.turnId || null
+  let turnLastSeq = 0
+  let startPersistPromise: Promise<unknown> | null = null
 
   const PER_CHUNK_IDLE_TIMEOUT_MS = parseInt(process.env.CHAT_STREAM_IDLE_TIMEOUT_MS || '3600000', 10)
 
@@ -282,9 +290,10 @@ async function trackUsageFromStream(
           const d = data.data ?? data
           const receivedTurnId = d.turnId || opts?.turnId
           if (receivedTurnId) {
+            streamTurnId = receivedTurnId
             const chatSessionId = requestBody?.chatSessionId
-            if (chatSessionId) {
-              prisma.agentTurn.upsert({
+            if (chatSessionId && !startPersistPromise) {
+              startPersistPromise = prisma.agentTurn.upsert({
                 where: { turnId: receivedTurnId },
                 create: {
                   chatSessionId,
@@ -297,12 +306,24 @@ async function trackUsageFromStream(
               }).catch((err: any) => {
                 console.warn(`[ProjectChat] Failed to upsert AgentTurn (start): ${err?.message}`)
               })
+              await startPersistPromise
             }
           }
         }
+        if (type === 'data-turn-seq') {
+          const seq = data.data?.seq ?? data.seq
+          if (typeof seq === 'number' && seq > turnLastSeq) {
+            turnLastSeq = seq
+          }
+        }
         if (type === 'data-turn-complete') {
+          const d = data.data ?? data
           turnCompleteReceived = true
-          turnCompleteStatus = data.data?.status || data.status || 'completed'
+          turnCompleteStatus = d.status || 'completed'
+          turnCompleteError = d.error || null
+          if (typeof d.lastSeq === 'number' && d.lastSeq > turnLastSeq) {
+            turnLastSeq = d.lastSeq
+          }
         }
 
         // Track usage from finish events or dedicated usage events
@@ -418,21 +439,36 @@ async function trackUsageFromStream(
   }
 
   // Update durable AgentTurn record with final status and linked messageId
-  const resolvedTurnId = opts?.turnId
-  if (resolvedTurnId) {
+  const resolvedTurnId = streamTurnId || opts?.turnId
+  if (resolvedTurnId && chatSessionId) {
+    await startPersistPromise
     const dbStatus = turnCompleteReceived
       ? (turnCompleteStatus === 'failed' ? 'failed' : 'completed')
       : streamInterrupted
         ? 'aborted'
-        : 'completed'
-    prisma.agentTurn.update({
+        : 'active'
+    prisma.agentTurn.upsert({
       where: { turnId: resolvedTurnId },
-      data: {
+      create: {
+        chatSessionId,
+        projectId: project.id,
+        turnId: resolvedTurnId,
         status: dbStatus as any,
-        completedAt: new Date(),
-        lastSeq: 0,
+        completedAt: dbStatus === 'active' ? undefined : new Date(),
+        lastSeq: turnLastSeq,
         messageId: assistantMessageId,
-        error: turnCompleteStatus === 'failed' ? 'Turn failed' : undefined,
+        error: dbStatus === 'failed' || dbStatus === 'aborted'
+          ? (turnCompleteError || (streamInterrupted ? 'Stream interrupted before turn completion' : undefined))
+          : undefined,
+      },
+      update: {
+        status: dbStatus as any,
+        completedAt: dbStatus === 'active' ? undefined : new Date(),
+        lastSeq: turnLastSeq,
+        messageId: assistantMessageId,
+        error: dbStatus === 'failed' || dbStatus === 'aborted'
+          ? (turnCompleteError || (streamInterrupted ? 'Stream interrupted before turn completion' : undefined))
+          : undefined,
       },
     }).catch((err: any) => {
       console.warn(`[ProjectChat] Failed to update AgentTurn (complete): ${err?.message}`)
@@ -1215,11 +1251,24 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
       }
 
       // Fallback: check DB-backed AgentTurn record
-      const dbTurn = await prisma.agentTurn.findFirst({
+      let dbTurn = await prisma.agentTurn.findFirst({
         where: { chatSessionId },
         orderBy: { startedAt: 'desc' },
       })
       if (dbTurn) {
+        if (
+          dbTurn.status === 'active' &&
+          Date.now() - dbTurn.startedAt.getTime() > AGENT_TURN_STALE_AFTER_MS
+        ) {
+          dbTurn = await prisma.agentTurn.update({
+            where: { turnId: dbTurn.turnId },
+            data: {
+              status: 'failed',
+              completedAt: new Date(),
+              error: `Turn marked failed after ${Math.round(AGENT_TURN_STALE_AFTER_MS / 60_000)} minutes without runtime activity`,
+            },
+          })
+        }
         return c.json({
           turnId: dbTurn.turnId,
           status: dbTurn.status,

--- a/apps/api/src/routes/project-chat.ts
+++ b/apps/api/src/routes/project-chat.ts
@@ -81,6 +81,7 @@ async function trackUsageFromStream(
   stream: ReadableStream<Uint8Array>,
   requestBody: any,
   project: { id: string; workspaceId: string },
+  opts?: { turnId?: string },
 ) {
   const decoder = new TextDecoder()
   const reader = stream.getReader()
@@ -110,6 +111,8 @@ async function trackUsageFromStream(
   let currentReasoningPart: { type: 'reasoning'; text: string; durationMs?: number } | null = null
   let reasoningStartedAt: number | null = null
   let streamInterrupted = false
+  let turnCompleteReceived = false
+  let turnCompleteStatus: string | null = null
 
   const PER_CHUNK_IDLE_TIMEOUT_MS = parseInt(process.env.CHAT_STREAM_IDLE_TIMEOUT_MS || '3600000', 10)
 
@@ -274,6 +277,34 @@ async function trackUsageFromStream(
           }
         }
 
+        // Track durable turn lifecycle markers
+        if (type === 'data-turn-start') {
+          const d = data.data ?? data
+          const receivedTurnId = d.turnId || opts?.turnId
+          if (receivedTurnId) {
+            const chatSessionId = requestBody?.chatSessionId
+            if (chatSessionId) {
+              prisma.agentTurn.upsert({
+                where: { turnId: receivedTurnId },
+                create: {
+                  chatSessionId,
+                  projectId: project.id,
+                  turnId: receivedTurnId,
+                  status: 'active',
+                  startedAt: new Date(),
+                },
+                update: { status: 'active' },
+              }).catch((err: any) => {
+                console.warn(`[ProjectChat] Failed to upsert AgentTurn (start): ${err?.message}`)
+              })
+            }
+          }
+        }
+        if (type === 'data-turn-complete') {
+          turnCompleteReceived = true
+          turnCompleteStatus = data.data?.status || data.status || 'completed'
+        }
+
         // Track usage from finish events or dedicated usage events
         if (type === 'finish' || type === 'finish-step' || type === 'usage' || type === 'data-usage') {
           // Custom data-usage event from runtime puts data in `data` field
@@ -333,8 +364,13 @@ async function trackUsageFromStream(
 
   const toolCallCount = toolCallMap.size
 
+  const turnState = turnCompleteReceived
+    ? `complete (turn-status=${turnCompleteStatus})`
+    : streamInterrupted
+      ? 'interrupted'
+      : 'eof-without-turn-complete'
   console.log(
-    `[ProjectChat] 📊 Stream ${streamInterrupted ? 'interrupted' : 'complete'} — tokens: ${totalTokens} (in: ${inputTokens}, out: ${outputTokens}), tool calls: ${toolCallCount}, agent mode: ${agentMode}`
+    `[ProjectChat] 📊 Stream ${turnState} — tokens: ${totalTokens} (in: ${inputTokens}, out: ${outputTokens}), tool calls: ${toolCallCount}, agent mode: ${agentMode}`
   )
 
   // Usage billing is handled by the AI proxy billing session (opened before
@@ -368,7 +404,8 @@ async function trackUsageFromStream(
           },
         })
         assistantMessageId = message.id
-        console.log(`[ProjectChat] 💾 Persisted assistant message (${accumulatedText.length} chars, ${toolCallCount} tool calls${streamInterrupted ? ', partial' : ''}) for session ${chatSessionId}`)
+        const partialTag = !turnCompleteReceived ? ', PARTIAL — turn not confirmed complete' : ''
+        console.log(`[ProjectChat] 💾 Persisted assistant message (${accumulatedText.length} chars, ${toolCallCount} tool calls${partialTag}) for session ${chatSessionId}`)
 
         prisma.project.update({
           where: { id: project.id },
@@ -378,6 +415,28 @@ async function trackUsageFromStream(
     } catch (err) {
       console.error("[ProjectChat] Failed to persist assistant message:", err)
     }
+  }
+
+  // Update durable AgentTurn record with final status and linked messageId
+  const resolvedTurnId = opts?.turnId
+  if (resolvedTurnId) {
+    const dbStatus = turnCompleteReceived
+      ? (turnCompleteStatus === 'failed' ? 'failed' : 'completed')
+      : streamInterrupted
+        ? 'aborted'
+        : 'completed'
+    prisma.agentTurn.update({
+      where: { turnId: resolvedTurnId },
+      data: {
+        status: dbStatus as any,
+        completedAt: new Date(),
+        lastSeq: 0,
+        messageId: assistantMessageId,
+        error: turnCompleteStatus === 'failed' ? 'Turn failed' : undefined,
+      },
+    }).catch((err: any) => {
+      console.warn(`[ProjectChat] Failed to update AgentTurn (complete): ${err?.message}`)
+    })
   }
 
   // Log tool calls with real args, results, duration, and the correct messageId
@@ -902,7 +961,7 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
                 } catch {
                   clearInterval(proxyKeepalive)
                 }
-              }, 15_000)
+              }, 10_000)
               ;(async () => {
                 try {
                   let chunkCount = 0
@@ -939,7 +998,8 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
           // closeSession after the stream finishes. Mark the handoff so
           // our finally guard doesn't double-close.
           billingSessionHandedOff = true
-          trackUsageFromStream(trackingStream, parsedBody, project).catch((err) =>
+          const streamTurnId = response.headers.get('X-Turn-Id') || undefined
+          trackUsageFromStream(trackingStream, parsedBody, project, { turnId: streamTurnId }).catch((err) =>
             console.error("[ProjectChat] Usage tracking error:", err)
           )
 
@@ -1139,18 +1199,40 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
         )
       }
 
-      const response = await fetchFromRuntime(
-        projectId,
-        `/agent/chat/${chatSessionId}/turn`,
-        { method: "GET" },
-      )
-
-      if (response.status === 404) {
-        return c.json({ status: "unknown" as const }, 404)
+      // Try runtime in-memory buffer first (fast path)
+      try {
+        const response = await fetchFromRuntime(
+          projectId,
+          `/agent/chat/${chatSessionId}/turn`,
+          { method: "GET" },
+        )
+        if (response.status !== 404) {
+          const data = await response.json()
+          return c.json(data, response.status as any)
+        }
+      } catch {
+        // Runtime unreachable — fall through to DB
       }
 
-      const data = await response.json()
-      return c.json(data, response.status as any)
+      // Fallback: check DB-backed AgentTurn record
+      const dbTurn = await prisma.agentTurn.findFirst({
+        where: { chatSessionId },
+        orderBy: { startedAt: 'desc' },
+      })
+      if (dbTurn) {
+        return c.json({
+          turnId: dbTurn.turnId,
+          status: dbTurn.status,
+          lastSeq: dbTurn.lastSeq,
+          terminal: dbTurn.error ? { error: dbTurn.error } : null,
+          createdAt: dbTurn.startedAt.getTime(),
+          completedAt: dbTurn.completedAt?.getTime() ?? null,
+          lastEventAt: dbTurn.completedAt?.getTime() ?? dbTurn.startedAt.getTime(),
+          source: 'db',
+        })
+      }
+
+      return c.json({ status: "unknown" as const }, 404)
     } catch (err: any) {
       console.warn(`[ProjectChat] turn snapshot proxy error for ${projectId}/${chatSessionId}:`, err?.message || err)
       return c.json({ status: "unknown" as const }, 404)

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -1956,13 +1956,21 @@ export const ChatPanel = observer(function ChatPanel({
   // transient disconnects, so reaching this state means it gave up after
   // exhausting its retry budget — the turn may still be running on the
   // server while the UI looks "done".
+  //
+  // When a stall is detected, poll the /turn endpoint to check if the turn
+  // is still active on the server. If it is, the user can reload to resume.
   const prevIsStreamingForTurnRef = useRef(false)
   const turnStalledRef = useRef(false)
+  const turnPollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   useEffect(() => {
     const wasStreaming = prevIsStreamingForTurnRef.current
     prevIsStreamingForTurnRef.current = isStreaming
     if (isStreaming && !wasStreaming) {
       turnStalledRef.current = false
+      if (turnPollTimerRef.current) {
+        clearInterval(turnPollTimerRef.current)
+        turnPollTimerRef.current = null
+      }
       return
     }
     if (wasStreaming && !isStreaming) {
@@ -1972,9 +1980,75 @@ export const ChatPanel = observer(function ChatPanel({
             currentTurnIdRef.current +
             ", lastSeq=" +
             turnLastSeqRef.current +
-            "); turn may still be running on the server",
+            "); polling server to check if turn is still active",
         )
         turnStalledRef.current = true
+
+        const sessionId = currentSessionId
+        const turnId = currentTurnIdRef.current
+        if (sessionId && projectId) {
+          setReconnecting(true)
+          let pollCount = 0
+          const MAX_POLLS = 120
+          const POLL_INTERVAL = 5_000
+          const doPoll = async () => {
+            pollCount++
+            if (pollCount > MAX_POLLS || turnCompletedRef.current) {
+              if (turnPollTimerRef.current) {
+                clearInterval(turnPollTimerRef.current)
+                turnPollTimerRef.current = null
+              }
+              setReconnecting(false)
+              return
+            }
+            try {
+              const baseUrl = localAgentUrl || API_URL
+              const fetchFn = expoFetch || fetch
+              const cookie = authClient.getCookie()
+              const resp = await fetchFn(
+                `${baseUrl}/projects/${projectId}/chat/${sessionId}/turn`,
+                {
+                  method: 'GET',
+                  headers: cookie ? { Cookie: cookie } : {},
+                },
+              )
+              if (resp.ok) {
+                const data = await resp.json()
+                if (data.status === 'completed' || data.status === 'failed') {
+                  console.log(`[ChatPanel] Turn ${turnId} finished on server (${data.status}), refreshing messages`)
+                  turnCompletedRef.current = true
+                  turnStalledRef.current = false
+                  if (turnPollTimerRef.current) {
+                    clearInterval(turnPollTimerRef.current)
+                    turnPollTimerRef.current = null
+                  }
+                  setReconnecting(false)
+                  onFilesChanged?.([])
+                } else if (data.status === 'active') {
+                  console.log(`[ChatPanel] Turn ${turnId} still active (seq=${data.lastSeq}), waiting...`)
+                }
+              } else if (resp.status === 404 || resp.status === 204) {
+                console.log(`[ChatPanel] Turn ${turnId} no longer tracked on server, treating as complete`)
+                turnStalledRef.current = false
+                if (turnPollTimerRef.current) {
+                  clearInterval(turnPollTimerRef.current)
+                  turnPollTimerRef.current = null
+                }
+                setReconnecting(false)
+              }
+            } catch (err: any) {
+              console.warn(`[ChatPanel] Turn poll failed: ${err?.message || err}`)
+            }
+          }
+          doPoll()
+          turnPollTimerRef.current = setInterval(doPoll, POLL_INTERVAL)
+        }
+      }
+    }
+    return () => {
+      if (turnPollTimerRef.current) {
+        clearInterval(turnPollTimerRef.current)
+        turnPollTimerRef.current = null
       }
     }
   }, [isStreaming])

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -1988,12 +1988,11 @@ export const ChatPanel = observer(function ChatPanel({
         const turnId = currentTurnIdRef.current
         if (sessionId && projectId) {
           setReconnecting(true)
-          let pollCount = 0
-          const MAX_POLLS = 120
-          const POLL_INTERVAL = 5_000
+          const pollStartedAt = Date.now()
+          const MAX_POLL_MS = 45 * 60_000
+          const POLL_INTERVAL = 10_000
           const doPoll = async () => {
-            pollCount++
-            if (pollCount > MAX_POLLS || turnCompletedRef.current) {
+            if (Date.now() - pollStartedAt > MAX_POLL_MS || turnCompletedRef.current) {
               if (turnPollTimerRef.current) {
                 clearInterval(turnPollTimerRef.current)
                 turnPollTimerRef.current = null
@@ -2004,12 +2003,12 @@ export const ChatPanel = observer(function ChatPanel({
             try {
               const baseUrl = localAgentUrl || API_URL
               const fetchFn = expoFetch || fetch
-              const cookie = authClient.getCookie()
+              const headers = nativeHeaders?.() ?? {}
               const resp = await fetchFn(
                 `${baseUrl}/projects/${projectId}/chat/${sessionId}/turn`,
                 {
                   method: 'GET',
-                  headers: cookie ? { Cookie: cookie } : {},
+                  headers,
                 },
               )
               if (resp.ok) {
@@ -2090,9 +2089,11 @@ export const ChatPanel = observer(function ChatPanel({
 
   // Idle timeout to force-complete hung streams.
   //
-  // The runtime emits `data-tool-progress` heartbeats every 15s during long
+  // The runtime emits `data-tool-progress` heartbeats every 10s during long
   // tool executions and the API proxy injects keep-alive frames, so a true
-  // idle window of 30 minutes means the runtime really has gone silent.
+  // idle window of 30 minutes is only fatal when there is no active durable
+  // turn. If the turn is still open, extend the timer and let /turn polling
+  // decide completion instead of sending stop() prematurely.
   // Anything shorter risks killing legitimate long Anthropic / Opus turns.
   const idleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastMessageContentRef = useRef<string>("")
@@ -2127,12 +2128,20 @@ export const ChatPanel = observer(function ChatPanel({
         lastMessageContentRef.current = currentContent
       }
 
-      idleTimeoutRef.current = setTimeout(() => {
-        if (isStreaming) {
-          console.warn("[ChatPanel] Stream idle timeout - forcing stop()")
-          handleStop()
-        }
-      }, IDLE_TIMEOUT_MS)
+      const scheduleIdleTimeout = () => {
+        idleTimeoutRef.current = setTimeout(() => {
+          if (isStreaming) {
+            if (currentTurnIdRef.current && !turnCompletedRef.current) {
+              console.warn("[ChatPanel] Stream idle timeout while durable turn is active - extending instead of forcing stop()")
+              scheduleIdleTimeout()
+              return
+            }
+            console.warn("[ChatPanel] Stream idle timeout with no active durable turn - forcing stop()")
+            handleStop()
+          }
+        }, IDLE_TIMEOUT_MS)
+      }
+      scheduleIdleTimeout()
     } else {
       if (idleTimeoutRef.current) {
         clearTimeout(idleTimeoutRef.current)

--- a/k8s/knative/config-defaults.yaml
+++ b/k8s/knative/config-defaults.yaml
@@ -1,0 +1,20 @@
+# =============================================================================
+# Knative Serving Defaults
+# =============================================================================
+# Applied to the knative-serving namespace on OCI clusters.
+#
+# max-revision-timeout-seconds must be >= any Service spec.timeoutSeconds.
+# Without this, Knative rejects or clamps revisions above the cluster cap
+# (default is commonly 600s), making long chat stream timeout settings
+# misleading.
+# =============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-defaults
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: serving
+    app.kubernetes.io/name: knative-serving
+data:
+  max-revision-timeout-seconds: "3600"

--- a/k8s/knative/config-kourier.yaml
+++ b/k8s/knative/config-kourier.yaml
@@ -26,3 +26,10 @@ data:
   certs-secret-name: kourier-tls
   certs-secret-namespace: kourier-system
   drain-time-seconds: "15"
+  # Envoy stream_idle_timeout: max time a stream connection can be idle
+  # (no data flowing in either direction) before Envoy closes it.
+  # Default is 300s (5 min) which kills long-running chat streams during
+  # tool calls or LLM thinking pauses. Healthy chat streams send keepalive
+  # comments every 10s, so 15 minutes is enough headroom without keeping
+  # truly idle/dead streams around for too long.
+  stream-idle-timeout: "900"

--- a/k8s/overlays/staging/api-service.yaml
+++ b/k8s/overlays/staging/api-service.yaml
@@ -102,6 +102,8 @@ spec:
       # run 30+ minutes; the previous 1800s limit caused premature stream
       # termination. The runtime sends keepalive comments every 10s so
       # truly dead connections are still detected by intermediate proxies.
+      # Requires knative-serving/config-defaults max-revision-timeout-seconds
+      # to be at least 3600 (see k8s/knative/config-defaults.yaml).
       timeoutSeconds: 3600
       serviceAccountName: api-service-account
       containers:
@@ -304,6 +306,8 @@ spec:
               value: "true"
             - name: PROMOTED_POD_IDLE_TIMEOUT_MS
               value: "1800000"
+            - name: AGENT_TURN_STALE_AFTER_MS
+              value: "7200000"
             - name: LOAD_TEST_SECRET
               valueFrom:
                 secretKeyRef:

--- a/k8s/overlays/staging/api-service.yaml
+++ b/k8s/overlays/staging/api-service.yaml
@@ -97,13 +97,12 @@ spec:
         autoscaling.knative.dev/scale-down-delay: "5m"
         autoscaling.knative.dev/window: "60s"
     spec:
-      # Max time a single request (inc. WS) can stay open. 1800s = 30 min.
-      # Desktops reconnect well before this on their own heartbeat cycle,
-      # so there's no benefit to going higher — and going higher (3600)
-      # risks being silently clamped by the cluster-level
-      # `max-request-timeout-seconds` in knative-serving/config-defaults.
-      # Keeping this within safe Knative defaults avoids that dependency.
-      timeoutSeconds: 1800
+      # Max time a single request (inc. WS + chat stream) can stay open.
+      # 3600s = 1 hour. Long agent turns with many tool calls can easily
+      # run 30+ minutes; the previous 1800s limit caused premature stream
+      # termination. The runtime sends keepalive comments every 10s so
+      # truly dead connections are still detected by intermediate proxies.
+      timeoutSeconds: 3600
       serviceAccountName: api-service-account
       containers:
         - name: api
@@ -304,7 +303,7 @@ spec:
             - name: PROMOTED_POD_GC_ENABLED
               value: "true"
             - name: PROMOTED_POD_IDLE_TIMEOUT_MS
-              value: "600000"
+              value: "1800000"
             - name: LOAD_TEST_SECRET
               valueFrom:
                 secretKeyRef:

--- a/packages/agent-runtime/src/gateway.ts
+++ b/packages/agent-runtime/src/gateway.ts
@@ -1869,7 +1869,7 @@ export class AgentGateway {
                 clearInterval(timer)
                 toolHeartbeatTimers.delete(toolCallId)
               }
-            }, 15_000)
+            }, 10_000)
             toolHeartbeatTimers.set(toolCallId, timer)
           }
           streamedToolCalls.delete(toolCallId)

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -956,7 +956,7 @@ app.post('/agent/chat', async (c) => {
     // If this client disconnects, only the replay subscriber is removed;
     // the background reader + agent keep running.
     const replayStream = streamBufferStore.createReplayStream(chatSessionKey)!
-    const wrappedStream = wrapStreamWithKeepalive(replayStream, 15_000)
+    const wrappedStream = wrapStreamWithKeepalive(replayStream, 10_000)
     const responseHeaders = new Headers(response.headers)
     responseHeaders.set('X-Turn-Id', turnId)
     responseHeaders.set('X-Chat-Session-Id', chatSessionKey)
@@ -1003,7 +1003,7 @@ app.get('/agent/chat/:chatSessionId/stream', (c) => {
     return new Response(null, { status: 204 })
   }
 
-  const wrappedStream = wrapStreamWithKeepalive(replayStream, 15_000)
+  const wrappedStream = wrapStreamWithKeepalive(replayStream, 10_000)
   return new Response(wrappedStream, {
     headers: {
       'Content-Type': 'text/x-ai-sdk-ui-stream',

--- a/packages/shared-app/src/chat/auto-resuming-fetch.ts
+++ b/packages/shared-app/src/chat/auto-resuming-fetch.ts
@@ -155,6 +155,7 @@ function createDurableBody(opts: DurableBodyOpts): ReadableStream<Uint8Array> {
   } = opts
 
   let cancelledFlag = false
+  let currentReader: ReadableStreamDefaultReader<Uint8Array> | null = null
 
   return new ReadableStream<Uint8Array>({
     async start(controller) {
@@ -216,6 +217,7 @@ function createDurableBody(opts: DurableBodyOpts): ReadableStream<Uint8Array> {
 
       const pumpBody = async (body: ReadableStream<Uint8Array>): Promise<{ bytes: number }> => {
         const reader = body.getReader()
+        currentReader = reader
         let bytes = 0
         try {
           while (!checkCancelled()) {
@@ -232,6 +234,7 @@ function createDurableBody(opts: DurableBodyOpts): ReadableStream<Uint8Array> {
             }
           }
         } finally {
+          if (currentReader === reader) currentReader = null
           try { reader.releaseLock() } catch { /* noop */ }
         }
         return { bytes }
@@ -242,9 +245,6 @@ function createDurableBody(opts: DurableBodyOpts): ReadableStream<Uint8Array> {
       try {
         await pumpBody(initialBody)
 
-        // Track the last seq before we entered the resume loop so we can
-        // detect forward progress even across 204 gaps.
-        let seqAtLoopStart = lastSeq
         let consecutiveNoProgress = 0
         const MAX_CONSECUTIVE_NO_PROGRESS = 10
 
@@ -291,7 +291,6 @@ function createDurableBody(opts: DurableBodyOpts): ReadableStream<Uint8Array> {
           const { bytes } = await pumpBody(resumeRes.body)
           if (bytes > 0) {
             resumeAttempts = 0
-            seqAtLoopStart = lastSeq
           }
         }
 
@@ -308,6 +307,7 @@ function createDurableBody(opts: DurableBodyOpts): ReadableStream<Uint8Array> {
     },
     cancel() {
       cancelledFlag = true
+      try { currentReader?.cancel() } catch { /* noop */ }
     },
   })
 }

--- a/packages/shared-app/src/chat/auto-resuming-fetch.ts
+++ b/packages/shared-app/src/chat/auto-resuming-fetch.ts
@@ -44,9 +44,9 @@ export interface AutoResumingFetchOptions {
 }
 
 const DEFAULT_OPTIONS: Required<Omit<AutoResumingFetchOptions, 'buildResumeUrl' | 'logger'>> = {
-  maxResumeAttempts: 8,
-  initialBackoffMs: 500,
-  maxBackoffMs: 5_000,
+  maxResumeAttempts: 30,
+  initialBackoffMs: 1_000,
+  maxBackoffMs: 15_000,
 }
 
 const TURN_HEADER = {
@@ -154,6 +154,8 @@ function createDurableBody(opts: DurableBodyOpts): ReadableStream<Uint8Array> {
     turnId,
   } = opts
 
+  let cancelledFlag = false
+
   return new ReadableStream<Uint8Array>({
     async start(controller) {
       let lastSeq = 0
@@ -162,6 +164,8 @@ function createDurableBody(opts: DurableBodyOpts): ReadableStream<Uint8Array> {
       let resumeAttempts = 0
       const decoder = new TextDecoder()
       let parseBuf = ''
+
+      const checkCancelled = () => cancelled || cancelledFlag
 
       const log = (msg: string) => {
         if (logger) logger.log(`[AutoResume:${turnId.slice(0, 8)}] ${msg}`)
@@ -214,7 +218,7 @@ function createDurableBody(opts: DurableBodyOpts): ReadableStream<Uint8Array> {
         const reader = body.getReader()
         let bytes = 0
         try {
-          while (!cancelled) {
+          while (!checkCancelled()) {
             const { done, value } = await reader.read()
             if (done) return { bytes }
             if (!value) continue
@@ -223,7 +227,6 @@ function createDurableBody(opts: DurableBodyOpts): ReadableStream<Uint8Array> {
             try {
               controller.enqueue(value)
             } catch {
-              // Downstream consumer (AI SDK) cancelled — stop pumping.
               cancelled = true
               return { bytes }
             }
@@ -239,17 +242,23 @@ function createDurableBody(opts: DurableBodyOpts): ReadableStream<Uint8Array> {
       try {
         await pumpBody(initialBody)
 
-        while (!turnCompleted && !cancelled && resumeAttempts < maxResumeAttempts) {
+        // Track the last seq before we entered the resume loop so we can
+        // detect forward progress even across 204 gaps.
+        let seqAtLoopStart = lastSeq
+        let consecutiveNoProgress = 0
+        const MAX_CONSECUTIVE_NO_PROGRESS = 10
+
+        while (!turnCompleted && !checkCancelled() && resumeAttempts < maxResumeAttempts) {
           resumeAttempts++
           const backoff = Math.min(
-            initialBackoffMs * Math.pow(2, resumeAttempts - 1),
+            initialBackoffMs * Math.pow(2, Math.min(resumeAttempts - 1, 6)),
             maxBackoffMs,
           )
           warn(
             `stream EOF without turn-complete; reconnecting fromSeq=${lastSeq} (attempt ${resumeAttempts}/${maxResumeAttempts}, backoff ${backoff}ms)`,
           )
           await sleep(backoff)
-          if (cancelled) break
+          if (checkCancelled()) break
 
           let resumeRes: Response
           try {
@@ -261,14 +270,17 @@ function createDurableBody(opts: DurableBodyOpts): ReadableStream<Uint8Array> {
           }
 
           if (resumeRes.status === 204 || !resumeRes.body) {
-            log(`resume returned ${resumeRes.status} — turn no longer buffered, stopping`)
-            break
+            consecutiveNoProgress++
+            if (consecutiveNoProgress >= MAX_CONSECUTIVE_NO_PROGRESS) {
+              log(`resume returned ${resumeRes.status} ${consecutiveNoProgress} times — turn no longer buffered, stopping`)
+              break
+            }
+            log(`resume returned ${resumeRes.status} — turn may not be buffered yet, will retry (${consecutiveNoProgress}/${MAX_CONSECUTIVE_NO_PROGRESS})`)
+            continue
           }
 
-          // Confirm we're still talking about the same turn. If the
-          // server has rotated to a new turnId on the same session, we
-          // would corrupt the AI SDK accumulator by appending the new
-          // turn's bytes onto the old one — bail out instead.
+          consecutiveNoProgress = 0
+
           const resumeTurnId = resumeRes.headers.get(TURN_HEADER.TURN_ID)
           if (resumeTurnId && resumeTurnId !== turnId) {
             warn(`resume returned a different turnId (${resumeTurnId}); stopping`)
@@ -276,14 +288,14 @@ function createDurableBody(opts: DurableBodyOpts): ReadableStream<Uint8Array> {
             break
           }
 
-          // Only reset the attempt counter if the resume actually
-          // delivered bytes — otherwise an endless loop of empty 200s
-          // would never surface as "stalled".
           const { bytes } = await pumpBody(resumeRes.body)
-          if (bytes > 0) resumeAttempts = 0
+          if (bytes > 0) {
+            resumeAttempts = 0
+            seqAtLoopStart = lastSeq
+          }
         }
 
-        if (!turnCompleted && !cancelled) {
+        if (!turnCompleted && !checkCancelled()) {
           warn(`gave up after ${resumeAttempts} resume attempts; closing stream`)
         }
       } catch (err: any) {
@@ -295,10 +307,7 @@ function createDurableBody(opts: DurableBodyOpts): ReadableStream<Uint8Array> {
       }
     },
     cancel() {
-      // Downstream cancelled (e.g. AI SDK got an error or user-stop).
-      // The async loop above checks `cancelled` and exits its read loop;
-      // we don't have direct access to it here, but pump will notice the
-      // controller refusing further enqueues and stop on the next chunk.
+      cancelledFlag = true
     },
   })
 }

--- a/packages/shared-runtime/src/stream-buffer.ts
+++ b/packages/shared-runtime/src/stream-buffer.ts
@@ -16,8 +16,14 @@
  */
 
 const CLEANUP_INTERVAL_MS = 60_000
-const MAX_BUFFER_AGE_MS = 30 * 60_000
-const COMPLETED_GRACE_MS = 30_000
+const MAX_BUFFER_AGE_MS = parseInt(
+  (typeof process !== 'undefined' && process.env?.STREAM_BUFFER_MAX_AGE_MS) || String(90 * 60_000),
+  10,
+)
+const COMPLETED_GRACE_MS = parseInt(
+  (typeof process !== 'undefined' && process.env?.STREAM_BUFFER_COMPLETED_GRACE_MS) || String(2 * 60_000),
+  10,
+)
 
 export type TurnStatus = 'active' | 'completed' | 'aborted' | 'failed'
 

--- a/prisma/migrations/20260428180000_add_agent_turns/migration.sql
+++ b/prisma/migrations/20260428180000_add_agent_turns/migration.sql
@@ -1,0 +1,39 @@
+-- CreateEnum
+CREATE TYPE "AgentTurnStatus" AS ENUM ('active', 'completed', 'failed', 'aborted');
+
+-- CreateTable
+CREATE TABLE "agent_turns" (
+    "id" TEXT NOT NULL,
+    "chatSessionId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "turnId" TEXT NOT NULL,
+    "status" "AgentTurnStatus" NOT NULL DEFAULT 'active',
+    "lastSeq" INTEGER NOT NULL DEFAULT 0,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+    "error" TEXT,
+    "messageId" TEXT,
+
+    CONSTRAINT "agent_turns_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "agent_turns_turnId_key" ON "agent_turns"("turnId");
+
+-- CreateIndex
+CREATE INDEX "agent_turns_chatSessionId_idx" ON "agent_turns"("chatSessionId");
+
+-- CreateIndex
+CREATE INDEX "agent_turns_projectId_idx" ON "agent_turns"("projectId");
+
+-- CreateIndex
+CREATE INDEX "agent_turns_turnId_idx" ON "agent_turns"("turnId");
+
+-- CreateIndex
+CREATE INDEX "agent_turns_chatSessionId_status_idx" ON "agent_turns"("chatSessionId", "status");
+
+-- AddForeignKey
+ALTER TABLE "agent_turns" ADD CONSTRAINT "agent_turns_chatSessionId_fkey" FOREIGN KEY ("chatSessionId") REFERENCES "chat_sessions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "agent_turns" ADD CONSTRAINT "agent_turns_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -183,6 +183,7 @@ model Project {
   meetings         Meeting[]
   marketplaceListing  MarketplaceListing?
   voiceConfig         VoiceProjectConfig?
+  agentTurns          AgentTurn[]
 
   @@index([workspaceId])
   @@index([folderId])
@@ -609,6 +610,7 @@ model ChatSession {
   project         Project?       @relation(fields: [contextId], references: [id], onDelete: Cascade)
   messages        ChatMessage[]
   toolCallLogs    ToolCallLog[]
+  agentTurns      AgentTurn[]
 
   @@index([contextType, contextId])
   @@map("chat_sessions")
@@ -649,6 +651,42 @@ model ChatMessage {
 enum ChatRole {
   user
   assistant
+}
+
+// =============================================================================
+// AGENT TURNS — Durable turn lifecycle tracking
+// =============================================================================
+// Persists the lifecycle of each chat turn so that a reconnecting client or
+// a replacement runtime pod can determine whether a turn is still in progress,
+// completed, or failed — even if the original in-memory stream buffer was lost.
+
+model AgentTurn {
+  id             String          @id @default(uuid())
+  chatSessionId  String
+  projectId      String
+  turnId         String          @unique
+  status         AgentTurnStatus @default(active)
+  lastSeq        Int             @default(0)
+  startedAt      DateTime        @default(now())
+  completedAt    DateTime?
+  error          String?         @db.Text
+  messageId      String?
+
+  session        ChatSession     @relation(fields: [chatSessionId], references: [id], onDelete: Cascade)
+  project        Project         @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@index([chatSessionId])
+  @@index([projectId])
+  @@index([turnId])
+  @@index([chatSessionId, status])
+  @@map("agent_turns")
+}
+
+enum AgentTurnStatus {
+  active
+  completed
+  failed
+  aborted
 }
 
 model ToolCallLog {


### PR DESCRIPTION
## Summary
- prevent false chat completion by persisting durable turn lifecycle (`AgentTurn`) and keying completion off turn markers instead of transport EOF
- harden long-running stream resilience with tighter keepalive heartbeats, stronger client auto-resume behavior, and durable `/turn` fallback via DB
- tune staging runtime/proxy settings to avoid early disconnects while keeping cost-aware retention bounds

## Root Cause Analysis (RCA)
- API/runtime stream lifecycle mismatch: transport EOF could be observed before durable turn completion was confirmed
- network/proxy idle pressure: default Kourier idle timeout can terminate long tool/think phases without explicit tuning
- volatile replay window: in-memory buffer retention was too short for realistic reconnect + mobile churn patterns
- no durable cross-pod turn authority: if in-memory buffer was unavailable, resume/status degraded

## Post-fix flow
1. Runtime emits `data-turn-start` -> API upserts `AgentTurn(active)`.
2. Runtime streams output + tool progress heartbeats and keepalive frames.
3. On disconnect, client resumes via `fromSeq`; if runtime snapshot is unavailable, API `/turn` falls back to DB `AgentTurn`.
4. Runtime emits `data-turn-complete` -> API marks `AgentTurn(completed|failed|aborted)` and links persisted message.
5. Chat UI stalled-state polling resolves from durable status and refreshes after server-side completion.

## Cost/retention guardrails
- `stream-idle-timeout` tuned to 15m (not 1h) in Kourier
- in-memory stream buffer defaults tuned to 90m active / 2m completed grace (env-configurable)
- request timeout remains high enough for legitimate long turns, with bounded idle + replay retention

## Linked issue
- Closes #454

## Test plan
- [x] Prisma schema validates (`npx prisma validate`)
- [x] Prisma client regenerates (`npx prisma generate`)
- [x] lint check on modified core files (`project-chat.ts`, `stream-buffer.ts`)
- [ ] staging verification: run a 20-30 minute tool-heavy turn and confirm no premature completion
- [ ] staging verification: force mid-turn reconnect and confirm durable resume/status via `/turn`

Made with [Cursor](https://cursor.com)