### PR TITLE
Add LRU cache for query embeddings in IndexEngine

### DIFF
--- a/packages/agent-runtime/src/__tests__/index-engine.test.ts
+++ b/packages/agent-runtime/src/__tests__/index-engine.test.ts
@@ -13,7 +13,7 @@
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
 import { mkdirSync, writeFileSync, rmSync, existsSync, statSync } from 'fs'
 import { join } from 'path'
-import { IndexEngine, createCodeSource, createFilesSource, type IndexEngineConfig, type ScanSource } from '../index-engine'
+import { IndexEngine, EmbeddingCache, createCodeSource, createFilesSource, type IndexEngineConfig, type ScanSource } from '../index-engine'
 
 const TEST_DIR = '/tmp/test-index-engine-unit'
 const CODE_DIR = TEST_DIR
@@ -322,5 +322,63 @@ describe('IndexEngine: source configuration', () => {
     expect(db).toBeDefined()
     const result = db.prepare('SELECT 1 as one').get() as { one: number }
     expect(result.one).toBe(1)
+  })
+})
+
+// ============================================================================
+// Embedding LRU Cache
+// ============================================================================
+
+describe('EmbeddingCache', () => {
+  test('returns undefined for cache miss', () => {
+    const cache = new EmbeddingCache(4)
+    expect(cache.get('unknown')).toBeUndefined()
+  })
+
+  test('stores and retrieves embeddings', () => {
+    const cache = new EmbeddingCache(4)
+    const vec = new Float32Array([1, 2, 3])
+    cache.set('hello', vec)
+    expect(cache.get('hello')).toBe(vec)
+  })
+
+  test('evicts oldest entry when capacity is exceeded', () => {
+    const cache = new EmbeddingCache(2)
+    cache.set('a', new Float32Array([1]))
+    cache.set('b', new Float32Array([2]))
+    cache.set('c', new Float32Array([3]))
+
+    expect(cache.get('a')).toBeUndefined()
+    expect(cache.get('b')).toBeDefined()
+    expect(cache.get('c')).toBeDefined()
+  })
+
+  test('accessing an entry refreshes its position', () => {
+    const cache = new EmbeddingCache(2)
+    cache.set('a', new Float32Array([1]))
+    cache.set('b', new Float32Array([2]))
+
+    cache.get('a')
+
+    cache.set('c', new Float32Array([3]))
+
+    expect(cache.get('a')).toBeDefined()
+    expect(cache.get('b')).toBeUndefined()
+    expect(cache.get('c')).toBeDefined()
+  })
+
+  test('overwriting a key does not grow the cache', () => {
+    const cache = new EmbeddingCache(2)
+    cache.set('a', new Float32Array([1]))
+    cache.set('b', new Float32Array([2]))
+
+    const updated = new Float32Array([10])
+    cache.set('a', updated)
+
+    cache.set('c', new Float32Array([3]))
+
+    expect(cache.get('a')).toBe(updated)
+    expect(cache.get('b')).toBeUndefined()
+    expect(cache.get('c')).toBeDefined()
   })
 })

--- a/packages/agent-runtime/src/index-engine.ts
+++ b/packages/agent-runtime/src/index-engine.ts
@@ -140,6 +140,40 @@ const EMBEDDING_BATCH_SIZE = 64
 const DEFAULT_CHUNK_LINES = 40
 const DEFAULT_CHUNK_OVERLAP = 10
 const MAX_EMBEDDING_FAILURES = 3
+const QUERY_EMBEDDING_CACHE_SIZE = 128
+
+// ---------------------------------------------------------------------------
+// Query Embedding LRU Cache
+// ---------------------------------------------------------------------------
+
+export class EmbeddingCache {
+  private cache = new Map<string, Float32Array>()
+  private maxSize: number
+
+  constructor(maxSize: number) {
+    this.maxSize = maxSize
+  }
+
+  get(key: string): Float32Array | undefined {
+    const value = this.cache.get(key)
+    if (value === undefined) return undefined
+    // Move to end (most recently used)
+    this.cache.delete(key)
+    this.cache.set(key, value)
+    return value
+  }
+
+  set(key: string, value: Float32Array): void {
+    if (this.cache.has(key)) {
+      this.cache.delete(key)
+    } else if (this.cache.size >= this.maxSize) {
+      // Evict oldest (first) entry
+      const oldest = this.cache.keys().next().value
+      if (oldest !== undefined) this.cache.delete(oldest)
+    }
+    this.cache.set(key, value)
+  }
+}
 
 // ---------------------------------------------------------------------------
 // IndexEngine
@@ -155,6 +189,7 @@ export class IndexEngine {
   private vecExtensionLoaded: boolean = false
   private indexing: Promise<any> | null = null
   private consecutiveEmbeddingFailures = 0
+  private queryEmbeddingCache = new EmbeddingCache(QUERY_EMBEDDING_CACHE_SIZE)
   private graph: { queryNeighbors(qn: string, edgeKinds?: string[], depth?: number): Array<{ filePath: string }> } | null = null
 
   constructor(config: IndexEngineConfig) {
@@ -618,13 +653,18 @@ export class IndexEngine {
     if (!this.openai) return []
 
     try {
-      const response = await this.openai.embeddings.create({
-        model: EMBEDDING_MODEL,
-        input: [query],
-        dimensions: EMBEDDING_DIMENSIONS,
-      })
+      const normalizedQuery = query.trim().toLowerCase()
+      let queryEmbedding = this.queryEmbeddingCache.get(normalizedQuery)
 
-      const queryEmbedding = new Float32Array(response.data[0].embedding)
+      if (!queryEmbedding) {
+        const response = await this.openai.embeddings.create({
+          model: EMBEDDING_MODEL,
+          input: [query],
+          dimensions: EMBEDDING_DIMENSIONS,
+        })
+        queryEmbedding = new Float32Array(response.data[0].embedding)
+        this.queryEmbeddingCache.set(normalizedQuery, queryEmbedding)
+      }
 
       let sql = `
         SELECT v.chunk_id, v.distance, c.source, c.path, c.chunk, c.line_start, c.line_end


### PR DESCRIPTION
### Title
Add LRU cache for query embeddings in IndexEngine

### Description
Adds an LRU cache (128 entries) for query embeddings in `IndexEngine` `vectorSearch`. Repeated searches with the same normalized query (trim + lowercase) reuse the cached `Float32Array` instead of calling the OpenAI embeddings API again.

### Why
Reduces latency (~200–500ms per hit on typical embedding calls) and embedding usage when users repeat similar semantic searches in one workspace/session.

### Scope / notes
- **Embeddings are currently off by default** (`enableEmbeddings: false`); vector search is inactive unless that’s enabled. This change is **safe additive behavior** when embeddings are turned on.
- Includes unit tests for `EmbeddingCache` (miss/hit, LRU eviction, MRU refresh, overwrite).

### Test plan
- [ ] Run `bun test packages/agent-runtime/src/__tests__/index-engine.test.ts` (EmbeddingCache tests).
- [ ] When embeddings are enabled in config: run two identical searches and confirm second avoids embedding latency / duplicate embedding usage (optional integration check).

### Files changed
- `packages/agent-runtime/src/index-engine.ts`
- `packages/agent-runtime/src/__tests__/index-engine.test.ts`