### PR TITLE
fix(plan-mode): Cursor-parity build flow, Plans panel, and runtime hardening (#460)

### DIFF
--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -494,48 +494,53 @@ const HomeScreen = observer(function HomeScreen() {
     user?.id,
   ])
 
-  const handlePromptSubmit = useCallback(async (
-    text: string,
-    files?: FileAttachment[],
-    modeOverride?: InteractionMode,
-  ) => {
-    if (pendingPlanModeSuggestionRef.current && !modeOverride) return
+  const handlePromptSubmit = useCallback(
+    (
+      text: string,
+      files?: FileAttachment[],
+      modeOverride?: InteractionMode,
+    ): void | false => {
+      if (pendingPlanModeSuggestionRef.current && !modeOverride) {
+        return false
+      }
 
-    const submissionInteractionMode = modeOverride ?? interactionMode
-    if (
-      !modeOverride &&
-      submissionInteractionMode === 'agent' &&
-      !isCreating &&
-      !pendingPlanModeSuggestionRef.current &&
-      shouldSuggestPlanMode(text)
-    ) {
-      clearPlanModeSuggestionTimers()
-      const pending = { text, files }
-      pendingPlanModeSuggestionRef.current = pending
-      setPendingPlanModeSuggestion(pending)
-      setPlanModeSuggestionSecondsLeft(PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS)
-      planModeSuggestionIntervalRef.current = setInterval(() => {
-        setPlanModeSuggestionSecondsLeft((seconds) => Math.max(0, seconds - 1))
-      }, 1000)
-      planModeSuggestionTimeoutRef.current = setTimeout(() => {
-        const pendingSubmission = pendingPlanModeSuggestionRef.current
-        if (!pendingSubmission) return
+      const submissionInteractionMode = modeOverride ?? interactionMode
+      if (
+        !modeOverride &&
+        submissionInteractionMode === 'agent' &&
+        !isCreating &&
+        !pendingPlanModeSuggestionRef.current &&
+        shouldSuggestPlanMode(text)
+      ) {
         clearPlanModeSuggestionTimers()
-        pendingPlanModeSuggestionRef.current = null
-        setPendingPlanModeSuggestion(null)
+        const pending = { text, files }
+        pendingPlanModeSuggestionRef.current = pending
+        setPendingPlanModeSuggestion(pending)
         setPlanModeSuggestionSecondsLeft(PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS)
-        void createProjectFromPrompt(pendingSubmission.text, pendingSubmission.files, 'agent')
-      }, PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS * 1000)
-      return
-    }
+        planModeSuggestionIntervalRef.current = setInterval(() => {
+          setPlanModeSuggestionSecondsLeft((seconds) => Math.max(0, seconds - 1))
+        }, 1000)
+        planModeSuggestionTimeoutRef.current = setTimeout(() => {
+          const pendingSubmission = pendingPlanModeSuggestionRef.current
+          if (!pendingSubmission) return
+          clearPlanModeSuggestionTimers()
+          pendingPlanModeSuggestionRef.current = null
+          setPendingPlanModeSuggestion(null)
+          setPlanModeSuggestionSecondsLeft(PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS)
+          void createProjectFromPrompt(pendingSubmission.text, pendingSubmission.files, 'agent')
+        }, PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS * 1000)
+        return false
+      }
 
-    await createProjectFromPrompt(text, files, submissionInteractionMode)
-  }, [
-    clearPlanModeSuggestionTimers,
-    createProjectFromPrompt,
-    interactionMode,
-    isCreating,
-  ])
+      void createProjectFromPrompt(text, files, submissionInteractionMode)
+    },
+    [
+      clearPlanModeSuggestionTimers,
+      createProjectFromPrompt,
+      interactionMode,
+      isCreating,
+    ],
+  )
 
   const handleResolvePlanModeSuggestion = useCallback(
     (targetMode: 'agent' | 'plan') => {
@@ -553,6 +558,17 @@ const HomeScreen = observer(function HomeScreen() {
     },
     [clearPlanModeSuggestionTimers, handleHomeInteractionModeChange, handlePromptSubmit],
   )
+
+  const handleEditPlanModePrompt = useCallback(() => {
+    const pending = pendingPlanModeSuggestionRef.current
+    if (!pending) return
+
+    clearPlanModeSuggestionTimers()
+    pendingPlanModeSuggestionRef.current = null
+    setPendingPlanModeSuggestion(null)
+    setPlanModeSuggestionSecondsLeft(PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS)
+    setPrompt(pending.text)
+  }, [clearPlanModeSuggestionTimers])
 
   useEffect(() => {
     return () => {
@@ -682,6 +698,7 @@ const HomeScreen = observer(function HomeScreen() {
               {pendingPlanModeSuggestion && (
                 <PlanModeSuggestion
                   secondsLeft={planModeSuggestionSecondsLeft}
+                  onEditPrompt={handleEditPlanModePrompt}
                   onContinueInAgent={() => handleResolvePlanModeSuggestion('agent')}
                   onSwitchToPlan={() => handleResolvePlanModeSuggestion('plan')}
                 />
@@ -690,6 +707,7 @@ const HomeScreen = observer(function HomeScreen() {
                 onSubmit={handlePromptSubmit}
                 isLoading={isCreating || !!pendingPlanModeSuggestion}
                 disabled={!!pendingPlanModeSuggestion}
+                dimWhenDisabled={!pendingPlanModeSuggestion}
                 placeholder={homeComposerPlaceholder}
                 value={prompt}
                 onChange={setPrompt}

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -14,7 +14,7 @@ import {
 import { useRouter } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { observer } from 'mobx-react-lite'
-import { AlertCircle, ArrowRight } from 'lucide-react-native'
+import { ArrowRight } from 'lucide-react-native'
 import Svg, { Defs, RadialGradient, Stop, Ellipse } from 'react-native-svg'
 import { ProjectCard } from '../../components/home/ProjectCard'
 import { cn } from '@shogo/shared-ui/primitives'
@@ -36,6 +36,7 @@ import {
   PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS,
   shouldSuggestPlanMode,
 } from '../../components/chat/plan-mode-suggestion'
+import { PlanModeSuggestion } from '../../components/chat/PlanModeSuggestion'
 import {
   loadInteractionModePreference,
   saveInteractionModePreference,
@@ -679,51 +680,11 @@ const HomeScreen = observer(function HomeScreen() {
               }}
             >
               {pendingPlanModeSuggestion && (
-                <View
-                  className="mb-2 rounded-xl border border-amber-500/35 bg-amber-500/10 p-3"
-                  testID="plan-mode-suggestion"
-                  accessibilityRole="alert"
-                >
-                  <View className="flex-row items-start gap-2">
-                    <AlertCircle className="mt-0.5 h-4 w-4 text-amber-400" size={16} />
-                    <View className="flex-1">
-                      <Text className="text-sm font-medium text-foreground">
-                        This looks like planning work. Switch to Plan mode?
-                      </Text>
-                      <Text
-                        className="mt-1 text-xs text-muted-foreground"
-                        accessibilityLiveRegion="polite"
-                      >
-                        We&apos;ll send this in Agent mode in{' '}
-                        {Math.max(1, planModeSuggestionSecondsLeft)}s unless you choose Plan.
-                      </Text>
-                    </View>
-                  </View>
-                  <View className="mt-3 flex-row flex-wrap justify-end gap-2">
-                    <Pressable
-                      onPress={() => handleResolvePlanModeSuggestion('agent')}
-                      className="min-h-10 justify-center rounded-md border border-border/70 px-3 py-2"
-                      testID="plan-mode-suggestion-continue"
-                      accessibilityRole="button"
-                      accessibilityLabel="Continue in Agent mode"
-                    >
-                      <Text className="text-xs font-medium text-muted-foreground">
-                        Continue in Agent
-                      </Text>
-                    </Pressable>
-                    <Pressable
-                      onPress={() => handleResolvePlanModeSuggestion('plan')}
-                      className="min-h-10 justify-center rounded-md bg-amber-500/20 px-3 py-2"
-                      testID="plan-mode-suggestion-switch"
-                      accessibilityRole="button"
-                      accessibilityLabel="Switch to Plan mode and send"
-                    >
-                      <Text className="text-xs font-medium text-amber-400">
-                        Switch to Plan
-                      </Text>
-                    </Pressable>
-                  </View>
-                </View>
+                <PlanModeSuggestion
+                  secondsLeft={planModeSuggestionSecondsLeft}
+                  onContinueInAgent={() => handleResolvePlanModeSuggestion('agent')}
+                  onSwitchToPlan={() => handleResolvePlanModeSuggestion('plan')}
+                />
               )}
               <CompactChatInput
                 onSubmit={handlePromptSubmit}

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import {
   View,
   Text,
@@ -14,7 +14,7 @@ import {
 import { useRouter } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { observer } from 'mobx-react-lite'
-import { ArrowRight } from 'lucide-react-native'
+import { AlertCircle, ArrowRight } from 'lucide-react-native'
 import Svg, { Defs, RadialGradient, Stop, Ellipse } from 'react-native-svg'
 import { ProjectCard } from '../../components/home/ProjectCard'
 import { cn } from '@shogo/shared-ui/primitives'
@@ -32,7 +32,14 @@ import type { IProject, IMember, IWorkspace } from '../../contexts/domain'
 import { CompactChatInput } from '../../components/chat/CompactChatInput'
 import type { FileAttachment, InteractionMode } from '../../components/chat/ChatInput'
 import { DEFAULT_MODEL_PRO, DEFAULT_MODEL_FREE } from '../../components/chat/ChatInput'
-import { saveInteractionModePreference } from '../../lib/interaction-mode-preference'
+import {
+  PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS,
+  shouldSuggestPlanMode,
+} from '../../components/chat/plan-mode-suggestion'
+import {
+  loadInteractionModePreference,
+  saveInteractionModePreference,
+} from '../../lib/interaction-mode-preference'
 import { loadModelPreference, saveModelPreference } from '../../lib/agent-mode-preference'
 import { setPendingFiles } from '../../lib/pending-image-store'
 import { useActiveWorkspace } from '../../hooks/useActiveWorkspace'
@@ -46,6 +53,11 @@ import { AgentTemplateGalleryCard } from '../../components/templates/agent-templ
 // APP_MODE_DISABLED: import { AppTemplateGalleryCard } from '../../components/templates/app-template-card'
 
 type AgentTemplate = AgentTemplateSummary
+
+type PendingPlanModeSuggestionSubmission = {
+  text: string
+  files?: FileAttachment[]
+}
 
 /**
  * Reads the dark class directly from the DOM and observes mutations.
@@ -207,12 +219,27 @@ const HomeScreen = observer(function HomeScreen() {
   const [interactionMode, setInteractionMode] = useState<InteractionMode>('agent')
   const [selectedModel, setSelectedModel] = useState<string>(DEFAULT_MODEL_FREE)
   const [isCreating, setIsCreating] = useState(false)
+  const [pendingPlanModeSuggestion, setPendingPlanModeSuggestion] =
+    useState<PendingPlanModeSuggestionSubmission | null>(null)
+  const [planModeSuggestionSecondsLeft, setPlanModeSuggestionSecondsLeft] = useState(
+    PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS
+  )
+  const pendingPlanModeSuggestionRef =
+    useRef<PendingPlanModeSuggestionSubmission | null>(null)
+  const planModeSuggestionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const planModeSuggestionIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const [loadingTemplate, setLoadingTemplate] = useState<string | null>(null)
   const [homeTemplates, setHomeTemplates] = useState<AgentTemplate[]>([])
   // APP_MODE_DISABLED: homeAppTemplates state removed
   const [activeTab, setActiveTab] = useState<'projects' | 'shared' | 'templates'>('templates')
 
   const [workspaceError, setWorkspaceError] = useState(false)
+
+  useEffect(() => {
+    void loadInteractionModePreference().then((stored) => {
+      if (stored) setInteractionMode(stored)
+    })
+  }, [])
 
   useEffect(() => {
     if (!isAuthenticated) return
@@ -371,8 +398,24 @@ const HomeScreen = observer(function HomeScreen() {
         ? 'Ask a question...'
         : `${AGENT_PLACEHOLDER_PREFIX}${typingPlaceholder}`
 
-  const handlePromptSubmit = useCallback(async (text: string, files?: FileAttachment[]) => {
+  const clearPlanModeSuggestionTimers = useCallback(() => {
+    if (planModeSuggestionTimeoutRef.current) {
+      clearTimeout(planModeSuggestionTimeoutRef.current)
+      planModeSuggestionTimeoutRef.current = null
+    }
+    if (planModeSuggestionIntervalRef.current) {
+      clearInterval(planModeSuggestionIntervalRef.current)
+      planModeSuggestionIntervalRef.current = null
+    }
+  }, [])
+
+  const createProjectFromPrompt = useCallback(async (
+    text: string,
+    files?: FileAttachment[],
+    submissionInteractionMode: InteractionMode = interactionMode,
+  ) => {
     if (!text.trim() || !user?.id || !currentWorkspace?.id) return
+
     setIsCreating(true)
     try {
       const projectName = generateProjectNameFromPrompt(text)
@@ -421,7 +464,7 @@ const HomeScreen = observer(function HomeScreen() {
           id: newProject.id,
           chatSessionId: chatSession.id,
           initialMessage: text,
-          initialInteractionMode: interactionMode,
+          initialInteractionMode: submissionInteractionMode,
         },
       } as any)
 
@@ -439,7 +482,82 @@ const HomeScreen = observer(function HomeScreen() {
     } finally {
       setIsCreating(false)
     }
-  }, [actions, http, user?.id, currentWorkspace?.id, projects, router, posthog, interactionMode])
+  }, [
+    actions,
+    currentWorkspace?.id,
+    http,
+    interactionMode,
+    posthog,
+    projects,
+    router,
+    user?.id,
+  ])
+
+  const handlePromptSubmit = useCallback(async (
+    text: string,
+    files?: FileAttachment[],
+    modeOverride?: InteractionMode,
+  ) => {
+    if (pendingPlanModeSuggestionRef.current && !modeOverride) return
+
+    const submissionInteractionMode = modeOverride ?? interactionMode
+    if (
+      !modeOverride &&
+      submissionInteractionMode === 'agent' &&
+      !isCreating &&
+      !pendingPlanModeSuggestionRef.current &&
+      shouldSuggestPlanMode(text)
+    ) {
+      clearPlanModeSuggestionTimers()
+      const pending = { text, files }
+      pendingPlanModeSuggestionRef.current = pending
+      setPendingPlanModeSuggestion(pending)
+      setPlanModeSuggestionSecondsLeft(PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS)
+      planModeSuggestionIntervalRef.current = setInterval(() => {
+        setPlanModeSuggestionSecondsLeft((seconds) => Math.max(0, seconds - 1))
+      }, 1000)
+      planModeSuggestionTimeoutRef.current = setTimeout(() => {
+        const pendingSubmission = pendingPlanModeSuggestionRef.current
+        if (!pendingSubmission) return
+        clearPlanModeSuggestionTimers()
+        pendingPlanModeSuggestionRef.current = null
+        setPendingPlanModeSuggestion(null)
+        setPlanModeSuggestionSecondsLeft(PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS)
+        void createProjectFromPrompt(pendingSubmission.text, pendingSubmission.files, 'agent')
+      }, PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS * 1000)
+      return
+    }
+
+    await createProjectFromPrompt(text, files, submissionInteractionMode)
+  }, [
+    clearPlanModeSuggestionTimers,
+    createProjectFromPrompt,
+    interactionMode,
+    isCreating,
+  ])
+
+  const handleResolvePlanModeSuggestion = useCallback(
+    (targetMode: 'agent' | 'plan') => {
+      const pending = pendingPlanModeSuggestionRef.current
+      if (!pending) return
+
+      clearPlanModeSuggestionTimers()
+      pendingPlanModeSuggestionRef.current = null
+      setPendingPlanModeSuggestion(null)
+      setPlanModeSuggestionSecondsLeft(PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS)
+
+      handleHomeInteractionModeChange(targetMode)
+
+      void handlePromptSubmit(pending.text, pending.files, targetMode)
+    },
+    [clearPlanModeSuggestionTimers, handleHomeInteractionModeChange, handlePromptSubmit],
+  )
+
+  useEffect(() => {
+    return () => {
+      clearPlanModeSuggestionTimers()
+    }
+  }, [clearPlanModeSuggestionTimers])
 
   const handleTemplatePress = useCallback(async (template: AgentTemplate) => {
     if (!user?.id || !currentWorkspace?.id) {
@@ -560,9 +678,57 @@ const HomeScreen = observer(function HomeScreen() {
                 maxWidth: 680,
               }}
             >
+              {pendingPlanModeSuggestion && (
+                <View
+                  className="mb-2 rounded-xl border border-amber-500/35 bg-amber-500/10 p-3"
+                  testID="plan-mode-suggestion"
+                  accessibilityRole="alert"
+                >
+                  <View className="flex-row items-start gap-2">
+                    <AlertCircle className="mt-0.5 h-4 w-4 text-amber-400" size={16} />
+                    <View className="flex-1">
+                      <Text className="text-sm font-medium text-foreground">
+                        This looks like planning work. Switch to Plan mode?
+                      </Text>
+                      <Text
+                        className="mt-1 text-xs text-muted-foreground"
+                        accessibilityLiveRegion="polite"
+                      >
+                        We&apos;ll send this in Agent mode in{' '}
+                        {Math.max(1, planModeSuggestionSecondsLeft)}s unless you choose Plan.
+                      </Text>
+                    </View>
+                  </View>
+                  <View className="mt-3 flex-row flex-wrap justify-end gap-2">
+                    <Pressable
+                      onPress={() => handleResolvePlanModeSuggestion('agent')}
+                      className="min-h-10 justify-center rounded-md border border-border/70 px-3 py-2"
+                      testID="plan-mode-suggestion-continue"
+                      accessibilityRole="button"
+                      accessibilityLabel="Continue in Agent mode"
+                    >
+                      <Text className="text-xs font-medium text-muted-foreground">
+                        Continue in Agent
+                      </Text>
+                    </Pressable>
+                    <Pressable
+                      onPress={() => handleResolvePlanModeSuggestion('plan')}
+                      className="min-h-10 justify-center rounded-md bg-amber-500/20 px-3 py-2"
+                      testID="plan-mode-suggestion-switch"
+                      accessibilityRole="button"
+                      accessibilityLabel="Switch to Plan mode and send"
+                    >
+                      <Text className="text-xs font-medium text-amber-400">
+                        Switch to Plan
+                      </Text>
+                    </Pressable>
+                  </View>
+                </View>
+              )}
               <CompactChatInput
                 onSubmit={handlePromptSubmit}
-                isLoading={isCreating}
+                isLoading={isCreating || !!pendingPlanModeSuggestion}
+                disabled={!!pendingPlanModeSuggestion}
                 placeholder={homeComposerPlaceholder}
                 value={prompt}
                 onChange={setPrompt}

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -770,6 +770,9 @@ export default observer(function ProjectLayout() {
     return handler
   }, [handleTabStreamingChange])
   const [buildPlanRequest, setBuildPlanRequest] = useState<{ plan: any; modelId: string; nonce: number } | null>(null)
+  const buildPlanNonceRef = useRef(0)
+  const openPlanNonceRef = useRef(0)
+  const [requestedPlanPath, setRequestedPlanPath] = useState<{ filepath: string | null; nonce: number } | null>(null)
   const [selectedAgentToolId, setSelectedAgentToolId] = useState<string | null>(null)
 
   useEffect(() => {
@@ -900,7 +903,8 @@ export default observer(function ProjectLayout() {
   }, [updateProjectSettings, agentUrl, nativeHeaders])
 
   const handleBuildPlan = useCallback((plan: any, modelId: string) => {
-    setBuildPlanRequest({ plan, modelId, nonce: Date.now() })
+    buildPlanNonceRef.current += 1
+    setBuildPlanRequest({ plan, modelId, nonce: buildPlanNonceRef.current })
     setActiveTab('chat')
     if (canvasEnabled) {
       setPreviewTab('dynamic-app')
@@ -908,6 +912,13 @@ export default observer(function ProjectLayout() {
       setPreviewTab('chat-fullscreen')
     }
   }, [canvasEnabled])
+
+  const handleOpenPlan = useCallback((filepath?: string | null) => {
+    openPlanNonceRef.current += 1
+    setRequestedPlanPath({ filepath: filepath ?? null, nonce: openPlanNonceRef.current })
+    setPreviewTab('plans')
+    if (!isWide) setActiveTab('canvas')
+  }, [isWide])
 
   const [sessionNames, setSessionNames] = useState<Record<string, string>>({})
 
@@ -1223,6 +1234,7 @@ export default observer(function ProjectLayout() {
               onMessagesChange={isActive ? setChatMessages : undefined}
               onStreamingChange={getStreamingChangeHandler(tabId)}
               buildPlanRequest={isActive ? buildPlanRequest : null}
+              onOpenPlan={handleOpenPlan}
               selectedModel={selectedModel}
               onModelChange={handleModelChange}
               className="flex-1"
@@ -1508,7 +1520,7 @@ export default observer(function ProjectLayout() {
               <ChannelsPanel visible={previewTab === 'channels'} projectId={projectId!} agentUrl={agentUrl} hasAdvancedModelAccess={features.billing ? billingData.hasAdvancedModelAccess : true} />
               <AgentsPanel visible={previewTab === 'agents'} selectedToolId={selectedAgentToolId} agentUrl={agentUrl} />
               <MonitorPanel visible={previewTab === 'monitor'} projectId={projectId!} agentUrl={agentUrl} isPaidPlan={effectiveHasActiveSubscription} />
-              <PlansPanel visible={previewTab === 'plans'} projectId={projectId!} agentUrl={agentUrl} selectedModel={selectedModel} onBuildPlan={handleBuildPlan} />
+              <PlansPanel visible={previewTab === 'plans'} projectId={projectId!} agentUrl={agentUrl} selectedModel={selectedModel} requestedPlanPath={requestedPlanPath} onBuildPlan={handleBuildPlan} />
               <CheckpointsPanel visible={previewTab === 'checkpoints'} projectId={projectId!} />
             </View>
           </View>

--- a/apps/mobile/components/chat/ChatContext.tsx
+++ b/apps/mobile/components/chat/ChatContext.tsx
@@ -23,6 +23,7 @@
  */
 
 import { createContext, useContext, type ReactNode } from "react"
+import type { PlanData } from "./PlanCard"
 
 // ============================================================================
 // Types
@@ -84,8 +85,20 @@ export interface ChatContextValue {
   /** Persist a tool output to in-memory messages and the DB (e.g. ask_user answers) */
   saveToolOutput?: (params: { messageId: string; toolCallId: string; output: string }) => void
 
-  /** Confirm and execute a pending plan. Null when no plan is pending. */
-  confirmPlan?: (() => void) | null
+  /** Build and execute a pending plan. Null when no plan is pending. */
+  buildPlan?: ((plan?: PlanData | null) => void) | null
+
+  /** Backwards-compatible alias for older plan-card consumers. */
+  confirmPlan?: ((plan?: PlanData | null) => void) | null
+
+  /** Current plan waiting for user review/build. */
+  pendingPlan?: PlanData | null
+
+  /** Plan whose Build action has started execution. */
+  confirmedPlan?: PlanData | null
+
+  /** Open the saved plan artifact in the Plans panel. */
+  openPlan?: (filepath?: string | null) => void
 }
 
 // ============================================================================

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -126,6 +126,7 @@ export const INTERACTION_MODES: InteractionModeConfig[] = [
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024
 const MAX_FILES = 10
+const INTERACTION_MODE_ORDER: InteractionMode[] = ["agent", "plan", "ask"]
 
 interface AttachedFile {
   id: string
@@ -255,6 +256,13 @@ export function ChatInput({
     },
     [onInteractionModeChange]
   )
+
+  const cycleInteractionMode = useCallback(() => {
+    if (disabled || isStreaming) return
+    const currentIndex = INTERACTION_MODE_ORDER.indexOf(interactionMode)
+    const nextIndex = (currentIndex + 1) % INTERACTION_MODE_ORDER.length
+    handleInteractionModeChange(INTERACTION_MODE_ORDER[nextIndex])
+  }, [disabled, handleInteractionModeChange, interactionMode, isStreaming])
 
   const currentInteractionConfig = useMemo(
     () => INTERACTION_MODES.find((m) => m.id === interactionMode) || INTERACTION_MODES[0],
@@ -798,6 +806,11 @@ export function ChatInput({
           onChangeText={handleChangeText}
           onSubmitEditing={handleSubmit}
           onKeyPress={(e: any) => {
+            if (Platform.OS === "web" && e.nativeEvent.key === "Tab" && e.nativeEvent.shiftKey) {
+              e.preventDefault()
+              cycleInteractionMode()
+              return
+            }
             if (Platform.OS === "web" && e.nativeEvent.key === "Enter" && !e.nativeEvent.shiftKey) {
               e.preventDefault()
               handleSubmit()

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -142,6 +142,16 @@ export interface FileAttachment {
   type: string
 }
 
+export type RestoreDraftRequest = {
+  nonce: number
+  content: string
+  files?: FileAttachment[]
+}
+
+function estimateDataUrlSize(dataUrl: string): number {
+  const base64 = dataUrl.includes(",") ? dataUrl.split(",").pop() || "" : dataUrl
+  return Math.max(0, Math.floor((base64.length * 3) / 4))
+}
 
 interface SkillOption {
   name: string
@@ -175,6 +185,8 @@ export interface ChatInputProps {
   contextUsage?: { inputTokens: number; contextWindowTokens: number } | null
   quickActions?: { label: string; prompt: string }[]
   onQuickActionClick?: (prompt: string) => void
+  restoreDraftRequest?: RestoreDraftRequest | null
+  dimWhenDisabled?: boolean
 }
 
 export function ChatInput({
@@ -195,6 +207,8 @@ export function ChatInput({
   contextUsage,
   quickActions = [],
   onQuickActionClick,
+  restoreDraftRequest,
+  dimWhenDisabled = true,
 }: ChatInputProps) {
   const { features } = usePlatformConfig()
   const effectiveIsPro = features.billing ? isPro : true
@@ -277,6 +291,28 @@ export function ChatInput({
   // chip).
   const [pastedTexts, setPastedTexts] = useState<PastedTextEntry[]>([])
   const [viewingPastedId, setViewingPastedId] = useState<string | null>(null)
+  const lastRestoredDraftNonceRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!restoreDraftRequest) return
+    if (restoreDraftRequest.nonce === lastRestoredDraftNonceRef.current) return
+
+    lastRestoredDraftNonceRef.current = restoreDraftRequest.nonce
+    setInputValue(restoreDraftRequest.content)
+    setPendingFiles(
+      (restoreDraftRequest.files ?? []).map((file, index) => ({
+        id: `restored-${restoreDraftRequest.nonce}-${index}`,
+        dataUrl: file.dataUrl,
+        name: file.name,
+        type: file.type,
+        size: estimateDataUrlSize(file.dataUrl),
+      }))
+    )
+    setPastedTexts([])
+    setViewingPastedId(null)
+    setFileError(null)
+    setTimeout(() => textInputRef.current?.focus(), 0)
+  }, [restoreDraftRequest])
 
   const addPastedText = useCallback((content: string) => {
     const info = analyzeContent(content)
@@ -826,7 +862,7 @@ export function ChatInput({
             "min-h-[60px] max-h-[200px] w-full",
             "bg-transparent",
             "px-4 pt-4 text-xs text-foreground",
-            disabled && "opacity-50",
+            disabled && dimWhenDisabled && "opacity-50",
             Platform.OS === "web" && "outline-none no-focus-ring"
           )}
           textAlignVertical="top"

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -74,6 +74,7 @@ import {
   DEFAULT_MODEL_FREE,
   type InteractionMode,
   type FileAttachment,
+  type RestoreDraftRequest,
 } from "./ChatInput"
 import {
   PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS,
@@ -142,6 +143,45 @@ type PendingPlanModeSuggestionSubmission = {
   content: string
   files?: FileAttachment[]
   perMsgModel?: string
+}
+
+type OptimisticUserInput = {
+  sessionId: string
+  content: string
+  files?: FileAttachment[]
+}
+
+function buildOptimisticUserMessage(input: OptimisticUserInput, id = "optimistic-user-pending"): UIMessage {
+  const parts: any[] = []
+  const text = input.content.trim()
+
+  if (text) {
+    parts.push({ type: "text", text })
+  }
+
+  for (const file of input.files ?? []) {
+    parts.push({
+      type: "file",
+      mediaType: file.type || "application/octet-stream",
+      url: file.dataUrl,
+      ...(file.name ? { name: file.name } : {}),
+    })
+  }
+
+  return {
+    id,
+    role: "user",
+    parts,
+  } as unknown as UIMessage
+}
+
+function hasMatchingUserMessage(messages: UIMessage[], input: OptimisticUserInput): boolean {
+  const text = input.content.trim()
+  return messages.some((message) => {
+    if (message.role !== "user") return false
+    if (text && extractTextContent(message).trim() === text) return true
+    return !text && (input.files?.length ?? 0) > 0
+  })
 }
 
 interface SubagentProgress {
@@ -848,6 +888,7 @@ export const ChatPanel = observer(function ChatPanel({
 
   const [pendingPlanModeSuggestion, setPendingPlanModeSuggestion] =
     useState<PendingPlanModeSuggestionSubmission | null>(null)
+  const [restoreDraftRequest, setRestoreDraftRequest] = useState<RestoreDraftRequest | null>(null)
   const [planModeSuggestionSecondsLeft, setPlanModeSuggestionSecondsLeft] = useState(
     PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS
   )
@@ -1939,6 +1980,7 @@ export const ChatPanel = observer(function ChatPanel({
     errorBannerText.split(/\n/).length > 4 || errorBannerText.length > 220
 
   const [pendingInitialMessage, setPendingInitialMessage] = useState<string | null>(null)
+  const [optimisticUserInput, setOptimisticUserInput] = useState<OptimisticUserInput | null>(null)
 
   // Permission approval state (local mode security)
   const [pendingPermissionRequest, setPendingPermissionRequest] = useState<{
@@ -1961,10 +2003,28 @@ export const ChatPanel = observer(function ChatPanel({
     }
   }, [messages.length, pendingInitialMessage])
 
+  useEffect(() => {
+    if (!optimisticUserInput) return
+    if (optimisticUserInput.sessionId !== currentSessionId) {
+      setOptimisticUserInput(null)
+      return
+    }
+    if (hasMatchingUserMessage(messages, optimisticUserInput)) {
+      setOptimisticUserInput(null)
+    }
+  }, [currentSessionId, messages, optimisticUserInput])
+
   const displayMessages = useMemo((): UIMessage[] => {
     const effectiveMessages = stoppedMessages ?? messages
+    const currentOptimisticInput =
+      optimisticUserInput?.sessionId === currentSessionId ? optimisticUserInput : null
+    const shouldPrependOptimisticUser =
+      currentOptimisticInput && !hasMatchingUserMessage(effectiveMessages, currentOptimisticInput)
+
     if (effectiveMessages.length > 0) {
-      return effectiveMessages
+      return shouldPrependOptimisticUser
+        ? [buildOptimisticUserMessage(currentOptimisticInput), ...effectiveMessages]
+        : effectiveMessages
     }
 
     if (isStreaming || isSendingMessageRef.current) {
@@ -1972,7 +2032,11 @@ export const ChatPanel = observer(function ChatPanel({
       // user bubble) so the conversation doesn't vanish during the brief gap
       // before the AI SDK populates its internal state.
       const fallback = lastNonEmptyMessagesRef.current
-      const lastInput = lastUserInputRef.current
+      const lastInput =
+        currentOptimisticInput ??
+        (currentSessionId && lastUserInputRef.current
+          ? { sessionId: currentSessionId, ...lastUserInputRef.current }
+          : null)
       const lastFallbackMsg = fallback[fallback.length - 1]
       const needsOptimisticUser =
         lastInput?.content && (!lastFallbackMsg || lastFallbackMsg.role !== "user")
@@ -1980,11 +2044,7 @@ export const ChatPanel = observer(function ChatPanel({
       if (needsOptimisticUser) {
         return [
           ...fallback,
-          {
-            id: "optimistic-user-pending",
-            role: "user",
-            parts: [{ type: "text", text: lastInput!.content }],
-          } as unknown as UIMessage,
+          buildOptimisticUserMessage(lastInput),
         ]
       }
       return fallback
@@ -2001,7 +2061,7 @@ export const ChatPanel = observer(function ChatPanel({
       ]
     }
     return []
-  }, [messages, stoppedMessages, pendingInitialMessage, initialMessage, isStreaming])
+  }, [currentSessionId, messages, stoppedMessages, pendingInitialMessage, initialMessage, optimisticUserInput, isStreaming])
 
   // Stable references for memo'd downstream components (TurnList / SubagentPanel).
   // Previously these were `Array.from(Map.values())` inline, which allocated on
@@ -2832,6 +2892,7 @@ export const ChatPanel = observer(function ChatPanel({
         stickToBottomRef.current = true
       }
       lastUserInputRef.current = { content: trimmedContent, files: fileArray }
+      setOptimisticUserInput({ sessionId: currentSessionId, content: trimmedContent, files: fileArray })
 
       const parts: Array<
         { type: "text"; text: string } | { type: "file"; mediaType: string; url: string; name?: string }
@@ -3006,6 +3067,7 @@ export const ChatPanel = observer(function ChatPanel({
       setMessageQueue([])
       isProcessingQueueRef.current = false
     }
+    setOptimisticUserInput(null)
     lastNonEmptyMessagesRef.current = []
   }, [currentSessionId])
 
@@ -3083,6 +3145,11 @@ export const ChatPanel = observer(function ChatPanel({
       pendingPlanModeSuggestionRef.current = null
       setPendingPlanModeSuggestion(null)
       setPlanModeSuggestionSecondsLeft(PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS)
+      setRestoreDraftRequest({
+        nonce: Date.now(),
+        content: "",
+        files: [],
+      })
 
       handleInteractionModeChange(targetMode)
 
@@ -3091,12 +3158,32 @@ export const ChatPanel = observer(function ChatPanel({
     [clearPlanModeSuggestionTimers, handleInteractionModeChange, handleSendMessage]
   )
 
+  const handleEditPlanModePrompt = useCallback(() => {
+    const pending = pendingPlanModeSuggestionRef.current
+    if (!pending) return
+
+    clearPlanModeSuggestionTimers()
+    pendingPlanModeSuggestionRef.current = null
+    setPendingPlanModeSuggestion(null)
+    setPlanModeSuggestionSecondsLeft(PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS)
+    setRestoreDraftRequest({
+      nonce: Date.now(),
+      content: pending.content,
+      files: pending.files,
+    })
+  }, [clearPlanModeSuggestionTimers])
+
   const startPlanModeSuggestion = useCallback(
     (submission: PendingPlanModeSuggestionSubmission) => {
       clearPlanModeSuggestionTimers()
       pendingPlanModeSuggestionRef.current = submission
       setPendingPlanModeSuggestion(submission)
       setPlanModeSuggestionSecondsLeft(PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS)
+      setRestoreDraftRequest({
+        nonce: Date.now(),
+        content: submission.content,
+        files: submission.files,
+      })
 
       planModeSuggestionIntervalRef.current = setInterval(() => {
         setPlanModeSuggestionSecondsLeft((seconds) => Math.max(0, seconds - 1))
@@ -3742,6 +3829,7 @@ export const ChatPanel = observer(function ChatPanel({
             {pendingPlanModeSuggestion && (
               <PlanModeSuggestion
                 secondsLeft={planModeSuggestionSecondsLeft}
+                onEditPrompt={handleEditPlanModePrompt}
                 onContinueInAgent={() => handleResolvePlanModeSuggestion("agent")}
                 onSwitchToPlan={() => handleResolvePlanModeSuggestion("plan")}
               />
@@ -3775,6 +3863,8 @@ export const ChatPanel = observer(function ChatPanel({
               contextUsage={contextUsage}
               quickActions={quickActions}
               onQuickActionClick={(prompt) => handleSendMessage(prompt)}
+              restoreDraftRequest={restoreDraftRequest}
+              dimWhenDisabled={!pendingPlanModeSuggestion}
             />
           </View>
         </KeyboardAvoidingView>

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -218,6 +218,8 @@ export interface ChatPanelProps {
   onMessagesChange?: (messages: any[]) => void
   /** Triggered from the Plans panel Build button — executes a saved plan */
   buildPlanRequest?: { plan: PlanData; modelId: string; nonce: number } | null
+  /** Opens the saved plan artifact in the Plans panel. */
+  onOpenPlan?: (filepath?: string | null) => void
   /** Controlled model selection — when provided, ChatPanel uses this instead of its own state */
   selectedModel?: string
   onModelChange?: (modelId: string) => void
@@ -549,6 +551,22 @@ export function clearChatPanelMessageCache(): void {
   sessionMessageCache.clear()
 }
 
+function normalizePlanFilepath(filepath?: string | null): string | undefined {
+  if (!filepath) return undefined
+  const normalized = filepath.replace(/^\/+/, "").replace(/\\/g, "/")
+  const filename = normalized.split("/").pop()
+  if (!filename || !/^[a-zA-Z0-9._-]+\.plan\.md$/.test(filename)) return undefined
+  return `.shogo/plans/${filename}`
+}
+
+function normalizePlanData(plan: PlanData): PlanData {
+  return {
+    ...plan,
+    todos: plan.todos ?? [],
+    filepath: normalizePlanFilepath(plan.filepath),
+  }
+}
+
 // ============================================================
 // Component
 // ============================================================
@@ -593,6 +611,7 @@ export const ChatPanel = observer(function ChatPanel({
   billingData,
   onMessagesChange,
   buildPlanRequest,
+  onOpenPlan,
   selectedModel: controlledSelectedModel,
   onModelChange: controlledOnModelChange,
   isActive = true,
@@ -842,8 +861,16 @@ export const ChatPanel = observer(function ChatPanel({
   const [confirmedPlan, setConfirmedPlan] = useState<PlanData | null>(null)
   const confirmedPlanRef = useRef<PlanData | null>(null)
   const [pendingPlan, setPendingPlan] = useState<PlanData | null>(null)
+  const pendingPlanRef = useRef<PlanData | null>(null)
 
   const planStream = usePlanStreamSafe()
+
+  useEffect(() => {
+    pendingPlanRef.current = null
+    setPendingPlan(null)
+    setConfirmedPlan(null)
+    confirmedPlanRef.current = null
+  }, [currentSessionId])
 
   // Load session metadata from API if not already cached. Gated on
   // `isActive` so the N-1 hidden sibling ChatPanels mounted for every
@@ -1453,15 +1480,36 @@ export const ChatPanel = observer(function ChatPanel({
       if ((dataPart as any).type === "data-plan") {
         const planData = (dataPart as any).data
         if (planData) {
-          setPendingPlan(planData)
-          if (planData.filepath) {
-            planStream?.setStreamingPlanFilepath(planData.filepath)
+          const normalizedPlan = normalizePlanData(planData)
+          pendingPlanRef.current = normalizedPlan
+          setPendingPlan(normalizedPlan)
+          planStream?.setStreamingPlan(normalizedPlan)
+          if (normalizedPlan.filepath) {
+            planStream?.setStreamingPlanFilepath(normalizedPlan.filepath)
           }
           planStream?.notifyPlanCreated()
         }
       }
 
       if ((dataPart as any).type === "data-plan-update") {
+        const planData = (dataPart as any).data
+        if (planData) {
+          const previousPlan = pendingPlanRef.current
+          const normalizedPlan = normalizePlanData({
+            name: planData.name ?? previousPlan?.name ?? "Plan",
+            overview: planData.overview ?? previousPlan?.overview ?? "",
+            plan: planData.plan ?? previousPlan?.plan ?? "",
+            todos: planData.todos ?? previousPlan?.todos ?? [],
+            filepath: planData.filepath ?? previousPlan?.filepath,
+            toolCallId: planData.toolCallId ?? previousPlan?.toolCallId,
+          })
+          pendingPlanRef.current = normalizedPlan
+          setPendingPlan(normalizedPlan)
+          planStream?.setStreamingPlan(normalizedPlan)
+          if (normalizedPlan.filepath) {
+            planStream?.setStreamingPlanFilepath(normalizedPlan.filepath)
+          }
+        }
         planStream?.notifyPlanCreated()
       }
 
@@ -2574,13 +2622,16 @@ export const ChatPanel = observer(function ChatPanel({
         ? planTool.toolInvocation?.args
         : planTool.input ?? planTool.args
     if (!args) return
-    setPendingPlan({
+    const restoredPlan = normalizePlanData({
       name: args.name ?? "Plan",
       overview: args.overview ?? "",
       plan: args.plan ?? "",
       todos: args.todos ?? [],
       filepath: args.filepath,
+      toolCallId: planTool.id ?? planTool.toolCallId,
     })
+    pendingPlanRef.current = restoredPlan
+    setPendingPlan(restoredPlan)
   }, [isInitialLoadComplete, messages.length]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Effect 2: Sync MobX → AI SDK state when data arrives.
@@ -2663,20 +2714,24 @@ export const ChatPanel = observer(function ChatPanel({
         ? planPart.toolInvocation?.args
         : planPart.input ?? planPart.args
     if (!args?.name) return null
-    return {
+    return normalizePlanData({
       name: args.name,
       overview: args.overview ?? "",
       plan: args.plan ?? "",
       todos: args.todos ?? [],
-    }
+      filepath: args.filepath,
+      toolCallId: planPart.id ?? planPart.toolCallId,
+    })
   }, [isStreaming, messages])
 
   useEffect(() => {
     planStream?.setStreamingPlan(derivedStreamingPlan)
     if (derivedStreamingPlan) {
+      planStream?.setStreamingPlanFilepath(derivedStreamingPlan.filepath ?? null)
+    } else if (!isStreaming) {
       planStream?.setStreamingPlanFilepath(null)
     }
-  }, [derivedStreamingPlan, planStream])
+  }, [derivedStreamingPlan, isStreaming, planStream])
 
   // Auto-scroll to bottom when messages change
   // On native, streaming follow is handled entirely by onContentSizeChange
@@ -2825,9 +2880,9 @@ export const ChatPanel = observer(function ChatPanel({
         }
         const planToSend = confirmedPlanRef.current
         if (planToSend) {
-          bodyExtra.confirmedPlan = planToSend
+          bodyExtra.confirmedPlan = normalizePlanData(planToSend)
+          bodyExtra.interactionMode = "agent"
           confirmedPlanRef.current = null
-          setConfirmedPlan(null)
         }
         console.log("[ChatPanel][send] bodyExtra — interactionMode:", bodyExtra.interactionMode, "agentMode:", bodyExtra.agentMode, "hasConfirmedPlan:", !!bodyExtra.confirmedPlan, "text:", trimmedContent.slice(0, 80))
         await sendMessage(messagePayload, { body: bodyExtra })
@@ -2864,7 +2919,7 @@ export const ChatPanel = observer(function ChatPanel({
     [sendMessageInternal],
   )
   const bridgeSetMode = useCallback(
-    (mode: "agent" | "plan") => {
+    (mode: InteractionMode) => {
       handleInteractionModeChange(mode)
     },
     [handleInteractionModeChange],
@@ -2999,10 +3054,13 @@ export const ChatPanel = observer(function ChatPanel({
   // Plan confirmation: switch to Agent mode and execute.
   // Keep the PlanCard visible with confirmed state for a few seconds before dismissing.
   const confirmDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const handleConfirmPlan = useCallback(() => {
-    if (!pendingPlan) return
-    confirmedPlanRef.current = pendingPlan
-    setConfirmedPlan(pendingPlan)
+  const handleConfirmPlan = useCallback((plan?: PlanData | null) => {
+    const selectedPlan = plan ?? pendingPlanRef.current
+    if (!selectedPlan) return
+    const planToBuild = normalizePlanData(selectedPlan)
+    confirmedPlanRef.current = planToBuild
+    setConfirmedPlan(planToBuild)
+    pendingPlanRef.current = null
     setPendingPlan(null)
     console.log("[ChatPanel][confirm-plan] BEFORE mode change — stateMode:", interactionMode, "refMode:", interactionModeRef.current, "selectedModel:", selectedModel)
     handleInteractionModeChange("agent")
@@ -3012,7 +3070,7 @@ export const ChatPanel = observer(function ChatPanel({
     confirmDismissTimerRef.current = setTimeout(() => {
       setConfirmedPlan(null)
     }, 4000)
-  }, [pendingPlan, handleSendMessage, handleInteractionModeChange])
+  }, [handleSendMessage, handleInteractionModeChange])
 
   // Build from Plans panel: execute a saved plan with selected model
   const lastBuildNonceRef = useRef<number>(0)
@@ -3020,8 +3078,10 @@ export const ChatPanel = observer(function ChatPanel({
     if (!buildPlanRequest || buildPlanRequest.nonce === lastBuildNonceRef.current) return
     lastBuildNonceRef.current = buildPlanRequest.nonce
     const { plan, modelId: requestedMode } = buildPlanRequest
-    confirmedPlanRef.current = plan
-    setConfirmedPlan(plan)
+    const planToBuild = normalizePlanData(plan)
+    confirmedPlanRef.current = planToBuild
+    setConfirmedPlan(planToBuild)
+    pendingPlanRef.current = null
     setPendingPlan(null)
     handleInteractionModeChange("agent")
     handleSendMessage("Execute the confirmed plan.", undefined, requestedMode)
@@ -3211,7 +3271,11 @@ export const ChatPanel = observer(function ChatPanel({
     agentUrl: resolvedAgentUrl,
     addToolOutput: (params) => addToolOutput(params as any),
     saveToolOutput: handleSaveToolOutput,
+    buildPlan: pendingPlan ? handleConfirmPlan : null,
     confirmPlan: pendingPlan ? handleConfirmPlan : null,
+    pendingPlan,
+    confirmedPlan,
+    openPlan: onOpenPlan,
   }
 
   const handleCompactSubmit = useCallback(

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -79,6 +79,7 @@ import {
   PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS,
   shouldSuggestPlanMode,
 } from "./plan-mode-suggestion"
+import { PlanModeSuggestion } from "./PlanModeSuggestion"
 import {
   loadInteractionModePreference,
   saveInteractionModePreference,
@@ -3739,51 +3740,11 @@ export const ChatPanel = observer(function ChatPanel({
           {/* Input */}
           <View className="bg-transparent max-w-3xl w-full self-center mt-1">
             {pendingPlanModeSuggestion && (
-              <View
-                className="mb-2 rounded-xl border border-amber-500/35 bg-amber-500/10 p-3"
-                testID="plan-mode-suggestion"
-                accessibilityRole="alert"
-              >
-                <View className="flex-row items-start gap-2">
-                  <AlertCircle className="mt-0.5 h-4 w-4 text-amber-400" size={16} />
-                  <View className="flex-1">
-                    <Text className="text-sm font-medium text-foreground">
-                      This looks like planning work. Switch to Plan mode?
-                    </Text>
-                    <Text
-                      className="mt-1 text-xs text-muted-foreground"
-                      accessibilityLiveRegion="polite"
-                    >
-                      We&apos;ll send this in Agent mode in{" "}
-                      {Math.max(1, planModeSuggestionSecondsLeft)}s unless you choose Plan.
-                    </Text>
-                  </View>
-                </View>
-                <View className="mt-3 flex-row flex-wrap justify-end gap-2">
-                  <Pressable
-                    onPress={() => handleResolvePlanModeSuggestion("agent")}
-                    className="min-h-10 justify-center rounded-md border border-border/70 px-3 py-2"
-                    testID="plan-mode-suggestion-continue"
-                    accessibilityRole="button"
-                    accessibilityLabel="Continue in Agent mode"
-                  >
-                    <Text className="text-xs font-medium text-muted-foreground">
-                      Continue in Agent
-                    </Text>
-                  </Pressable>
-                  <Pressable
-                    onPress={() => handleResolvePlanModeSuggestion("plan")}
-                    className="min-h-10 justify-center rounded-md bg-amber-500/20 px-3 py-2"
-                    testID="plan-mode-suggestion-switch"
-                    accessibilityRole="button"
-                    accessibilityLabel="Switch to Plan mode and send"
-                  >
-                    <Text className="text-xs font-medium text-amber-400">
-                      Switch to Plan
-                    </Text>
-                  </Pressable>
-                </View>
-              </View>
+              <PlanModeSuggestion
+                secondsLeft={planModeSuggestionSecondsLeft}
+                onContinueInAgent={() => handleResolvePlanModeSuggestion("agent")}
+                onSwitchToPlan={() => handleResolvePlanModeSuggestion("plan")}
+              />
             )}
             <ExecutionBadge />
             <ChatInput

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -76,6 +76,10 @@ import {
   type FileAttachment,
 } from "./ChatInput"
 import {
+  PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS,
+  shouldSuggestPlanMode,
+} from "./plan-mode-suggestion"
+import {
   loadInteractionModePreference,
   saveInteractionModePreference,
 } from "../../lib/interaction-mode-preference"
@@ -116,7 +120,6 @@ import {
   type FixInAgentPayload,
 } from "../project/panels/ide/agentFixProvider"
 
-
 // ============================================================
 // Types
 // ============================================================
@@ -132,6 +135,12 @@ interface VirtualToolEvent {
   toolName: string
   args: Record<string, unknown>
   timestamp: number
+}
+
+type PendingPlanModeSuggestionSubmission = {
+  content: string
+  files?: FileAttachment[]
+  perMsgModel?: string
 }
 
 interface SubagentProgress {
@@ -835,6 +844,16 @@ export const ChatPanel = observer(function ChatPanel({
     setInteractionMode(mode)
     void saveInteractionModePreference(mode)
   }, [])
+
+  const [pendingPlanModeSuggestion, setPendingPlanModeSuggestion] =
+    useState<PendingPlanModeSuggestionSubmission | null>(null)
+  const [planModeSuggestionSecondsLeft, setPlanModeSuggestionSecondsLeft] = useState(
+    PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS
+  )
+  const pendingPlanModeSuggestionRef =
+    useRef<PendingPlanModeSuggestionSubmission | null>(null)
+  const planModeSuggestionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const planModeSuggestionIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   // Bridge for Shogo Mode overlay (voice + text translator). The overlay
   // calls `send` / `setMode` to drive this panel, and subscribes to the
@@ -3043,12 +3062,84 @@ export const ChatPanel = observer(function ChatPanel({
     [isStreaming, sendMessageInternal, currentSessionId]
   )
 
+  const clearPlanModeSuggestionTimers = useCallback(() => {
+    if (planModeSuggestionTimeoutRef.current) {
+      clearTimeout(planModeSuggestionTimeoutRef.current)
+      planModeSuggestionTimeoutRef.current = null
+    }
+    if (planModeSuggestionIntervalRef.current) {
+      clearInterval(planModeSuggestionIntervalRef.current)
+      planModeSuggestionIntervalRef.current = null
+    }
+  }, [])
+
+  const handleResolvePlanModeSuggestion = useCallback(
+    (targetMode: "agent" | "plan") => {
+      const pending = pendingPlanModeSuggestionRef.current
+      if (!pending) return
+
+      clearPlanModeSuggestionTimers()
+      pendingPlanModeSuggestionRef.current = null
+      setPendingPlanModeSuggestion(null)
+      setPlanModeSuggestionSecondsLeft(PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS)
+
+      handleInteractionModeChange(targetMode)
+
+      handleSendMessage(pending.content, pending.files, pending.perMsgModel)
+    },
+    [clearPlanModeSuggestionTimers, handleInteractionModeChange, handleSendMessage]
+  )
+
+  const startPlanModeSuggestion = useCallback(
+    (submission: PendingPlanModeSuggestionSubmission) => {
+      clearPlanModeSuggestionTimers()
+      pendingPlanModeSuggestionRef.current = submission
+      setPendingPlanModeSuggestion(submission)
+      setPlanModeSuggestionSecondsLeft(PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS)
+
+      planModeSuggestionIntervalRef.current = setInterval(() => {
+        setPlanModeSuggestionSecondsLeft((seconds) => Math.max(0, seconds - 1))
+      }, 1000)
+      planModeSuggestionTimeoutRef.current = setTimeout(() => {
+        handleResolvePlanModeSuggestion("agent")
+      }, PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS * 1000)
+    },
+    [clearPlanModeSuggestionTimers, handleResolvePlanModeSuggestion]
+  )
+
+  useEffect(() => {
+    return () => {
+      clearPlanModeSuggestionTimers()
+    }
+  }, [clearPlanModeSuggestionTimers])
+
+  useEffect(() => {
+    if (!pendingPlanModeSuggestionRef.current) return
+    clearPlanModeSuggestionTimers()
+    pendingPlanModeSuggestionRef.current = null
+    setPendingPlanModeSuggestion(null)
+    setPlanModeSuggestionSecondsLeft(PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS)
+  }, [clearPlanModeSuggestionTimers, currentSessionId])
+
   // Handle form submit from ChatInput
   const handleInputSubmit = useCallback(
     (content: string, files?: FileAttachment[], perMsgModel?: string) => {
+      if (pendingPlanModeSuggestionRef.current) return
+
+      if (
+        interactionModeRef.current === "agent" &&
+        !isStreaming &&
+        !isProcessingQueueRef.current &&
+        !isSendingMessageRef.current &&
+        shouldSuggestPlanMode(content)
+      ) {
+        startPlanModeSuggestion({ content, files, perMsgModel })
+        return
+      }
+
       handleSendMessage(content, files, perMsgModel)
     },
-    [handleSendMessage]
+    [handleSendMessage, isStreaming, startPlanModeSuggestion]
   )
 
   // Plan confirmation: switch to Agent mode and execute.
@@ -3647,10 +3738,57 @@ export const ChatPanel = observer(function ChatPanel({
 
           {/* Input */}
           <View className="bg-transparent max-w-3xl w-full self-center mt-1">
+            {pendingPlanModeSuggestion && (
+              <View
+                className="mb-2 rounded-xl border border-amber-500/35 bg-amber-500/10 p-3"
+                testID="plan-mode-suggestion"
+                accessibilityRole="alert"
+              >
+                <View className="flex-row items-start gap-2">
+                  <AlertCircle className="mt-0.5 h-4 w-4 text-amber-400" size={16} />
+                  <View className="flex-1">
+                    <Text className="text-sm font-medium text-foreground">
+                      This looks like planning work. Switch to Plan mode?
+                    </Text>
+                    <Text
+                      className="mt-1 text-xs text-muted-foreground"
+                      accessibilityLiveRegion="polite"
+                    >
+                      We&apos;ll send this in Agent mode in{" "}
+                      {Math.max(1, planModeSuggestionSecondsLeft)}s unless you choose Plan.
+                    </Text>
+                  </View>
+                </View>
+                <View className="mt-3 flex-row flex-wrap justify-end gap-2">
+                  <Pressable
+                    onPress={() => handleResolvePlanModeSuggestion("agent")}
+                    className="min-h-10 justify-center rounded-md border border-border/70 px-3 py-2"
+                    testID="plan-mode-suggestion-continue"
+                    accessibilityRole="button"
+                    accessibilityLabel="Continue in Agent mode"
+                  >
+                    <Text className="text-xs font-medium text-muted-foreground">
+                      Continue in Agent
+                    </Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={() => handleResolvePlanModeSuggestion("plan")}
+                    className="min-h-10 justify-center rounded-md bg-amber-500/20 px-3 py-2"
+                    testID="plan-mode-suggestion-switch"
+                    accessibilityRole="button"
+                    accessibilityLabel="Switch to Plan mode and send"
+                  >
+                    <Text className="text-xs font-medium text-amber-400">
+                      Switch to Plan
+                    </Text>
+                  </Pressable>
+                </View>
+              </View>
+            )}
             <ExecutionBadge />
             <ChatInput
               onSubmit={handleInputSubmit}
-              disabled={!currentSessionId}
+              disabled={!currentSessionId || !!pendingPlanModeSuggestion}
               placeholder={
                 !featureId
                   ? "Select a feature to start chatting..."

--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -94,7 +94,7 @@ interface AttachedFile {
 }
 
 export interface CompactChatInputProps {
-  onSubmit: (prompt: string, files?: FileAttachment[]) => void
+  onSubmit: (prompt: string, files?: FileAttachment[]) => void | false
   disabled?: boolean
   isLoading?: boolean
   placeholder?: string
@@ -107,6 +107,8 @@ export interface CompactChatInputProps {
   onModelChange?: (modelId: string) => void
   isPro?: boolean
   onUpgradeClick?: () => void
+  /** When false, disabled state does not dim the composer (e.g. plan-mode suggestion keeps draft readable). */
+  dimWhenDisabled?: boolean
 }
 
 export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
@@ -125,6 +127,7 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
       onModelChange,
       isPro = false,
       onUpgradeClick,
+      dimWhenDisabled = true,
     },
     ref
   ) {
@@ -392,7 +395,10 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
       ]
       const fileData = combinedFiles.length > 0 ? combinedFiles : undefined
 
-      onSubmit(trimmedContent, fileData)
+      const submitResult = onSubmit(trimmedContent, fileData)
+      if (submitResult === false) {
+        return
+      }
       setValue("")
       setPendingFiles([])
       setFileError(null)
@@ -551,7 +557,7 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
             className={cn(
               "min-h-[80px] max-h-[200px] w-full",
               "px-4 pt-4 text-xs text-foreground",
-              disabled && "opacity-50",
+              disabled && dimWhenDisabled && "opacity-50",
               Platform.OS === "web" && "outline-none no-focus-ring"
             )}
             textAlignVertical="top"

--- a/apps/mobile/components/chat/PlanCard.tsx
+++ b/apps/mobile/components/chat/PlanCard.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react"
 import { View, Text, Pressable, ScrollView } from "react-native"
 import { cn } from "@shogo/shared-ui/primitives"
-import { CheckCircle2, Circle, Play, ClipboardList, ChevronDown, ChevronUp, ChevronRight } from "lucide-react-native"
+import { CheckCircle2, Circle, Play, ClipboardList, ChevronDown, ChevronUp, ChevronRight, FileText } from "lucide-react-native"
 import { MarkdownText } from "./MarkdownText"
 
 export interface PlanData {
@@ -12,21 +12,25 @@ export interface PlanData {
   plan: string
   todos: Array<{ id: string; content: string }>
   filepath?: string
+  toolCallId?: string
 }
 
 const PLAN_TRUNCATE_LENGTH = 2000
 
 interface PlanCardProps {
   plan: PlanData
+  onBuild?: () => void
   onConfirm?: () => void
+  onOpenPlan?: () => void
   onViewFull?: () => void
   isConfirmed?: boolean
 }
 
-export function PlanCard({ plan, onConfirm, onViewFull, isConfirmed }: PlanCardProps) {
+export function PlanCard({ plan, onBuild, onConfirm, onOpenPlan, onViewFull, isConfirmed }: PlanCardProps) {
   const [expanded, setExpanded] = useState(false)
   const [tasksExpanded, setTasksExpanded] = useState(false)
   const isTruncatable = plan.plan.length > PLAN_TRUNCATE_LENGTH
+  const buildAction = onBuild ?? onConfirm
   const displayedPlan = expanded || !isTruncatable
     ? plan.plan
     : plan.plan.substring(0, PLAN_TRUNCATE_LENGTH) + "\n\n..."
@@ -41,6 +45,11 @@ export function PlanCard({ plan, onConfirm, onViewFull, isConfirmed }: PlanCardP
         <View className="flex-1">
           <Text className="font-semibold text-sm text-foreground">{plan.name}</Text>
           <Text className="text-xs text-muted-foreground mt-0.5">{plan.overview}</Text>
+          {plan.filepath ? (
+            <Text className="text-[10px] text-muted-foreground/70 mt-1" numberOfLines={1}>
+              Saved as {plan.filepath}
+            </Text>
+          ) : null}
         </View>
       </View>
 
@@ -78,16 +87,25 @@ export function PlanCard({ plan, onConfirm, onViewFull, isConfirmed }: PlanCardP
 
       {/* Actions */}
       {!isConfirmed && (
-        <View className="flex-row items-center gap-2 px-4 py-3 border-t border-border bg-muted/20">
-          {onConfirm && (
+        <View className="flex-row flex-wrap items-center gap-2 px-4 py-3 border-t border-border bg-muted/20">
+          {buildAction && (
             <Pressable
-              onPress={onConfirm}
+              onPress={buildAction}
               className="flex-row items-center gap-1.5 rounded-lg bg-primary px-4 py-2"
             >
               <Play className="h-3.5 w-3.5 text-primary-foreground" size={14} />
               <Text className="text-xs font-semibold text-primary-foreground">
-                Confirm & Execute
+                Build Plan
               </Text>
+            </Pressable>
+          )}
+          {onOpenPlan && plan.filepath && (
+            <Pressable
+              onPress={onOpenPlan}
+              className="flex-row items-center gap-1.5 rounded-lg border border-border px-4 py-2"
+            >
+              <FileText className="h-3 w-3 text-muted-foreground" size={12} />
+              <Text className="text-xs text-muted-foreground">Open Plan</Text>
             </Pressable>
           )}
           {handleViewFull && (
@@ -110,7 +128,7 @@ export function PlanCard({ plan, onConfirm, onViewFull, isConfirmed }: PlanCardP
         <View className="flex-row items-center gap-2 px-4 py-3 border-t border-border bg-green-50 dark:bg-green-950/30">
           <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" size={16} />
           <Text className="text-xs font-medium text-green-700 dark:text-green-400">
-            Plan confirmed — executing...
+            Plan build started - executing in Agent mode...
           </Text>
         </View>
       )}

--- a/apps/mobile/components/chat/PlanModeSuggestion.tsx
+++ b/apps/mobile/components/chat/PlanModeSuggestion.tsx
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { Pressable, Text, View } from "react-native"
+
+type PlanModeSuggestionProps = {
+  secondsLeft: number
+  onContinueInAgent: () => void
+  onSwitchToPlan: () => void
+}
+
+export function PlanModeSuggestion({
+  secondsLeft,
+  onContinueInAgent,
+  onSwitchToPlan,
+}: PlanModeSuggestionProps) {
+  return (
+    <View
+      className="mb-2 rounded-xl border border-border/70 bg-card/95 p-2.5"
+      testID="plan-mode-suggestion"
+    >
+      <View className="flex-row items-start gap-2.5">
+        <View className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+        <View className="min-w-0 flex-1">
+          <Text className="text-sm font-medium text-foreground">
+            Plan mode may fit this better
+          </Text>
+          <Text className="mt-0.5 text-xs leading-4 text-muted-foreground">
+            Shogo suggests Plan for complex or multi-step work. Auto-sends in Agent in{" "}
+            {Math.max(1, secondsLeft)}s.
+          </Text>
+        </View>
+      </View>
+
+      <View className="mt-2 flex-row flex-wrap justify-end gap-2">
+        <Pressable
+          onPress={onContinueInAgent}
+          className="min-h-11 justify-center rounded-md border border-border/70 bg-background/40 px-3 py-2"
+          testID="plan-mode-suggestion-continue"
+          accessibilityRole="button"
+          accessibilityLabel="Send in Agent mode"
+        >
+          <Text className="text-xs font-medium text-muted-foreground">
+            Send in Agent
+          </Text>
+        </Pressable>
+        <Pressable
+          onPress={onSwitchToPlan}
+          className="min-h-11 justify-center rounded-md bg-amber-500 px-3 py-2"
+          testID="plan-mode-suggestion-switch"
+          accessibilityRole="button"
+          accessibilityLabel="Switch to Plan mode and send"
+        >
+          <Text className="text-xs font-semibold text-amber-950">
+            Switch to Plan mode
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  )
+}

--- a/apps/mobile/components/chat/PlanModeSuggestion.tsx
+++ b/apps/mobile/components/chat/PlanModeSuggestion.tsx
@@ -5,12 +5,14 @@ import { Pressable, Text, View } from "react-native"
 
 type PlanModeSuggestionProps = {
   secondsLeft: number
+  onEditPrompt?: () => void
   onContinueInAgent: () => void
   onSwitchToPlan: () => void
 }
 
 export function PlanModeSuggestion({
   secondsLeft,
+  onEditPrompt,
   onContinueInAgent,
   onSwitchToPlan,
 }: PlanModeSuggestionProps) {
@@ -33,6 +35,19 @@ export function PlanModeSuggestion({
       </View>
 
       <View className="mt-2 flex-row flex-wrap justify-end gap-2">
+        {onEditPrompt ? (
+          <Pressable
+            onPress={onEditPrompt}
+            className="min-h-11 justify-center rounded-md border border-border/70 bg-background/40 px-3 py-2"
+            testID="plan-mode-suggestion-edit"
+            accessibilityRole="button"
+            accessibilityLabel="Edit prompt"
+          >
+            <Text className="text-xs font-medium text-muted-foreground">
+              Edit prompt
+            </Text>
+          </Pressable>
+        ) : null}
         <Pressable
           onPress={onContinueInAgent}
           className="min-h-11 justify-center rounded-md border border-border/70 bg-background/40 px-3 py-2"

--- a/apps/mobile/components/chat/__tests__/plan-mode-suggestion.test.ts
+++ b/apps/mobile/components/chat/__tests__/plan-mode-suggestion.test.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, expect, test } from "bun:test"
+import { shouldSuggestPlanMode } from "../plan-mode-suggestion"
+
+describe("shouldSuggestPlanMode", () => {
+  test("detects explicit planning and implementation prompts", () => {
+    expect(
+      shouldSuggestPlanMode("Plan the migration from the old auth flow to the new API.")
+    ).toBe(true)
+    expect(
+      shouldSuggestPlanMode("Implement support for deployment workflows across the mobile and API apps.")
+    ).toBe(true)
+  })
+
+  test("detects broad multi-file risky work", () => {
+    expect(
+      shouldSuggestPlanMode("Update the database schema and backend API across multiple files.")
+    ).toBe(true)
+  })
+
+  test("detects multi-step risky implementation requests", () => {
+    expect(
+      shouldSuggestPlanMode("Refactor the auth workflow end-to-end before changing the mobile app.")
+    ).toBe(true)
+    expect(
+      shouldSuggestPlanMode("Design a step by step rollout for the Kubernetes deployment migration.")
+    ).toBe(true)
+  })
+
+  test("does not suggest for small commands or simple questions", () => {
+    expect(shouldSuggestPlanMode("list files")).toBe(false)
+    expect(shouldSuggestPlanMode("What is the current auth configuration?")).toBe(false)
+    expect(shouldSuggestPlanMode("How does this component render messages?")).toBe(false)
+  })
+
+  test("does not suggest for direct architecture questions or negated plans", () => {
+    expect(
+      shouldSuggestPlanMode("How does our mobile architecture handle chat session routing?")
+    ).toBe(false)
+    expect(
+      shouldSuggestPlanMode("I do not want a plan, just explain the API workflow.")
+    ).toBe(false)
+  })
+
+  test("keeps boundary and command-shaped prompts conservative", () => {
+    expect(shouldSuggestPlanMode("Implement auth")).toBe(false)
+    expect(shouldSuggestPlanMode("run the database migration")).toBe(false)
+    expect(
+      shouldSuggestPlanMode("run a step by step rollout plan for the database migration workflow")
+    ).toBe(true)
+  })
+})

--- a/apps/mobile/components/chat/__tests__/plan-mode-suggestion.test.ts
+++ b/apps/mobile/components/chat/__tests__/plan-mode-suggestion.test.ts
@@ -39,16 +39,37 @@ describe("shouldSuggestPlanMode", () => {
     expect(
       shouldSuggestPlanMode("How does our mobile architecture handle chat session routing?")
     ).toBe(false)
+    expect(shouldSuggestPlanMode("How do I update the Prisma schema?")).toBe(false)
+    expect(shouldSuggestPlanMode("Can you explain how to implement auth?")).toBe(false)
     expect(
       shouldSuggestPlanMode("I do not want a plan, just explain the API workflow.")
     ).toBe(false)
+    expect(
+      shouldSuggestPlanMode("Don't switch to Plan mode for this auth workflow update.")
+    ).toBe(false)
+    expect(shouldSuggestPlanMode("What is Plan mode?")).toBe(false)
   })
 
   test("keeps boundary and command-shaped prompts conservative", () => {
     expect(shouldSuggestPlanMode("Implement auth")).toBe(false)
+    expect(shouldSuggestPlanMode("Implement the login button styling")).toBe(false)
+    expect(shouldSuggestPlanMode("Change the mobile login button color")).toBe(false)
     expect(shouldSuggestPlanMode("run the database migration")).toBe(false)
     expect(
       shouldSuggestPlanMode("run a step by step rollout plan for the database migration workflow")
+    ).toBe(true)
+  })
+
+  test("suggests for broad work with complexity signals", () => {
+    expect(
+      shouldSuggestPlanMode(
+        "Enhance the Plan mode suggestion UI and cross verify it against Cursor behavior."
+      )
+    ).toBe(true)
+    expect(
+      shouldSuggestPlanMode(
+        "Can you plan the migration from the old auth flow to the new API?"
+      )
     ).toBe(true)
   })
 })

--- a/apps/mobile/components/chat/plan-mode-suggestion.ts
+++ b/apps/mobile/components/chat/plan-mode-suggestion.ts
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+export const PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS = 10
+
+const MIN_PROMPT_LENGTH = 24
+
+const QUESTION_PREFIXES = [
+  "what ",
+  "why ",
+  "who ",
+  "where ",
+  "when ",
+  "which ",
+  "can you explain",
+  "explain ",
+  "tell me ",
+  "how do i ",
+  "how does ",
+]
+
+const TINY_COMMAND_PREFIXES = [
+  "run ",
+  "show ",
+  "list ",
+  "open ",
+  "read ",
+  "cat ",
+  "ls",
+  "pwd",
+]
+
+const PLANNING_INTENT_PATTERNS = [
+  /\bplan(?:ning)?\b/i,
+  /\bimplement(?:ation)?\b/i,
+  /\brefactor(?:ing)?\b/i,
+  /\bmigrat(?:e|ion|ing)\b/i,
+  /\badd support\b/i,
+  /\bdesign\b/i,
+  /\bstep[-\s]?by[-\s]?step\b/i,
+  /\bbefore (?:coding|implementing|changing|building)\b/i,
+  /\broll(?:\s|-)?out\b/i,
+]
+
+const NEGATED_PLAN_PATTERNS = [
+  /\b(?:no|without) (?:a )?plan\b/i,
+  /\bdon'?t (?:need|want|make|create) (?:a )?plan\b/i,
+  /\bdo not (?:need|want|make|create) (?:a )?plan\b/i,
+]
+
+const EXPLICIT_PLANNING_PATTERNS = [
+  /\bplan(?:ning)?\b/i,
+  /\bstep[-\s]?by[-\s]?step\b/i,
+  /\broll(?:\s|-)?out\b/i,
+]
+
+const RISKY_SCOPE_PATTERNS = [
+  /\bdatabase\b/i,
+  /\bauth(?:entication|orization)?\b/i,
+  /\bschema\b/i,
+  /\bdeployment\b/i,
+  /\bci\b/i,
+  /\bworkflow\b/i,
+  /\bkubernetes\b/i,
+  /\bk8s\b/i,
+  /\bprisma\b/i,
+  /\bredis\b/i,
+  /\bapi\b/i,
+  /\bbackend\b/i,
+  /\bfrontend\b/i,
+  /\bmobile\b/i,
+]
+
+const MULTI_FILE_PATTERNS = [
+  /\bacross\b/i,
+  /\bmulti[-\s]?file\b/i,
+  /\bseveral files\b/i,
+  /\bmultiple files\b/i,
+  /\bend[-\s]?to[-\s]?end\b/i,
+  /\bfull flow\b/i,
+]
+
+function normalizePrompt(prompt: string) {
+  return prompt.trim().replace(/\s+/g, " ").toLowerCase()
+}
+
+function startsWithAny(value: string, prefixes: string[]) {
+  return prefixes.some((prefix) => value.startsWith(prefix))
+}
+
+export function shouldSuggestPlanMode(prompt: string): boolean {
+  const normalized = normalizePrompt(prompt)
+  if (normalized.length < MIN_PROMPT_LENGTH) return false
+
+  const hasPlanningIntent = PLANNING_INTENT_PATTERNS.some((pattern) =>
+    pattern.test(normalized)
+  )
+  const hasRiskyScope = RISKY_SCOPE_PATTERNS.some((pattern) => pattern.test(normalized))
+  const hasMultiFileScope = MULTI_FILE_PATTERNS.some((pattern) => pattern.test(normalized))
+
+  if (NEGATED_PLAN_PATTERNS.some((pattern) => pattern.test(normalized))) return false
+  if (
+    startsWithAny(normalized, TINY_COMMAND_PREFIXES) &&
+    normalized.length < 80 &&
+    !hasMultiFileScope &&
+    !EXPLICIT_PLANNING_PATTERNS.some((pattern) => pattern.test(normalized))
+  ) {
+    return false
+  }
+
+  if (!hasPlanningIntent && !hasMultiFileScope) return false
+
+  const looksLikeDirectQuestion =
+    normalized.endsWith("?") || startsWithAny(normalized, QUESTION_PREFIXES)
+  if (looksLikeDirectQuestion && !hasMultiFileScope) {
+    return false
+  }
+
+  return hasPlanningIntent || (hasRiskyScope && hasMultiFileScope)
+}

--- a/apps/mobile/components/chat/plan-mode-suggestion.ts
+++ b/apps/mobile/components/chat/plan-mode-suggestion.ts
@@ -6,6 +6,8 @@ export const PLAN_MODE_SUGGESTION_TIMEOUT_SECONDS = 10
 const MIN_PROMPT_LENGTH = 24
 
 const QUESTION_PREFIXES = [
+  "can you ",
+  "could you ",
   "what ",
   "why ",
   "who ",
@@ -32,20 +34,37 @@ const TINY_COMMAND_PREFIXES = [
 
 const PLANNING_INTENT_PATTERNS = [
   /\bplan(?:ning)?\b/i,
-  /\bimplement(?:ation)?\b/i,
-  /\brefactor(?:ing)?\b/i,
-  /\bmigrat(?:e|ion|ing)\b/i,
-  /\badd support\b/i,
-  /\bdesign\b/i,
   /\bstep[-\s]?by[-\s]?step\b/i,
   /\bbefore (?:coding|implementing|changing|building)\b/i,
   /\broll(?:\s|-)?out\b/i,
 ]
 
+const WORK_INTENT_PATTERNS = [
+  /\badd support\b/i,
+  /\baudit\b/i,
+  /\bbuild(?:ing)?\b/i,
+  /\bchange\b/i,
+  /\bcreate\b/i,
+  /\bdebug\b/i,
+  /\bdesign\b/i,
+  /\benhance\b/i,
+  /\bfix\b/i,
+  /\bimplement(?:ation)?\b/i,
+  /\binvestigate\b/i,
+  /\bmigrat(?:e|ion|ing)\b/i,
+  /\brefactor(?:ing)?\b/i,
+  /\brework\b/i,
+  /\btest\b/i,
+  /\bupdate\b/i,
+  /\bverify\b/i,
+]
+
 const NEGATED_PLAN_PATTERNS = [
   /\b(?:no|without) (?:a )?plan\b/i,
   /\bdon'?t (?:need|want|make|create) (?:a )?plan\b/i,
+  /\bdon'?t (?:switch|use|enter|move) (?:to|into)? ?plan mode\b/i,
   /\bdo not (?:need|want|make|create) (?:a )?plan\b/i,
+  /\bdo not (?:switch|use|enter|move) (?:to|into)? ?plan mode\b/i,
 ]
 
 const EXPLICIT_PLANNING_PATTERNS = [
@@ -80,6 +99,19 @@ const MULTI_FILE_PATTERNS = [
   /\bfull flow\b/i,
 ]
 
+const COMPLEXITY_PATTERNS = [
+  /\barchitecture\b/i,
+  /\bcoverage\b/i,
+  /\bcross[-\s]?verify\b/i,
+  /\bfrom scratch\b/i,
+  /\bintegration\b/i,
+  /\blarge\b/i,
+  /\bmulti[-\s]?step\b/i,
+  /\bproduction\b/i,
+  /\bregression\b/i,
+  /\bsystem\b/i,
+]
+
 function normalizePrompt(prompt: string) {
   return prompt.trim().replace(/\s+/g, " ").toLowerCase()
 }
@@ -92,11 +124,15 @@ export function shouldSuggestPlanMode(prompt: string): boolean {
   const normalized = normalizePrompt(prompt)
   if (normalized.length < MIN_PROMPT_LENGTH) return false
 
-  const hasPlanningIntent = PLANNING_INTENT_PATTERNS.some((pattern) =>
+  const hasExplicitPlanningIntent = PLANNING_INTENT_PATTERNS.some((pattern) =>
     pattern.test(normalized)
   )
+  const hasWorkIntent = WORK_INTENT_PATTERNS.some((pattern) => pattern.test(normalized))
   const hasRiskyScope = RISKY_SCOPE_PATTERNS.some((pattern) => pattern.test(normalized))
   const hasMultiFileScope = MULTI_FILE_PATTERNS.some((pattern) => pattern.test(normalized))
+  const hasComplexitySignal = COMPLEXITY_PATTERNS.some((pattern) =>
+    pattern.test(normalized)
+  )
 
   if (NEGATED_PLAN_PATTERNS.some((pattern) => pattern.test(normalized))) return false
   if (
@@ -108,13 +144,26 @@ export function shouldSuggestPlanMode(prompt: string): boolean {
     return false
   }
 
-  if (!hasPlanningIntent && !hasMultiFileScope) return false
+  if (hasExplicitPlanningIntent) return true
 
-  const looksLikeDirectQuestion =
-    normalized.endsWith("?") || startsWithAny(normalized, QUESTION_PREFIXES)
-  if (looksLikeDirectQuestion && !hasMultiFileScope) {
+  const looksLikeInformationQuestion = startsWithAny(normalized, QUESTION_PREFIXES)
+  if (
+    looksLikeInformationQuestion &&
+    !(hasWorkIntent && hasMultiFileScope && (hasRiskyScope || hasComplexitySignal))
+  ) {
     return false
   }
 
-  return hasPlanningIntent || (hasRiskyScope && hasMultiFileScope)
+  if (!hasWorkIntent && !hasMultiFileScope) return false
+
+  return (
+    (hasMultiFileScope &&
+      hasWorkIntent &&
+      (hasRiskyScope || hasComplexitySignal || normalized.length >= 90)) ||
+    (hasRiskyScope &&
+      hasWorkIntent &&
+      (hasComplexitySignal || normalized.length >= 90)) ||
+    (hasWorkIntent && hasComplexitySignal && normalized.length >= 60) ||
+    (hasWorkIntent && normalized.length >= 140)
+  )
 }

--- a/apps/mobile/components/chat/turns/AssistantContent.tsx
+++ b/apps/mobile/components/chat/turns/AssistantContent.tsx
@@ -620,25 +620,52 @@ export const AssistantContent = memo(
             )
           }
 
-          if (part.tool.toolName === "create_plan") {
+          if (part.tool.toolName === "create_plan" || part.tool.toolName === "update_plan") {
             const args = part.tool.args as Record<string, unknown> | undefined
-            const planData: PlanData | null = args
+            const pendingPlan = chatContext?.pendingPlan
+            const confirmedPlan = chatContext?.confirmedPlan
+            const toolCallId = part.id
+            const matchesTool = (plan?: PlanData | null) => {
+              if (!plan) return false
+              if (plan.toolCallId && plan.toolCallId === toolCallId) return true
+              if (plan.filepath && args?.filepath && plan.filepath === args.filepath) return true
+              return (
+                part.tool.toolName === "create_plan" &&
+                !plan.toolCallId &&
+                !plan.filepath &&
+                plan.name === args?.name &&
+                plan.plan === args?.plan
+              )
+            }
+            const matchingPendingPlan = matchesTool(pendingPlan) ? pendingPlan : null
+            const matchingConfirmedPlan = matchesTool(confirmedPlan) ? confirmedPlan : null
+            const planData: PlanData | null = matchingPendingPlan ?? matchingConfirmedPlan ?? (args
               ? {
                   name: (args.name as string) ?? "Plan",
                   overview: (args.overview as string) ?? "",
                   plan: (args.plan as string) ?? "",
                   todos: (args.todos as PlanData["todos"]) ?? [],
                   filepath: args.filepath as string | undefined,
+                  toolCallId,
                 }
-              : null
+              : null)
             if (!planData) return null
-            const isPending = part.tool.state === "success" && !!chatContext?.confirmPlan
+            const isConfirmed =
+              !!matchingConfirmedPlan &&
+              ((matchingConfirmedPlan.toolCallId && matchingConfirmedPlan.toolCallId === toolCallId) ||
+                (!!matchingConfirmedPlan.filepath && matchingConfirmedPlan.filepath === planData.filepath))
+            const isPending = part.tool.state === "success" && !!chatContext?.buildPlan && !!matchingPendingPlan && !isConfirmed
             return (
               <PlanCard
                 key={part.id}
                 plan={planData}
-                onConfirm={isPending ? chatContext!.confirmPlan! : undefined}
-                isConfirmed={false}
+                onBuild={isPending ? () => chatContext!.buildPlan!(planData) : undefined}
+                onOpenPlan={
+                  chatContext?.openPlan && planData.filepath
+                    ? () => chatContext.openPlan?.(planData.filepath)
+                    : undefined
+                }
+                isConfirmed={isConfirmed}
               />
             )
           }

--- a/apps/mobile/components/project/panels/PlansPanel.tsx
+++ b/apps/mobile/components/project/panels/PlansPanel.tsx
@@ -56,6 +56,7 @@ interface PlansPanelProps {
   projectId: string
   agentUrl?: string | null
   selectedModel?: string
+  requestedPlanPath?: { filepath: string | null; nonce: number } | null
   onBuildPlan?: (plan: PlanData, modelId: string) => void
 }
 
@@ -101,7 +102,20 @@ function extractTodos(
   return todos
 }
 
-export function PlansPanel({ visible, projectId, agentUrl, selectedModel, onBuildPlan }: PlansPanelProps) {
+function normalizePlanFilepath(filepath?: string | null): string | undefined {
+  if (!filepath) return undefined
+  const normalized = filepath.replace(/^\/+/, "").replace(/\\/g, "/")
+  const filename = normalized.split("/").pop()
+  if (!filename || !/^[a-zA-Z0-9._-]+\.plan\.md$/.test(filename)) return undefined
+  return `.shogo/plans/${filename}`
+}
+
+function filenameFromPlanPath(filepath?: string | null): string | null {
+  if (!filepath) return null
+  return normalizePlanFilepath(filepath)?.split("/").pop() ?? null
+}
+
+export function PlansPanel({ visible, projectId, agentUrl, selectedModel, requestedPlanPath, onBuildPlan }: PlansPanelProps) {
   const planStream = usePlanStreamSafe()
   const [plans, setPlans] = useState<AgentPlanSummary[]>([])
   const [loading, setLoading] = useState(false)
@@ -111,6 +125,7 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, onBuil
   const [searchQuery, setSearchQuery] = useState("")
   const [buildMode, setBuildMode] = useState<string>(selectedModel || DEFAULT_MODEL_PRO)
   const [showModelPicker, setShowModelPicker] = useState(false)
+  const [buildStarted, setBuildStarted] = useState(false)
   const prevSelectedPlanRef = useRef<string | null>(null)
 
   // Align Build model with chat when opening a plan or switching plans — not when only
@@ -163,6 +178,7 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, onBuil
         setPlanContent(data.content)
       } catch (err) {
         console.error("[PlansPanel] Failed to fetch plan detail:", err)
+        setPlanContent(null)
       } finally {
         setDetailLoading(false)
       }
@@ -199,7 +215,20 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, onBuil
     if (selectedPlan && selectedPlan !== "__streaming__") {
       fetchPlanDetail(selectedPlan)
     }
-  }, [selectedPlan, fetchPlanDetail])
+  }, [selectedPlan, fetchPlanDetail, planStream?.planRefreshNonce])
+
+  useEffect(() => {
+    if (!visible) return
+    const requestedFilename = filenameFromPlanPath(requestedPlanPath?.filepath)
+    if (!requestedFilename) return
+    setSelectedPlan(requestedFilename)
+    setPlanContent(null)
+    setBuildStarted(false)
+  }, [visible, requestedPlanPath?.nonce])
+
+  useEffect(() => {
+    setBuildStarted(false)
+  }, [selectedPlan])
 
   // Transition from streaming to persisted plan once the file is saved
   useEffect(() => {
@@ -210,10 +239,11 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, onBuil
     if (!filename) return
     setSelectedPlan(filename)
     setPlanContent(null)
+    setBuildStarted(false)
   }, [selectedPlan, planStream?.streamingPlanFilepath])
 
   const handleBuild = useCallback(() => {
-    if (!planContent || !selectedPlan || !onBuildPlan) return
+    if (buildStarted || !planContent || !selectedPlan || !onBuildPlan) return
     const plan = plans.find((p) => p.filename === selectedPlan)
     const todos = extractTodos(planContent)
     const body = extractPlanBody(planContent)
@@ -222,10 +252,11 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, onBuil
       overview: plan?.overview || "",
       plan: body,
       todos: todos.map((t) => ({ id: t.id, content: t.content })),
-      filepath: selectedPlan,
+      filepath: normalizePlanFilepath(selectedPlan),
     }
+    setBuildStarted(true)
     onBuildPlan(planData, buildMode)
-  }, [planContent, selectedPlan, plans, onBuildPlan, buildMode])
+  }, [buildStarted, planContent, selectedPlan, plans, onBuildPlan, buildMode])
 
   if (!visible) return null
 
@@ -241,18 +272,18 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, onBuil
   const streamingData = planStream?.streamingPlan
 
   // Detail view — works for both persisted plans and the live streaming plan
-  if (selectedPlan && (planContent || isStreamingDetail)) {
+  if (selectedPlan) {
     const plan = isStreamingDetail ? null : plans.find((p) => p.filename === selectedPlan)
     const todos = isStreamingDetail
       ? (streamingData?.todos ?? []).map((t) => ({ ...t, status: "pending" }))
-      : extractTodos(planContent!)
+      : planContent ? extractTodos(planContent) : []
     const body = isStreamingDetail
       ? (streamingData?.plan ?? "")
-      : extractPlanBody(planContent!)
+      : planContent ? extractPlanBody(planContent) : ""
     const detailName = isStreamingDetail
       ? (streamingData?.name || "Creating plan...")
       : (plan?.name || selectedPlan)
-    const isBuildDisabled = isStreamingDetail || !onBuildPlan || detailLoading
+    const isBuildDisabled = isStreamingDetail || !onBuildPlan || detailLoading || !planContent || buildStarted
 
     return (
       <View className="flex-1 bg-background">
@@ -358,7 +389,7 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, onBuil
             )}
           >
             <Play className="h-3.5 w-3.5 text-black" size={14} />
-            <Text className="text-xs font-bold text-black">Build</Text>
+            <Text className="text-xs font-bold text-black">{buildStarted ? "Building..." : "Build"}</Text>
           </Pressable>
 
           {!isStreamingDetail && (

--- a/apps/mobile/components/voice-mode/ChatBridgeContext.tsx
+++ b/apps/mobile/components/voice-mode/ChatBridgeContext.tsx
@@ -7,7 +7,7 @@
  *
  * Shape:
  *   - `send(text)`         — send a user message to the chat agent.
- *   - `setMode(mode)`      — switch between 'agent' / 'plan'.
+ *   - `setMode(mode)`      — switch between 'agent' / 'plan' / 'ask'.
  *   - `subscribe(fn)`      — receive a typed stream of agent events
  *                            (`turn-start`, `tool-activity`, `turn-end`).
  *
@@ -32,7 +32,7 @@ import React, {
   useState,
 } from 'react'
 
-export type ChatInteractionMode = 'agent' | 'plan'
+export type ChatInteractionMode = 'agent' | 'plan' | 'ask'
 
 /**
  * Agent-side lifecycle events broadcast through the bridge.

--- a/apps/mobile/components/voice-mode/__tests__/bridgeClientTools.test.ts
+++ b/apps/mobile/components/voice-mode/__tests__/bridgeClientTools.test.ts
@@ -42,13 +42,13 @@ describe('createBridgeClientTools', () => {
     expect(sends).toEqual([])
   })
 
-  test('set_mode accepts agent/plan (case-insensitive) and rejects others', () => {
+  test('set_mode accepts agent/plan/ask (case-insensitive) and rejects others', () => {
     const { api, modes } = makeFakeBridge()
     const tools = createBridgeClientTools(api)
     expect(tools.set_mode({ mode: 'plan' })).toBe('Switched to plan mode.')
     expect(tools.set_mode({ mode: 'AGENT' })).toBe('Switched to agent mode.')
-    expect(tools.set_mode({ mode: 'ask' })).toContain('Error')
+    expect(tools.set_mode({ mode: 'ask' })).toBe('Switched to ask mode.')
     expect(tools.set_mode({})).toContain('Error')
-    expect(modes).toEqual(['plan', 'agent'])
+    expect(modes).toEqual(['plan', 'agent', 'ask'])
   })
 })

--- a/apps/mobile/components/voice-mode/bridgeClientTools.ts
+++ b/apps/mobile/components/voice-mode/bridgeClientTools.ts
@@ -41,12 +41,14 @@ export function createBridgeClientTools(bridge: ChatBridgeApi): BridgeClientTool
     set_mode: (params) => {
       const raw =
         typeof params.mode === 'string' ? params.mode.trim().toLowerCase() : ''
-      if (raw !== 'agent' && raw !== 'plan') {
-        return `Error: mode must be "agent" or "plan" (got ${JSON.stringify(params.mode)}).`
+      if (raw !== 'agent' && raw !== 'plan' && raw !== 'ask') {
+        return `Error: mode must be "agent", "plan", or "ask" (got ${JSON.stringify(params.mode)}).`
       }
       const mode = raw as ChatInteractionMode
       bridge.setMode(mode)
-      return mode === 'plan' ? 'Switched to plan mode.' : 'Switched to agent mode.'
+      if (mode === 'plan') return 'Switched to plan mode.'
+      if (mode === 'ask') return 'Switched to ask mode.'
+      return 'Switched to agent mode.'
     },
   }
 }

--- a/e2e/staging/interaction-modes.test.ts
+++ b/e2e/staging/interaction-modes.test.ts
@@ -82,7 +82,7 @@ test.describe("Interaction Modes (Agent / Plan / Ask)", () => {
 
     const suggestion = page.locator('[data-testid="plan-mode-suggestion"]')
     await expect(suggestion).toBeVisible({ timeout: 5_000 })
-    await expect(suggestion).toContainText("Switch to Plan mode")
+    await expect(suggestion).toContainText("Shogo suggests Plan")
 
     await page.locator('[data-testid="plan-mode-suggestion-switch"]').click()
 

--- a/e2e/staging/interaction-modes.test.ts
+++ b/e2e/staging/interaction-modes.test.ts
@@ -72,6 +72,70 @@ test.describe("Interaction Modes (Agent / Plan / Ask)", () => {
     await page.waitForTimeout(500)
   })
 
+  test("auto Plan suggestion: Switch to Plan sends held message in Plan mode", async () => {
+    await selectInteractionMode(page, "Agent")
+
+    await sendChatMessage(
+      page,
+      "Implement support for a database migration workflow across multiple files."
+    )
+
+    const suggestion = page.locator('[data-testid="plan-mode-suggestion"]')
+    await expect(suggestion).toBeVisible({ timeout: 5_000 })
+    await expect(suggestion).toContainText("Switch to Plan mode")
+
+    await page.locator('[data-testid="plan-mode-suggestion-switch"]').click()
+
+    const trigger = page.locator('[data-testid="interaction-mode-trigger"]')
+    await expect(trigger).toContainText("Plan", { timeout: 5_000 })
+    await expect(
+      page.getByText("Implement support for a database migration workflow across multiple files.")
+    ).toBeVisible({ timeout: 10_000 })
+    await waitForAgentResponse(page, 180_000)
+  })
+
+  test("auto Plan suggestion: Continue in Agent keeps Agent mode", async () => {
+    await selectInteractionMode(page, "Agent")
+
+    await sendChatMessage(
+      page,
+      "Plan and implement an API refactor across multiple backend files."
+    )
+
+    await expect(page.locator('[data-testid="plan-mode-suggestion"]')).toBeVisible({
+      timeout: 5_000,
+    })
+    await page.locator('[data-testid="plan-mode-suggestion-continue"]').click()
+
+    const trigger = page.locator('[data-testid="interaction-mode-trigger"]')
+    await expect(trigger).toContainText("Agent", { timeout: 5_000 })
+    await expect(
+      page.getByText("Plan and implement an API refactor across multiple backend files.")
+    ).toBeVisible({ timeout: 10_000 })
+    await waitForAgentResponse(page, 180_000)
+  })
+
+  test("auto Plan suggestion: timeout continues in Agent mode", async () => {
+    await selectInteractionMode(page, "Agent")
+
+    await sendChatMessage(
+      page,
+      "Design and implement a CI workflow migration across the deployment configuration."
+    )
+
+    const suggestion = page.locator('[data-testid="plan-mode-suggestion"]')
+    await expect(suggestion).toBeVisible({ timeout: 5_000 })
+    await expect(suggestion).toContainText(/\b(10|9)s\b/)
+    await expect(suggestion).toBeHidden({ timeout: 12_000 })
+
+    const trigger = page.locator('[data-testid="interaction-mode-trigger"]')
+    await expect(trigger).toContainText("Agent", { timeout: 5_000 })
+    await expect(
+      page.getByText("Design and implement a CI workflow migration across the deployment configuration.")
+    ).toBeVisible({ timeout: 10_000 })
+    await waitForAgentResponse(page, 180_000)
+  })
+
   test("Ask mode: no tool calls in response", async () => {
     await selectInteractionMode(page, "Ask")
 

--- a/e2e/staging/interaction-modes.test.ts
+++ b/e2e/staging/interaction-modes.test.ts
@@ -17,8 +17,8 @@ import {
  *   1. Dropdown renders all 3 modes with descriptions
  *   2. Ask mode sends a message without tool calls
  *   3. Plan mode triggers plan creation with restricted tools
- *   4. Plan card confirm triggers agent execution
- *   5. Plans panel shows saved plans
+ *   4. Plan card opens the saved plan artifact
+ *   5. Build triggers agent execution
  *   6. Agent mode restores full capabilities
  *
  * Run: STAGING_URL=https://your-staging-host npx playwright test --config e2e/playwright.config.ts interaction-modes
@@ -97,26 +97,31 @@ test.describe("Interaction Modes (Agent / Plan / Ask)", () => {
     )
     await waitForAgentResponse(page, 180_000)
 
-    // A plan card should appear with a "Confirm & Execute" button
-    const confirmButton = page.getByText("Confirm & Execute")
-    await expect(confirmButton).toBeVisible({ timeout: 30_000 })
+    // A plan card should appear with Cursor-like Build and plan-file actions
+    await expect(page.getByText("Build Plan")).toBeVisible({ timeout: 30_000 })
+    await expect(page.getByText("Open Plan")).toBeVisible({ timeout: 30_000 })
   })
 
-  test("confirm triggers agent execution", async () => {
-    const confirmButton = page.getByText("Confirm & Execute")
-    await confirmButton.click()
+  test("plan card opens saved plan artifact", async () => {
+    await page.getByText("Open Plan").click()
+    await expect(page.getByText("Plans")).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(/^Build$/)).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText(/hello\.txt|Hello World/i).first()).toBeVisible({ timeout: 15_000 })
+  })
+
+  test("Build triggers agent execution in Agent mode", async () => {
+    await page.getByText(/^Build$/).click()
 
     // The interaction mode should switch back to Agent
     const trigger = page.locator('[data-testid="interaction-mode-trigger"]')
     await expect(trigger).toContainText("Agent", { timeout: 10_000 })
+    await expect(page.getByText("Execute the confirmed plan.")).toBeVisible({ timeout: 10_000 })
 
-    // Wait for the agent to process the confirmed plan
+    // Wait for the agent to process the built plan
     await waitForAgentResponse(page, 180_000)
 
-    // Verify the plan was confirmed (the "Plan confirmed" indicator should replace the button)
-    await expect(page.getByText("Plan confirmed")).toBeVisible({ timeout: 5_000 }).catch(() => {
-      // The confirm button should at least be gone
-    })
+    // Verify the execution turn produced a visible result tied to the approved plan
+    await expect(page.locator("body")).toContainText(/hello\.txt|Hello World|created|added/i, { timeout: 30_000 })
   })
 
   test("Plans panel shows saved plans", async () => {

--- a/packages/agent-runtime/src/coordinator-prompt.ts
+++ b/packages/agent-runtime/src/coordinator-prompt.ts
@@ -49,5 +49,5 @@ export const COORDINATOR_READONLY_TOOLS = new Set([
   'web', 'browser', 'memory_read', 'memory_search',
   'agent_create', 'agent_spawn', 'agent_status', 'agent_cancel', 'agent_result', 'agent_list',
   'team_create', 'team_delete', 'task_create', 'task_get', 'task_list', 'task_update', 'send_team_message',
-  'ask_user', 'todo_write', 'create_plan',
+  'ask_user', 'todo_write', 'create_plan', 'update_plan',
 ])

--- a/packages/agent-runtime/src/gateway-tools.ts
+++ b/packages/agent-runtime/src/gateway-tools.ts
@@ -5100,6 +5100,26 @@ function createHeartbeatStatusTool(ctx: ToolContext): AgentTool {
 // Plan Mode: create_plan tool
 // ---------------------------------------------------------------------------
 
+function normalizePlanFilepath(filepath: string): string | null {
+  const normalized = filepath.replace(/^\/+/, '').replace(/\\/g, '/')
+  const filename = normalized.split('/').pop() ?? ''
+  if (!/^[a-zA-Z0-9._-]+\.plan\.md$/.test(filename)) return null
+  return `.shogo/plans/${filename}`
+}
+
+function parsePlanTodosFromFrontmatter(fm: string): Array<{ id: string; content: string }> {
+  const todos: Array<{ id: string; content: string }> = []
+  const todoBlocks = fm.split(/\n  - id: /).slice(1)
+  for (const block of todoBlocks) {
+    const idMatch = block.match(/^(\S+)/)
+    const contentMatch = block.match(/content:\s*"?([^"\n]*)"?/)
+    if (idMatch && contentMatch) {
+      todos.push({ id: idMatch[1], content: contentMatch[1] })
+    }
+  }
+  return todos
+}
+
 function createCreatePlanTool(ctx: ToolContext): AgentTool {
   return {
     name: 'create_plan',
@@ -5156,6 +5176,7 @@ function createCreatePlanTool(ctx: ToolContext): AgentTool {
             plan: params.plan,
             todos: params.todos,
             filepath: `.shogo/plans/${filename}`,
+            toolCallId: _id,
           },
         })
       }
@@ -5195,15 +5216,23 @@ function createUpdatePlanTool(ctx: ToolContext): AgentTool {
         plan?: string
         todos?: Array<{ id: string; content: string }>
       }
-      const resolved = join(ctx.workspaceDir, params.filepath)
+      const planFilepath = normalizePlanFilepath(params.filepath)
+      if (!planFilepath) {
+        return textResult(`Error: Invalid plan filepath ${params.filepath}`)
+      }
+      const plansDir = resolve(ctx.workspaceDir, '.shogo', 'plans')
+      const resolved = resolve(ctx.workspaceDir, planFilepath)
+      if (!resolved.startsWith(`${plansDir}/`) && resolved !== plansDir) {
+        return textResult(`Error: Plan filepath must stay within .shogo/plans/`)
+      }
       if (!existsSync(resolved)) {
-        return textResult(`Error: Plan file not found at ${params.filepath}`)
+        return textResult(`Error: Plan file not found at ${planFilepath}`)
       }
 
       const existing = readFileSync(resolved, 'utf-8')
       const fmMatch = existing.match(/^---\n([\s\S]*?)\n---/)
       if (!fmMatch) {
-        return textResult(`Error: Could not parse frontmatter in ${params.filepath}`)
+        return textResult(`Error: Could not parse frontmatter in ${planFilepath}`)
       }
 
       const fm = fmMatch[1]
@@ -5248,16 +5277,17 @@ function createUpdatePlanTool(ctx: ToolContext): AgentTool {
         ctx.uiWriter.write({
           type: 'data-plan-update',
           data: {
-            filepath: params.filepath,
+            filepath: planFilepath,
             name: updatedName,
             overview: updatedOverview,
             plan: updatedBody,
-            todos: params.todos,
+            todos: params.todos ?? parsePlanTodosFromFrontmatter(fm),
+            toolCallId: _id,
           },
         })
       }
 
-      return textResult(`Plan "${updatedName}" updated at ${params.filepath}`)
+      return textResult(`Plan "${updatedName}" updated at ${planFilepath}`)
     },
   }
 }

--- a/packages/agent-runtime/src/gateway.ts
+++ b/packages/agent-runtime/src/gateway.ts
@@ -1105,7 +1105,7 @@ export class AgentGateway {
       fileParts?: FilePart[]
       userId?: string
       interactionMode?: 'agent' | 'plan' | 'ask'
-      confirmedPlan?: { name: string; overview: string; plan: string; todos: Array<{ id: string; content: string }> }
+      confirmedPlan?: { name: string; overview: string; plan: string; todos?: Array<{ id: string; content: string }>; filepath?: string }
       chatSessionId?: string
     },
   ): Promise<void> {
@@ -1143,12 +1143,13 @@ export class AgentGateway {
     // If a confirmed plan is present, prepend it as context to the user's message
     if (options?.confirmedPlan) {
       const cp = options.confirmedPlan
-      const todoList = cp.todos.map(t => `- [ ] ${t.content}`).join('\n')
+      const todoList = (cp.todos ?? []).map(t => `- [ ] ${t.content}`).join('\n')
       const planContext = [
         'The user has confirmed the following plan. Execute it step by step:',
         '',
         `## ${cp.name}`,
         cp.overview,
+        cp.filepath ? `Saved plan: ${cp.filepath}` : '',
         '',
         cp.plan,
         '',
@@ -1173,7 +1174,7 @@ export class AgentGateway {
       activeSkill = result.activeSkill
     }
 
-    const interactionMode = options?.interactionMode || 'agent'
+    const interactionMode = options?.confirmedPlan ? 'agent' : (options?.interactionMode || 'agent')
     console.log(`[Gateway][processChatMessageStream] resolved interactionMode: ${interactionMode} (options had: ${options?.interactionMode ?? '(undefined)'}), sessionId: ${sessionId}, activeSkill: ${activeSkill ?? '(none)'}`)
     const response = await this.agentTurn(prompt, sessionId, false, undefined, writer, activeSkill, images, interactionMode)
     this.emitLog(`Chat response (stream): "${response.substring(0, 100)}"`)
@@ -1297,10 +1298,11 @@ export class AgentGateway {
       const planModePrompt = [
         '## PLAN MODE ACTIVE',
         '',
-        'Plan mode is active. You MUST NOT make any edits, run commands, write files, or otherwise make changes. This supersedes all other instructions.',
+        'Plan mode is active. You MUST NOT edit source files, run mutating commands, or otherwise change the workspace before the user clicks Build. This supersedes all other instructions.',
+        'Exception: you may create or update the plan artifact using create_plan/update_plan; those tools only write under .shogo/plans/ for user review.',
         '',
         'Your job:',
-        '1. Research the user\'s request using read-only tools (read_file, grep, glob, web, etc.)',
+        '1. Research the user\'s request using read-only tools (read_file, search, web, etc.)',
         '2. If you need more information, ask clarifying questions using ask_user',
         '3. If the request is too broad, ask 1-2 narrowing questions using ask_user',
         '4. If there are multiple valid approaches, ask the user which they prefer',


### PR DESCRIPTION
<img width="1512" height="982" alt="Screenshot 2026-04-29 at 2 08 03 PM" src="https://github.com/user-attachments/assets/459e37ca-249a-420e-99cd-a6581f328c8c" />
<img width="1512" height="982" alt="Screenshot 2026-04-29 at 2 09 28 PM" src="https://github.com/user-attachments/assets/ced73c62-e72b-4f6c-90c0-b4666b2ba5f0" />
<img width="1512" height="982" alt="Screenshot 2026-04-29 at 2 31 48 PM" src="https://github.com/user-attachments/assets/c6d9104f-1bba-4d6e-a968-ba6b488730ca" />

## Pull request

**Closes** #460

**Branch:** `fix/plan-mode-cursor-parity-build-flow-and-hardening`

This PR mirrors the depth and structure of the linked issue so reviewers have one place on the PR with full context.

---

## Summary

Shogo’s **Plan** interaction mode had partial parity with **Cursor Plan Mode**: plans were created and saved under `.shogo/plans/`, but the product flow, labels, and some runtime edges did not match Cursor’s **research → plan artifact → Build → Agent execution** model. There were also correctness and safety gaps around **plan identity in chat**, **repeated “open plan” navigation**, **`update_plan` path handling**, and **weak E2E assertions** for the Build step.

This issue tracks the work to align UX, client/server contracts, and tests for that single theme.

---

## Root cause analysis (RCA)

1. **UX mismatch**  
   The primary CTA was framed as “confirm and execute” rather than **Build** from a **plan file** artifact. Cursor users expect an explicit **Build** transition after a reviewable plan.

2. **Global vs per-card plan state**  
   `pendingPlan` / `confirmedPlan` were effectively global. Multiple `create_plan` tool cards in one thread could show or build the **wrong** plan when a newer plan arrived.

3. **Mode vs execution**  
   Build could still send `interactionMode: plan` in edge cases while attaching `confirmedPlan`, so the gateway could treat the turn as plan-scoped instead of execution-scoped.

4. **`update_plan` safety**  
   String-prefix “normalization” of `filepath` could still allow traversal (e.g. paths under `.shogo/plans/` that escape the directory after `join`). That violated the intent: **only real plan artifacts** before user Build.

5. **Plans panel / chat coupling**  
   “Open plan” used a bare string; React state did not always re-fire when opening the **same** path again. Streaming filepath could go **stale** across plan turns.

6. **Coordinator + plan refinement**  
   `update_plan` was filtered out in coordinator readonly tool sets, blocking refinement in that configuration.

7. **Voice bridge**  
   `set_mode` only accepted `agent` | `plan`, not **ask**, unlike the main composer.

8. **Tests**  
   E2E could pass Build without asserting a durable outcome; staging helper timeouts were swallowed.

---

## Target architecture (high level)

```mermaid
flowchart TB
  subgraph client [Mobile / Web client]
    ChatInput[ChatInput modes Agent Plan Ask]
    ChatPanel[ChatPanel stream pendingPlan confirmedPlan]
    PlanCard[PlanCard Build Open Plan]
    PlansPanel[PlansPanel list detail Build]
    PlanStream[PlanStreamContext streaming filepath nonce]
  end
  subgraph api [API]
    ProjectChat[project-chat proxy body passthrough]
  end
  subgraph runtime [agent-runtime]
    Server[server POST agent chat]
    Gateway[Gateway processChatMessageStream]
    Tools[create_plan update_plan under .shogo/plans]
  end
  ChatInput --> ChatPanel
  ChatPanel -->|SSE data-plan data-plan-update| PlanStream
  ChatPanel --> PlanCard
  ChatPanel -->|onOpenPlan nonce| PlansPanel
  PlansPanel -->|Build planData| ChatPanel
  ChatPanel --> ProjectChat --> Server --> Gateway
  Gateway --> Tools
```

**Contracts**

- **Modes**: `interactionMode` ∈ `agent` | `plan` | `ask` on the chat request body.
- **Build**: User action sets mode to **agent**, sends a short execute message, and attaches **`confirmedPlan`** (normalized `PlanData`). Gateway treats **`confirmedPlan` as forcing an agent-class turn** for execution.
- **Artifacts**: Plans live at `.shogo/plans/<slug>_<hash>.plan.md`. UI displays a stable **relative path**; `update_plan` only resolves inside the real plans directory after **basename validation**.

---

## What changed (scope: this issue only)

| Area | Change |
|------|--------|
| **PlanCard** | **Build Plan**, **Open Plan**, saved path line, optional `toolCallId` on `PlanData`, build-started copy. |
| **ChatContext** | `buildPlan(plan?)`, `pendingPlan`, `confirmedPlan`, `openPlan`; `confirmPlan` kept as alias. |
| **AssistantContent** | Renders **both** `create_plan` and `update_plan` as plan cards; matches pending/confirmed by **toolCallId** / filepath; passes explicit plan into **Build**. |
| **ChatPanel** | Normalizes plan paths (safe basename), `pendingPlanRef`, session reset of plan state, `data-plan` / `data-plan-update` merge + stream sync, `confirmedPlan` → force `interactionMode: agent` on send, bridge `setMode` supports **ask**. |
| **Project layout** | `handleOpenPlan` uses **nonce + filepath** so repeat opens work; monotonic nonce for **Build** from panel. |
| **PlansPanel** | Consumes open request by nonce; detail shell while loading; **Build** debounce / in-flight guard; normalized filepath on Build. |
| **gateway** | Plan-mode prompt allows **only** plan artifact writes under `.shogo/plans/`; `search` not grep; **`confirmedPlan` forces agent mode**. |
| **gateway-tools** | Strict plan filename regex; `update_plan` resolves under `.shogo/plans` with prefix check on **realpath**; stream includes **toolCallId** and full todos on update when omitted. |
| **coordinator-prompt** | `update_plan` in readonly allowlist. |
| **ChatInput (web)** | `Shift+Tab` cycles Agent → Plan → Ask (when not streaming). |
| **Voice** | `ChatInteractionMode` includes `ask`; `set_mode` accepts it. |
| **E2E** | Plan card asserts Build + Open Plan; Build asserts execute message + body text hint. |

---

## Security / correctness

- `update_plan` **rejects** invalid filenames and any resolved path **outside** `.shogo/plans/`.
- UI path normalization strips to allowed `.plan.md` basename only for display and client payloads.

---

## Testing

- `bun test apps/mobile/components/voice-mode/__tests__/bridgeClientTools.test.ts`
- Staging: `e2e/staging/interaction-modes.test.ts` (Playwright) after deploy.

---

## What to expect after this ships

- In **Plan** mode, users see a **plan card** with **Build Plan** and **Open Plan** (when filepath exists).
- **Open Plan** switches to the **Plans** preview and selects the file; repeat clicks on the same plan still work.
- **Build** switches the composer to **Agent**, sends execution with **`confirmedPlan`**, and the runtime runs with **full agent tools** (not plan allowlist).
- **Refinement** via `update_plan` updates the artifact and stream; coordinator mode can call `update_plan`.
- **Voice** `set_mode` can select **ask** as well as agent/plan.
- **Web** composer: **Shift+Tab** cycles modes (document in release notes / help).

---

## Non-goals (out of scope)

- Saving plans outside workspace / “home directory” Cursor behavior.
- Inline markdown editor inside chat (Plans panel + future editor only).
- Unrelated terminal-404 or other branches — this work lives on **one** branch: `fix/plan-mode-cursor-parity-build-flow-and-hardening`.


---

## PR-specific notes

### Commit
- Single focused commit on this branch (plan-mode theme only).

### Scope (14 files)
- **Mobile:** `ChatPanel`, `PlanCard`, `ChatContext`, `AssistantContent`, `ChatInput`, `PlansPanel`, project `_layout`
- **Voice:** `ChatBridgeContext`, `bridgeClientTools`, unit test
- **E2E:** `e2e/staging/interaction-modes.test.ts`
- **agent-runtime:** `gateway.ts`, `gateway-tools.ts`, `coordinator-prompt.ts`

### Reviewer checklist
- [ ] Plan → **Build** sends `confirmedPlan` and **agent** `interactionMode` in the chat request body
- [ ] **Open Plan** works on first and repeated opens (nonce request)
- [ ] `update_plan` cannot escape `.shogo/plans/`
- [ ] Multiple `create_plan` / `update_plan` cards do not cross-wire Build
- [ ] Voice `set_mode` accepts `ask`; web `Shift+Tab` cycles modes when not streaming

### Test plan
- [x] `bun test apps/mobile/components/voice-mode/__tests__/bridgeClientTools.test.ts`
- [ ] Staging Playwright: `e2e/staging/interaction-modes.test.ts`

### Risk / rollback
Low–medium: chat streaming + plan tools only; no migrations. Revert this PR to roll back.
