### PR TITLE
fix(agent-runtime): keep runtime alive when vite spawn fails on Windows; per-attempt proxy timeout

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2074,11 +2074,16 @@ app.all('/api/projects/:projectId/agent-proxy/*', async (c) => {
   let lastError: Error | null = null
 
   const proxyClientSignal = c.req.raw.signal
-  const proxyFetchSignal = proxyClientSignal
-    ? AbortSignal.any([AbortSignal.timeout(FETCH_TIMEOUT_MS), proxyClientSignal])
-    : AbortSignal.timeout(FETCH_TIMEOUT_MS)
 
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    // Per-attempt timeout. Sharing one `AbortSignal.timeout` across all
+    // retries means a single timeout aborts every subsequent attempt
+    // instantly (the signal is already in the aborted state), wasting the
+    // cold-start retry budget. Build a fresh combined signal each attempt.
+    const proxyFetchSignal = proxyClientSignal
+      ? AbortSignal.any([AbortSignal.timeout(FETCH_TIMEOUT_MS), proxyClientSignal])
+      : AbortSignal.timeout(FETCH_TIMEOUT_MS)
+
     try {
       const response = await fetch(targetUrl, {
         method: c.req.method,

--- a/packages/agent-runtime/src/preview-manager.ts
+++ b/packages/agent-runtime/src/preview-manager.ts
@@ -992,24 +992,52 @@ export class PreviewManager {
     const cwd = this.bundlerCwd
     const buildLogPath = join(cwd, BUILD_LOG_FILE)
 
-    if (!existsSync(join(cwd, 'node_modules', '.bin', 'vite'))) {
+    // On Windows the bun/npm-installed shim at `.bin/vite` is a POSIX shell
+    // script that `child_process.spawn` cannot execute directly — it has to
+    // be `.bin/vite.CMD`. Pick the right shim per-platform and bail out
+    // cleanly if neither exists (e.g. dependency install failed earlier).
+    const binDir = join(cwd, 'node_modules', '.bin')
+    const isWindows = process.platform === 'win32'
+    const viteCandidates = isWindows
+      ? [join(binDir, 'vite.CMD'), join(binDir, 'vite.cmd'), join(binDir, 'vite.exe')]
+      : [join(binDir, 'vite')]
+    const viteBin = viteCandidates.find((p) => existsSync(p))
+    if (!viteBin) {
       console.log(`[${LOG_PREFIX}] Vite not found in node_modules — skipping watch`)
       return
     }
 
     console.log(`[${LOG_PREFIX}] Starting vite build --watch...`)
 
-    const viteProcess = spawn('node_modules/.bin/vite', ['build', '--watch'], {
-      cwd,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: {
-        ...process.env,
-        NODE_ENV: 'development',
-        VITE_RUNTIME_PORT: String(this.runtimePort),
-      },
-    })
+    let viteProcess: ChildProcess
+    try {
+      viteProcess = spawn(viteBin, ['build', '--watch'], {
+        cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        // `.CMD` shims must go through cmd.exe on Windows.
+        shell: isWindows,
+        env: {
+          ...process.env,
+          NODE_ENV: 'development',
+          VITE_RUNTIME_PORT: String(this.runtimePort),
+        },
+      })
+    } catch (err: any) {
+      console.error(`[${LOG_PREFIX}] Failed to spawn vite build --watch: ${err?.message ?? err}`)
+      return
+    }
 
     this.buildWatchProcess = viteProcess
+
+    // Async spawn errors (e.g. ENOENT surfaced after the call returns) must
+    // not bubble up — without this listener Node treats them as uncaught and
+    // tears down the entire agent runtime process.
+    viteProcess.on('error', (err: Error) => {
+      console.error(`[${LOG_PREFIX}] Vite build --watch error: ${err.message}`)
+      if (this.buildWatchProcess === viteProcess) {
+        this.buildWatchProcess = null
+      }
+    })
 
     viteProcess.stdout?.on('data', (data: Buffer) => {
       const line = data.toString().trim()
@@ -1032,7 +1060,6 @@ export class PreviewManager {
       }
     })
 
-    // Wait briefly for initial build
     await new Promise((resolve) => setTimeout(resolve, 3000))
   }
 


### PR DESCRIPTION
## Summary

Two fixes that surfaced from a Windows dev session where the agent runtime crashed and the `/agent/canvas/stream` proxy spammed `failed after 24 attempts: Unable to connect` repeatedly.

- **`packages/agent-runtime/src/preview-manager.ts` — `startBuildWatch`**
  - Resolve the vite shim per-platform: `vite.CMD` / `vite.cmd` / `vite.exe` on Windows, `vite` elsewhere. The plain `node_modules/.bin/vite` shim that bun/npm install on Windows is a POSIX shell script, which is why `child_process.spawn` raised `ENOENT` even though the file existed.
  - Pass `shell: true` on Windows so the `.CMD` shim is executed by `cmd.exe`.
  - Wrap the `spawn` call in `try/catch` and add a `viteProcess.on('error', ...)` listener. Either path used to surface as an uncaught exception that killed the entire agent runtime process (`[RuntimeManager] Agent process exited ... code=1`); now the watcher just logs and is skipped, and the rest of the runtime keeps serving `/agent/*` endpoints.

- **`apps/api/src/server.ts` — `/api/projects/:projectId/agent-proxy/*` retry loop**
  - Move `proxyFetchSignal` construction inside the retry loop so each of the 24 attempts gets a fresh `AbortSignal.timeout(...)` combined with the (still-shared) client signal. Previously a single timeout would put the signal in an already-aborted state and every remaining retry would abort instantly without doing real work, defeating the cold-start retry budget.

No new dependencies; no schema or API surface changes.

## Test plan

- [ ] On Windows with Node.js missing / deps not installed: start `bun run dev:all`, open a project canvas, confirm the agent runtime stays up (no `Agent process exited code=1`) and that the build watcher logs a benign `Vite not found` / spawn error instead of crashing.
- [ ] On Windows with deps installed: confirm `vite build --watch` actually starts via the `.CMD` shim and emits build output to the log.
- [ ] Cold-start scenario (kill agent runtime mid-stream): confirm `/agent/canvas/stream` retries actually use multiple attempts (look for `succeeded after N attempts` log) instead of all 24 attempts aborting instantly with `TimeoutError`.
- [ ] Linux/macOS regression: `vite build --watch` still spawns through the POSIX `.bin/vite` shim without `shell: true`.
