### PR TITLE
fix(mobile): reduce plan mode suggestion false positives

### DIFF
--- a/apps/mobile/components/chat/__tests__/plan-mode-suggestion.test.ts
+++ b/apps/mobile/components/chat/__tests__/plan-mode-suggestion.test.ts
@@ -72,4 +72,17 @@ describe("shouldSuggestPlanMode", () => {
       )
     ).toBe(true)
   })
+
+  test("does not suggest only because an implementation prompt is long", () => {
+    expect(
+      shouldSuggestPlanMode(
+        "Implement this straightforward copy tweak in the settings screen so the empty state describes how to add a teammate, keeps the current layout, and preserves the existing button behavior."
+      )
+    ).toBe(false)
+    expect(
+      shouldSuggestPlanMode(
+        "Fix the chat input so the submit button stays aligned while typing a longer message, without changing the surrounding composer behavior or touching unrelated files."
+      )
+    ).toBe(false)
+  })
 })

--- a/apps/mobile/components/chat/plan-mode-suggestion.ts
+++ b/apps/mobile/components/chat/plan-mode-suggestion.ts
@@ -162,8 +162,8 @@ export function shouldSuggestPlanMode(prompt: string): boolean {
       (hasRiskyScope || hasComplexitySignal || normalized.length >= 90)) ||
     (hasRiskyScope &&
       hasWorkIntent &&
-      (hasComplexitySignal || normalized.length >= 90)) ||
-    (hasWorkIntent && hasComplexitySignal && normalized.length >= 60) ||
-    (hasWorkIntent && normalized.length >= 140)
+      hasComplexitySignal &&
+      normalized.length >= 90) ||
+    (hasWorkIntent && hasComplexitySignal && normalized.length >= 60)
   )
 }


### PR DESCRIPTION
## Summary
- Fixes #467.
- Narrows the Plan mode suggestion heuristic so prompt length alone no longer interrupts Agent-mode submissions.
- Adds regression coverage for long but straightforward implementation prompts.

## Detailed Implementation
The Plan mode suggestion is rendered by `ChatPanel` only when `shouldSuggestPlanMode(content)` returns true before the message is sent. The previous heuristic allowed any prompt with work intent and at least 140 normalized characters to trigger the suggestion, even without explicit planning, multi-file scope, risky scope, or complexity signals.

This PR removes that length-only fallback and requires stronger signals before the suggestion is shown:

- explicit planning intent still immediately qualifies
- multi-file work can qualify when paired with risk, complexity, or enough scope detail
- risky work now also needs complexity and enough detail
- complexity plus work intent still qualifies for broader implementation prompts

The result is that detailed Agent prompts like copy tweaks, layout fixes, or narrowly scoped UI behavior changes are sent directly in Agent mode instead of being held behind the Plan mode suggestion.

## Architecture Diagram
```mermaid
flowchart TD
  A[User submits prompt] --> B[ChatInput onSubmit]
  B --> C[ChatPanel handleInputSubmit]
  C --> D{Mode is Agent and send path is idle?}
  D -- No --> I[Send message normally]
  D -- Yes --> E[shouldSuggestPlanMode prompt]
  E --> F{Explicit planning, broad multi-file scope, or risk + complexity?}
  F -- No --> I
  F -- Yes --> G[Show Plan mode suggestion and hold prompt]
  G --> H{User action or timeout}
  H -- Switch to Plan --> J[Set Plan mode and send held prompt]
  H -- Send in Agent / timeout --> I
```

## Test Plan
- [x] `bun test apps/mobile/components/chat/__tests__/plan-mode-suggestion.test.ts`

Made with [Cursor](https://cursor.com)