### PR TITLE
feat(mobile): add scoped PanelErrorBoundary to isolate panel crashes

### DIFF
--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -83,6 +83,7 @@ import { InspectorPanel } from '../../../../components/dynamic-app/edit/Inspecto
 import { ComponentTreePanel } from '../../../../components/dynamic-app/edit/ComponentTreePanel'
 import { CanvasThemeProvider, CanvasThemedContainer, useCanvasThemeOptional } from '../../../../components/dynamic-app/CanvasThemeContext'
 import { ProjectTopBar } from '../../../../components/project/ProjectTopBar'
+import { PanelErrorBoundary } from '../../../../components/project/panels/PanelErrorBoundary'
 import {
   ChannelsPanel,
   FilesBrowserPanel,
@@ -1223,31 +1224,33 @@ export default observer(function ProjectLayout() {
             style={!isActive ? { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, opacity: 0 } : undefined}
             pointerEvents={isActive ? 'auto' : 'none'}
           >
-            <ChatPanel
-              featureId={projectId ?? null}
-              featureName={project.name}
-              phase={null}
-              chatSessionId={tabId}
-              onChatSessionChange={handleChatSessionChange}
-              workspaceId={project?.workspaceId}
-              userId={user?.id}
-              projectId={projectId}
-              projectType="unified"
-              isActive={isActive}
-              localAgentUrl={remoteProjectAgentBaseUrl ?? undefined}
-              initialMessage={isInitialSession ? capturedInitialMessage : undefined}
-              initialInteractionMode={isInitialSession ? capturedInitialInteractionMode : undefined}
-              initialFiles={isInitialSession ? capturedInitialFiles : undefined}
-              billingData={billingDataResolved}
-              onCanvasPreview={handleCanvasPreview}
-              onMessagesChange={isActive ? setChatMessages : undefined}
-              onStreamingChange={getStreamingChangeHandler(tabId)}
-              buildPlanRequest={isActive ? buildPlanRequest : null}
-              onOpenPlan={handleOpenPlan}
-              selectedModel={selectedModel}
-              onModelChange={handleModelChange}
-              className="flex-1"
-            />
+            <PanelErrorBoundary panelName="Chat">
+              <ChatPanel
+                featureId={projectId ?? null}
+                featureName={project.name}
+                phase={null}
+                chatSessionId={tabId}
+                onChatSessionChange={handleChatSessionChange}
+                workspaceId={project?.workspaceId}
+                userId={user?.id}
+                projectId={projectId}
+                projectType="unified"
+                isActive={isActive}
+                localAgentUrl={remoteProjectAgentBaseUrl ?? undefined}
+                initialMessage={isInitialSession ? capturedInitialMessage : undefined}
+                initialInteractionMode={isInitialSession ? capturedInitialInteractionMode : undefined}
+                initialFiles={isInitialSession ? capturedInitialFiles : undefined}
+                billingData={billingDataResolved}
+                onCanvasPreview={handleCanvasPreview}
+                onMessagesChange={isActive ? setChatMessages : undefined}
+                onStreamingChange={getStreamingChangeHandler(tabId)}
+                buildPlanRequest={isActive ? buildPlanRequest : null}
+                onOpenPlan={handleOpenPlan}
+                selectedModel={selectedModel}
+                onModelChange={handleModelChange}
+                className="flex-1"
+              />
+            </PanelErrorBoundary>
           </View>
         )
       })}
@@ -1501,7 +1504,11 @@ export default observer(function ProjectLayout() {
             )}
 
             {canvasEnabled && previewTab === 'dynamic-app' && (
-              <View className="absolute inset-0">{canvasPanel}</View>
+              <View className="absolute inset-0">
+                <PanelErrorBoundary panelName="Canvas">
+                  {canvasPanel}
+                </PanelErrorBoundary>
+              </View>
             )}
             {previewTab === 'app-preview' && (
               <View
@@ -1526,15 +1533,33 @@ export default observer(function ProjectLayout() {
                   : 'none'
               }
             >
-              <IDEPanel visible={previewTab === 'ide'} projectId={projectId!} projectName={project.name} agentUrl={agentUrl} />
-              <FilesBrowserPanel visible={previewTab === 'files'} projectId={projectId!} agentUrl={agentUrl} />
-              <TerminalPanel visible={previewTab === 'terminal'} messages={chatMessages} />
-              <CapabilitiesPanel visible={previewTab === 'capabilities'} projectId={projectId!} agentUrl={agentUrl} capabilities={capabilitySettings} onCapabilityToggle={handleCapabilityToggle} isPaidPlan={effectiveHasActiveSubscription} activeMode={activeMode} onModeChange={handleManualModeChange} techStackId={techStackId} onTechStackChange={handleTechStackChange} selectedModel={selectedModel} onModelChange={handleModelChange} />
-              <ChannelsPanel visible={previewTab === 'channels'} projectId={projectId!} agentUrl={agentUrl} hasAdvancedModelAccess={features.billing ? billingData.hasAdvancedModelAccess : true} />
-              <AgentsPanel visible={previewTab === 'agents'} selectedToolId={selectedAgentToolId} agentUrl={agentUrl} />
-              <MonitorPanel visible={previewTab === 'monitor'} projectId={projectId!} agentUrl={agentUrl} isPaidPlan={effectiveHasActiveSubscription} />
-              <PlansPanel visible={previewTab === 'plans'} projectId={projectId!} agentUrl={agentUrl} selectedModel={selectedModel} requestedPlanPath={requestedPlanPath} onBuildPlan={handleBuildPlan} />
-              <CheckpointsPanel visible={previewTab === 'checkpoints'} projectId={projectId!} />
+              <PanelErrorBoundary panelName="IDE">
+                <IDEPanel visible={previewTab === 'ide'} projectId={projectId!} projectName={project.name} agentUrl={agentUrl} />
+              </PanelErrorBoundary>
+              <PanelErrorBoundary panelName="Files">
+                <FilesBrowserPanel visible={previewTab === 'files'} projectId={projectId!} agentUrl={agentUrl} />
+              </PanelErrorBoundary>
+              <PanelErrorBoundary panelName="Terminal">
+                <TerminalPanel visible={previewTab === 'terminal'} messages={chatMessages} />
+              </PanelErrorBoundary>
+              <PanelErrorBoundary panelName="Capabilities">
+                <CapabilitiesPanel visible={previewTab === 'capabilities'} projectId={projectId!} agentUrl={agentUrl} capabilities={capabilitySettings} onCapabilityToggle={handleCapabilityToggle} isPaidPlan={effectiveHasActiveSubscription} activeMode={activeMode} onModeChange={handleManualModeChange} techStackId={techStackId} onTechStackChange={handleTechStackChange} selectedModel={selectedModel} onModelChange={handleModelChange} />
+              </PanelErrorBoundary>
+              <PanelErrorBoundary panelName="Channels">
+                <ChannelsPanel visible={previewTab === 'channels'} projectId={projectId!} agentUrl={agentUrl} hasAdvancedModelAccess={features.billing ? billingData.hasAdvancedModelAccess : true} />
+              </PanelErrorBoundary>
+              <PanelErrorBoundary panelName="Agents">
+                <AgentsPanel visible={previewTab === 'agents'} selectedToolId={selectedAgentToolId} agentUrl={agentUrl} />
+              </PanelErrorBoundary>
+              <PanelErrorBoundary panelName="Monitor">
+                <MonitorPanel visible={previewTab === 'monitor'} projectId={projectId!} agentUrl={agentUrl} isPaidPlan={effectiveHasActiveSubscription} />
+              </PanelErrorBoundary>
+              <PanelErrorBoundary panelName="Plans">
+                <PlansPanel visible={previewTab === 'plans'} projectId={projectId!} agentUrl={agentUrl} selectedModel={selectedModel} requestedPlanPath={requestedPlanPath} onBuildPlan={handleBuildPlan} />
+              </PanelErrorBoundary>
+              <PanelErrorBoundary panelName="Checkpoints">
+                <CheckpointsPanel visible={previewTab === 'checkpoints'} projectId={projectId!} />
+              </PanelErrorBoundary>
             </View>
           </View>
 

--- a/apps/mobile/components/project/panels/PanelErrorBoundary.tsx
+++ b/apps/mobile/components/project/panels/PanelErrorBoundary.tsx
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import { Component, type ReactNode } from 'react'
+import { View } from 'react-native'
+import * as Sentry from '@sentry/react-native'
+import { Text } from '@/components/ui/text'
+import { Button, ButtonText } from '@/components/ui/button'
+import { AlertTriangle, RefreshCw } from 'lucide-react-native'
+
+interface Props {
+  children: ReactNode
+  panelName: string
+  onRetry?: () => void
+}
+
+interface State {
+  hasError: boolean
+  error: Error | null
+  errorCount: number
+  autoRetrying: boolean
+}
+
+const AUTO_RETRY_DELAY_MS = 1500
+const MAX_AUTO_RETRIES = 1
+
+/**
+ * Scoped error boundary for project panels (Chat, IDE, Terminal, etc.).
+ * Catches rendering crashes, auto-retries once, then shows manual recovery UI.
+ * Each instance is independent — a crash in one panel does not affect others.
+ */
+export class PanelErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null, errorCount: 0, autoRetrying: false }
+  private autoRetryTimer: ReturnType<typeof setTimeout> | null = null
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error) {
+    Sentry.captureException(error, {
+      tags: { boundary: 'panel' },
+      extra: { panelName: this.props.panelName },
+    })
+    console.error(`[PanelErrorBoundary:${this.props.panelName}] Render crash: ${error.message}`)
+
+    if (this.state.errorCount < MAX_AUTO_RETRIES) {
+      this.scheduleAutoRetry()
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.autoRetryTimer) clearTimeout(this.autoRetryTimer)
+  }
+
+  private scheduleAutoRetry() {
+    this.setState({ autoRetrying: true })
+    this.autoRetryTimer = setTimeout(() => {
+      this.autoRetryTimer = null
+      this.setState(prev => ({
+        hasError: false,
+        error: null,
+        errorCount: prev.errorCount + 1,
+        autoRetrying: false,
+      }))
+    }, AUTO_RETRY_DELAY_MS)
+  }
+
+  handleRetry = () => {
+    if (this.autoRetryTimer) {
+      clearTimeout(this.autoRetryTimer)
+      this.autoRetryTimer = null
+    }
+    this.setState(prev => ({
+      hasError: false,
+      error: null,
+      errorCount: prev.errorCount + 1,
+      autoRetrying: false,
+    }))
+    this.props.onRetry?.()
+  }
+
+  render() {
+    if (!this.state.hasError) return this.props.children
+
+    if (this.state.autoRetrying) {
+      return (
+        <View className="flex-1 flex-col items-center justify-center gap-3 px-8 py-12">
+          <RefreshCw size={20} className="text-muted-foreground animate-spin" />
+          <Text className="text-sm text-muted-foreground">
+            Recovering {this.props.panelName}...
+          </Text>
+        </View>
+      )
+    }
+
+    return (
+      <View className="flex-1 flex-col items-center justify-center gap-4 px-8 py-12">
+        <View className="w-14 h-14 rounded-2xl bg-amber-500/10 items-center justify-center">
+          <AlertTriangle size={28} className="text-amber-500" />
+        </View>
+        <View className="gap-1.5 items-center">
+          <Text className="text-base font-semibold">
+            {this.props.panelName} encountered an error
+          </Text>
+          <Text className="text-sm text-muted-foreground text-center max-w-[300px]">
+            Something went wrong. Your data is safe.
+          </Text>
+        </View>
+        <Button
+          action="primary"
+          variant="solid"
+          size="sm"
+          onPress={this.handleRetry}
+          accessibilityLabel={`Retry ${this.props.panelName}`}
+        >
+          <ButtonText>Retry</ButtonText>
+        </Button>
+        {this.state.errorCount > 0 && (
+          <Text className="text-xs text-muted-foreground">
+            Retry attempt {this.state.errorCount}
+          </Text>
+        )}
+      </View>
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- **Created `PanelErrorBoundary`** — a reusable class component at `apps/mobile/components/project/panels/PanelErrorBoundary.tsx` modeled after `CanvasErrorBoundary`. Catches render errors, reports to Sentry with `boundary: 'panel'` tag, auto-retries once after 1.5s, then shows a per-panel fallback UI (warning icon, error message, Retry button).
- **Wrapped all panels in `_layout.tsx`** — each `ChatPanel` (inside `openChatTabIds.map`), all 9 standalone panels (IDE, Files, Terminal, Capabilities, Channels, Agents, Monitor, Plans, Checkpoints), and the outer `CanvasPanel` render are now individually wrapped. A crash in any one panel no longer takes down the entire project view.
- No internal panel components were modified. The existing `CanvasErrorBoundary` inside `CanvasPanel` is left untouched.

<img width="1919" height="939" alt="image" src="https://github.com/user-attachments/assets/0675cf3d-95e7-4c30-afd2-126ab879023f" />