### PR TITLE
feat(cloud-login): add workspace picker for multi-workspace sign-in

### DIFF
--- a/apps/api/src/__tests__/cloud-login-e2e.test.ts
+++ b/apps/api/src/__tests__/cloud-login-e2e.test.ts
@@ -597,6 +597,81 @@ describe('Cloud Login E2E', () => {
       expect(status.cloudUrl).toBe(CLOUD_HOST)
     })
 
+    test('start echoes preselected workspaceId into the bridge URL', async () => {
+      // The desktop "Switch workspace" affordance passes a workspaceId so
+      // the bridge picker can pre-select. start must round-trip it as a
+      // query param on the generated authUrl.
+      const startRes = await app.request('/api/local/cloud-login/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          deviceId: 'e2e-preselect-ws',
+          workspaceId: 'ws-2',
+        }),
+      })
+      expect(startRes.status).toBe(200)
+      const start = await startRes.json()
+      const parsed = new URL(start.authUrl)
+      expect(parsed.searchParams.get('workspaceId')).toBe('ws-2')
+    })
+
+    test('start omits workspaceId when none provided', async () => {
+      // The default sign-in flow leaves workspaceId off so the bridge
+      // shows its picker (or auto-mints when the user has only one ws).
+      const startRes = await app.request('/api/local/cloud-login/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceId: 'e2e-no-preselect' }),
+      })
+      const start = await startRes.json()
+      const parsed = new URL(start.authUrl)
+      expect(parsed.searchParams.has('workspaceId')).toBe(false)
+    })
+
+    test('happy path: explicit workspaceId mints + persists for the chosen ws', async () => {
+      // Multi-workspace user picks ws-2 instead of the default ws-1
+      // (the user's first membership by createdAt). The minted key, the
+      // /complete response, and SHOGO_KEY_INFO must all reflect ws-2.
+      const startRes = await app.request('/api/local/cloud-login/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          deviceId: 'e2e-pick-ws-2',
+          deviceName: 'E2E Mac',
+          workspaceId: 'ws-2',
+        }),
+      })
+      const start = await startRes.json()
+
+      const mint = await app.request('/api/api-keys/device', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          workspaceId: 'ws-2',
+          deviceId: 'e2e-pick-ws-2',
+          deviceName: 'E2E Mac',
+        }),
+      })
+      const minted = await mint.json()
+      expect(minted.workspace?.id).toBe('ws-2')
+
+      const completeRes = await app.request('/api/local/cloud-login/complete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          state: start.state,
+          key: minted.key,
+        }),
+      })
+      expect(completeRes.status).toBe(200)
+      const complete = await completeRes.json()
+      expect(complete.workspace?.id).toBe('ws-2')
+
+      const info = JSON.parse(localConfig.get('SHOGO_KEY_INFO')!)
+      expect(info.workspace?.id).toBe('ws-2')
+      expect(info.workspace?.name).toBe('Team')
+    })
+
     test('start ignores cloudUrl in body (env-only contract)', async () => {
       // Even if a stale client sends a cloudUrl in the request body, the
       // server must use process.env.SHOGO_CLOUD_URL.

--- a/apps/api/src/routes/local-auth.ts
+++ b/apps/api/src/routes/local-auth.ts
@@ -101,6 +101,10 @@ export function localAuthRoutes() {
       deviceName?: string
       devicePlatform?: string
       deviceAppVersion?: string
+      /** Optional pre-selected workspace for the bridge picker. The bridge
+       * will skip the picker when this matches one of the user's
+       * memberships; otherwise it falls back to showing the picker. */
+      workspaceId?: string
     }>().catch(() => ({} as any))
 
     if (!body?.deviceId || typeof body.deviceId !== 'string') {
@@ -125,6 +129,9 @@ export function localAuthRoutes() {
     if (body.deviceName) params.set('deviceName', body.deviceName)
     if (body.devicePlatform) params.set('devicePlatform', body.devicePlatform)
     if (body.deviceAppVersion) params.set('appVersion', body.deviceAppVersion)
+    if (body.workspaceId && typeof body.workspaceId === 'string') {
+      params.set('workspaceId', body.workspaceId)
+    }
 
     const authUrl = `${cloudUrl}/auth/local-link?${params.toString()}`
     return c.json({ ok: true, state, authUrl, cloudUrl, expiresInMs: STATE_TTL_MS })

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -334,7 +334,10 @@ function registerIpcHandlers(): void {
 
   // Cloud login: ask the local API for a one-shot authUrl (includes state
   // nonce + device metadata), then open it in the user's default browser.
-  ipcMain.handle('start-cloud-login', async () => {
+  // Renderer may pass `{ workspaceId }` to pre-select a workspace on the
+  // bridge picker (e.g. for the "Switch workspace" affordance). When
+  // omitted, the bridge prompts the user if they have >1 workspace.
+  ipcMain.handle('start-cloud-login', async (_event, opts?: { workspaceId?: string }) => {
     try {
       const device = getDeviceInfo()
       const res = await fetch(`${getApiUrl()}/api/local/cloud-login/start`, {
@@ -345,6 +348,7 @@ function registerIpcHandlers(): void {
           deviceName: device.name,
           devicePlatform: device.platform,
           deviceAppVersion: device.appVersion,
+          workspaceId: opts?.workspaceId,
         }),
       })
       const body = (await res.json().catch(() => ({}))) as CloudLoginBody

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -214,8 +214,8 @@ contextBridge.exposeInMainWorld('shogoDesktop', {
   // Cloud login (replaces the old paste-API-key flow)
   getDeviceInfo: (): Promise<{ id: string; name: string; platform: string; appVersion: string }> =>
     ipcRenderer.invoke('get-device-info'),
-  startCloudLogin: (): Promise<{ ok: boolean; error?: string }> =>
-    ipcRenderer.invoke('start-cloud-login'),
+  startCloudLogin: (opts?: { workspaceId?: string }): Promise<{ ok: boolean; error?: string }> =>
+    ipcRenderer.invoke('start-cloud-login', opts),
   signOutCloud: (): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('sign-out-cloud'),
   onCloudLoginResult: (

--- a/apps/mobile/app/(admin)/general.tsx
+++ b/apps/mobile/app/(admin)/general.tsx
@@ -27,6 +27,7 @@ import {
   LogIn,
   Flag,
   RotateCcw,
+  RefreshCw,
 } from 'lucide-react-native'
 import { cn } from '@shogo/shared-ui/primitives'
 import { PlatformApi, type InstanceInfo, type FeatureFlagOverrides } from '@shogo-ai/sdk'
@@ -177,6 +178,54 @@ export default function AdminGeneralPage() {
     }
   }
 
+  /**
+   * Re-run the cloud-login flow without disconnecting first, so the user
+   * can switch the device key to a different workspace they belong to.
+   * We deliberately don't pass `{ workspaceId }` so the bridge always
+   * shows its picker (even when only one workspace exists, in which case
+   * the picker auto-skips and just refreshes the key).
+   *
+   * TODO: cloud's per-workspace dedup at apps/api/src/routes/api-keys.ts
+   * lines 162-171 only revokes prior device keys within the *new*
+   * workspace, so the previously-bound workspace will keep a dangling
+   * `apiKey` row for this device. Cleaning that up needs a cross-workspace
+   * dedup pass on the cloud side; out of scope for the picker landing.
+   */
+  const handleSwitchWorkspace = async () => {
+    setLoginStatus('connecting')
+    setLoginError('')
+    try {
+      if (hasDesktopBridge()) {
+        const result = await (window as any).shogoDesktop.startCloudLogin()
+        if (!result?.ok) {
+          setLoginStatus('error')
+          setLoginError(result?.error || 'Could not start workspace switch')
+        }
+        return
+      }
+      // Dev fallback (Metro/browser): same as handleStartLogin — open the
+      // bridge in a new tab and let the user complete it manually.
+      const start = await platform.startCloudLogin({
+        id: 'dev-browser',
+        name: 'Dev Browser',
+        platform: 'web',
+        appVersion: '0.0.0-dev',
+      })
+      if (!start.ok) {
+        setLoginStatus('error')
+        setLoginError('Could not start workspace switch')
+        return
+      }
+      if (typeof window !== 'undefined') {
+        window.open(start.authUrl, '_blank', 'noopener,noreferrer')
+      }
+      setLoginStatus('idle')
+    } catch (err: any) {
+      setLoginStatus('error')
+      setLoginError(err?.message || 'Workspace switch failed')
+    }
+  }
+
   const handleDisconnectShogoKey = async () => {
     setIsDisconnecting(true)
     try {
@@ -267,6 +316,23 @@ export default function AdminGeneralPage() {
                 ) : (
                   <View className="flex-1" />
                 )}
+                <Pressable
+                  onPress={handleSwitchWorkspace}
+                  disabled={loginStatus === 'connecting' || isDisconnecting}
+                  className={cn(
+                    'flex-row items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border',
+                    (loginStatus === 'connecting' || isDisconnecting) && 'opacity-50',
+                  )}
+                >
+                  {loginStatus === 'connecting' ? (
+                    <ActivityIndicator size="small" />
+                  ) : (
+                    <RefreshCw size={14} className="text-foreground" />
+                  )}
+                  <Text className="text-sm text-foreground">
+                    {loginStatus === 'connecting' ? 'Switching…' : 'Switch workspace'}
+                  </Text>
+                </Pressable>
                 <Pressable
                   onPress={handleDisconnectShogoKey}
                   disabled={isDisconnecting}

--- a/apps/mobile/app/auth/local-link.tsx
+++ b/apps/mobile/app/auth/local-link.tsx
@@ -7,12 +7,17 @@
  * clicks "Sign in to Shogo Cloud". Once the user is authenticated (via
  * Better Auth — we redirect to /sign-in?next=/auth/local-link if not), we:
  *
- *   1. Mint a device-tagged API key for the signed-in user's default
- *      workspace (POST /api/api-keys/device — cloud dedupes any previous
- *      key for this deviceId).
- *   2. Redirect back to the desktop app via a shogo://auth-callback deep
+ *   1. Fetch the workspaces the signed-in user belongs to. If the user has
+ *      more than one workspace and the desktop didn't pre-select one via
+ *      the `workspaceId` query param, render a picker and wait for the user
+ *      to choose. With a single workspace (or a valid pre-selection) we
+ *      skip the picker and proceed straight to mint.
+ *   2. Mint a device-tagged API key for the chosen workspace
+ *      (POST /api/api-keys/device — cloud dedupes any previous key for this
+ *      deviceId within the same workspace).
+ *   3. Redirect back to the desktop app via a shogo://auth-callback deep
  *      link that carries the fresh key + original state nonce.
- *   3. Leave a "Return to your Shogo desktop app" fallback screen so the
+ *   4. Leave a "Return to your Shogo desktop app" fallback screen so the
  *      user has recourse if the deep link doesn't fire.
  *
  * Query params we consume:
@@ -22,13 +27,15 @@
  *   deviceName      — hostname/"My Laptop"
  *   devicePlatform  — darwin / win32 / linux
  *   appVersion      — desktop app version string
+ *   workspaceId     — optional pre-selected workspace id (used by the
+ *                     desktop "Switch workspace" affordance)
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { View, Text, ActivityIndicator, Platform } from 'react-native'
+import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
+import { View, Text, ActivityIndicator, Platform, Pressable } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
-import { Button } from '@shogo/shared-ui/primitives'
-import { PlatformApi } from '@shogo-ai/sdk'
+import { Button, cn } from '@shogo/shared-ui/primitives'
+import { PlatformApi, type WorkspaceSummary } from '@shogo-ai/sdk'
 import { useAuth } from '../../contexts/auth'
 import { useDomainHttp } from '../../contexts/domain'
 
@@ -39,9 +46,17 @@ interface LocalLinkParams {
   deviceName?: string
   devicePlatform?: string
   appVersion?: string
+  workspaceId?: string
 }
 
-type Status = 'checking-auth' | 'redirect-signin' | 'minting' | 'ready' | 'error'
+type Status =
+  | 'checking-auth'
+  | 'redirect-signin'
+  | 'loading-workspaces'
+  | 'picking-workspace'
+  | 'minting'
+  | 'ready'
+  | 'error'
 
 export default function LocalLinkBridge() {
   const router = useRouter()
@@ -53,8 +68,12 @@ export default function LocalLinkBridge() {
   const [status, setStatus] = useState<Status>('checking-auth')
   const [error, setError] = useState<string | null>(null)
   const [callbackUrl, setCallbackUrl] = useState<string | null>(null)
+  const [workspaces, setWorkspaces] = useState<WorkspaceSummary[]>([])
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null)
   // Guard so strict-mode double-renders / re-runs don't mint two device keys.
   const mintedRef = useRef(false)
+  // Guard so we only fetch the workspace list once per page load.
+  const workspacesLoadedRef = useRef(false)
 
   // Re-use the exact callback scheme from the desktop app. We default to
   // shogo://auth-callback if no override was provided.
@@ -62,6 +81,56 @@ export default function LocalLinkBridge() {
     ? params.callback
     : 'shogo://auth-callback'
   const state = typeof params.state === 'string' ? params.state : ''
+  const preselectedWorkspaceId = typeof params.workspaceId === 'string' ? params.workspaceId : ''
+
+  /** Mint a device key for the chosen workspace and fire the deep link. */
+  const completeMint = useCallback(async (workspaceId: string | undefined) => {
+    if (mintedRef.current) return
+    mintedRef.current = true
+    setStatus('minting')
+    try {
+      const minted = await platform.createDeviceApiKey(
+        {
+          id: String(params.deviceId),
+          name: typeof params.deviceName === 'string' ? params.deviceName : 'Shogo Desktop',
+          platform: typeof params.devicePlatform === 'string' ? params.devicePlatform : 'unknown',
+          appVersion: typeof params.appVersion === 'string' ? params.appVersion : 'unknown',
+        },
+        workspaceId ? { workspaceId } : undefined,
+      )
+
+      // Assemble the callback URL that carries everything the desktop app
+      // needs to finalize sign-in. The state nonce is required; it's
+      // validated server-side in /api/local/cloud-login/complete. The
+      // cloud endpoint is sourced from the desktop's SHOGO_CLOUD_URL env
+      // var, so we deliberately do NOT echo a cloudUrl back here.
+      const callbackParams = new URLSearchParams({
+        state,
+        key: minted.key,
+      })
+      if (user?.email) callbackParams.set('email', user.email)
+      if (minted.workspace?.name) callbackParams.set('workspace', minted.workspace.name)
+      const url = `${callback}?${callbackParams.toString()}`
+
+      setCallbackUrl(url)
+      setStatus('ready')
+
+      // Auto-trigger the deep link. Most OSes will prompt once before
+      // opening; the fallback UI below gives the user a manual button.
+      if (typeof window !== 'undefined') {
+        window.location.replace(url)
+      }
+    } catch (err) {
+      console.error('[LocalLink] Failed to mint device key:', err)
+      mintedRef.current = false
+      setStatus('error')
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Failed to create a sign-in key. Please try again.',
+      )
+    }
+  }, [platform, params.deviceId, params.deviceName, params.devicePlatform, params.appVersion, callback, state, user?.email])
 
   useEffect(() => {
     if (Platform.OS !== 'web') {
@@ -89,51 +158,51 @@ export default function LocalLinkBridge() {
       return
     }
 
-    if (mintedRef.current) return
-    mintedRef.current = true
+    if (workspacesLoadedRef.current) return
+    workspacesLoadedRef.current = true
 
-    setStatus('minting')
+    setStatus('loading-workspaces')
     ;(async () => {
       try {
-        const minted = await platform.createDeviceApiKey({
-          id: String(params.deviceId),
-          name: typeof params.deviceName === 'string' ? params.deviceName : 'Shogo Desktop',
-          platform: typeof params.devicePlatform === 'string' ? params.devicePlatform : 'unknown',
-          appVersion: typeof params.appVersion === 'string' ? params.appVersion : 'unknown',
-        })
+        const list = await platform.listMyWorkspaces()
+        setWorkspaces(list)
 
-        // Assemble the callback URL that carries everything the desktop
-        // app needs to finalize sign-in. The state nonce is required; it's
-        // validated server-side in /api/local/cloud-login/complete. The
-        // cloud endpoint is sourced from the desktop's SHOGO_CLOUD_URL env
-        // var, so we deliberately do NOT echo a cloudUrl back here.
-        const callbackParams = new URLSearchParams({
-          state,
-          key: minted.key,
-        })
-        if (user?.email) callbackParams.set('email', user.email)
-        if (minted.workspace?.name) callbackParams.set('workspace', minted.workspace.name)
-        const url = `${callback}?${callbackParams.toString()}`
-
-        setCallbackUrl(url)
-        setStatus('ready')
-
-        // Auto-trigger the deep link. Most OSes will prompt once before
-        // opening; the fallback UI below gives the user a manual button.
-        if (typeof window !== 'undefined') {
-          window.location.replace(url)
+        if (list.length === 0) {
+          setStatus('error')
+          setError('Your account has no workspaces. Create one in Shogo Cloud first.')
+          return
         }
+
+        // Auto-skip the picker when there's only one workspace, or when
+        // the desktop app pre-selected a valid workspaceId.
+        const preselected = preselectedWorkspaceId
+          ? list.find((w) => w.id === preselectedWorkspaceId)
+          : null
+        if (preselected) {
+          await completeMint(preselected.id)
+          return
+        }
+        if (list.length === 1) {
+          await completeMint(list[0].id)
+          return
+        }
+
+        // Multiple workspaces, no valid pre-selection: render the picker.
+        // Default-select the first one so the Continue button is enabled.
+        setSelectedWorkspaceId(list[0].id)
+        setStatus('picking-workspace')
       } catch (err) {
-        console.error('[LocalLink] Failed to mint device key:', err)
+        console.error('[LocalLink] Failed to load workspaces:', err)
+        workspacesLoadedRef.current = false
         setStatus('error')
         setError(
           err instanceof Error
             ? err.message
-            : 'Failed to create a sign-in key. Please try again.',
+            : 'Failed to load your workspaces. Please try again.',
         )
       }
     })()
-  }, [isAuthLoading, isAuthenticated, state, params.deviceId, params.deviceName, params.devicePlatform, params.appVersion, callback, platform, router, user?.email])
+  }, [isAuthLoading, isAuthenticated, state, params.deviceId, preselectedWorkspaceId, platform, router, completeMint])
 
   return (
     <View className="flex-1 bg-background items-center justify-center px-6">
@@ -149,6 +218,59 @@ export default function LocalLinkBridge() {
 
         {status === 'redirect-signin' && (
           <Text className="text-sm text-muted-foreground text-center">Redirecting you to sign in...</Text>
+        )}
+
+        {status === 'loading-workspaces' && (
+          <>
+            <ActivityIndicator />
+            <Text className="text-sm text-muted-foreground text-center">Loading your workspaces...</Text>
+          </>
+        )}
+
+        {status === 'picking-workspace' && (
+          <View className="gap-3 w-full">
+            <Text className="text-sm text-muted-foreground text-center">
+              Choose which workspace to link to this device. You can switch later from
+              the desktop app's General settings.
+            </Text>
+            <View className="gap-2 w-full">
+              {workspaces.map((ws) => {
+                const isSelected = selectedWorkspaceId === ws.id
+                return (
+                  <Pressable
+                    key={ws.id}
+                    onPress={() => setSelectedWorkspaceId(ws.id)}
+                    className={cn(
+                      'flex-row items-center gap-3 px-4 py-3 rounded-lg border',
+                      isSelected ? 'border-primary bg-primary/5' : 'border-border',
+                    )}
+                  >
+                    <View
+                      className={cn(
+                        'w-4 h-4 rounded-full border-2',
+                        isSelected ? 'border-primary bg-primary' : 'border-muted-foreground',
+                      )}
+                    />
+                    <View className="flex-1">
+                      <Text className="font-medium text-foreground">{ws.name}</Text>
+                      <Text className="text-xs text-muted-foreground">{ws.slug}</Text>
+                    </View>
+                  </Pressable>
+                )
+              })}
+            </View>
+            <Button
+              onPress={() => {
+                if (selectedWorkspaceId) {
+                  void completeMint(selectedWorkspaceId)
+                }
+              }}
+              disabled={!selectedWorkspaceId}
+              className="w-full"
+            >
+              Continue
+            </Button>
+          </View>
         )}
 
         {status === 'minting' && (
@@ -192,6 +314,7 @@ export default function LocalLinkBridge() {
               variant="outline"
               onPress={() => {
                 mintedRef.current = false
+                workspacesLoadedRef.current = false
                 setStatus('checking-auth')
                 setError(null)
               }}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -88,6 +88,7 @@ export {
   type DeviceInfo,
   type CloudLoginStart,
   type CloudLoginStatus,
+  type WorkspaceSummary,
   type FeatureFlagOverrides,
   type FeatureFlagPatch,
 } from './platform/index.js'

--- a/packages/sdk/src/platform/index.ts
+++ b/packages/sdk/src/platform/index.ts
@@ -123,6 +123,13 @@ export interface CloudLoginStart {
   expiresInMs: number
 }
 
+/** Minimal workspace fields surfaced by the bridge picker and admin switcher. */
+export interface WorkspaceSummary {
+  id: string
+  name: string
+  slug: string
+}
+
 export interface CloudLoginStatus {
   signedIn: boolean
   cloudUrl?: string
@@ -305,8 +312,16 @@ export class PlatformApi {
   // CLI / headless contexts that paste a raw shogo_sk_ key.
 
   /** Start a cloud login flow. Opens the returned authUrl in the system
-   * browser to complete sign-in. */
-  async startCloudLogin(device: DeviceInfo): Promise<CloudLoginStart> {
+   * browser to complete sign-in.
+   *
+   * Pass `opts.workspaceId` to pre-select a workspace on the bridge picker
+   * (the desktop-side "Switch workspace" button uses this). When omitted,
+   * the bridge prompts the user to pick if they have >1 workspace, and
+   * silently picks the only one otherwise. */
+  async startCloudLogin(
+    device: DeviceInfo,
+    opts?: { workspaceId?: string },
+  ): Promise<CloudLoginStart> {
     const res = await this.http.post<CloudLoginStart>(
       '/api/local/cloud-login/start',
       {
@@ -314,9 +329,21 @@ export class PlatformApi {
         deviceName: device.name,
         devicePlatform: device.platform,
         deviceAppVersion: device.appVersion,
+        workspaceId: opts?.workspaceId,
       },
     )
     return res.data!
+  }
+
+  /** List workspaces the signed-in cloud user is a member of.
+   * Used by the local-link bridge to render a workspace picker when the
+   * user has more than one membership. Requires an authenticated cloud
+   * session (cookie); returns an empty list if unauthenticated. */
+  async listMyWorkspaces(): Promise<WorkspaceSummary[]> {
+    const res = await this.http.get<{ ok?: boolean; items?: WorkspaceSummary[] }>(
+      '/api/workspaces',
+    )
+    return res.data?.items ?? []
   }
 
   /** Read the current local-mode cloud login status. */


### PR DESCRIPTION
## Description (Required)
<!-- Provide a brief description of the changes in this PR -->
Local-mode cloud sign-in always bound the desktop's device API key to the user's oldest workspace membership (`Member.findFirst orderBy createdAt asc` in `apps/api/src/routes/api-keys.ts`). Users with multiple workspaces couldn't target a different one — the local app would stay stuck on whichever workspace they joined first, and any workspace-scoped state (plan, quota, billing) reflected only that workspace.

This PR adds a workspace picker to the bridge page at `/auth/local-link`, so when a signed-in user has 2+ memberships they're prompted to choose which workspace to bind the device key to. Single-workspace users see no UI change (picker auto-skips). The desktop General settings also gains a "Switch workspace" button next to "Sign out" that re-runs the same flow without disconnecting first.

No cloud API changes — `POST /api/api-keys/device` already accepts optional `workspaceId` and `GET /api/workspaces` already returns the user's full membership list. The fix is purely client + local-API plumbing.

Files touched:
- `apps/mobile/app/auth/local-link.tsx` — bridge picker UI (new state machine + radio list)
- `apps/mobile/app/(admin)/general.tsx` — "Switch workspace" button + handler
- `apps/api/src/routes/local-auth.ts` — `/local/cloud-login/start` accepts and forwards optional `workspaceId`
- `apps/desktop/src/main.ts`, `apps/desktop/src/preload.ts` — IPC plumbing for optional `workspaceId`
- `packages/sdk/src/platform/index.ts`, `packages/sdk/src/index.ts` — `WorkspaceSummary` type, `listMyWorkspaces()`, optional `workspaceId` arg on `startCloudLogin`
- `apps/api/src/__tests__/cloud-login-e2e.test.ts` — 3 new round-trip tests

## Related Issue (Required)
https://odin-ai.atlassian.net/browse/EN-3603

## Type of Change (Required)
<!-- Select ONE option by changing [ ] to [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring (no functional changes, no test changes)
- [ ] Added new tests

## How Has This Been Tested? (Required)
<!-- Describe the tests you ran to verify your changes. Provide instructions so we can reproduce. -->
**Automated**
- `bun test apps/api/src/__tests__/cloud-login-e2e.test.ts` → 25/25 pass (3 new cases: `workspaceId` echoed into `authUrl`, omitted when not provided, full happy-path round-trip with explicit `workspaceId=ws-2` persisting into `SHOGO_KEY_INFO`).
- Lints clean across all 8 changed files (`ReadLints`).
- SDK rebuild clean (`bun build:sdk`) — new `WorkspaceSummary` export resolves.

**Manual smoke (against running dev stack)**
- Confirmed local API hot-reloaded the new `start` handler:
  ```bash
  curl -s -X POST http://localhost:8002/api/local/cloud-login/start \
    -H 'Content-Type: application/json' \
    -d '{"deviceId":"dev-browser","workspaceId":"some-test-id"}'
  # → authUrl includes ?workspaceId=some-test-id