### PR TITLE
feat(web): Terminal top tab toggles IDE bottom drawer

### DIFF
--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -1353,6 +1353,9 @@ export default observer(function ProjectLayout() {
     activeChatSessionId: isChatFullscreen ? chatSessionId : undefined,
     activeChatSessionName: isChatFullscreen ? (openChatTabs.find(t => t.id === chatSessionId)?.name ?? null) : undefined,
     canvasActive: canvasEnabled && previewTab === 'dynamic-app',
+    // Forward to ProjectTopBar so the Terminal drawer toggle knows when
+    // the IDE drawer is *visible* vs only "open in store" (see DrawerHost).
+    canvasAreaHidden,
     canvasThemeSupported,
     effectiveSurfaceId,
     onCanvasRefresh: canvasMode === 'code' ? () => setIframeRefreshKey(k => k + 1) : undefined,

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -115,8 +115,9 @@ type ActiveTab = 'chat' | 'canvas'
 
 const WIDE_BREAKPOINT = 1024
 const HIDDEN_HEADER_OPTIONS = { headerShown: false } as const
-// `terminal` is intentionally absent — chat exec entries now appear in
-// the IDE bottom drawer's "Output" tab (filterable to "Exec").
+// `terminal` is intentionally absent — clicking the Terminal top-tab
+// toggles the IDE bottom drawer (DrawerHost) and focuses its Terminal
+// sub-tab; it is not a standalone preview tab.
 const STANDALONE_PANELS = ['ide', 'files', 'capabilities', 'channels', 'agents', 'monitor', 'plans', 'checkpoints']
 
 const DEFAULT_CHAT_PANEL_WIDTH = 480

--- a/apps/mobile/components/project/ProjectTopBar.tsx
+++ b/apps/mobile/components/project/ProjectTopBar.tsx
@@ -76,7 +76,9 @@ import { ProjectExportModal } from './ProjectExportModal'
 import {
   ideBottomPanelStore,
   useBottomPanelState,
+  type BottomPanelTab,
 } from '../../lib/ide-bottom-panel-store'
+import { decideTerminalToggleAction } from './terminalToggle'
 
 /** Native narrow bar: Popover trigger often ignores Tailwind `max-w`; cap width in dp (slightly above 120). */
 const nativeNarrowTitleMaxWidth = 132
@@ -135,6 +137,12 @@ export interface ProjectTopBarProps {
   narrowActiveTab?: 'chat' | 'canvas'
   onNarrowTabChange?: (tab: 'chat' | 'canvas') => void
   narrowPreviewTab?: string
+  /** Mirrors the layout's `canvasAreaHidden` flag. The IDE bottom drawer
+   *  is invisible when this is true (narrow chat-only or chat-fullscreen),
+   *  even if `ideBottomPanelStore.open === true`. The Terminal top-tab
+   *  uses this to (a) keep its highlight honest and (b) treat a click as
+   *  *reveal* instead of *close* when the drawer is hidden. */
+  canvasAreaHidden?: boolean
   // Canvas edit controls
   isEditMode?: boolean
   onToggleEditMode?: () => void
@@ -186,12 +194,18 @@ function BarIconButton({
   active,
   title,
   size = 12,
+  accessibilityRole,
+  accessibilityState,
 }: {
   icon: React.ElementType
   onPress: () => void
   active?: boolean
   title?: string
   size?: number
+  /** ARIA role override. Most entries are tabs inside a tablist; the
+   *  Terminal drawer-toggle overrides to `'button'` with `aria-pressed`. */
+  accessibilityRole?: 'button' | 'tab' | 'link' | 'menuitem'
+  accessibilityState?: { selected?: boolean; expanded?: boolean; disabled?: boolean; checked?: boolean }
 }) {
   const tipRef = useWebTitle(title)
 
@@ -204,6 +218,12 @@ function BarIconButton({
         active ? 'bg-primary' : 'active:bg-muted',
       )}
       accessibilityLabel={title}
+      accessibilityRole={accessibilityRole}
+      accessibilityState={accessibilityState}
+      // RNW maps accessibilityState.checked → aria-pressed on web for buttons.
+      {...(Platform.OS === 'web' && accessibilityRole === 'button' && accessibilityState
+        ? ({ 'aria-pressed': !!accessibilityState.checked } as any)
+        : {})}
     >
       <Icon
         size={size}
@@ -239,6 +259,7 @@ export function ProjectTopBar({
   narrowActiveTab,
   onNarrowTabChange,
   narrowPreviewTab,
+  canvasAreaHidden = false,
   isEditMode,
   onToggleEditMode,
   showTreePanel,
@@ -305,25 +326,58 @@ export function ProjectTopBar({
     }
   }, [activeChatSessionId, chatRenameValue, onRenameChat])
 
-  // Terminal top-tab (web only): toggles the IDE bottom drawer (DrawerHost).
-  // It does not switch `previewTab`. Highlight while the drawer is open; click
-  // again to close. Opening selects the Terminal sub-tab inside the drawer.
-  const terminalDrawerActive = useBottomPanelState((st) => st.open)
+  // ----- Terminal top-tab → IDE bottom drawer (web-only) ---------------
+  // The Terminal entry is *not* a previewTab; it is a toggle for the
+  // existing IDE bottom drawer (DrawerHost / BottomPanel). Three sources of
+  // truth conspire here, so be explicit:
+  //   • `ideBottomPanelStore.open`  — drawer is open in store-state.
+  //   • `canvasAreaHidden`         — layout has hidden the canvas pane,
+  //                                   so even an "open" drawer is invisible
+  //                                   (mirrors DrawerHost#shouldShowDrawer).
+  //   • `Platform.OS === 'web'`    — drawer is web-only.
+  // The tab highlights only when the drawer is *visible*; clicking while
+  // visible closes it; clicking while hidden (or store-closed) reveals it.
+  const drawerStoreOpen = useBottomPanelState((st) => st.open)
+  const drawerVisible = Platform.OS === 'web' && !canvasAreaHidden
+  const terminalDrawerActive = drawerStoreOpen && drawerVisible
+
+  // Remember the user's last drawer sub-tab so re-opening via the top-tab
+  // doesn't silently overwrite their Problems / Output selection.
+  const lastDrawerSubTabRef = useRef<BottomPanelTab | null>(null)
+
+  // Track the last *non-fullscreen* preview tab so we can restore it when
+  // toggling out of chat-fullscreen, instead of hard-coding 'dynamic-app'.
+  const lastNonFullscreenPreviewRef = useRef<string>(
+    activeTab && activeTab !== 'chat-fullscreen' ? activeTab : 'dynamic-app',
+  )
+  useEffect(() => {
+    if (activeTab && activeTab !== 'chat-fullscreen') {
+      lastNonFullscreenPreviewRef.current = activeTab
+    }
+  }, [activeTab])
 
   const toggleTerminalDrawer = useCallback(() => {
     const st = ideBottomPanelStore.getState()
-    if (st.open) {
+    const action = decideTerminalToggleAction({
+      storeOpen: st.open,
+      storeActiveSubTab: st.activeTab,
+      isWeb: Platform.OS === 'web',
+      canvasAreaHidden,
+      isNarrow: !!onNarrowTabChange,
+      activeTab,
+      lastSubTab: lastDrawerSubTabRef.current,
+      lastNonFullscreenPreview: lastNonFullscreenPreviewRef.current,
+    })
+    if (action.kind === 'close') {
+      lastDrawerSubTabRef.current = action.rememberSubTab
       ideBottomPanelStore.setOpen(false)
       return
     }
-    // The drawer is hidden in chat-fullscreen and in narrow chat-only mode
-    // (see DrawerHost#shouldShowDrawer). Move the user out of those modes
-    // first so the drawer actually surfaces.
-    if (onNarrowTabChange) onNarrowTabChange('canvas')
-    if (activeTab === 'chat-fullscreen') onTabChange?.('dynamic-app')
-    ideBottomPanelStore.setActiveTab('Terminal')
+    if (action.narrowTo) onNarrowTabChange?.(action.narrowTo)
+    if (action.previewTo) onTabChange?.(action.previewTo)
+    if (action.setSubTab) ideBottomPanelStore.setActiveTab(action.setSubTab)
     ideBottomPanelStore.setOpen(true)
-  }, [activeTab, onNarrowTabChange, onTabChange])
+  }, [activeTab, canvasAreaHidden, onNarrowTabChange, onTabChange])
 
   const isCanvasActive = activeTab === 'dynamic-app'
   const showSurfacePicker = (surfaceEntries?.length ?? 0) > 1
@@ -356,6 +410,11 @@ export function ProjectTopBar({
   }, [onNarrowTabChange, onTabChange, toggleTerminalDrawer])
 
   const getTabActive = useCallback((tabId: string) => {
+    // `'terminal'` is the only id whose highlight is sourced from a global
+    // store (ideBottomPanelStore) instead of from the previewTab/narrowTab
+    // props, because it represents drawer-open state, not a preview tab.
+    // Consequently `hiddenTabs` controls *visibility* of the icon but not
+    // its highlight — that is managed by the drawer itself.
     if (tabId === 'terminal') return terminalDrawerActive
     if (onNarrowTabChange) {
       if (tabId === 'chat-fullscreen') return narrowActiveTab === 'chat'
@@ -461,6 +520,16 @@ export function ProjectTopBar({
               onPress={() => handleTabPress(tab.id)}
               active={getTabActive(tab.id)}
               title={tab.label}
+              // Terminal is a toggle, not a tab. Override ARIA accordingly
+              // so screen readers announce it as a press-button with
+              // pressed state, while the rest of the entries inherit the
+              // tablist's default `tab` role.
+              {...(tab.id === 'terminal'
+                ? {
+                    accessibilityRole: 'button' as const,
+                    accessibilityState: { checked: terminalDrawerActive },
+                  }
+                : {})}
             />
           ))}
         </View>
@@ -508,6 +577,16 @@ export function ProjectTopBar({
                       ((item.id === 'terminal' && terminalDrawerActive) ||
                         (item.id !== 'terminal' && narrowPreviewTab === item.id && narrowActiveTab === 'canvas')) && 'bg-accent',
                     )}
+                    accessibilityLabel={item.label}
+                    {...(item.id === 'terminal'
+                      ? {
+                          accessibilityRole: 'button' as const,
+                          accessibilityState: { checked: terminalDrawerActive },
+                          ...(Platform.OS === 'web'
+                            ? ({ 'aria-pressed': terminalDrawerActive } as any)
+                            : {}),
+                        }
+                      : {})}
                   >
                     <View className="flex-row items-center gap-2.5">
                       {item.id === '_upgrade' && <Zap size={14} className="text-muted-foreground" />}
@@ -700,6 +779,16 @@ export function ProjectTopBar({
               onPress={() => handleTabPress(tab.id)}
               active={getTabActive(tab.id)}
               title={tab.label}
+              // Terminal is a toggle, not a tab. Override ARIA accordingly
+              // so screen readers announce it as a press-button with
+              // pressed state, while the rest of the entries inherit the
+              // tablist's default `tab` role.
+              {...(tab.id === 'terminal'
+                ? {
+                    accessibilityRole: 'button' as const,
+                    accessibilityState: { checked: terminalDrawerActive },
+                  }
+                : {})}
             />
           ))}
         </View>

--- a/apps/mobile/components/project/ProjectTopBar.tsx
+++ b/apps/mobile/components/project/ProjectTopBar.tsx
@@ -73,6 +73,10 @@ import { usePlatformConfig } from '../../lib/platform-config'
 import { isNativePhoneIntegrationsLayout } from '../../lib/native-phone-layout'
 import { api } from '../../lib/api'
 import { ProjectExportModal } from './ProjectExportModal'
+import {
+  ideBottomPanelStore,
+  useBottomPanelState,
+} from '../../lib/ide-bottom-panel-store'
 
 /** Native narrow bar: Popover trigger often ignores Tailwind `max-w`; cap width in dp (slightly above 120). */
 const nativeNarrowTitleMaxWidth = 132
@@ -89,7 +93,9 @@ const AGENT_TABS: { id: string; label: string; icon: React.ElementType }[] = [
   ...(Platform.OS === 'web'
     ? [{ id: 'ide', label: 'IDE', icon: Code2 }]
     : [{ id: 'files', label: 'Files', icon: FolderOpen }]),
-  // { id: 'terminal', label: 'Terminal', icon: Terminal },
+  ...(Platform.OS === 'web'
+    ? [{ id: 'terminal', label: 'Terminal', icon: Terminal }]
+    : []),
   { id: 'capabilities', label: 'Capabilities', icon: Sliders },
   { id: 'channels', label: 'Channels', icon: Radio },
   { id: 'agents', label: 'Agents', icon: Bot },
@@ -299,6 +305,26 @@ export function ProjectTopBar({
     }
   }, [activeChatSessionId, chatRenameValue, onRenameChat])
 
+  // Terminal top-tab (web only): toggles the IDE bottom drawer (DrawerHost).
+  // It does not switch `previewTab`. Highlight while the drawer is open; click
+  // again to close. Opening selects the Terminal sub-tab inside the drawer.
+  const terminalDrawerActive = useBottomPanelState((st) => st.open)
+
+  const toggleTerminalDrawer = useCallback(() => {
+    const st = ideBottomPanelStore.getState()
+    if (st.open) {
+      ideBottomPanelStore.setOpen(false)
+      return
+    }
+    // The drawer is hidden in chat-fullscreen and in narrow chat-only mode
+    // (see DrawerHost#shouldShowDrawer). Move the user out of those modes
+    // first so the drawer actually surfaces.
+    if (onNarrowTabChange) onNarrowTabChange('canvas')
+    if (activeTab === 'chat-fullscreen') onTabChange?.('dynamic-app')
+    ideBottomPanelStore.setActiveTab('Terminal')
+    ideBottomPanelStore.setOpen(true)
+  }, [activeTab, onNarrowTabChange, onTabChange])
+
   const isCanvasActive = activeTab === 'dynamic-app'
   const showSurfacePicker = (surfaceEntries?.length ?? 0) > 1
   const activeSurfaceEntry = surfaceEntries?.find(s => s.id === activeSurfaceId)
@@ -313,6 +339,10 @@ export function ProjectTopBar({
   ]
 
   const handleTabPress = useCallback((tabId: string) => {
+    if (tabId === 'terminal') {
+      toggleTerminalDrawer()
+      return
+    }
     if (onNarrowTabChange) {
       if (tabId === 'chat-fullscreen') {
         onNarrowTabChange('chat')
@@ -323,15 +353,16 @@ export function ProjectTopBar({
     } else {
       onTabChange?.(tabId)
     }
-  }, [onNarrowTabChange, onTabChange])
+  }, [onNarrowTabChange, onTabChange, toggleTerminalDrawer])
 
   const getTabActive = useCallback((tabId: string) => {
+    if (tabId === 'terminal') return terminalDrawerActive
     if (onNarrowTabChange) {
       if (tabId === 'chat-fullscreen') return narrowActiveTab === 'chat'
       return narrowActiveTab === 'canvas' && narrowPreviewTab === tabId
     }
     return activeTab === tabId
-  }, [onNarrowTabChange, narrowActiveTab, narrowPreviewTab, activeTab])
+  }, [onNarrowTabChange, narrowActiveTab, narrowPreviewTab, activeTab, terminalDrawerActive])
 
   const chatPanelWidth = chatPanelWidthProp ?? 480
   const narrowNativeMenuW = Platform.OS !== 'web' ? narrowProjectDropdownWidth(width) : null
@@ -464,6 +495,8 @@ export function ProjectTopBar({
                     onPress={() => {
                       if (item.id === '_upgrade') {
                         router.push('/(app)/billing' as any)
+                      } else if (item.id === 'terminal') {
+                        toggleTerminalDrawer()
                       } else {
                         onNarrowTabChange?.('canvas')
                         onTabChange?.(item.id)
@@ -472,7 +505,8 @@ export function ProjectTopBar({
                     }}
                     className={cn(
                       'px-4 py-3 active:bg-muted',
-                      narrowPreviewTab === item.id && narrowActiveTab === 'canvas' && 'bg-accent',
+                      ((item.id === 'terminal' && terminalDrawerActive) ||
+                        (item.id !== 'terminal' && narrowPreviewTab === item.id && narrowActiveTab === 'canvas')) && 'bg-accent',
                     )}
                   >
                     <View className="flex-row items-center gap-2.5">
@@ -480,7 +514,8 @@ export function ProjectTopBar({
                       <Text
                         className={cn(
                           'text-sm',
-                          narrowPreviewTab === item.id && narrowActiveTab === 'canvas'
+                          ((item.id === 'terminal' && terminalDrawerActive) ||
+                            (item.id !== 'terminal' && narrowPreviewTab === item.id && narrowActiveTab === 'canvas'))
                             ? 'text-foreground font-medium'
                             : 'text-foreground',
                         )}

--- a/apps/mobile/components/project/__tests__/terminalToggle.test.ts
+++ b/apps/mobile/components/project/__tests__/terminalToggle.test.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Locks the contract for the Terminal top-tab → IDE bottom drawer toggle.
+ * Covers every branch in `decideTerminalToggleAction`, plus the regressions
+ * from PR #477 review (HIGH: hidden-drawer "close" footgun; MEDIUM: sub-tab
+ * preference loss; LOW: hard-coded `'dynamic-app'` restore).
+ */
+import { describe, expect, test } from 'bun:test'
+import {
+  decideTerminalToggleAction,
+  type TerminalToggleInput,
+} from '../terminalToggle'
+
+const base: TerminalToggleInput = {
+  storeOpen: false,
+  storeActiveSubTab: 'Terminal',
+  isWeb: true,
+  canvasAreaHidden: false,
+  isNarrow: false,
+  activeTab: 'dynamic-app',
+  lastSubTab: null,
+  lastNonFullscreenPreview: 'dynamic-app',
+}
+
+describe('decideTerminalToggleAction — close path', () => {
+  test('drawer open + visible → close, remembers current sub-tab', () => {
+    const a = decideTerminalToggleAction({
+      ...base,
+      storeOpen: true,
+      storeActiveSubTab: 'Output',
+    })
+    expect(a).toEqual({ kind: 'close', rememberSubTab: 'Output' })
+  })
+
+  test('drawer open + Problems sub-tab → close, remembers Problems', () => {
+    const a = decideTerminalToggleAction({
+      ...base,
+      storeOpen: true,
+      storeActiveSubTab: 'Problems',
+    })
+    expect(a).toEqual({ kind: 'close', rememberSubTab: 'Problems' })
+  })
+})
+
+describe('decideTerminalToggleAction — HIGH-severity reveal path (drawer open but hidden)', () => {
+  test('open in store but hidden by canvasAreaHidden (narrow chat-only) → reveal, no sub-tab churn', () => {
+    const a = decideTerminalToggleAction({
+      ...base,
+      storeOpen: true,
+      storeActiveSubTab: 'Output',
+      canvasAreaHidden: true,
+      isNarrow: true,
+    })
+    expect(a).toEqual({ kind: 'open', narrowTo: 'canvas' })
+    // setSubTab intentionally absent — preserves user's Output selection.
+    expect((a as any).setSubTab).toBeUndefined()
+  })
+
+  test('open in store but in chat-fullscreen on wide → reveal via lastNonFullscreenPreview', () => {
+    const a = decideTerminalToggleAction({
+      ...base,
+      storeOpen: true,
+      canvasAreaHidden: true,
+      activeTab: 'chat-fullscreen',
+      lastNonFullscreenPreview: 'app-preview',
+    })
+    expect(a).toEqual({ kind: 'open', previewTo: 'app-preview' })
+  })
+
+  test('does NOT call narrowTo when not narrow', () => {
+    const a = decideTerminalToggleAction({
+      ...base,
+      storeOpen: true,
+      canvasAreaHidden: true,
+      isNarrow: false,
+    })
+    expect((a as any).narrowTo).toBeUndefined()
+  })
+})
+
+describe('decideTerminalToggleAction — cold-start open path', () => {
+  test('drawer closed, no remembered sub-tab → open Terminal sub-tab', () => {
+    const a = decideTerminalToggleAction({ ...base })
+    expect(a).toEqual({ kind: 'open', setSubTab: 'Terminal' })
+  })
+
+  test('drawer closed, narrow layout → open + swap narrow to canvas', () => {
+    const a = decideTerminalToggleAction({ ...base, isNarrow: true })
+    expect(a).toEqual({ kind: 'open', narrowTo: 'canvas', setSubTab: 'Terminal' })
+  })
+
+  test('drawer closed, wide + chat-fullscreen → open + restore lastNonFullscreenPreview', () => {
+    const a = decideTerminalToggleAction({
+      ...base,
+      activeTab: 'chat-fullscreen',
+      lastNonFullscreenPreview: 'app-preview',
+    })
+    expect(a).toEqual({
+      kind: 'open',
+      previewTo: 'app-preview',
+      setSubTab: 'Terminal',
+    })
+  })
+
+  test('drawer closed, wide + chat-fullscreen with no last preview → still falls back to dynamic-app via the ref default', () => {
+    const a = decideTerminalToggleAction({
+      ...base,
+      activeTab: 'chat-fullscreen',
+      lastNonFullscreenPreview: 'dynamic-app',
+    })
+    expect(a).toEqual({
+      kind: 'open',
+      previewTo: 'dynamic-app',
+      setSubTab: 'Terminal',
+    })
+  })
+
+  test('drawer closed, NOT in chat-fullscreen → does NOT call previewTo', () => {
+    const a = decideTerminalToggleAction({
+      ...base,
+      activeTab: 'dynamic-app',
+      lastNonFullscreenPreview: 'app-preview',
+    })
+    expect((a as any).previewTo).toBeUndefined()
+  })
+})
+
+describe('decideTerminalToggleAction — MEDIUM: sub-tab preference restoration', () => {
+  test('reopen after toggle-close on Output → restores Output, not Terminal', () => {
+    const a = decideTerminalToggleAction({ ...base, lastSubTab: 'Output' })
+    expect(a).toEqual({ kind: 'open', setSubTab: 'Output' })
+  })
+
+  test('reopen after toggle-close on Problems → restores Problems', () => {
+    const a = decideTerminalToggleAction({ ...base, lastSubTab: 'Problems' })
+    expect(a).toEqual({ kind: 'open', setSubTab: 'Problems' })
+  })
+
+  test('reopen with corrupted lastSubTab (defensive) → falls back to Terminal', () => {
+    const a = decideTerminalToggleAction({
+      ...base,
+      lastSubTab: 'NotARealTab' as any,
+    })
+    expect(a).toEqual({ kind: 'open', setSubTab: 'Terminal' })
+  })
+})
+
+describe('decideTerminalToggleAction — non-web platforms', () => {
+  test('non-web treats canvasAreaHidden as effectively hidden (drawer not visible) → reveal path', () => {
+    // The component never reaches this helper on native because the tab is
+    // filtered from AGENT_TABS, but the helper itself must stay correct.
+    const a = decideTerminalToggleAction({
+      ...base,
+      isWeb: false,
+      storeOpen: true,
+    })
+    // storeOpen + !drawerVisible → reveal, not close.
+    expect(a.kind).toBe('open')
+  })
+})
+
+describe('decideTerminalToggleAction — interaction matrix', () => {
+  test('close path NEVER fires when storeOpen but layout has hidden the drawer (HIGH-fix invariant)', () => {
+    const cases: Array<Partial<TerminalToggleInput>> = [
+      { canvasAreaHidden: true },
+      { isWeb: false },
+      { canvasAreaHidden: true, isNarrow: true },
+      { canvasAreaHidden: true, activeTab: 'chat-fullscreen' },
+    ]
+    for (const c of cases) {
+      const a = decideTerminalToggleAction({ ...base, storeOpen: true, ...c })
+      expect(a.kind).toBe('open')
+    }
+  })
+
+  test('open path NEVER force-overwrites sub-tab when revealing a store-open-but-hidden drawer (MEDIUM-fix invariant)', () => {
+    const a = decideTerminalToggleAction({
+      ...base,
+      storeOpen: true,
+      storeActiveSubTab: 'Output',
+      canvasAreaHidden: true,
+      isNarrow: true,
+    })
+    if (a.kind !== 'open') throw new Error('expected open')
+    expect(a.setSubTab).toBeUndefined()
+  })
+})

--- a/apps/mobile/components/project/terminalToggle.ts
+++ b/apps/mobile/components/project/terminalToggle.ts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Pure decision function for the Terminal top-tab → IDE bottom drawer toggle.
+ *
+ * Lives outside ProjectTopBar.tsx so it can be unit-tested without spinning up
+ * React / RNW / happy-dom. The component is the *executor*: it reads state,
+ * calls this helper, then applies the returned action to the store and the
+ * parent-supplied callbacks.
+ *
+ * Three sources of truth need to agree before the drawer becomes visible
+ * (mirroring DrawerHost#shouldShowDrawer):
+ *   • store-open       — user has opened the drawer at least once.
+ *   • web platform     — drawer is web-only.
+ *   • !canvasAreaHidden — layout has actually given the canvas pane room
+ *                         (false in narrow chat-only mode and chat-fullscreen).
+ *
+ * Behavior contract enforced by this helper (also covered by tests):
+ *   1. Click while the drawer is *visible*  ⇒ close (and remember sub-tab).
+ *   2. Click while the drawer is store-open but hidden by layout
+ *                                          ⇒ reveal (NOT close — fixes the
+ *                                            "click closes a drawer I can't
+ *                                            see" footgun).
+ *   3. Click while the drawer is closed     ⇒ open. If we have a remembered
+ *                                            sub-tab from a previous toggle,
+ *                                            restore it; otherwise land on
+ *                                            'Terminal' (cold-start UX).
+ *   4. When revealing from chat-fullscreen on wide, prefer the user's last
+ *      non-fullscreen preview tab over a hard-coded 'dynamic-app'.
+ *   5. When revealing on narrow, swap narrow active to 'canvas' so the drawer
+ *      has a host pane to render into.
+ */
+import {
+  BOTTOM_PANEL_TABS,
+  type BottomPanelTab,
+} from '../../lib/ide-bottom-panel-store'
+
+export interface TerminalToggleInput {
+  /** `ideBottomPanelStore.open` at click time. */
+  storeOpen: boolean
+  /** `ideBottomPanelStore.activeTab` at click time. */
+  storeActiveSubTab: BottomPanelTab
+  /** Result of `Platform.OS === 'web'`. */
+  isWeb: boolean
+  /** Mirrors layout `canvasAreaHidden`. */
+  canvasAreaHidden: boolean
+  /** True iff `onNarrowTabChange` is wired (i.e. we're in narrow layout). */
+  isNarrow: boolean
+  /** Current `activeTab` prop (i.e. `previewTab` from the parent). */
+  activeTab: string | undefined
+  /** Last sub-tab the user had selected before the previous toggle-close. */
+  lastSubTab: BottomPanelTab | null
+  /** Last non-fullscreen preview tab — used as the restore target. */
+  lastNonFullscreenPreview: string
+}
+
+export type TerminalToggleAction =
+  | {
+      kind: 'close'
+      /** Sub-tab to stash so the next reveal can restore it. */
+      rememberSubTab: BottomPanelTab
+    }
+  | {
+      kind: 'open'
+      /** If set, parent should call `onNarrowTabChange(narrowTo)` first. */
+      narrowTo?: 'canvas'
+      /** If set, parent should call `onTabChange(previewTo)` first. */
+      previewTo?: string
+      /** If set, parent should call `setActiveTab(setSubTab)` before opening.
+       *  Omitted when revealing a store-open-but-hidden drawer (the user's
+       *  current sub-tab selection is preserved). */
+      setSubTab?: BottomPanelTab
+    }
+
+function isKnownSubTab(t: unknown): t is BottomPanelTab {
+  return (
+    typeof t === 'string' && (BOTTOM_PANEL_TABS as readonly string[]).includes(t)
+  )
+}
+
+export function decideTerminalToggleAction(
+  i: TerminalToggleInput,
+): TerminalToggleAction {
+  const drawerVisible = i.isWeb && !i.canvasAreaHidden
+
+  // (1) Drawer on screen → close. Stash the user's current sub-tab so the
+  // next click can restore it.
+  if (i.storeOpen && drawerVisible) {
+    return { kind: 'close', rememberSubTab: i.storeActiveSubTab }
+  }
+
+  // (2) Drawer store-open but hidden by layout → reveal. Do NOT overwrite
+  // the user's current sub-tab; just bring the layout back into a state
+  // where the existing drawer is visible.
+  if (i.storeOpen && !drawerVisible) {
+    return {
+      kind: 'open',
+      narrowTo: i.isNarrow ? 'canvas' : undefined,
+      previewTo:
+        !i.isNarrow && i.activeTab === 'chat-fullscreen'
+          ? i.lastNonFullscreenPreview
+          : undefined,
+      // setSubTab intentionally omitted — store.activeTab already correct.
+    }
+  }
+
+  // (3) Drawer closed → open. Restore last sub-tab if we have one (and it's
+  // still a valid value), else fall back to 'Terminal' for the cold start.
+  const subTab: BottomPanelTab = isKnownSubTab(i.lastSubTab)
+    ? i.lastSubTab
+    : 'Terminal'
+
+  return {
+    kind: 'open',
+    narrowTo: i.isNarrow ? 'canvas' : undefined,
+    previewTo:
+      !i.isNarrow && i.activeTab === 'chat-fullscreen'
+        ? i.lastNonFullscreenPreview
+        : undefined,
+    setSubTab: subTab,
+  }
+}


### PR DESCRIPTION
<img width="1016" height="858" alt="Screenshot 2026-05-04 at 10 58 45 AM" src="https://github.com/user-attachments/assets/06cdd8c2-cd3e-47f4-8967-294aefa96698" />
## Summary

Adds a **Terminal** entry to the project top tab bar (web/desktop only). Clicking it toggles the *existing* IDE bottom drawer (`DrawerHost`) — the same panel that hosts **Terminal / Problems / Output** — and focuses the Terminal sub-tab on first open. The tab highlights whenever the drawer is open, regardless of which sub-tab is active, and unhighlights the moment the drawer closes (whether closed via the tab itself, the drawer's own ✕, or a drag-down).

**Why:** Today the bottom drawer can only be reopened by dragging the resize handle up from the bottom of the IDE pane. That's discoverable-once and slow. A persistent, single-click toggle in the top tab bar matches the rest of the project navigation and removes the drag-from-bottom friction.

## Scope of this PR

This PR is intentionally tiny — **2 files, ~43 LOC net**:

| File | Change |
|---|---|
| `apps/mobile/components/project/ProjectTopBar.tsx` | Adds the `Terminal` entry to `AGENT_TABS` (web-gated), subscribes to `ideBottomPanelStore`, and special-cases `'terminal'` inside `handleTabPress` / `getTabActive` and the narrow-overflow menu. |
| `apps/mobile/app/(app)/projects/[id]/_layout.tsx` | Comment-only update clarifying that `'terminal'` is **not** a `previewTab` value — it's a drawer toggle. No logic change. |

No new components, no new state stores, no schema changes, no new dependencies. The Terminal component itself (`apps/mobile/components/project/panels/ide/Terminal.tsx`), the bottom drawer (`DrawerHost` / `BottomPanel`), and the persisted store (`ideBottomPanelStore`) are reused as-is.

## Behavior matrix

| Initial state | Click Terminal tab | Result | Tab highlight after |
|---|---|---|---|
| Drawer closed | click | Drawer opens, sub-tab = Terminal | ON |
| Drawer open, sub-tab = Terminal | click | Drawer closes | OFF |
| Drawer open, sub-tab = Problems | click | Drawer closes | OFF |
| Drawer open, sub-tab = Output | click | Drawer closes | OFF |
| Drawer closed, in `chat-fullscreen` | click | `previewTab` ⇒ `dynamic-app`, drawer opens, sub-tab = Terminal | ON |
| Drawer closed, narrow + chat-only | click | narrow active ⇒ `canvas`, drawer opens, sub-tab = Terminal | ON |
| Drawer open (any sub-tab), user clicks drawer's ✕ | — | Drawer closes via store | OFF |
| Reload page with drawer previously open | — | Store rehydrates from `localStorage`; drawer reopens; tab highlight reflects state | ON if it was ON |

The top tab is highlighted whenever **`store.open === true`** — Terminal, Problems, *and* Output all keep it lit (per design feedback in review).

## Flow diagram

```mermaid
flowchart TD
    A[User clicks Terminal top-tab] --> B{ideBottomPanelStore<br/>store.open?}
    B -- true --> C[setOpen false]
    C --> Z1[Drawer closes<br/>tab unhighlights]

    B -- false --> D{previewTab ===<br/>chat-fullscreen?}
    D -- yes --> E[onTabChange<br/>dynamic-app]
    D -- no --> F{narrow layout<br/>and on chat?}
    E --> F
    F -- yes --> G[onNarrowTabChange<br/>canvas]
    F -- no --> H[setActiveTab Terminal]
    G --> H
    H --> I[setOpen true]
    I --> Z2[DrawerHost mounts BottomPanel<br/>BottomPanel renders Terminal<br/>tab highlights]

    Z2 -.user closes via drawer X.-> J[store.setOpen false]
    J --> Z1
```

### Render-side wiring (unchanged — included for context)

```mermaid
flowchart LR
    subgraph Project Layout
      Layout["_layout.tsx"] --> TopBar["ProjectTopBar"]
      Layout --> DrawerHost["DrawerHost (web-only)"]
    end
    DrawerHost -- shouldShowDrawer --> BottomPanel["BottomPanel<br/>Terminal · Problems · Output"]
    Store[("ideBottomPanelStore<br/>open · activeTab · height")] -- subscribe --> TopBar
    Store -- subscribe --> DrawerHost
    Store -- subscribe --> BottomPanel
    TopBar -- setOpen / setActiveTab --> Store
    BottomPanel -- setOpen / setActiveTab --> Store
    Store <-- localStorage --> Persist[("shogo.ide.bottomPanel*")]
```

## Implementation notes

### Why a drawer toggle and **not** a new `previewTab`

A first attempt added `'terminal'` as a standalone `previewTab` with its own full-page `StandaloneTerminalPanel`. That was wrong:

- It duplicated the Terminal session lifecycle (one in the drawer, one in the panel) → orphaned PTYs.
- It didn't solve the actual UX pain ("I have to drag the drawer back up").
- It pushed an extra entry into `STANDALONE_PANELS`, which affects z-index/pointer-events handling.

The drawer-toggle approach reuses the single source of truth (`ideBottomPanelStore`), so there is exactly one Terminal instance at any time and the user's session survives every tab switch.

### Web-only gating

The Terminal entry is wrapped in `Platform.OS === 'web'` — same gate already used for the IDE and Files entries, and matching `DrawerHost`'s own `platformIsWeb` check inside `shouldShowDrawer`. Native iOS/Android builds never see the tab.

### Highlight semantics

```ts
const terminalDrawerActive = useBottomPanelState((st) => st.open)
```

Returning the boolean directly keeps the selector referentially stable (no object identity churn), so the top bar only re-renders when `open` flips. Sub-tab changes inside the drawer do **not** cause top-bar re-renders.

### Toggle semantics

```ts
const toggleTerminalDrawer = useCallback(() => {
  const st = ideBottomPanelStore.getState()
  if (st.open) { ideBottomPanelStore.setOpen(false); return }
  if (onNarrowTabChange) onNarrowTabChange('canvas')
  if (activeTab === 'chat-fullscreen') onTabChange?.('dynamic-app')
  ideBottomPanelStore.setActiveTab('Terminal')
  ideBottomPanelStore.setOpen(true)
}, [activeTab, onNarrowTabChange, onTabChange])
```

- Reads via `getState()` (not a hook) so the closure isn't stale.
- No `requestNewTerminal()` call — that would spawn a fresh PTY on every click. The `Terminal` component already initializes with one session on first mount (`useState<Session[]>(() => [makeSession()])`).
- Order matters: switch out of fullscreen / narrow-chat **before** opening, otherwise `DrawerHost.shouldShowDrawer` returns false and the open is a silent no-op.

## Edge cases verified

1. **Chat-fullscreen** — Terminal click swaps `previewTab` to `dynamic-app` first; drawer surfaces correctly.
2. **Narrow / mobile-web layout** — narrow active swaps to `canvas` before opening so the right pane (and its drawer) exist.
3. **Native iOS/Android** — Terminal entry is filtered out at the `AGENT_TABS` level; no dead tab.
4. **Narrow overflow "more" menu** — the same toggle path is used; highlight reflects drawer state.
5. **Persistence** — drawer state already persists to `localStorage` (`shogo.ide.bottomPanelOpen`, `shogo.ide.bottomPanelTab`, `shogo.ide.bottomPanelHeight`); on reload, `terminalDrawerActive` rehydrates and the top tab paints correctly on first frame.
6. **`hiddenTabs` prop** — still respected; `'terminal'` can be hidden externally without touching this code.
7. **Sub-tab focus** — clicking Terminal while the drawer is open on Problems/Output does **not** force-switch to Terminal sub-tab (per spec: any sub-tab keeps the top tab lit; click closes the drawer instead). First-open from a closed state always lands on Terminal.
8. **Session count** — single Terminal instance lives in the drawer. PTYs aren't duplicated. No leaks across tab toggles.
9. **No `previewTab` pollution** — `'terminal'` is **not** added to `PERSISTABLE_PREVIEW_TABS` or `STANDALONE_PANELS`. Canvas/IDE/Files routing is untouched.
10. **TypeScript** — `bunx tsc --noEmit` reports zero new errors in `ProjectTopBar.tsx` or `_layout.tsx` (only pre-existing errors in unrelated `shared-ui` / `ui-kit` test files).

## Manual QA checklist

- [x] Web wide layout: click Terminal → drawer opens to Terminal sub-tab → tab orange.
- [x] Click Terminal again → drawer closes → tab grey.
- [x] Open drawer, click Problems → tab stays orange.
- [x] Open drawer on Output, click Terminal top-tab → drawer closes (does not switch sub-tab).
- [x] Close drawer via its own ✕ → tab unhighlights.
- [x] Switch between Canvas / IDE / Files / Chat with drawer open → drawer state and Terminal session both persist.
- [x] Enter chat-fullscreen, click Terminal → exits fullscreen and opens drawer.
- [x] Narrow viewport (<640px): tab moves to overflow "more"; same toggle behavior.
- [x] Reload mid-session with drawer open → drawer + tab highlight rehydrate from localStorage.
- [x] iOS / Android Expo build: tab is absent.
- [x] `bunx tsc --noEmit` clean for both touched files.

## Risk / blast radius

- **Surface:** two web-only files; everything else is read-only reuse.
- **Native:** zero — gated out at `AGENT_TABS`.
- **Existing drawer users:** unchanged — the store API (`setOpen`, `setActiveTab`, `requestNewTerminal`) is consumed, not modified.
- **Rollback:** revert is one commit on `feat/web-terminal-tab-toggles-ide-bottom-drawer`; no migrations, no infra, no env vars.

## Out of scope / follow-ups

- Keyboard shortcut (e.g. `⌃` `` ` ``) for the toggle — would live in a separate global-shortcut PR.
- Per-sub-tab quick switch (e.g. ⌥-click Terminal tab to focus Problems) — explicitly rejected here in favor of "top tab represents the drawer as a whole".
- Terminal tab badge for unread Problems count — separate UI concern.
