### PR TITLE
feat(ide-terminal): VS Code-style cd path completion on Tab

### DIFF
--- a/apps/api/src/routes/terminal.ts
+++ b/apps/api/src/routes/terminal.ts
@@ -43,6 +43,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs"
 import { tmpdir } from "os"
 import { isAbsolute, join, resolve } from "path"
 import { makeKillChild, spawnPresetShell, spawnRunShell } from "@shogo/agent-runtime/src/terminal-shell"
+import { completeTerminalPath } from "@shogo/agent-runtime/src/terminal-completion"
 
 /**
  * ASCII Record-Separator framed sentinel used to carry post-command metadata
@@ -199,6 +200,33 @@ export function terminalRoutes(config: TerminalRoutesConfig) {
     }, {} as Record<string, Array<{ id: string; label: string; description: string; category: string; dangerous: boolean }>>)
 
     return c.json({ commands: commandsByCategory }, 200)
+  })
+
+  /**
+   * POST /projects/:projectId/terminal/complete - List path completion entries.
+   */
+  router.post("/projects/:projectId/terminal/complete", async (c) => {
+    const projectId = c.req.param("projectId")
+    const projectDir = join(workspacesDir, projectId)
+
+    if (!existsSync(projectDir)) {
+      return c.json(
+        { error: { code: "project_not_found", message: "Project not found" } },
+        404,
+      )
+    }
+
+    let body: { cwd?: string; pathPrefix?: string; onlyDirectories?: boolean }
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json(
+        { error: { code: "invalid_body", message: "Invalid request body" } },
+        400,
+      )
+    }
+
+    return c.json(completeTerminalPath(projectDir, body), 200)
   })
 
   /**

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2558,6 +2558,95 @@ app.get('/api/projects/:projectId/terminal/commands', async (c) => {
   return router.fetch(newReq)
 })
 
+// List path completion entries for the free-form terminal prompt.
+app.post('/api/projects/:projectId/terminal/complete', async (c) => {
+  const projectId = c.req.param('projectId')
+
+  if (isKubernetes()) {
+    try {
+      const { getProjectPodUrl } = await import('./lib/knative-project-manager')
+      const { deriveRuntimeToken } = await import('./lib/runtime-token')
+      const podUrl = await getProjectPodUrl(projectId)
+      const targetUrl = `${podUrl}/terminal/complete`
+
+      const body = await c.req.text()
+      const response = await fetch(targetUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': c.req.header('Content-Type') || 'application/json',
+          'x-runtime-token': deriveRuntimeToken(projectId),
+        },
+        body,
+        signal: c.req.raw.signal,
+      })
+
+      if (!response.ok) {
+        const contentType = response.headers.get('content-type') || ''
+        if (contentType.includes('application/json')) {
+          const responseHeaders = new Headers()
+          response.headers.forEach((value, key) => {
+            if (!['transfer-encoding', 'connection'].includes(key.toLowerCase())) {
+              responseHeaders.set(key, value)
+            }
+          })
+          return new Response(response.body, { status: response.status, headers: responseHeaders })
+        }
+
+        const errorCode = response.status === 503
+          ? 'service_starting'
+          : response.status === 502 ? 'service_unavailable' : 'upstream_error'
+        const headers = new Headers({ 'Content-Type': 'application/json' })
+        if (response.status === 503) headers.set('Retry-After', '5')
+        return new Response(JSON.stringify({
+          error: { code: errorCode, message: `Terminal completion unavailable (${response.status})` },
+        }), { status: response.status, headers })
+      }
+
+      const responseHeaders = new Headers()
+      response.headers.forEach((value, key) => {
+        if (!['transfer-encoding', 'connection'].includes(key.toLowerCase())) {
+          responseHeaders.set(key, value)
+        }
+      })
+
+      return new Response(response.body, {
+        status: response.status,
+        headers: responseHeaders,
+      })
+    } catch (error: any) {
+      const isPodNotReady = error.message?.includes('not ready') ||
+        error.message?.includes('not found') ||
+        error.message?.includes('starting')
+
+      if (isPodNotReady) {
+        return c.json({
+          error: { code: 'service_starting', message: 'Project runtime is starting...' },
+        }, 503)
+      }
+
+      console.error('[TerminalProxy] Completion error:', error)
+      return c.json({
+        error: { code: 'proxy_error', message: error.message || 'Failed to complete terminal path' },
+      }, 502)
+    }
+  }
+
+  // Local development: Use local filesystem
+  const workspacesDir = process.env.WORKSPACES_DIR || resolve(PROJECT_ROOT, 'workspaces')
+  const router = terminalRoutes({ workspacesDir })
+  const url = new URL(c.req.url)
+  url.pathname = `/projects/${projectId}/terminal/complete`
+  const newReq = new Request(url.toString(), {
+    method: 'POST',
+    headers: c.req.raw.headers,
+    body: c.req.raw.body,
+    // @ts-expect-error - required when forwarding a streaming request body in Node
+    duplex: 'half',
+    signal: c.req.raw.signal,
+  })
+  return router.fetch(newReq)
+})
+
 // Execute a preset command
 app.post('/api/projects/:projectId/terminal/exec', async (c) => {
   const projectId = c.req.param('projectId')

--- a/apps/mobile/components/project/panels/ide/Terminal.tsx
+++ b/apps/mobile/components/project/panels/ide/Terminal.tsx
@@ -13,6 +13,13 @@ import {
 } from "lucide-react-native";
 import { API_URL } from "../../../../lib/api";
 import { agentFetch } from "../../../../lib/agent-fetch";
+import {
+  advanceCdCompletion,
+  applyCdCompletion,
+  parseCdCompletion,
+  type CdCompletionState,
+  type TerminalCompletionEntry,
+} from "./terminal/completion";
 import { formatPromptCwd } from "./terminal/cwd-format";
 import { readTerminalError } from "./terminal/error-reader";
 import { pushHistory, walkHistory } from "./terminal/history";
@@ -525,6 +532,30 @@ export function Terminal({
     patchSession(active.id, (s) => ({ ...s, output: "" }));
   }, [active, patchSession]);
 
+  const completeCdPath = useCallback(
+    async (pathPrefix: string): Promise<TerminalCompletionEntry[]> => {
+      if (!projectId) return [];
+      const target = sessionsRef.current.find((s) => s.id === activeId);
+      const res = await agentFetch(`${apiBase}/api/projects/${projectId}/terminal/complete`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          cwd: target?.cwd ?? undefined,
+          pathPrefix,
+          onlyDirectories: true,
+        }),
+      });
+      if (!res.ok) return [];
+      const contentType = res.headers.get("content-type") ?? "";
+      if (!contentType.includes("application/json")) return [];
+      const json = (await res.json()) as {
+        entries?: TerminalCompletionEntry[];
+      };
+      return Array.isArray(json.entries) ? json.entries : [];
+    },
+    [apiBase, projectId, activeId],
+  );
+
   // ─── Early exits ────────────────────────────────────────────────────
   if (!projectId) {
     return (
@@ -610,6 +641,7 @@ export function Terminal({
             cwdLabel={formatPromptCwd(active?.cwd ?? null)}
             onRun={(cmd) => void runFreeCommand(cmd)}
             onClear={clear}
+            onCompleteCdPath={completeCdPath}
           />
         )}
       </div>
@@ -923,79 +955,155 @@ const Prompt = React.forwardRef<
     cwdLabel: string;
     onRun: (cmd: string) => void;
     onClear: () => void;
+    onCompleteCdPath: (pathPrefix: string) => Promise<TerminalCompletionEntry[]>;
   }
->(function Prompt({ disabled, history, cwdLabel, onRun, onClear }, ref) {
+>(function Prompt({ disabled, history, cwdLabel, onRun, onClear, onCompleteCdPath }, ref) {
   const [value, setValue] = useState("");
   const [histIdx, setHistIdx] = useState<number | null>(null);
+  const [completionState, setCompletionState] = useState<CdCompletionState | null>(null);
+  const [completionCandidates, setCompletionCandidates] = useState<TerminalCompletionEntry[]>([]);
+  const valueRef = useRef(value);
+  valueRef.current = value;
 
   // Reset history cursor when the underlying history changes (e.g. after
   // submitting a new command).
   useEffect(() => {
     setHistIdx(null);
+    setCompletionState(null);
+    setCompletionCandidates([]);
   }, [history]);
 
+  const resetCompletion = () => {
+    setCompletionState(null);
+    setCompletionCandidates([]);
+  };
+
   return (
-    <form
-      className="flex items-center gap-2"
-      onSubmit={(e) => {
-        e.preventDefault();
-        if (disabled) return;
-        const v = value.trim();
-        if (!v) return;
-        onRun(v);
-        setValue("");
-        setHistIdx(null);
-      }}
-    >
-      {cwdLabel && (
-        <span className="shrink-0 select-none text-[#6a9955]">{cwdLabel}</span>
+    <div className="relative">
+      {completionCandidates.length > 1 && (
+        <div className="absolute bottom-full left-0 z-10 mb-1 max-w-[min(520px,90vw)] rounded border border-[#2a2a2a] bg-[#252526] px-2 py-1 text-[11px] text-[#cccccc] shadow-lg">
+          <div className="mb-1 text-[10px] uppercase tracking-wide text-[#6a6a6a]">Tab completions</div>
+          <div className="flex max-h-28 flex-wrap gap-x-3 gap-y-1 overflow-auto">
+            {completionCandidates.map((entry) => (
+              <span key={`${entry.type}:${entry.name}`} className="whitespace-nowrap text-[#d4d4d4]">
+                {entry.name}{entry.type === "directory" ? "/" : ""}
+              </span>
+            ))}
+          </div>
+        </div>
       )}
-      <span className="shrink-0 select-none text-[#4ec9b0]">$</span>
-      <input
-        ref={ref}
-        value={value}
-        onChange={(e) => {
-          setValue(e.target.value);
+      <form
+        className="flex items-center gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (disabled) return;
+          const v = value.trim();
+          if (!v) return;
+          onRun(v);
+          valueRef.current = "";
+          setValue("");
           setHistIdx(null);
+          resetCompletion();
         }}
-        onKeyDown={(e) => {
-          if (e.key === "ArrowUp" || e.key === "ArrowDown") {
-            const dir = e.key === "ArrowUp" ? "up" : "down";
-            const result = walkHistory(history, histIdx, dir);
-            if (!result) return;
-            e.preventDefault();
-            setHistIdx(result.index);
-            setValue(result.value);
-          } else if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "l") {
-            // Ctrl+L / ⌘K parity with a real shell: clear the buffer but
-            // preserve whatever the user was typing. We swallow the event so
-            // the browser doesn't focus the URL bar on Ctrl+L.
-            e.preventDefault();
-            onClear();
-          } else if (e.ctrlKey && e.key.toLowerCase() === "c" && !value) {
-            // Empty-line Ctrl+C in a real shell just reprints the prompt.
-            // With text selected we let the browser handle copy normally.
-            const sel = window.getSelection?.()?.toString();
-            if (!sel) {
+      >
+        {cwdLabel && (
+          <span className="shrink-0 select-none text-[#6a9955]">{cwdLabel}</span>
+        )}
+        <span className="shrink-0 select-none text-[#4ec9b0]">$</span>
+        <input
+          ref={ref}
+          value={value}
+          onChange={(e) => {
+            const next = e.target.value;
+            valueRef.current = next;
+            setValue(next);
+            setHistIdx(null);
+            resetCompletion();
+          }}
+          onKeyDown={(e) => {
+            const currentValue = e.currentTarget.value;
+            if (e.key === "Tab") {
+              const cycled = advanceCdCompletion(currentValue, completionState);
+              if (cycled) {
+                e.preventDefault();
+                valueRef.current = cycled.value;
+                setValue(cycled.value);
+                setCompletionState(cycled.state);
+                setCompletionCandidates(cycled.candidates);
+                return;
+              }
+
+              const cursor = e.currentTarget.selectionStart ?? currentValue.length;
+              const context = parseCdCompletion(currentValue, cursor);
+              if (!context) {
+                resetCompletion();
+                return;
+              }
+
               e.preventDefault();
+              void (async () => {
+                try {
+                  const line = currentValue;
+                  const entries = await onCompleteCdPath(context.pathPrefix);
+                  if (valueRef.current !== line) return;
+                  const completed = applyCdCompletion(line, context, entries);
+                  if (!completed) {
+                    resetCompletion();
+                    return;
+                  }
+                  valueRef.current = completed.value;
+                  setValue(completed.value);
+                  setCompletionState(completed.state);
+                  setCompletionCandidates(completed.candidates);
+                } catch {
+                  resetCompletion();
+                }
+              })();
+            } else if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+              const dir = e.key === "ArrowUp" ? "up" : "down";
+              const result = walkHistory(history, histIdx, dir);
+              if (!result) return;
+              e.preventDefault();
+              setHistIdx(result.index);
+              valueRef.current = result.value;
+              setValue(result.value);
+              resetCompletion();
+            } else if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "l") {
+              // Ctrl+L / ⌘K parity with a real shell: clear the buffer but
+              // preserve whatever the user was typing. We swallow the event so
+              // the browser doesn't focus the URL bar on Ctrl+L.
+              e.preventDefault();
+              resetCompletion();
+              onClear();
+            } else if (e.ctrlKey && e.key.toLowerCase() === "c" && !currentValue) {
+              // Empty-line Ctrl+C in a real shell just reprints the prompt.
+              // With text selected we let the browser handle copy normally.
+              const sel = window.getSelection?.()?.toString();
+              if (!sel) {
+                e.preventDefault();
+                valueRef.current = "";
+                setValue("");
+                setHistIdx(null);
+                resetCompletion();
+              }
+            } else if (e.ctrlKey && e.key.toLowerCase() === "u") {
+              // Ctrl+U: kill line (shell parity).
+              e.preventDefault();
+              valueRef.current = "";
               setValue("");
               setHistIdx(null);
+              resetCompletion();
             }
-          } else if (e.ctrlKey && e.key.toLowerCase() === "u") {
-            // Ctrl+U: kill line (shell parity).
-            e.preventDefault();
-            setValue("");
-            setHistIdx(null);
-          }
-        }}
-        disabled={disabled}
-        aria-label="Command"
-        spellCheck={false}
-        autoCapitalize="off"
-        autoCorrect="off"
-        className="no-focus-ring flex-1 border-0 bg-transparent p-0 font-mono text-[12px] text-[#d4d4d4] outline-none focus:ring-0 disabled:opacity-50"
-      />
-    </form>
+          }}
+          disabled={disabled}
+          aria-label="Command"
+          spellCheck={false}
+          autoCapitalize="off"
+          autoCorrect="off"
+          className="no-focus-ring flex-1 border-0 bg-transparent p-0 font-mono text-[12px] text-[#d4d4d4] outline-none focus:ring-0 disabled:opacity-50"
+        />
+      </form>
+    </div>
   );
 });
 

--- a/apps/mobile/components/project/panels/ide/__tests__/Terminal.rtl.test.tsx
+++ b/apps/mobile/components/project/panels/ide/__tests__/Terminal.rtl.test.tsx
@@ -188,6 +188,59 @@ describe('Terminal — prompt built-ins', () => {
     await user.keyboard('{Control>}u{/Control}')
     expect(input).toHaveValue('')
   })
+
+  test('Tab completes cd directory prefixes and keeps focus in the prompt', async () => {
+    const user = userEvent.setup()
+    fetcher.setRoute('/terminal/complete', () =>
+      jsonOk({
+        ok: true,
+        base: '/workspace',
+        entries: [{ name: 'files', type: 'directory' }],
+      }),
+    )
+    render(<Terminal projectId="p1" visible />)
+
+    const input = screen.getByRole('textbox', { name: /command/i })
+    await user.type(input, 'cd f')
+    await user.keyboard('{Tab}')
+
+    await waitFor(() => {
+      expect(input).toHaveValue('cd files/')
+    })
+    expect(input).toHaveFocus()
+    const call = fetcher.calls.find((c) => c.url.includes('/terminal/complete'))
+    expect(call).toBeDefined()
+    expect(JSON.parse(String(call?.init?.body))).toMatchObject({
+      pathPrefix: 'f',
+      onlyDirectories: true,
+    })
+  })
+
+  test('repeated Tab cycles ambiguous cd completions without another fetch', async () => {
+    const user = userEvent.setup()
+    fetcher.setRoute('/terminal/complete', () =>
+      jsonOk({
+        ok: true,
+        base: '/workspace',
+        entries: [
+          { name: 'files', type: 'directory' },
+          { name: 'folders', type: 'directory' },
+        ],
+      }),
+    )
+    render(<Terminal projectId="p1" visible />)
+
+    const input = screen.getByRole('textbox', { name: /command/i })
+    await user.type(input, 'cd f')
+    await user.keyboard('{Tab}')
+    await waitFor(() => {
+      expect(input).toHaveValue('cd files/')
+    })
+
+    await user.keyboard('{Tab}')
+    expect(input).toHaveValue('cd folders/')
+    expect(fetcher.calls.filter((c) => c.url.includes('/terminal/complete'))).toHaveLength(1)
+  })
 })
 
 describe('Terminal — dangerous preset confirmation', () => {

--- a/apps/mobile/components/project/panels/ide/terminal/__tests__/completion.test.ts
+++ b/apps/mobile/components/project/panels/ide/terminal/__tests__/completion.test.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import { describe, expect, test } from 'bun:test'
+import {
+  advanceCdCompletion,
+  applyCdCompletion,
+  parseCdCompletion,
+  type TerminalCompletionEntry,
+} from '../completion'
+
+const dirs = (...names: string[]): TerminalCompletionEntry[] =>
+  names.map((name) => ({ name, type: 'directory' }))
+
+describe('parseCdCompletion', () => {
+  test('detects a cd path prefix at the end of the line', () => {
+    expect(parseCdCompletion('cd f')).toMatchObject({
+      pathPrefix: 'f',
+      dirPrefix: '',
+      leafPrefix: 'f',
+    })
+  })
+
+  test('splits nested prefixes into directory and leaf parts', () => {
+    expect(parseCdCompletion('cd src/comp')).toMatchObject({
+      pathPrefix: 'src/comp',
+      dirPrefix: 'src/',
+      leafPrefix: 'comp',
+    })
+  })
+
+  test('decodes escaped spaces for unquoted paths', () => {
+    expect(parseCdCompletion('cd my\\ fol')).toMatchObject({
+      pathPrefix: 'my fol',
+      leafPrefix: 'my fol',
+      quote: null,
+    })
+  })
+
+  test('preserves quoted paths with spaces', () => {
+    expect(parseCdCompletion('cd "my fol')).toMatchObject({
+      pathPrefix: 'my fol',
+      leafPrefix: 'my fol',
+      quote: '"',
+    })
+  })
+
+  test('does not activate for non-cd commands or cd special cases', () => {
+    expect(parseCdCompletion('ls f')).toBeNull()
+    expect(parseCdCompletion('cd')).toBeNull()
+    expect(parseCdCompletion('cd ')).toBeNull()
+    expect(parseCdCompletion('cd -')).toBeNull()
+    expect(parseCdCompletion('cd --')).toBeNull()
+  })
+
+  test('does not activate in the middle of the input', () => {
+    expect(parseCdCompletion('cd files', 3)).toBeNull()
+  })
+})
+
+describe('applyCdCompletion', () => {
+  test('completes a single directory and appends slash', () => {
+    const ctx = parseCdCompletion('cd f')
+    expect(ctx).not.toBeNull()
+
+    const result = applyCdCompletion('cd f', ctx!, dirs('files'))
+
+    expect(result?.value).toBe('cd files/')
+    expect(result?.candidates.map((entry) => entry.name)).toEqual(['files'])
+  })
+
+  test('extends to a common prefix before cycling', () => {
+    const ctx = parseCdCompletion('cd fo')
+    expect(ctx).not.toBeNull()
+
+    const result = applyCdCompletion('cd fo', ctx!, dirs('foo-app', 'foo-api'))
+
+    expect(result?.value).toBe('cd foo-ap')
+    expect(result?.state.index).toBe(-1)
+  })
+
+  test('cycles ambiguous candidates on repeated tab', () => {
+    const ctx = parseCdCompletion('cd f')
+    expect(ctx).not.toBeNull()
+
+    const first = applyCdCompletion('cd f', ctx!, dirs('files', 'folders'))
+    expect(first?.value).toBe('cd files/')
+
+    const second = advanceCdCompletion(first!.value, first!.state)
+    expect(second?.value).toBe('cd folders/')
+
+    const third = advanceCdCompletion(second!.value, second!.state)
+    expect(third?.value).toBe('cd files/')
+  })
+
+  test('keeps quote style when completing paths with spaces', () => {
+    const ctx = parseCdCompletion('cd "my fol')
+    expect(ctx).not.toBeNull()
+
+    const result = applyCdCompletion('cd "my fol', ctx!, dirs('my folder'))
+
+    expect(result?.value).toBe('cd "my folder/"')
+  })
+
+  test('escapes spaces when completing an unquoted path', () => {
+    const ctx = parseCdCompletion('cd my\\ fol')
+    expect(ctx).not.toBeNull()
+
+    const result = applyCdCompletion('cd my\\ fol', ctx!, dirs('my folder'))
+
+    expect(result?.value).toBe('cd my\\ folder/')
+  })
+
+  test('returns null when no candidates match the parsed prefix', () => {
+    const ctx = parseCdCompletion('cd z')
+    expect(ctx).not.toBeNull()
+
+    expect(applyCdCompletion('cd z', ctx!, dirs('alpha'))).toBeNull()
+  })
+})

--- a/apps/mobile/components/project/panels/ide/terminal/completion.ts
+++ b/apps/mobile/components/project/panels/ide/terminal/completion.ts
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Pure helpers for shell-like path completion in the prompt. The terminal is
+ * not a PTY, so the UI has to parse the current line and apply directory
+ * candidates returned by the runtime.
+ */
+
+export interface TerminalCompletionEntry {
+  name: string
+  type: 'file' | 'directory'
+}
+
+export interface CdCompletionContext {
+  replacementStart: number
+  replacementEnd: number
+  pathPrefix: string
+  dirPrefix: string
+  leafPrefix: string
+  quote: '"' | "'" | null
+  key: string
+}
+
+export interface CdCompletionState {
+  key: string
+  valueAfter: string
+  replacementStart: number
+  dirPrefix: string
+  quote: '"' | "'" | null
+  entries: TerminalCompletionEntry[]
+  index: number
+}
+
+export interface CdCompletionResult {
+  value: string
+  candidates: TerminalCompletionEntry[]
+  state: CdCompletionState
+}
+
+export function parseCdCompletion(line: string, cursor = line.length): CdCompletionContext | null {
+  if (cursor !== line.length) return null
+
+  let i = 0
+  while (line[i] === ' ' || line[i] === '\t') i++
+  if (line.slice(i, i + 2) !== 'cd') return null
+  const afterCd = i + 2
+  const after = line[afterCd]
+  if (after && after !== ' ' && after !== '\t') return null
+
+  let tokenStart = afterCd
+  while (line[tokenStart] === ' ' || line[tokenStart] === '\t') tokenStart++
+  if (tokenStart >= line.length) return null
+
+  const rawToken = line.slice(tokenStart)
+  if (rawToken === '-' || rawToken === '--') return null
+
+  const parsed = parsePathToken(rawToken)
+  if (!parsed) return null
+  if (parsed.pathPrefix === '-' || parsed.pathPrefix === '--') return null
+
+  const slash = parsed.pathPrefix.lastIndexOf('/')
+  const dirPrefix = slash === -1 ? '' : parsed.pathPrefix.slice(0, slash + 1)
+  const leafPrefix = slash === -1 ? parsed.pathPrefix : parsed.pathPrefix.slice(slash + 1)
+
+  return {
+    replacementStart: tokenStart,
+    replacementEnd: line.length,
+    pathPrefix: parsed.pathPrefix,
+    dirPrefix,
+    leafPrefix,
+    quote: parsed.quote,
+    key: `${tokenStart}:${parsed.quote ?? ''}:${parsed.pathPrefix}`,
+  }
+}
+
+export function advanceCdCompletion(
+  line: string,
+  previous: CdCompletionState | null,
+): CdCompletionResult | null {
+  if (!previous || previous.entries.length <= 1 || line !== previous.valueAfter) return null
+  const index = (previous.index + 1) % previous.entries.length
+  return buildResult({
+    line,
+    replacementStart: previous.replacementStart,
+    replacementEnd: line.length,
+    dirPrefix: previous.dirPrefix,
+    quote: previous.quote,
+    entries: previous.entries,
+    index,
+    key: previous.key,
+  })
+}
+
+export function applyCdCompletion(
+  line: string,
+  context: CdCompletionContext,
+  entries: TerminalCompletionEntry[],
+): CdCompletionResult | null {
+  const candidates = entries
+    .filter((entry) => entry.name.startsWith(context.leafPrefix))
+    .sort(compareCompletionEntries)
+  if (candidates.length === 0) return null
+
+  if (candidates.length === 1) {
+    return buildResult({
+      line,
+      replacementStart: context.replacementStart,
+      replacementEnd: context.replacementEnd,
+      dirPrefix: context.dirPrefix,
+      quote: context.quote,
+      entries: candidates,
+      index: 0,
+      key: context.key,
+    })
+  }
+
+  const common = commonPrefix(candidates.map((entry) => entry.name))
+  if (common.length > context.leafPrefix.length) {
+    const value = replacePathToken(line, {
+      replacementStart: context.replacementStart,
+      replacementEnd: context.replacementEnd,
+      dirPrefix: context.dirPrefix,
+      leaf: common,
+      quote: context.quote,
+      isDirectory: false,
+    })
+    return {
+      value,
+      candidates,
+      state: {
+        key: context.key,
+        valueAfter: value,
+        replacementStart: context.replacementStart,
+        dirPrefix: context.dirPrefix,
+        quote: context.quote,
+        entries: candidates,
+        index: -1,
+      },
+    }
+  }
+
+  return buildResult({
+    line,
+    replacementStart: context.replacementStart,
+    replacementEnd: context.replacementEnd,
+    dirPrefix: context.dirPrefix,
+    quote: context.quote,
+    entries: candidates,
+    index: 0,
+    key: context.key,
+  })
+}
+
+function parsePathToken(raw: string): { pathPrefix: string; quote: '"' | "'" | null } | null {
+  const quote = raw[0] === '"' || raw[0] === "'" ? raw[0] : null
+  if (quote) {
+    let escaped = false
+    let out = ''
+    for (let i = 1; i < raw.length; i++) {
+      const ch = raw[i]
+      if (quote === '"' && escaped) {
+        out += ch
+        escaped = false
+        continue
+      }
+      if (quote === '"' && ch === '\\') {
+        escaped = true
+        continue
+      }
+      if (ch === quote) {
+        return raw.slice(i + 1).trim() ? null : { pathPrefix: out, quote }
+      }
+      out += ch
+    }
+    if (escaped) out += '\\'
+    return { pathPrefix: out, quote }
+  }
+
+  let escaped = false
+  let out = ''
+  for (const ch of raw) {
+    if (escaped) {
+      out += ch
+      escaped = false
+      continue
+    }
+    if (ch === '\\') {
+      escaped = true
+      continue
+    }
+    if (ch === ' ' || ch === '\t') return null
+    out += ch
+  }
+  if (escaped) out += '\\'
+  return { pathPrefix: out, quote: null }
+}
+
+function buildResult(args: {
+  line: string
+  replacementStart: number
+  replacementEnd: number
+  dirPrefix: string
+  quote: '"' | "'" | null
+  entries: TerminalCompletionEntry[]
+  index: number
+  key: string
+}): CdCompletionResult {
+  const entry = args.entries[args.index]
+  const value = replacePathToken(args.line, {
+    replacementStart: args.replacementStart,
+    replacementEnd: args.replacementEnd,
+    dirPrefix: args.dirPrefix,
+    leaf: entry.name,
+    quote: args.quote,
+    isDirectory: entry.type === 'directory',
+  })
+  return {
+    value,
+    candidates: args.entries,
+    state: {
+      key: args.key,
+      valueAfter: value,
+      replacementStart: args.replacementStart,
+      dirPrefix: args.dirPrefix,
+      quote: args.quote,
+      entries: args.entries,
+      index: args.index,
+    },
+  }
+}
+
+function replacePathToken(
+  line: string,
+  args: {
+    replacementStart: number
+    replacementEnd: number
+    dirPrefix: string
+    leaf: string
+    quote: '"' | "'" | null
+    isDirectory: boolean
+  },
+): string {
+  const completed = `${args.dirPrefix}${args.leaf}${args.isDirectory ? '/' : ''}`
+  const token = formatPathToken(completed, args.quote)
+  return line.slice(0, args.replacementStart) + token + line.slice(args.replacementEnd)
+}
+
+function formatPathToken(path: string, quote: '"' | "'" | null): string {
+  if (quote === "'") {
+    return `'${path.replace(/'/g, `'\\''`)}`
+  }
+  if (quote === '"') {
+    return `"${path.replace(/(["\\$`])/g, '\\$1')}"`
+  }
+  return path.replace(/([\\\s'"$`])/g, '\\$1')
+}
+
+function commonPrefix(values: string[]): string {
+  if (values.length === 0) return ''
+  let prefix = values[0] ?? ''
+  for (const value of values.slice(1)) {
+    while (!value.startsWith(prefix)) {
+      prefix = prefix.slice(0, -1)
+      if (!prefix) return ''
+    }
+  }
+  return prefix
+}
+
+function compareCompletionEntries(a: TerminalCompletionEntry, b: TerminalCompletionEntry): number {
+  if (a.type !== b.type) return a.type === 'directory' ? -1 : 1
+  return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+}

--- a/packages/agent-runtime/src/__tests__/runtime-terminal-routes.test.ts
+++ b/packages/agent-runtime/src/__tests__/runtime-terminal-routes.test.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Shogo Technologies, Inc.
 
 import { describe, expect, test } from 'bun:test'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { runtimeTerminalRoutes } from '../runtime-terminal-routes'
@@ -63,6 +63,93 @@ describe('runtimeTerminalRoutes', () => {
       const body = await res.json() as { commands: Record<string, Array<{ id: string }>> }
       const all = Object.values(body.commands).flat()
       expect(all.some((c) => c.id === 'bun-install')).toBe(false)
+    })
+  })
+
+  test('serves cd completion entries from the workspace root', async () => {
+    await withWorkspace(async (workspaceDir) => {
+      mkdirSync(join(workspaceDir, 'files'))
+      mkdirSync(join(workspaceDir, 'fixtures'))
+      writeFileSync(join(workspaceDir, 'final.txt'), 'nope', 'utf-8')
+      const app = runtimeTerminalRoutes({ workspaceDir })
+
+      const res = await app.request('/terminal/complete', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ pathPrefix: 'fi', onlyDirectories: true }),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json() as { entries: Array<{ name: string; type: string }> }
+      expect(body.entries).toEqual([
+        { name: 'files', type: 'directory' },
+        { name: 'fixtures', type: 'directory' },
+      ])
+    })
+  })
+
+  test('keeps terminal completion bounded to the workspace', async () => {
+    await withWorkspace(async (workspaceDir) => {
+      mkdirSync(join(workspaceDir, 'files'))
+      const app = runtimeTerminalRoutes({ workspaceDir })
+
+      const res = await app.request('/terminal/complete', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ pathPrefix: '../', onlyDirectories: true }),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json() as { entries: unknown[] }
+      expect(body.entries).toEqual([])
+    })
+  })
+
+  test('hides dot directories unless the prefix starts with a dot', async () => {
+    await withWorkspace(async (workspaceDir) => {
+      mkdirSync(join(workspaceDir, '.config'))
+      mkdirSync(join(workspaceDir, 'components'))
+      const app = runtimeTerminalRoutes({ workspaceDir })
+
+      const hidden = await app.request('/terminal/complete', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ pathPrefix: 'c', onlyDirectories: true }),
+      })
+      const hiddenBody = await hidden.json() as { entries: Array<{ name: string }> }
+      expect(hiddenBody.entries.map((entry) => entry.name)).toEqual(['components'])
+
+      const dot = await app.request('/terminal/complete', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ pathPrefix: '.c', onlyDirectories: true }),
+      })
+      const dotBody = await dot.json() as { entries: Array<{ name: string }> }
+      expect(dotBody.entries.map((entry) => entry.name)).toEqual(['.config'])
+    })
+  })
+
+  test('includes symlinked directories only when they stay inside the workspace', async () => {
+    await withWorkspace(async (workspaceDir) => {
+      mkdirSync(join(workspaceDir, 'real-dir'))
+      symlinkSync(join(workspaceDir, 'real-dir'), join(workspaceDir, 'real-link'))
+      const outside = mkdtempSync(join(tmpdir(), 'shogo-runtime-terminal-outside-'))
+      try {
+        symlinkSync(outside, join(workspaceDir, 'outside-link'))
+        const app = runtimeTerminalRoutes({ workspaceDir })
+
+        const res = await app.request('/terminal/complete', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ pathPrefix: '', onlyDirectories: true }),
+        })
+
+        const body = await res.json() as { entries: Array<{ name: string }> }
+        expect(body.entries.map((entry) => entry.name)).toContain('real-link')
+        expect(body.entries.map((entry) => entry.name)).not.toContain('outside-link')
+      } finally {
+        rmSync(outside, { recursive: true, force: true })
+      }
     })
   })
 

--- a/packages/agent-runtime/src/runtime-terminal-routes.ts
+++ b/packages/agent-runtime/src/runtime-terminal-routes.ts
@@ -14,6 +14,7 @@ import { tmpdir } from 'os'
 import { isAbsolute, join, resolve } from 'path'
 import { Hono } from 'hono'
 import { makeKillChild, spawnPresetShell, spawnRunShell } from './terminal-shell'
+import { completeTerminalPath } from './terminal-completion'
 import { buildQuickCommands, groupQuickCommandsByCategory } from './quick-commands'
 
 const META_SENTINEL_PREFIX = '\u001eSHOGO_TERM_META:'
@@ -29,6 +30,21 @@ export function runtimeTerminalRoutes(config: { workspaceDir: string }) {
     // See `quick-commands.ts` for the layering rules.
     const commands = groupQuickCommandsByCategory(buildQuickCommands(workspaceDir))
     return c.json({ commands })
+  })
+
+  router.post('/terminal/complete', async (c) => {
+    if (!existsSync(workspaceDir)) {
+      return c.json({ error: { code: 'workspace_not_found', message: 'Workspace not found' } }, 404)
+    }
+
+    let body: { cwd?: string; pathPrefix?: string; onlyDirectories?: boolean }
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: { code: 'invalid_body', message: 'Invalid request body' } }, 400)
+    }
+
+    return c.json(completeTerminalPath(workspaceDir, body))
   })
 
   router.post('/terminal/exec', async (c) => {

--- a/packages/agent-runtime/src/terminal-completion.ts
+++ b/packages/agent-runtime/src/terminal-completion.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import {
+  existsSync,
+  readdirSync,
+  realpathSync,
+  statSync,
+} from 'fs'
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'path'
+
+export interface TerminalCompletionRequest {
+  cwd?: string
+  pathPrefix?: string
+  onlyDirectories?: boolean
+}
+
+export interface TerminalCompletionEntry {
+  name: string
+  type: 'file' | 'directory'
+}
+
+export interface TerminalCompletionResponse {
+  ok: true
+  base: string
+  entries: TerminalCompletionEntry[]
+}
+
+const MAX_COMPLETION_ENTRIES = 100
+
+export function completeTerminalPath(
+  workspaceDir: string,
+  request: TerminalCompletionRequest,
+): TerminalCompletionResponse {
+  const root = resolve(workspaceDir)
+  const cwd = pickWorkspaceCwd(request.cwd, root)
+  const prefix = typeof request.pathPrefix === 'string' ? request.pathPrefix : ''
+  const expanded = expandWorkspaceHome(prefix, root)
+  const emptyPrefix = expanded === ''
+  const target = emptyPrefix ? cwd : isAbsolute(expanded) ? resolve(expanded) : resolve(cwd, expanded)
+  const wantsDirectoryContents = emptyPrefix || /[/\\]$/.test(expanded)
+  const base = wantsDirectoryContents ? target : dirname(target)
+  const leaf = wantsDirectoryContents ? '' : basename(target)
+
+  if (!isInsideWorkspace(base, root) || !isRealPathInsideWorkspace(base, root)) {
+    return { ok: true, base: root, entries: [] }
+  }
+
+  let entries
+  try {
+    entries = readdirSync(base, { withFileTypes: true })
+  } catch {
+    return { ok: true, base, entries: [] }
+  }
+
+  const includeDotEntries = leaf.startsWith('.')
+  const onlyDirectories = request.onlyDirectories !== false
+  const out: TerminalCompletionEntry[] = []
+
+  for (const entry of entries) {
+    if (!includeDotEntries && entry.name.startsWith('.')) continue
+    if (!entry.name.startsWith(leaf)) continue
+
+    const abs = join(base, entry.name)
+    const type = classifyEntry(abs, entry)
+    if (!type) continue
+    if (onlyDirectories && type !== 'directory') continue
+    if (!isRealPathInsideWorkspace(abs, root)) continue
+
+    out.push({ name: entry.name, type })
+  }
+
+  out.sort(compareEntries)
+  return { ok: true, base, entries: out.slice(0, MAX_COMPLETION_ENTRIES) }
+}
+
+function pickWorkspaceCwd(candidate: string | undefined, root: string): string {
+  if (!candidate || typeof candidate !== 'string') return root
+  const abs = isAbsolute(candidate) ? resolve(candidate) : resolve(root, candidate)
+  if (!existsSync(abs) || !isInsideWorkspace(abs, root) || !isRealPathInsideWorkspace(abs, root)) {
+    return root
+  }
+  try {
+    return statSync(abs).isDirectory() ? abs : root
+  } catch {
+    return root
+  }
+}
+
+function expandWorkspaceHome(prefix: string, root: string): string {
+  if (prefix === '~') return root
+  if (prefix.startsWith('~/') || prefix.startsWith('~\\')) {
+    return join(root, prefix.slice(2))
+  }
+  return prefix
+}
+
+function classifyEntry(
+  abs: string,
+  entry: { isDirectory: () => boolean; isFile: () => boolean; isSymbolicLink: () => boolean },
+): 'file' | 'directory' | null {
+  if (entry.isDirectory()) return 'directory'
+  if (entry.isFile()) return 'file'
+  if (!entry.isSymbolicLink()) return null
+
+  try {
+    const stat = statSync(abs)
+    if (stat.isDirectory()) return 'directory'
+    if (stat.isFile()) return 'file'
+  } catch {
+    return null
+  }
+  return null
+}
+
+function isInsideWorkspace(candidate: string, root: string): boolean {
+  const rel = relative(root, resolve(candidate))
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
+}
+
+function isRealPathInsideWorkspace(candidate: string, root: string): boolean {
+  try {
+    const realRoot = realpathSync(root)
+    const realCandidate = realpathSync(candidate)
+    return isInsideWorkspace(realCandidate, realRoot)
+  } catch {
+    return false
+  }
+}
+
+function compareEntries(a: TerminalCompletionEntry, b: TerminalCompletionEntry): number {
+  if (a.type !== b.type) return a.type === 'directory' ? -1 : 1
+  return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+}


### PR DESCRIPTION
Closes #478

## What this PR does

Adds **VS Code–style `cd` path completion** to the in-app IDE terminal: **Tab** completes directory names inside the workspace, extends to a **common prefix**, and **cycles** ambiguous matches. Completion is **workspace-bounded** on the runtime (no path escape via `..` or symlinks).

## Architecture

```mermaid
flowchart TB
  subgraph mobile["apps/mobile — Terminal"]
    UI[Terminal.tsx Prompt]
    LIB[terminal/completion.ts]
    UI -->|Tab + line + cwd| Fetch[agentFetch complete]
    Fetch -->|candidates| LIB
    LIB -->|updated line| UI
  end

  subgraph api["apps/api"]
    L["routes/terminal.ts — dev"]
    S["server.ts — POST /api/.../terminal/complete"]
    L --> Px[Forward to runtime]
    S --> K8s[K8s pod proxy + x-runtime-token]
    K8s --> Px
  end

  subgraph rt["packages/agent-runtime"]
    R["POST /terminal/complete"]
    M[terminal-completion.ts]
    R --> M
  end

  Fetch --> L
  Fetch --> S
  Px --> R
```

## Implementation

### Runtime (`packages/agent-runtime`)

- **`terminal-completion.ts`** — Resolves the directory for the partial `cd` path relative to session **cwd**, `readdir`, applies **dotfile** visibility rules, **symlink** containment checks, and a **max entry** cap.
- **`runtime-terminal-routes.ts`** — Registers **`POST /terminal/complete`** with the same auth expectations as other terminal endpoints.

### API (`apps/api`)

- **`routes/terminal.ts`** — Project-scoped **`POST .../terminal/complete`** for local/dev routing to the runtime.
- **`server.ts`** — Public **`POST /api/projects/:projectId/terminal/complete`**; in Kubernetes, proxies to **`${podUrl}/terminal/complete`** with **`x-runtime-token`** (same pattern as `/terminal/run`).

### Mobile IDE (`apps/mobile`)

- **`terminal/completion.ts`** — Pure functions: detect `cd` + path prefix (quoted/unquoted, escaped spaces), apply **single match** / **common prefix** / **cycle** semantics.
- **`Terminal.tsx`** — **Tab** `preventDefault`; request completions; display multi-match hint; **`valueRef`** kept in sync with **`e.currentTarget.value`** on keydown to avoid **stale React state** when typing fast.

### Tests

- `terminal/__tests__/completion.test.ts` — Parser and apply logic.
- `runtime-terminal-routes.test.ts` — Completion responses, workspace bounds, dots, symlinks.
- `Terminal.rtl.test.tsx` — Tab completion wiring.

## Rollout

Deploy **API + agent-runtime** together so the new route exists end-to-end. Missing route should not break shell execution; completion may no-op.
