### PR TITLE
[fix]: Standardize project panel loading with content-aware skeletons

### DIFF
--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -84,6 +84,7 @@ import { ComponentTreePanel } from '../../../../components/dynamic-app/edit/Comp
 import { CanvasThemeProvider, CanvasThemedContainer, useCanvasThemeOptional } from '../../../../components/dynamic-app/CanvasThemeContext'
 import { ProjectTopBar } from '../../../../components/project/ProjectTopBar'
 import { PanelErrorBoundary } from '../../../../components/project/panels/PanelErrorBoundary'
+import { ProjectShellSkeleton } from '../../../../components/project/panels/PanelSkeletons'
 import {
   ChannelsPanel,
   FilesBrowserPanel,
@@ -1233,10 +1234,7 @@ export default observer(function ProjectLayout() {
     return (
       <>
         <Stack.Screen options={HIDDEN_HEADER_OPTIONS} />
-        <View className="flex-1 bg-background items-center justify-center">
-          <ActivityIndicator size="large" />
-          <Text className="text-muted-foreground mt-3 text-sm">Loading project...</Text>
-        </View>
+        <ProjectShellSkeleton />
       </>
     )
   }

--- a/apps/mobile/components/project/panels/ChannelsPanel.tsx
+++ b/apps/mobile/components/project/panels/ChannelsPanel.tsx
@@ -26,6 +26,7 @@ import * as Clipboard from 'expo-clipboard'
 import { agentFetch } from '../../../lib/agent-fetch'
 import { usePlatformConfig } from '../../../lib/platform-config'
 import { PhonePanel } from './PhonePanel'
+import { ChannelsSkeleton } from './PanelSkeletons'
 
 interface ChannelInfo {
   type: string
@@ -317,9 +318,7 @@ export function ChannelsPanel({ projectId, agentUrl, visible, hasAdvancedModelAc
 
       <ScrollView className="flex-1" contentContainerStyle={{ padding: 16 }}>
         {isLoading && channels.length === 0 ? (
-          <View className="items-center py-8">
-            <ActivityIndicator size="small" />
-          </View>
+          <ChannelsSkeleton />
         ) : (
           <View className="gap-2">
             {Object.entries(CHANNEL_DEFS).map(([type, def]) => {

--- a/apps/mobile/components/project/panels/CheckpointsPanel.tsx
+++ b/apps/mobile/components/project/panels/CheckpointsPanel.tsx
@@ -32,6 +32,7 @@ import {
 } from 'lucide-react-native'
 import { API_URL } from '../../../lib/api'
 import { authClient } from '../../../lib/auth-client'
+import { CheckpointsSkeleton } from './PanelSkeletons'
 
 interface CheckpointsPanelProps {
   projectId: string
@@ -126,10 +127,7 @@ export function CheckpointsPanel({ projectId, visible }: CheckpointsPanelProps) 
 
       {/* Content */}
       {isLoading ? (
-        <View className="flex-1 items-center justify-center">
-          <ActivityIndicator size="large" />
-          <Text className="text-muted-foreground text-sm mt-3">Loading checkpoints...</Text>
-        </View>
+        <CheckpointsSkeleton />
       ) : error ? (
         <View className="flex-1 items-center justify-center px-6">
           <AlertTriangle size={24} className="text-destructive mb-2" />

--- a/apps/mobile/components/project/panels/FilesBrowserPanel.tsx
+++ b/apps/mobile/components/project/panels/FilesBrowserPanel.tsx
@@ -35,6 +35,7 @@ import {
   Settings,
 } from 'lucide-react-native'
 import { cn } from '@shogo/shared-ui/primitives'
+import { FileTreeSkeleton, FileContentSkeleton } from './PanelSkeletons'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -744,9 +745,7 @@ export function FilesBrowserPanel({ projectId, agentUrl, visible }: FilesBrowser
               )}
             </View>
           ) : isLoadingTree ? (
-            <View className="flex-1 items-center justify-center p-4">
-              <ActivityIndicator size="small" />
-            </View>
+            <FileTreeSkeleton />
           ) : (
             <View className="p-1">
               {/* General file tree */}
@@ -961,9 +960,7 @@ export function FilesBrowserPanel({ projectId, agentUrl, visible }: FilesBrowser
             )}
 
             {isLoadingFile ? (
-              <View className="flex-1 items-center justify-center">
-                <ActivityIndicator size="small" />
-              </View>
+              <FileContentSkeleton />
             ) : (
               <TextInput
                 value={content}

--- a/apps/mobile/components/project/panels/PanelSkeletons.tsx
+++ b/apps/mobile/components/project/panels/PanelSkeletons.tsx
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import { View } from 'react-native'
+import { Skeleton } from '@shogo/shared-ui/primitives'
+
+/**
+ * Content-aware loading skeletons for project panels.
+ * Each variant mirrors the real layout of its panel so the user
+ * sees a stable shape while data loads (no layout shift).
+ */
+
+export function ProjectShellSkeleton() {
+  return (
+    <View className="flex-1 bg-background">
+      {/* Top bar */}
+      <View className="h-12 border-b border-border px-4 flex-row items-center gap-3">
+        <Skeleton className="h-5 w-5 rounded-md" />
+        <Skeleton className="h-4 w-40 rounded-md" />
+        <View className="flex-1" />
+        <Skeleton className="h-6 w-20 rounded-md" />
+      </View>
+      {/* Body */}
+      <View className="flex-1 flex-row">
+        {/* Chat column skeleton */}
+        <View className="w-[480px] border-r border-border p-4 gap-4">
+          <View className="gap-3">
+            <Skeleton className="h-4 w-3/4 rounded-md" />
+            <Skeleton className="h-4 w-1/2 rounded-md" />
+          </View>
+          <View className="gap-3 mt-4">
+            <Skeleton className="h-16 w-full rounded-lg" />
+            <Skeleton className="h-16 w-4/5 rounded-lg" />
+            <Skeleton className="h-16 w-full rounded-lg" />
+          </View>
+          <View className="flex-1" />
+          <Skeleton className="h-12 w-full rounded-xl" />
+        </View>
+        {/* Canvas column skeleton */}
+        <View className="flex-1 p-4 gap-4">
+          <Skeleton className="h-6 w-48 rounded-md" />
+          <Skeleton className="flex-1 rounded-2xl" />
+        </View>
+      </View>
+    </View>
+  )
+}
+
+export function FileTreeSkeleton() {
+  return (
+    <View className="p-2 gap-1.5">
+      <Skeleton className="h-3 w-20 rounded-sm" />
+      {[1, 0.85, 0.7, 0.9, 0.6, 0.75, 0.8].map((w, i) => (
+        <View key={i} className="flex-row items-center gap-2 py-1 pl-2">
+          <Skeleton className="h-3 w-3 rounded-sm" />
+          <Skeleton className="h-3 rounded-sm" style={{ width: `${w * 60}%` }} />
+        </View>
+      ))}
+    </View>
+  )
+}
+
+export function FileContentSkeleton() {
+  return (
+    <View className="flex-1 p-4 gap-2">
+      {[0.9, 0.7, 0.85, 0.6, 0.95, 0.5, 0.8, 0.65, 0.75, 0.4].map((w, i) => (
+        <Skeleton key={i} className="h-3.5 rounded-sm" style={{ width: `${w * 100}%` }} />
+      ))}
+    </View>
+  )
+}
+
+export function ChannelsSkeleton() {
+  return (
+    <View className="gap-2">
+      {[1, 2, 3, 4].map((i) => (
+        <View key={i} className="border border-border rounded-lg p-3 gap-2">
+          <View className="flex-row items-center gap-2.5">
+            <Skeleton className="h-8 w-8 rounded-lg" />
+            <View className="flex-1 gap-1.5">
+              <Skeleton className="h-4 w-32 rounded-md" />
+              <Skeleton className="h-3 w-48 rounded-sm" />
+            </View>
+            <Skeleton className="h-5 w-16 rounded-full" />
+          </View>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+export function CheckpointsSkeleton() {
+  return (
+    <View className="flex-1 p-4 gap-3">
+      {[1, 2, 3].map((i) => (
+        <View key={i} className="border border-border rounded-lg p-3 gap-2">
+          <View className="flex-row items-center gap-2">
+            <Skeleton className="h-4 w-4 rounded-full" />
+            <Skeleton className="h-4 w-40 rounded-md" />
+            <View className="flex-1" />
+            <Skeleton className="h-3 w-20 rounded-sm" />
+          </View>
+          <Skeleton className="h-3 w-3/4 rounded-sm" />
+        </View>
+      ))}
+    </View>
+  )
+}
+
+export function SkillsSkeleton() {
+  return (
+    <View className="gap-3">
+      {[1, 2, 3].map((i) => (
+        <View key={i} className="border border-border rounded-lg p-3 gap-2">
+          <View className="flex-row items-center gap-2">
+            <Skeleton className="h-5 w-5 rounded-md" />
+            <Skeleton className="h-4 w-36 rounded-md" />
+          </View>
+          <Skeleton className="h-3 w-full rounded-sm" />
+          <Skeleton className="h-3 w-2/3 rounded-sm" />
+        </View>
+      ))}
+    </View>
+  )
+}
+
+export function StatusSkeleton() {
+  return (
+    <View className="gap-4">
+      {/* Stats row */}
+      <View className="flex-row flex-wrap gap-3">
+        {[1, 2, 3, 4].map((i) => (
+          <View key={i} className="flex-1 min-w-[100px] border border-border rounded-lg p-3 gap-2">
+            <View className="flex-row items-center gap-2">
+              <Skeleton className="h-4 w-4 rounded-md" />
+              <Skeleton className="h-3 w-16 rounded-sm" />
+            </View>
+            <Skeleton className="h-5 w-20 rounded-md" />
+          </View>
+        ))}
+      </View>
+      {/* Sections */}
+      {[1, 2].map((i) => (
+        <View key={i} className="border border-border rounded-lg p-3 gap-2">
+          <Skeleton className="h-4 w-28 rounded-md" />
+          <Skeleton className="h-3 w-full rounded-sm" />
+          <Skeleton className="h-3 w-3/4 rounded-sm" />
+        </View>
+      ))}
+    </View>
+  )
+}
+
+export function PlansSkeleton() {
+  return (
+    <View className="gap-2 p-4">
+      {[1, 2, 3].map((i) => (
+        <View key={i} className="border border-border rounded-lg px-4 py-3 gap-2">
+          <Skeleton className="h-4 w-48 rounded-md" />
+          <Skeleton className="h-3 w-full rounded-sm" />
+          <View className="flex-row items-center gap-2 mt-1">
+            <Skeleton className="h-3 w-16 rounded-sm" />
+            <Skeleton className="h-3 w-24 rounded-sm" />
+          </View>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+export function AgentsSkeleton() {
+  return (
+    <View className="p-4 gap-3">
+      {/* Tab bar placeholder */}
+      <View className="flex-row gap-2 mb-1">
+        {[1, 2, 3, 4].map((i) => (
+          <Skeleton key={i} className="h-7 w-20 rounded-md" />
+        ))}
+      </View>
+      {/* Activity cards */}
+      {[1, 2, 3].map((i) => (
+        <View key={i} className="border border-border rounded-lg p-3 gap-2">
+          <View className="flex-row items-center gap-2">
+            <Skeleton className="h-6 w-6 rounded-full" />
+            <Skeleton className="h-4 w-32 rounded-md" />
+            <View className="flex-1" />
+            <Skeleton className="h-3 w-12 rounded-sm" />
+          </View>
+          <Skeleton className="h-3 w-full rounded-sm" />
+          <Skeleton className="h-3 w-2/3 rounded-sm" />
+        </View>
+      ))}
+    </View>
+  )
+}
+
+export function LogsSkeleton() {
+  return (
+    <View className="flex-1 p-2 gap-0.5">
+      {[0.95, 0.7, 0.85, 0.6, 0.9, 0.75, 0.5, 0.8, 0.65, 0.88, 0.72, 0.55].map((w, i) => (
+        <View key={i} className="flex-row items-center gap-2 px-2 py-1">
+          <Skeleton className="h-3 w-14 rounded-sm" />
+          <Skeleton className="h-2.5 w-8 rounded-sm" />
+          <Skeleton className="h-3 rounded-sm" style={{ width: `${w * 60}%` }} />
+        </View>
+      ))}
+    </View>
+  )
+}
+
+export function CapabilitiesSkeleton() {
+  return (
+    <View className="p-4 gap-4">
+      {/* Model selector */}
+      <View className="border border-border rounded-lg p-3 gap-2">
+        <Skeleton className="h-4 w-24 rounded-md" />
+        <Skeleton className="h-10 w-full rounded-lg" />
+      </View>
+      {/* Toggle rows */}
+      {[1, 2, 3, 4, 5].map((i) => (
+        <View key={i} className="flex-row items-center justify-between py-2">
+          <View className="flex-row items-center gap-3">
+            <Skeleton className="h-5 w-5 rounded-md" />
+            <View className="gap-1">
+              <Skeleton className="h-4 w-28 rounded-md" />
+              <Skeleton className="h-3 w-44 rounded-sm" />
+            </View>
+          </View>
+          <Skeleton className="h-6 w-10 rounded-full" />
+        </View>
+      ))}
+    </View>
+  )
+}

--- a/apps/mobile/components/project/panels/PanelSkeletons.tsx
+++ b/apps/mobile/components/project/panels/PanelSkeletons.tsx
@@ -9,6 +9,24 @@ import { Skeleton } from '@shogo/shared-ui/primitives'
  * sees a stable shape while data loads (no layout shift).
  */
 
+/**
+ * A single skeleton "line" whose width is a fraction of `percent`.
+ * Shared by the skeleton variants that render a stack of varied-width
+ * bars (file tree, file content, logs) so the width-list -> bar mapping
+ * only needs to be written once.
+ */
+function SkeletonBar({
+  widthFraction,
+  percent = 60,
+  className = 'h-3 rounded-sm',
+}: {
+  widthFraction: number
+  percent?: number
+  className?: string
+}) {
+  return <Skeleton className={className} style={{ width: `${widthFraction * percent}%` }} />
+}
+
 export function ProjectShellSkeleton() {
   return (
     <View className="flex-1 bg-background">
@@ -52,7 +70,7 @@ export function FileTreeSkeleton() {
       {[1, 0.85, 0.7, 0.9, 0.6, 0.75, 0.8].map((w, i) => (
         <View key={i} className="flex-row items-center gap-2 py-1 pl-2">
           <Skeleton className="h-3 w-3 rounded-sm" />
-          <Skeleton className="h-3 rounded-sm" style={{ width: `${w * 60}%` }} />
+          <SkeletonBar widthFraction={w} />
         </View>
       ))}
     </View>
@@ -63,7 +81,7 @@ export function FileContentSkeleton() {
   return (
     <View className="flex-1 p-4 gap-2">
       {[0.9, 0.7, 0.85, 0.6, 0.95, 0.5, 0.8, 0.65, 0.75, 0.4].map((w, i) => (
-        <Skeleton key={i} className="h-3.5 rounded-sm" style={{ width: `${w * 100}%` }} />
+        <SkeletonBar key={i} widthFraction={w} percent={100} className="h-3.5 rounded-sm" />
       ))}
     </View>
   )
@@ -200,7 +218,7 @@ export function LogsSkeleton() {
         <View key={i} className="flex-row items-center gap-2 px-2 py-1">
           <Skeleton className="h-3 w-14 rounded-sm" />
           <Skeleton className="h-2.5 w-8 rounded-sm" />
-          <Skeleton className="h-3 rounded-sm" style={{ width: `${w * 60}%` }} />
+          <SkeletonBar widthFraction={w} />
         </View>
       ))}
     </View>

--- a/apps/mobile/components/project/panels/PlansPanel.tsx
+++ b/apps/mobile/components/project/panels/PlansPanel.tsx
@@ -34,6 +34,7 @@ import { agentFetch } from "../../../lib/agent-fetch"
 import { API_URL } from "../../../lib/api"
 import { DEFAULT_MODEL_PRO } from "../../chat/ChatInput"
 import type { PlanData } from "../../chat/PlanCard"
+import { PlansSkeleton } from "./PanelSkeletons"
 
 const PLAN_MODEL_GROUPS = getModelsByProvider().map((g) => ({
   label: g.label,
@@ -405,7 +406,7 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
         {/* Detail body */}
         <ScrollView className="flex-1 px-4 py-3" onScrollBeginDrag={() => setShowModelPicker(false)}>
           {!isStreamingDetail && detailLoading ? (
-            <ActivityIndicator className="mt-8" />
+            <PlansSkeleton />
           ) : (
             <>
               <MarkdownText>{body}</MarkdownText>
@@ -519,7 +520,7 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
         )}
 
         {loading && !planStream?.isPlanStreaming ? (
-          <ActivityIndicator className="mt-8" />
+          <PlansSkeleton />
         ) : filteredPlans.length === 0 && !planStream?.isPlanStreaming && !planStream?.streamingPlan ? (
           <View className="items-center justify-center py-12 px-4">
             <ClipboardList className="h-8 w-8 text-muted-foreground/40 mb-3" size={32} />

--- a/apps/mobile/components/project/panels/SkillsPanel.tsx
+++ b/apps/mobile/components/project/panels/SkillsPanel.tsx
@@ -5,6 +5,7 @@ import { View, Text, Pressable, ScrollView, ActivityIndicator, TextInput } from 
 import { Zap, RefreshCw, BookOpen, Download, Check, Trash2, Plus, ChevronDown, ChevronRight, Search, Globe, FileCode } from 'lucide-react-native'
 import { cn } from '@shogo/shared-ui/primitives'
 import { agentFetch } from '../../../lib/agent-fetch'
+import { SkillsSkeleton } from './PanelSkeletons'
 
 interface Skill {
   name: string
@@ -265,10 +266,7 @@ export function SkillsPanel({ projectId, agentUrl, visible }: SkillsPanelProps) 
 
       <ScrollView className="flex-1" contentContainerStyle={{ padding: 16 }}>
         {isLoading ? (
-          <View className="items-center py-8">
-            <ActivityIndicator size="small" />
-            <Text className="text-sm text-muted-foreground mt-2">Loading skills...</Text>
-          </View>
+          <SkillsSkeleton />
         ) : showLibrary ? (
           <View className="gap-3">
             {/* Library tabs */}

--- a/apps/mobile/components/project/panels/StatusPanel.tsx
+++ b/apps/mobile/components/project/panels/StatusPanel.tsx
@@ -27,6 +27,7 @@ import { agentFetch } from '../../../lib/agent-fetch'
 import { API_URL } from '../../../lib/api'
 import { usePlatformConfig } from '../../../lib/platform-config'
 import { MarkdownText } from '../../chat/MarkdownText'
+import { StatusSkeleton } from './PanelSkeletons'
 
 const CONTEXT_FILES = [
   { id: 'AGENTS.md', label: 'Agent' },
@@ -357,10 +358,7 @@ export function StatusPanel({ projectId, agentUrl, visible, isPaidPlan }: Status
       {/* Dashboard Content */}
       <ScrollView className="flex-1" contentContainerStyle={{ padding: 16 }}>
         {isLoading && !status ? (
-          <View className="items-center justify-center py-16 gap-3">
-            <ActivityIndicator size="large" />
-            <Text className="text-sm text-muted-foreground">Loading agent status...</Text>
-          </View>
+          <StatusSkeleton />
         ) : !status ? (
           <View className="items-center justify-center py-16 gap-4">
             <Activity size={32} className="text-muted-foreground" />


### PR DESCRIPTION
### Issue

Loading feedback in the project experience was inconsistent: the project shell used a full-screen `ActivityIndicator` and “Loading project…”, while many tool panels (Files, Channels, Checkpoints, Skills, Status, Plans) used plain centered spinners with little or no layout hint. That produced **blank or generic loading states**, **perceived jank** when real content replaced the spinner, and **inconsistent product feel** next to other screens (e.g. settings) that already use skeleton-style placeholders.

**Scope of this PR:** initial / list / detail **data-loading** states for the project layout and the listed panels. **Not** in scope: short **inline** spinners for user actions (connect, save, diff, etc.), or panels that are **fully real-time** with no fetch-based “first paint” (e.g. streaming-only views).

---

### Fix

- Introduced **`PanelSkeletons.tsx`**: a single module of **content-aware** skeletons built with the existing `Skeleton` primitive from `@shogo/shared-ui/primitives` (simple muted blocks that match each surface’s structure).
- Replaced **primary** `ActivityIndicator` + text (or empty spinners) with the matching skeleton in:
  - **Project route** `apps/mobile/app/(app)/projects/[id]/_layout.tsx` — `ProjectShellSkeleton` (top bar + chat column + canvas area) instead of a bare spinner.
  - **Files** — `FileTreeSkeleton` (tree) and `FileContentSkeleton` (editor body).
  - **Channels** — `ChannelsSkeleton` (stack of channel-card-shaped rows).
  - **Checkpoints** — `CheckpointsSkeleton`.
  - **Skills** — `SkillsSkeleton`.
  - **Status** (Monitor → Overview) — `StatusSkeleton` (stats grid + section blocks).
  - **Plans** — `PlansSkeleton` for both plan list load and plan detail load.
- **Kept** `ActivityIndicator` where a **small, inline** busy state is still the right pattern (e.g. connect/save/mutate, search-in-progress in files, diff loading in checkpoints, streaming indicators in plans).

---

### Summary (what changed, file by file)

| File | Change |
|------|--------|
| `apps/mobile/components/project/panels/PanelSkeletons.tsx` | **New.** Exports `ProjectShellSkeleton`, `FileTreeSkeleton`, `FileContentSkeleton`, `ChannelsSkeleton`, `CheckpointsSkeleton`, `SkillsSkeleton`, `StatusSkeleton`, `PlansSkeleton`, plus additional skeleton exports reserved for future use (`AgentsSkeleton`, `LogsSkeleton`, `CapabilitiesSkeleton`). |
| `apps/mobile/app/(app)/projects/[id]/_layout.tsx` | **Project load:** while `isLoading \|\| !project`, render `ProjectShellSkeleton` instead of centered `ActivityIndicator` + copy. |
| `FilesBrowserPanel.tsx` | **Tree load:** `FileTreeSkeleton`. **File content load:** `FileContentSkeleton`. Search spinner unchanged. |
| `ChannelsPanel.tsx` | **Initial channel list load** (empty list + loading): `ChannelsSkeleton`. |
| `CheckpointsPanel.tsx` | **Initial checkpoints load:** `CheckpointsSkeleton`. Inline mutating/diff spinners unchanged. |
| `SkillsPanel.tsx` | **Initial skills load:** `SkillsSkeleton`. Per-skill content expand spinner unchanged. |
| `StatusPanel.tsx` | **Initial agent status** (`isLoading && !status`): `StatusSkeleton`. Context subsection spinner unchanged. |
| `PlansPanel.tsx` | **Plan list** fetch while not streaming, and **plan detail** load: `PlansSkeleton`. Streaming / “researching” indicators kept as spinners where appropriate. |
