### PR TITLE
v1.5.0 prep — live Stripe IDs + port voice/tunnel to prod overlays

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -874,6 +874,9 @@ jobs:
           if [ -n "${{ secrets.SMTP_PASSWORD }}" ]; then SECRET_ARGS+=(--from-literal=SMTP_PASSWORD="${{ secrets.SMTP_PASSWORD }}"); fi
           if [ -n "${{ secrets.ELEVENLABS_API_KEY }}" ]; then SECRET_ARGS+=(--from-literal=ELEVENLABS_API_KEY="${{ secrets.ELEVENLABS_API_KEY }}"); fi
           if [ -n "${{ secrets.ELEVENLABS_VOICE_MODE_AGENT_ID }}" ]; then SECRET_ARGS+=(--from-literal=ELEVENLABS_VOICE_MODE_AGENT_ID="${{ secrets.ELEVENLABS_VOICE_MODE_AGENT_ID }}"); fi
+          if [ -n "${{ secrets.ELEVENLABS_WEBHOOK_SECRET }}" ]; then SECRET_ARGS+=(--from-literal=ELEVENLABS_WEBHOOK_SECRET="${{ secrets.ELEVENLABS_WEBHOOK_SECRET }}"); fi
+          if [ -n "${{ secrets.TWILIO_ACCOUNT_SID }}" ]; then SECRET_ARGS+=(--from-literal=TWILIO_ACCOUNT_SID="${{ secrets.TWILIO_ACCOUNT_SID }}"); fi
+          if [ -n "${{ secrets.TWILIO_AUTH_TOKEN }}" ]; then SECRET_ARGS+=(--from-literal=TWILIO_AUTH_TOKEN="${{ secrets.TWILIO_AUTH_TOKEN }}"); fi
 
           kubectl create secret generic api-secrets \
             --namespace=${{ env.NS_SYSTEM }} \
@@ -1121,6 +1124,9 @@ jobs:
           if [ -n "${{ secrets.SMTP_PASSWORD }}" ]; then SECRET_ARGS+=(--from-literal=SMTP_PASSWORD="${{ secrets.SMTP_PASSWORD }}"); fi
           if [ -n "${{ secrets.ELEVENLABS_API_KEY }}" ]; then SECRET_ARGS+=(--from-literal=ELEVENLABS_API_KEY="${{ secrets.ELEVENLABS_API_KEY }}"); fi
           if [ -n "${{ secrets.ELEVENLABS_VOICE_MODE_AGENT_ID }}" ]; then SECRET_ARGS+=(--from-literal=ELEVENLABS_VOICE_MODE_AGENT_ID="${{ secrets.ELEVENLABS_VOICE_MODE_AGENT_ID }}"); fi
+          if [ -n "${{ secrets.ELEVENLABS_WEBHOOK_SECRET }}" ]; then SECRET_ARGS+=(--from-literal=ELEVENLABS_WEBHOOK_SECRET="${{ secrets.ELEVENLABS_WEBHOOK_SECRET }}"); fi
+          if [ -n "${{ secrets.TWILIO_ACCOUNT_SID }}" ]; then SECRET_ARGS+=(--from-literal=TWILIO_ACCOUNT_SID="${{ secrets.TWILIO_ACCOUNT_SID }}"); fi
+          if [ -n "${{ secrets.TWILIO_AUTH_TOKEN }}" ]; then SECRET_ARGS+=(--from-literal=TWILIO_AUTH_TOKEN="${{ secrets.TWILIO_AUTH_TOKEN }}"); fi
 
           kubectl create secret generic api-secrets \
             --namespace=${{ env.NS_SYSTEM }} \
@@ -1359,6 +1365,9 @@ jobs:
           if [ -n "${{ secrets.SMTP_PASSWORD }}" ]; then SECRET_ARGS+=(--from-literal=SMTP_PASSWORD="${{ secrets.SMTP_PASSWORD }}"); fi
           if [ -n "${{ secrets.ELEVENLABS_API_KEY }}" ]; then SECRET_ARGS+=(--from-literal=ELEVENLABS_API_KEY="${{ secrets.ELEVENLABS_API_KEY }}"); fi
           if [ -n "${{ secrets.ELEVENLABS_VOICE_MODE_AGENT_ID }}" ]; then SECRET_ARGS+=(--from-literal=ELEVENLABS_VOICE_MODE_AGENT_ID="${{ secrets.ELEVENLABS_VOICE_MODE_AGENT_ID }}"); fi
+          if [ -n "${{ secrets.ELEVENLABS_WEBHOOK_SECRET }}" ]; then SECRET_ARGS+=(--from-literal=ELEVENLABS_WEBHOOK_SECRET="${{ secrets.ELEVENLABS_WEBHOOK_SECRET }}"); fi
+          if [ -n "${{ secrets.TWILIO_ACCOUNT_SID }}" ]; then SECRET_ARGS+=(--from-literal=TWILIO_ACCOUNT_SID="${{ secrets.TWILIO_ACCOUNT_SID }}"); fi
+          if [ -n "${{ secrets.TWILIO_AUTH_TOKEN }}" ]; then SECRET_ARGS+=(--from-literal=TWILIO_AUTH_TOKEN="${{ secrets.TWILIO_AUTH_TOKEN }}"); fi
 
           kubectl create secret generic api-secrets \
             --namespace=${{ env.NS_SYSTEM }} \

--- a/apps/api/scripts/update-stripe-product-copy.ts
+++ b/apps/api/scripts/update-stripe-product-copy.ts
@@ -75,6 +75,42 @@ const STAGING_PRICES: PriceCopy[] = [
   { id: 'price_1TRH5lAp5PDuxitpM51P3JNm', nickname: 'Business (annual per seat)',     lookupKey: 'shogo_business_annual_v2',  metadata: { plan: 'business', interval: 'annual',  included_usd_per_seat: '40', per_seat: 'true' } },
 ]
 
+const PRODUCTION_PRODUCTS: ProductCopy[] = [
+  {
+    id: 'prod_UD3pguoX3NJ9Q6',
+    name: 'Shogo Basic',
+    description: '$5 of monthly AI usage + $0.50/day. All usage billed at raw provider cost plus a flat 20% markup. Single user — no seats. No credits, no unit conversions.',
+    metadata: { plan: 'basic', included_usd: '5', per_seat: 'false', markup: '0.20' },
+  },
+  {
+    id: 'prod_U4QkVZtCUtKWOw',
+    name: 'Shogo Pro',
+    description: "Includes $20 of AI usage per seat per month. Every request billed at the AI provider's raw cost plus a flat 20% markup. Opt-in usage-based overage with a hard cap. No credits, no unit conversions.",
+    metadata: { plan: 'pro', included_usd_per_seat: '20', per_seat: 'true', markup: '0.20' },
+  },
+  {
+    id: 'prod_U4QkWE1XUGKOvb',
+    name: 'Shogo Business',
+    description: "Includes $40 of AI usage per seat per month. Team analytics, SSO, audit logs, per-member spending limits. Every request billed at the AI provider's raw cost plus a flat 20% markup. No credits, no unit conversions.",
+    metadata: { plan: 'business', included_usd_per_seat: '40', per_seat: 'true', markup: '0.20' },
+  },
+  {
+    id: 'prod_USCo7QeG0HkY8s',
+    name: 'Shogo Usage Overage',
+    description: "Metered overage beyond your plan's included monthly usage. Charged at provider cost + 20% with an optional hard cap.",
+    metadata: { purpose: 'usage_overage', currency: 'usd', markup: '0.20' },
+  },
+]
+
+const PRODUCTION_PRICES: PriceCopy[] = [
+  { id: 'price_1TEdi4ADDMNd95Ggym2MWpEQ', nickname: 'Basic (monthly)',                lookupKey: 'shogo_basic_monthly_v2',    metadata: { plan: 'basic',    interval: 'monthly', included_usd: '5',  per_seat: 'false' } },
+  { id: 'price_1TEdi6ADDMNd95GgYZaoUHiQ', nickname: 'Basic (annual)',                 lookupKey: 'shogo_basic_annual_v2',     metadata: { plan: 'basic',    interval: 'annual',  included_usd: '5',  per_seat: 'false' } },
+  { id: 'price_1TTIOfADDMNd95GgDyGQlaqH', nickname: 'Pro (monthly per seat)',         lookupKey: 'shogo_pro_monthly_v2',      metadata: { plan: 'pro',      interval: 'monthly', included_usd_per_seat: '20', per_seat: 'true' } },
+  { id: 'price_1TTIOgADDMNd95GgwQGlpBLa', nickname: 'Pro (annual per seat)',          lookupKey: 'shogo_pro_annual_v2',       metadata: { plan: 'pro',      interval: 'annual',  included_usd_per_seat: '20', per_seat: 'true' } },
+  { id: 'price_1TTIOgADDMNd95Gg5DgR006y', nickname: 'Business (monthly per seat)',    lookupKey: 'shogo_business_monthly_v2', metadata: { plan: 'business', interval: 'monthly', included_usd_per_seat: '40', per_seat: 'true' } },
+  { id: 'price_1TTIOhADDMNd95Gg6JaJzKzZ', nickname: 'Business (annual per seat)',     lookupKey: 'shogo_business_annual_v2',  metadata: { plan: 'business', interval: 'annual',  included_usd_per_seat: '40', per_seat: 'true' } },
+]
+
 interface Cli {
   env: 'staging' | 'production'
   dryRun: boolean
@@ -114,10 +150,6 @@ function shallowEqual(a: Record<string, string> | null, b: Record<string, string
 
 async function main() {
   const cli = parseArgs(process.argv.slice(2))
-  if (cli.env === 'production') {
-    console.error('Production support requires STRIPE_LIVE_* product IDs configured. Aborting.')
-    process.exit(1)
-  }
 
   const apiKey = process.env.STRIPE_SECRET_KEY
   if (!apiKey) {
@@ -128,10 +160,14 @@ async function main() {
     console.error(`Refusing to run --env staging with a non-test key (${apiKey.slice(0, 8)}...).`)
     process.exit(1)
   }
+  if (cli.env === 'production' && !apiKey.startsWith('sk_live_')) {
+    console.error(`Refusing to run --env production with a non-live key (${apiKey.slice(0, 8)}...).`)
+    process.exit(1)
+  }
 
   const stripe = new Stripe(apiKey, { apiVersion: '2025-09-30.clover' as Stripe.LatestApiVersion })
-  const products = STAGING_PRODUCTS
-  const prices = STAGING_PRICES
+  const products = cli.env === 'production' ? PRODUCTION_PRODUCTS : STAGING_PRODUCTS
+  const prices = cli.env === 'production' ? PRODUCTION_PRICES : STAGING_PRICES
 
   console.log(`[stripe-copy] Syncing ${products.length} products and ${prices.length} prices in ${cli.env}${cli.dryRun ? ' (dry-run)' : ''}`)
 

--- a/apps/api/src/config/STRIPE_PRODUCT_COPY.md
+++ b/apps/api/src/config/STRIPE_PRODUCT_COPY.md
@@ -95,7 +95,63 @@ Production overage IDs in [`stripe-prices.ts`](./stripe-prices.ts).
 
 ## Production product / price IDs
 
-To be filled in after the production rollout. The script in
+Created 2026-05-04 during v1.5.0 cutover. The script in
 [`scripts/update-stripe-product-copy.ts`](../../../scripts/update-stripe-product-copy.ts)
-keeps the descriptions / metadata in sync; price creation is a one-time CLI
-operation logged here for traceability.
+keeps descriptions / metadata in sync via `--env production`.
+
+### Products (live)
+
+| Product                | Live product ID         |
+|------------------------|-------------------------|
+| Shogo Basic            | `prod_UD3pguoX3NJ9Q6`   |
+| Shogo Pro              | `prod_U4QkVZtCUtKWOw`   |
+| Shogo Business         | `prod_U4QkWE1XUGKOvb`   |
+| Shogo Usage Overage    | `prod_USCo7QeG0HkY8s`   |
+
+Names/descriptions/metadata match the Staging entries above verbatim; see
+`PRODUCTION_PRODUCTS` in `update-stripe-product-copy.ts`.
+
+### Prices (live)
+
+| Lookup key                    | Interval | Amount       | Per-seat | Live price ID                      |
+|-------------------------------|----------|--------------|----------|------------------------------------|
+| `shogo_basic_monthly_v2`      | month    | $8           | no       | `price_1TEdi4ADDMNd95Ggym2MWpEQ`   |
+| `shogo_basic_annual_v2`       | year     | $80          | no       | `price_1TEdi6ADDMNd95GgYZaoUHiQ`   |
+| `shogo_pro_monthly_v2`        | month    | $20 / seat   | yes      | `price_1TTIOfADDMNd95GgDyGQlaqH`   |
+| `shogo_pro_annual_v2`         | year     | $200 / seat  | yes      | `price_1TTIOgADDMNd95GgwQGlpBLa`   |
+| `shogo_business_monthly_v2`   | month    | $40 / seat   | yes      | `price_1TTIOgADDMNd95Gg5DgR006y`   |
+| `shogo_business_annual_v2`    | year     | $400 / seat  | yes      | `price_1TTIOhADDMNd95Gg6JaJzKzZ`   |
+| `shogo_usage_overage_v2`      | month    | $0.01 / unit | metered  | `price_1TTIP5ADDMNd95GgJ1GcpCVA`   |
+
+### Overage meter (live)
+
+- **Meter ID**: `mtr_61UcgM4v14tWWuwy541ADDMNd95GgJ4K`
+- **Event name**: `usage_overage_cents`
+- **Aggregation**: `sum(value)`
+- **Customer mapping**: `stripe_customer_id` (by_id)
+- **Value key**: `value` (cents)
+
+### Webhook (live)
+
+- **Endpoint**: `we_1T6HtMADDMNd95GgEpGNhe9E` → `https://studio.shogo.ai/api/webhooks/stripe`
+- **Enabled events**: `checkout.session.completed`,
+  `customer.subscription.created` / `updated` / `deleted`,
+  `invoice.paid`, `invoice.payment_succeeded`, `invoice.payment_failed`.
+
+### Legacy tiered products (live, to be archived post-Gate-6)
+
+`prod_U4PiFWAdHOsky0` (Pro), `prod_U4PihLHhw2G8Yj` (Business),
+`prod_U4PiRLFfgYJJ55` (Pro 200), `prod_U4PirBUJxQJRgj` (Pro 400),
+`prod_U4PiN80MLzDUbg` (Pro 800), `prod_U4PiR64r0BJjod` (Pro 1200),
+`prod_U4Pi0eUcncLdKh` (Pro 2000), `prod_U4PirBUJxQJRgj` (Pro 3000),
+`prod_U4PiLCNTe6JNgj` (Pro 5000), `prod_U4Piw1WkrlG40V` (Pro 7500),
+`prod_U4PihnqSIYvPRf` (Pro 10000), `prod_U4PixtkUlMtb4A` (Business 200),
+`prod_U4PiRC1IEDH6Rv` (Business 400), `prod_U4PiLXq9KS2Eyt` (Business 800),
+`prod_U4PiRZDxrspdBC` (Business 1200), `prod_U4Piy4of19swNb` (Business 2000),
+`prod_U4PiXu214pRgxu` (Business 3000), `prod_U4Pi8w5ayDpDXP` (Business 5000),
+`prod_U4Pin0KJ8EGEVI` (Business 7500), `prod_U4PidR3QUrEzv5` (Business 10000),
+`prod_U4Piwjj7Zfb5Nv` (myproduct).
+
+Kept active until `apps/api/scripts/migrate-tier-subscriptions.ts` runs in
+Gate 6 and moves every subscriber off them. After verification, archive them
+so they don't appear in future Checkout sessions.

--- a/apps/api/src/config/stripe-prices.ts
+++ b/apps/api/src/config/stripe-prices.ts
@@ -50,20 +50,21 @@ export const STRIPE_PRICES_STAGING: StripePriceConfig = {
 
 /**
  * Production (Live) environment Stripe price IDs.
- * Filled in by the production rollout step.
+ * Created 2026-05-04 as part of the v1.5.0 rollout (see
+ * `scripts/gate1-stripe-setup` in the release notes).
  */
 export const STRIPE_PRICES_PRODUCTION: StripePriceConfig = {
   basic: {
-    monthly: "price_basic_monthly_live_TODO",
-    annual: "price_basic_annual_live_TODO",
+    monthly: "price_1TEdi4ADDMNd95Ggym2MWpEQ",
+    annual: "price_1TEdi6ADDMNd95GgYZaoUHiQ",
   },
   pro: {
-    monthly: "price_pro_monthly_per_seat_live_TODO",
-    annual: "price_pro_annual_per_seat_live_TODO",
+    monthly: "price_1TTIOfADDMNd95GgDyGQlaqH",
+    annual: "price_1TTIOgADDMNd95GgwQGlpBLa",
   },
   business: {
-    monthly: "price_business_monthly_per_seat_live_TODO",
-    annual: "price_business_annual_per_seat_live_TODO",
+    monthly: "price_1TTIOgADDMNd95Gg5DgR006y",
+    annual: "price_1TTIOhADDMNd95Gg6JaJzKzZ",
   },
 }
 
@@ -295,8 +296,8 @@ export const OVERAGE_PRICE_STAGING: OveragePriceConfig = {
 }
 
 export const OVERAGE_PRICE_PRODUCTION: OveragePriceConfig = {
-  priceId: "price_overage_usd_metered_live",
-  meterId: "mtr_overage_usd_live",
+  priceId: "price_1TTIP5ADDMNd95GgJ1GcpCVA",
+  meterId: "mtr_61UcgM4v14tWWuwy541ADDMNd95GgJ4K",
   meterEventName: "usage_overage_cents",
   unitsPerDollar: 100,
 }

--- a/k8s/overlays/production-eu/api-service.yaml
+++ b/k8s/overlays/production-eu/api-service.yaml
@@ -122,6 +122,12 @@ spec:
               value: "https://studio.shogo.ai"
             - name: ALLOWED_ORIGINS
               value: "https://studio.shogo.ai,https://eu.studio.shogo.ai,https://india.studio.shogo.ai"
+            # Public hostname the desktop should use for the on-demand
+            # tunnel WebSocket. Points at the regional EU api ksvc via
+            # api-tunnel-ingress.yaml so the WS Upgrade bypasses the
+            # DomainMapping loopback.
+            - name: SHOGO_TUNNEL_WS_URL
+              value: "wss://eu.tunnel.shogo.ai"
             - name: REDIS_URL
               value: "redis://redis-master.shogo-production-system:6379"
             - name: DATABASE_URL
@@ -229,6 +235,36 @@ spec:
                   name: api-secrets
                   key: GOOGLE_API_KEY
                   optional: true
+            - name: ELEVENLABS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: ELEVENLABS_API_KEY
+                  optional: true
+            - name: ELEVENLABS_VOICE_MODE_AGENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: ELEVENLABS_VOICE_MODE_AGENT_ID
+                  optional: true
+            - name: ELEVENLABS_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: ELEVENLABS_WEBHOOK_SECRET
+                  optional: true
+            - name: TWILIO_ACCOUNT_SID
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: TWILIO_ACCOUNT_SID
+                  optional: true
+            - name: TWILIO_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: TWILIO_AUTH_TOKEN
+                  optional: true
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "https://ingest.us.signoz.cloud:443"
             - name: OTEL_SERVICE_NAME
@@ -255,8 +291,10 @@ spec:
               value: "3600000"
             - name: PROMOTED_POD_GC_ENABLED
               value: "true"
+            # 30 min: aligns with prod-us, long enough to keep pods warm
+            # through multi-minute user think-time between chat turns.
             - name: PROMOTED_POD_IDLE_TIMEOUT_MS
-              value: "600000"
+              value: "1800000"
             - name: LOAD_TEST_SECRET
               valueFrom:
                 secretKeyRef:

--- a/k8s/overlays/production-eu/api-tunnel-ingress.yaml
+++ b/k8s/overlays/production-eu/api-tunnel-ingress.yaml
@@ -1,0 +1,59 @@
+# =============================================================================
+# Desktop Tunnel WebSocket Ingress — Production EU (Frankfurt)
+# =============================================================================
+# See k8s/overlays/staging/api-tunnel-ingress.yaml for the full rationale.
+#
+# Routes `eu.tunnel.shogo.ai` → the EU api ksvc revision pods' queue-proxy
+# port, bypassing the Knative DomainMapping that drops WebSocket Upgrade.
+#
+# The regional hostname is intentional: the desktop must reach the same
+# region whose API issued its heartbeat, so each region advertises its own
+# SHOGO_TUNNEL_WS_URL (see api-service.yaml). Cloudflare resolves
+# `eu.tunnel.shogo.ai` to the Frankfurt OCI LB only.
+# =============================================================================
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-tunnel-direct
+  namespace: shogo-production-system
+  labels:
+    app.kubernetes.io/part-of: shogo
+    app.kubernetes.io/component: instance-tunnel
+    environment: production
+    region: eu-frankfurt-1
+spec:
+  type: ClusterIP
+  selector:
+    serving.knative.dev/service: api
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8012
+      protocol: TCP
+---
+apiVersion: networking.internal.knative.dev/v1alpha1
+kind: Ingress
+metadata:
+  name: api-tunnel
+  namespace: shogo-production-system
+  annotations:
+    networking.knative.dev/ingress.class: kourier.ingress.networking.knative.dev
+  labels:
+    app.kubernetes.io/part-of: shogo
+    app.kubernetes.io/component: instance-tunnel
+    environment: production
+    region: eu-frankfurt-1
+spec:
+  httpOption: Enabled
+  rules:
+    - hosts:
+        - eu.tunnel.shogo.ai
+      visibility: ExternalIP
+      http:
+        paths:
+          - splits:
+              - serviceName: api-tunnel-direct
+                serviceNamespace: shogo-production-system
+                servicePort: 80
+                percent: 100

--- a/k8s/overlays/production-eu/kustomization.yaml
+++ b/k8s/overlays/production-eu/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - api-service.yaml
+  - api-tunnel-ingress.yaml
   - web-service.yaml
   - docs-service.yaml
 

--- a/k8s/overlays/production-india/api-service.yaml
+++ b/k8s/overlays/production-india/api-service.yaml
@@ -122,6 +122,12 @@ spec:
               value: "https://studio.shogo.ai"
             - name: ALLOWED_ORIGINS
               value: "https://studio.shogo.ai,https://eu.studio.shogo.ai,https://india.studio.shogo.ai"
+            # Public hostname the desktop should use for the on-demand
+            # tunnel WebSocket. Points at the regional India api ksvc via
+            # api-tunnel-ingress.yaml so the WS Upgrade bypasses the
+            # DomainMapping loopback.
+            - name: SHOGO_TUNNEL_WS_URL
+              value: "wss://india.tunnel.shogo.ai"
             - name: REDIS_URL
               value: "redis://redis-master.shogo-production-system:6379"
             - name: DATABASE_URL
@@ -229,6 +235,36 @@ spec:
                   name: api-secrets
                   key: GOOGLE_API_KEY
                   optional: true
+            - name: ELEVENLABS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: ELEVENLABS_API_KEY
+                  optional: true
+            - name: ELEVENLABS_VOICE_MODE_AGENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: ELEVENLABS_VOICE_MODE_AGENT_ID
+                  optional: true
+            - name: ELEVENLABS_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: ELEVENLABS_WEBHOOK_SECRET
+                  optional: true
+            - name: TWILIO_ACCOUNT_SID
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: TWILIO_ACCOUNT_SID
+                  optional: true
+            - name: TWILIO_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: TWILIO_AUTH_TOKEN
+                  optional: true
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "https://ingest.us.signoz.cloud:443"
             - name: OTEL_SERVICE_NAME
@@ -255,8 +291,10 @@ spec:
               value: "3600000"
             - name: PROMOTED_POD_GC_ENABLED
               value: "true"
+            # 30 min: aligns with prod-us/eu, long enough to keep pods warm
+            # through multi-minute user think-time between chat turns.
             - name: PROMOTED_POD_IDLE_TIMEOUT_MS
-              value: "600000"
+              value: "1800000"
             - name: LOAD_TEST_SECRET
               valueFrom:
                 secretKeyRef:

--- a/k8s/overlays/production-india/api-tunnel-ingress.yaml
+++ b/k8s/overlays/production-india/api-tunnel-ingress.yaml
@@ -1,0 +1,60 @@
+# =============================================================================
+# Desktop Tunnel WebSocket Ingress — Production India (Mumbai)
+# =============================================================================
+# See k8s/overlays/staging/api-tunnel-ingress.yaml for the full rationale.
+#
+# Routes `india.tunnel.shogo.ai` → the India api ksvc revision pods'
+# queue-proxy port, bypassing the Knative DomainMapping that drops
+# WebSocket Upgrade.
+#
+# The regional hostname is intentional: the desktop must reach the same
+# region whose API issued its heartbeat, so each region advertises its own
+# SHOGO_TUNNEL_WS_URL (see api-service.yaml). Cloudflare resolves
+# `india.tunnel.shogo.ai` to the Mumbai OCI LB only.
+# =============================================================================
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-tunnel-direct
+  namespace: shogo-production-system
+  labels:
+    app.kubernetes.io/part-of: shogo
+    app.kubernetes.io/component: instance-tunnel
+    environment: production
+    region: ap-mumbai-1
+spec:
+  type: ClusterIP
+  selector:
+    serving.knative.dev/service: api
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8012
+      protocol: TCP
+---
+apiVersion: networking.internal.knative.dev/v1alpha1
+kind: Ingress
+metadata:
+  name: api-tunnel
+  namespace: shogo-production-system
+  annotations:
+    networking.knative.dev/ingress.class: kourier.ingress.networking.knative.dev
+  labels:
+    app.kubernetes.io/part-of: shogo
+    app.kubernetes.io/component: instance-tunnel
+    environment: production
+    region: ap-mumbai-1
+spec:
+  httpOption: Enabled
+  rules:
+    - hosts:
+        - india.tunnel.shogo.ai
+      visibility: ExternalIP
+      http:
+        paths:
+          - splits:
+              - serviceName: api-tunnel-direct
+                serviceNamespace: shogo-production-system
+                servicePort: 80
+                percent: 100

--- a/k8s/overlays/production-india/kustomization.yaml
+++ b/k8s/overlays/production-india/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - api-service.yaml
+  - api-tunnel-ingress.yaml
   - web-service.yaml
   - docs-service.yaml
 

--- a/k8s/overlays/production-us/api-service.yaml
+++ b/k8s/overlays/production-us/api-service.yaml
@@ -120,6 +120,13 @@ spec:
               value: "https://studio.shogo.ai"
             - name: ALLOWED_ORIGINS
               value: "https://studio.shogo.ai,https://shogo.ai,https://eu.studio.shogo.ai,https://india.studio.shogo.ai"
+            # Public hostname the desktop should use for the on-demand
+            # tunnel WebSocket. Routed by api-tunnel-ingress.yaml directly
+            # to the api revision pod (no DomainMapping → no broken WS
+            # Upgrade hop). Heartbeat traffic stays on
+            # SHOGO_PUBLIC_API_URL above.
+            - name: SHOGO_TUNNEL_WS_URL
+              value: "wss://tunnel.shogo.ai"
             - name: REDIS_URL
               value: "redis://redis-master.shogo-production-system:6379"
             - name: DATABASE_URL
@@ -227,6 +234,36 @@ spec:
                   name: api-secrets
                   key: GOOGLE_API_KEY
                   optional: true
+            - name: ELEVENLABS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: ELEVENLABS_API_KEY
+                  optional: true
+            - name: ELEVENLABS_VOICE_MODE_AGENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: ELEVENLABS_VOICE_MODE_AGENT_ID
+                  optional: true
+            - name: ELEVENLABS_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: ELEVENLABS_WEBHOOK_SECRET
+                  optional: true
+            - name: TWILIO_ACCOUNT_SID
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: TWILIO_ACCOUNT_SID
+                  optional: true
+            - name: TWILIO_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: TWILIO_AUTH_TOKEN
+                  optional: true
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "https://ingest.us.signoz.cloud:443"
             - name: OTEL_SERVICE_NAME
@@ -253,8 +290,14 @@ spec:
               value: "3600000"
             - name: PROMOTED_POD_GC_ENABLED
               value: "true"
+            # 30 min: needs to be longer than typical user-think-time
+            # between chat turns. With 10 min users would idle out while
+            # reading/typing the next message and the next visit hit a
+            # cold start, which (combined with the activator's hardcoded
+            # 5-minute request timeout) was producing the
+            # `eof-without-turn-complete` log lines.
             - name: PROMOTED_POD_IDLE_TIMEOUT_MS
-              value: "600000"
+              value: "1800000"
             - name: LOAD_TEST_SECRET
               valueFrom:
                 secretKeyRef:

--- a/k8s/overlays/production-us/api-tunnel-ingress.yaml
+++ b/k8s/overlays/production-us/api-tunnel-ingress.yaml
@@ -1,0 +1,74 @@
+# =============================================================================
+# Desktop Tunnel WebSocket Ingress — Production US (Ashburn)
+# =============================================================================
+# See k8s/overlays/staging/api-tunnel-ingress.yaml for the full rationale.
+#
+# Short version: Knative DomainMapping wraps its KIngress in a `rewriteHost`
+# + ExternalName loopback that silently drops `Upgrade: websocket` (503 UC
+# after ~1s) because the upstream HTTP/2 cluster does not enable RFC 8441
+# extended-CONNECT. Plain HTTP works fine, hence the desktop heartbeat is
+# green but the remote-control WS upgrade stalls in "standby".
+#
+# Workaround: a non-DomainMapping public route, `tunnel.shogo.ai`, whose
+# KIngress points directly at a label-selector Service tracking the live
+# api ksvc revision pods on their queue-proxy port (8012). No rewriteHost,
+# no ExternalName — Kourier emits a normal Envoy upstream cluster that
+# happily passes the WS Upgrade.
+#
+# Routing chain:
+#   Cloudflare (TLS, shogo.ai cert)
+#     → OCI LoadBalancer (kourier:80/443)
+#     → Kourier external listener
+#     → Knative Ingress `api-tunnel`     (no DomainMapping, no rewriteHost)
+#     → Service `api-tunnel-direct`      (selector: serving.knative.dev/service=api)
+#     → api revision Pod  port 8012      (queue-proxy, then user container)
+#
+# Heartbeat / HTTP traffic is unchanged — it still flows through the
+# studio.shogo.ai DomainMapping.
+# =============================================================================
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-tunnel-direct
+  namespace: shogo-production-system
+  labels:
+    app.kubernetes.io/part-of: shogo
+    app.kubernetes.io/component: instance-tunnel
+    environment: production
+    region: us-ashburn-1
+spec:
+  type: ClusterIP
+  selector:
+    serving.knative.dev/service: api
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8012
+      protocol: TCP
+---
+apiVersion: networking.internal.knative.dev/v1alpha1
+kind: Ingress
+metadata:
+  name: api-tunnel
+  namespace: shogo-production-system
+  annotations:
+    networking.knative.dev/ingress.class: kourier.ingress.networking.knative.dev
+  labels:
+    app.kubernetes.io/part-of: shogo
+    app.kubernetes.io/component: instance-tunnel
+    environment: production
+    region: us-ashburn-1
+spec:
+  httpOption: Enabled
+  rules:
+    - hosts:
+        - tunnel.shogo.ai
+      visibility: ExternalIP
+      http:
+        paths:
+          - splits:
+              - serviceName: api-tunnel-direct
+                serviceNamespace: shogo-production-system
+                servicePort: 80
+                percent: 100

--- a/k8s/overlays/production-us/kustomization.yaml
+++ b/k8s/overlays/production-us/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - api-service.yaml
+  - api-tunnel-ingress.yaml
   - web-service.yaml
   - docs-service.yaml
 

--- a/scripts/rollback-credits-to-usd-migration.sql
+++ b/scripts/rollback-credits-to-usd-migration.sql
@@ -1,0 +1,131 @@
+-- ============================================================================
+-- Rollback: Credits -> USD (v1.5.0)
+-- ============================================================================
+-- INVERSE of prisma/migrations/20260424000000_credits_to_usd/migration.sql
+-- AND prisma/migrations/20260429210000_add_overage_billed_trust/migration.sql.
+--
+-- Run this ONLY if we need to revert the v1.5.0 code deploy AND the
+-- billing data must be readable by v1.4.3 again. Do NOT run if
+-- migrate-tier-subscriptions.ts has already executed — that changes live
+-- Stripe subscription items in ways that cannot be unwound by SQL.
+--
+-- Usage:
+--   psql "$DATABASE_URL" -f scripts/rollback-credits-to-usd-migration.sql
+--
+-- Behaviour:
+--   * Renames usage_wallets -> credit_ledgers and each new USD column back
+--     to the legacy credit-named column, dividing by 0.10 to restore the
+--     legacy credit count (inverse of the original conversion).
+--   * Drops the overage + metered-price columns added in 20260424000000 and
+--     20260429210000 (overageEnabled, overageHardLimitUsd,
+--     overageAccumulatedUsd, stripeMeteredItemId, overageBilledUsd).
+--   * Reverts usage_events.billedUsd -> creditCost and source -> creditSource
+--     (dividing by 0.10 to restore credit amounts). Drops rawUsd.
+--   * Renames UsageSource -> CreditSource. We cannot remove the 'overage'
+--     enum value in place in PostgreSQL, so we recreate the type.
+--   * Recreates billing_accounts.creditsBalance (defaults to 0 — data is
+--     NOT recoverable; legacy code allocates from CreditLedger anyway).
+--   * Reverts analytics_digests.totalSpendUsd -> totalCreditsUsed (dividing
+--     by 0.10).
+--
+-- Idempotency: this script uses IF EXISTS guards where possible, but
+-- running it twice is undefined. Take a backup first.
+-- ============================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. usage_events: revert USD columns to credit columns
+-- ---------------------------------------------------------------------------
+
+-- Convert billedUsd back to creditCost at the legacy $0.10 / credit rate.
+UPDATE "usage_events" SET "billedUsd" = "billedUsd" / 0.10;
+
+ALTER TABLE "usage_events" RENAME COLUMN "billedUsd" TO "creditCost";
+ALTER TABLE "usage_events" RENAME COLUMN "source"     TO "creditSource";
+ALTER TABLE "usage_events" DROP  COLUMN IF EXISTS "rawUsd";
+
+-- Recreate CreditSource enum without the 'overage' value and swap the column
+-- over. Cannot just rename UsageSource back because we need to drop the new
+-- 'overage' variant that v1.4.3 has no UPDATE path for.
+CREATE TYPE "CreditSource" AS ENUM ('daily', 'monthly');
+ALTER TABLE "usage_events"
+  ALTER COLUMN "creditSource" TYPE "CreditSource"
+  USING (
+    CASE "creditSource"::text
+      WHEN 'overage' THEN 'monthly'::"CreditSource"
+      ELSE "creditSource"::text::"CreditSource"
+    END
+  );
+
+DROP TYPE "UsageSource";
+
+-- ---------------------------------------------------------------------------
+-- 2. usage_wallets: drop new columns and rename back to credit_ledgers
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE "usage_wallets" DROP COLUMN IF EXISTS "overageBilledUsd";
+ALTER TABLE "usage_wallets" DROP COLUMN IF EXISTS "stripeMeteredItemId";
+ALTER TABLE "usage_wallets" DROP COLUMN IF EXISTS "overageAccumulatedUsd";
+ALTER TABLE "usage_wallets" DROP COLUMN IF EXISTS "overageHardLimitUsd";
+ALTER TABLE "usage_wallets" DROP COLUMN IF EXISTS "overageEnabled";
+
+-- Invert the USD conversion back to credits.
+UPDATE "usage_wallets" SET
+  "monthlyIncludedUsd"            = "monthlyIncludedUsd" / 0.10,
+  "dailyIncludedUsd"              = "dailyIncludedUsd" / 0.10,
+  "monthlyIncludedAllocationUsd"  = "monthlyIncludedAllocationUsd" / 0.10,
+  "dailyUsedThisMonthUsd"         = "dailyUsedThisMonthUsd" / 0.10;
+
+ALTER TABLE "usage_wallets" RENAME COLUMN "monthlyIncludedUsd"           TO "monthlyCredits";
+ALTER TABLE "usage_wallets" RENAME COLUMN "dailyIncludedUsd"             TO "dailyCredits";
+ALTER TABLE "usage_wallets" RENAME COLUMN "monthlyIncludedAllocationUsd" TO "monthlyAllocation";
+ALTER TABLE "usage_wallets" RENAME COLUMN "dailyUsedThisMonthUsd"        TO "dailyCreditsDispensedThisMonth";
+
+ALTER TABLE "usage_wallets" RENAME TO "credit_ledgers";
+
+-- ---------------------------------------------------------------------------
+-- 3. billing_accounts.creditsBalance — recreate (data is lost)
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE "billing_accounts" ADD COLUMN "creditsBalance" DOUBLE PRECISION NOT NULL DEFAULT 0;
+
+-- ---------------------------------------------------------------------------
+-- 4. analytics_digests: totalSpendUsd -> totalCreditsUsed
+-- ---------------------------------------------------------------------------
+
+UPDATE "analytics_digests" SET "totalSpendUsd" = "totalSpendUsd" / 0.10;
+ALTER TABLE "analytics_digests" RENAME COLUMN "totalSpendUsd" TO "totalCreditsUsed";
+
+-- ---------------------------------------------------------------------------
+-- 5. Prisma _prisma_migrations: delete the three billing migration rows
+--    so re-deploying v1.5.0 will re-run them cleanly.
+-- ---------------------------------------------------------------------------
+
+DELETE FROM "_prisma_migrations" WHERE "migration_name" IN (
+  '20260424000000_credits_to_usd',
+  '20260428210000_add_subscription_seats',
+  '20260429210000_add_overage_billed_trust'
+);
+
+-- ---------------------------------------------------------------------------
+-- 6. subscriptions: drop the seats column
+-- ---------------------------------------------------------------------------
+-- Safe to drop: legacy code doesn't reference it and the v1.4.3 Stripe
+-- subscription items still carry the quantity, so no data is lost that
+-- the old code could have used.
+
+ALTER TABLE "subscriptions" DROP COLUMN IF EXISTS "seats";
+
+COMMIT;
+
+-- ============================================================================
+-- Verification
+-- ============================================================================
+-- After running, expected state:
+--   \d credit_ledgers    -- table exists with monthlyCredits, dailyCredits
+--   \d usage_events      -- has creditCost + creditSource columns, no rawUsd
+--   \d billing_accounts  -- has creditsBalance column (default 0)
+--   \d subscriptions     -- no seats column
+--   \dT                  -- CreditSource enum exists, no UsageSource
+-- ============================================================================

--- a/terraform/environments/production-global/main.tf
+++ b/terraform/environments/production-global/main.tf
@@ -166,6 +166,40 @@ resource "cloudflare_record" "india_studio" {
 }
 
 # =============================================================================
+# Desktop Tunnel WebSocket — regional A records (NOT load-balanced)
+# =============================================================================
+# The desktop tunnel WebSocket must stay in the same region whose API
+# issued its heartbeat, so each region gets a direct A record to its own
+# OCI LB. Cloudflare proxying is kept on for TLS termination + WS
+# passthrough; the Knative Ingress (api-tunnel) inside each cluster routes
+# to the api revision pods' queue-proxy port 8012 and bypasses the
+# DomainMapping loopback that drops WS Upgrade.
+
+resource "cloudflare_record" "us_tunnel" {
+  zone_id = var.cloudflare_zone_id
+  name    = "tunnel"
+  content = var.us_lb_ip
+  type    = "A"
+  proxied = true
+}
+
+resource "cloudflare_record" "eu_tunnel" {
+  zone_id = var.cloudflare_zone_id
+  name    = "eu.tunnel"
+  content = var.eu_lb_ip
+  type    = "A"
+  proxied = true
+}
+
+resource "cloudflare_record" "india_tunnel" {
+  zone_id = var.cloudflare_zone_id
+  name    = "india.tunnel"
+  content = var.india_lb_ip
+  type    = "A"
+  proxied = true
+}
+
+# =============================================================================
 # Outputs
 # =============================================================================
 
@@ -173,6 +207,9 @@ output "studio_lb_id" { value = cloudflare_load_balancer.studio.id }
 output "docs_lb_id"   { value = cloudflare_load_balancer.docs.id }
 output "eu_studio_record" { value = cloudflare_record.eu_studio.hostname }
 output "india_studio_record" { value = cloudflare_record.india_studio.hostname }
+output "us_tunnel_record"    { value = cloudflare_record.us_tunnel.hostname }
+output "eu_tunnel_record"    { value = cloudflare_record.eu_tunnel.hostname }
+output "india_tunnel_record" { value = cloudflare_record.india_tunnel.hostname }
 output "pool_ids" {
   value = {
     us = cloudflare_load_balancer_pool.us.id


### PR DESCRIPTION
## Summary

Gate 2 of the v1.5.0 cutover (credits → USD + per-seat + metered overage). Everything that has to land before the `v1.5.0` tag fires `deploy.yml`.

- **Stripe (live)**: paste the 6 per-seat price IDs + overage price/meter from Gate 1 into `stripe-prices.ts`; add `PRODUCTION_PRODUCTS`/`PRODUCTION_PRICES` arrays to `update-stripe-product-copy.ts` so it can sync Dashboard copy with a live key; record live IDs + webhook + legacy-product list in `STRIPE_PRODUCT_COPY.md`.
- **Voice + desktop tunnel in all 3 prod regions**: port the staging overlay changes that have been baking for a week — `SHOGO_TUNNEL_WS_URL` (region-specific), `ELEVENLABS_*` + `TWILIO_*` env refs, `PROMOTED_POD_IDLE_TIMEOUT_MS` 10m→30m. New `api-tunnel-ingress.yaml` per region + kustomization wiring so WS Upgrade bypasses the DomainMapping that drops it.
- **CI secrets**: `deploy.yml` production blocks now propagate `ELEVENLABS_WEBHOOK_SECRET` + `TWILIO_ACCOUNT_SID` + `TWILIO_AUTH_TOKEN`. Values already pushed to `production-us/eu/india` GH Actions envs.
- **DNS**: add `tunnel.shogo.ai` / `eu.tunnel.shogo.ai` / `india.tunnel.shogo.ai` regional A records to `production-global` terraform.
- **Safety net**: `scripts/rollback-credits-to-usd-migration.sql` inverts the 3 billing migrations in case we need to revert.

## Test plan

- [x] `bun tsc --noEmit` in `apps/api` — no new errors in touched files
- [x] `bun test src/__tests__/billing-service.test.ts` — 31 pass / 0 fail / 108 expect() calls
- [x] All 9 changed/new YAMLs parse (`python3 -c "yaml.safe_load_all(...)"`)
- [x] Stripe CLI verified all 7 live lookup keys, meter, and webhook event subscription (Gate 1)
- [ ] `terraform apply` in `production-global/` to create the 3 tunnel A records (pre-tag)
- [ ] `update-stripe-product-copy.ts --env production` (post-merge, pre-tag)
- [ ] Canary `migrate-tier-subscriptions.ts` on internal workspace (Gate 6)

Made with [Cursor](https://cursor.com)