### PR TITLE
test(e2e): fix v1.5.0 UI drift — home composer + API keys accordion + pricing (PR 1/5)

### DIFF
--- a/e2e/staging/billing-upgrade.test.ts
+++ b/e2e/staging/billing-upgrade.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page } from "@playwright/test"
-import { makeTestUser, signUpAndOnboard } from "./helpers"
+import { homeComposerInput, makeTestUser, signUpAndOnboard } from "./helpers"
 
 /**
  * Billing & Upgrade Flow E2E Tests (USD pricing)
@@ -100,15 +100,22 @@ test.describe("Billing & Upgrade Flow", () => {
     ).toBeVisible()
   })
 
-  test("free plan: three pricing tiers displayed", async () => {
+  test("free plan: per-seat pricing tiers displayed (v1.5.0 USD)", async () => {
     await navigateToBilling(page)
 
+    // v1.5.0 pricing: Basic $8/mo, Pro $20/seat, Business $40/seat, Enterprise custom.
+    // Source: apps/mobile/app/(app)/billing.tsx → PLAN_PRICING.
+    await expect(page.getByText("Basic", { exact: true }).first()).toBeVisible()
     await expect(page.getByText("Pro").first()).toBeVisible()
-    await expect(page.getByText("$25")).toBeVisible()
     await expect(page.getByText("Business", { exact: true }).first()).toBeVisible()
-    await expect(page.getByText("$365")).toBeVisible()
     await expect(page.getByText("Enterprise", { exact: true }).first()).toBeVisible()
     await expect(page.getByText("Custom", { exact: true })).toBeVisible()
+    // The per-seat dollar labels appear on each plan card; each tier
+    // exposes its price in a "$X/seat" or "$X" badge.
+    await expect(page.getByText("$8").first()).toBeVisible()
+    await expect(page.getByText("$20").first()).toBeVisible()
+    await expect(page.getByText("$40").first()).toBeVisible()
+    await expect(page.getByText(/\/seat/).first()).toBeVisible()
   })
 
   // ── Phase 3: Stripe Checkout (Reach-Only) ────────────────────────
@@ -130,7 +137,9 @@ test.describe("Billing & Upgrade Flow", () => {
     expect(page.url()).toContain("checkout.stripe.com")
 
     await expect(page.getByText("Subscribe to Pro")).toBeVisible({ timeout: 15_000 })
-    await expect(page.getByText("$25.00")).toBeVisible()
+    // v1.5.0: Pro is $20/seat/month. The exact label on Stripe Checkout
+    // is "$20.00 per seat / month" so a partial "$20.00" match is enough.
+    await expect(page.getByText("$20.00")).toBeVisible()
   })
 
   // ── Phase 4: Post-Upgrade UI (skipped) ───────────────────────────
@@ -182,7 +191,7 @@ test.describe("Billing & Upgrade Flow", () => {
     await page.goto("/")
     await page.waitForSelector("text=What's on your mind", { timeout: 10_000 })
 
-    const input = page.getByPlaceholder("Ask Shogo to ...")
+    const input = homeComposerInput(page)
     await input.click()
     await input.fill("Test model gating for Pro plan")
     await page.waitForTimeout(500)

--- a/e2e/staging/chat-file-upload.test.ts
+++ b/e2e/staging/chat-file-upload.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page } from "@playwright/test"
-import { makeTestUser, signUpAndOnboard } from "./helpers"
+import { homeComposerInput, makeTestUser, signUpAndOnboard } from "./helpers"
 import * as path from "path"
 import * as fs from "fs"
 import * as os from "os"
@@ -41,7 +41,7 @@ async function createProjectAndWait(page: Page, prompt: string) {
   await page.goto("/")
   await page.waitForSelector("text=What's on your mind", { timeout: 15_000 })
 
-  const input = page.getByPlaceholder("Ask Shogo to ...")
+  const input = homeComposerInput(page)
   await input.click()
   await input.fill(prompt)
   await page.waitForTimeout(500)

--- a/e2e/staging/composio-cloud-proxy.test.ts
+++ b/e2e/staging/composio-cloud-proxy.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page, type APIRequestContext } from "@playwright/test"
-import { makeTestUser, signUpAndOnboard } from "./helpers"
+import { expandManualApiKeys, homeComposerInput, makeTestUser, signUpAndOnboard } from "./helpers"
 
 /**
  * API Key Feature — Full E2E Tests
@@ -102,7 +102,9 @@ test.describe("API Key Feature — Full E2E", () => {
     }).catch(() => {})
     await page.waitForTimeout(500)
 
-    // Click "Create Key" button
+    // v1.5.0: "Create Key" lives behind the "Manual API keys" accordion on /api-keys
+    await expandManualApiKeys(page)
+
     const createBtn = page.getByText("Create Key").first()
     await createBtn.waitFor({ state: "visible", timeout: 10_000 })
     await createBtn.click()
@@ -188,7 +190,7 @@ test.describe("API Key Feature — Full E2E", () => {
     await page.goto("/")
     await page.waitForSelector("text=What's on your mind", { timeout: 15_000 })
 
-    const input = page.getByPlaceholder("Ask Shogo to ...")
+    const input = homeComposerInput(page)
     await input.click()
     await input.fill("Test project for API key E2E")
     await page.waitForTimeout(500)

--- a/e2e/staging/composio-integrations.test.ts
+++ b/e2e/staging/composio-integrations.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect } from "@playwright/test"
-import { makeTestUser, signUpAndOnboard } from "./helpers"
+import { homeComposerInput, makeTestUser, signUpAndOnboard } from "./helpers"
 
 /**
  * Composio Integration E2E Tests
@@ -50,7 +50,7 @@ test.describe("Composio Integrations", () => {
   })
 
   test("MCP catalog includes composio authType fields", async () => {
-    const input = page.getByPlaceholder("Ask Shogo to ...")
+    const input = homeComposerInput(page)
     await input.click()
     await input.fill("Test composio integrations")
     await page.waitForTimeout(500)

--- a/e2e/staging/helpers.ts
+++ b/e2e/staging/helpers.ts
@@ -152,6 +152,31 @@ export async function signUpAndOnboardWithAppTemplate(
  *
  * Leaves the browser on the app after the Stripe redirect.
  */
+// ── API Keys page helpers ────────────────────────────────────────────────────
+
+/**
+ * The `/api-keys` page was redesigned in v1.5.0: the "Devices" section is
+ * primary, and manual workspace API keys live behind a collapsed
+ * `"Manual API keys (N) · advanced"` accordion. Tests that need to create
+ * a manual key must expand the accordion first.
+ *
+ * See apps/mobile/app/(app)/api-keys.tsx — the `showManualKeys` state.
+ */
+export async function expandManualApiKeys(page: Page) {
+  const toggle = page.getByRole("button", { name: /Manual API keys/ })
+  await toggle.waitFor({ state: "visible", timeout: 10_000 })
+  // Avoid re-collapsing if the accordion is already open.
+  const expanded = await toggle.getAttribute("aria-expanded").catch(() => null)
+  if (expanded !== "true") {
+    await toggle.click()
+  }
+  // "Create Key" only renders after the accordion animates open.
+  await page
+    .getByText("Create Key")
+    .first()
+    .waitFor({ state: "visible", timeout: 10_000 })
+}
+
 // ── Interaction mode helpers ─────────────────────────────────────────────────
 
 export async function selectInteractionMode(page: Page, mode: "Agent" | "Plan" | "Ask") {
@@ -194,8 +219,24 @@ export async function selectInteractionMode(page: Page, mode: "Agent" | "Plan" |
   await page.waitForTimeout(300)
 }
 
+/**
+ * The home composer uses an animated typewriter placeholder
+ * (`"Ask Shogo to " + rotating suggestion`), so the old
+ * `getByPlaceholder("Ask Shogo to ...")` selector never matches.
+ * `CompactChatInput` renders a stable `accessibilityLabel` we can target
+ * regardless of interaction mode and placeholder churn.
+ *
+ * See apps/mobile/components/chat/CompactChatInput.tsx — the TextInput
+ * label "Describe the agent you want to build".
+ */
+export function homeComposerInput(page: Page) {
+  return page.getByRole("textbox", {
+    name: "Describe the agent you want to build",
+  })
+}
+
 export async function sendChatMessage(page: Page, text: string) {
-  const chatInput = page.getByPlaceholder(/Ask Shogo|Describe what|Ask a question/)
+  const chatInput = homeComposerInput(page)
   await chatInput.click()
   await chatInput.fill(text)
   await page.waitForTimeout(300)
@@ -221,7 +262,7 @@ export async function createProjectAndWait(page: Page, prompt: string) {
   await page.goto("/")
   await page.waitForSelector("text=What's on your mind", { timeout: 15_000 })
 
-  const input = page.getByPlaceholder("Ask Shogo to ...")
+  const input = homeComposerInput(page)
   await input.click()
   await input.fill(prompt)
   await page.waitForTimeout(500)

--- a/e2e/staging/pro-feature-gating.test.ts
+++ b/e2e/staging/pro-feature-gating.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page } from "@playwright/test"
-import { makeTestUser, signUpAndUpgradeToPro } from "./helpers"
+import { homeComposerInput, makeTestUser, signUpAndUpgradeToPro } from "./helpers"
 
 /**
  * Pro Feature Gating E2E Tests
@@ -63,7 +63,7 @@ test.describe("Pro Feature Gating", () => {
     await page.goto("/")
     await page.waitForSelector("text=What's on your mind", { timeout: 15_000 })
 
-    const input = page.getByPlaceholder("Ask Shogo to ...")
+    const input = homeComposerInput(page)
     await input.click()
     await input.fill("Test model gating")
     await page.waitForTimeout(500)

--- a/e2e/staging/remote-control.test.ts
+++ b/e2e/staging/remote-control.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page, type APIRequestContext } from "@playwright/test"
-import { makeTestUser, signUpAndOnboard } from "./helpers"
+import { expandManualApiKeys, makeTestUser, signUpAndOnboard } from "./helpers"
 
 /**
  * Remote Control — E2E Tests
@@ -82,6 +82,9 @@ test.describe("Remote Control — E2E", () => {
       .waitForSelector("text=Loading API keys...", { state: "hidden", timeout: 15_000 })
       .catch(() => {})
     await page.waitForTimeout(500)
+
+    // v1.5.0: "Create Key" lives behind the "Manual API keys" accordion on /api-keys
+    await expandManualApiKeys(page)
 
     const createBtn = page.getByText("Create Key").first()
     await createBtn.waitFor({ state: "visible", timeout: 10_000 })

--- a/e2e/staging/streaming-latency.test.ts
+++ b/e2e/staging/streaming-latency.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page, type APIRequestContext } from "@playwright/test"
-import { makeTestUser, signUpAndOnboard } from "./helpers"
+import { expandManualApiKeys, makeTestUser, signUpAndOnboard } from "./helpers"
 
 /**
  * Streaming Relay Latency — E2E Tests
@@ -143,6 +143,9 @@ test.describe("Streaming Relay Latency — E2E", () => {
       .waitForSelector("text=Loading API keys...", { state: "hidden", timeout: 15_000 })
       .catch(() => {})
     await page.waitForTimeout(500)
+
+    // v1.5.0: "Create Key" lives behind the "Manual API keys" accordion on /api-keys
+    await expandManualApiKeys(page)
 
     const createBtn = page.getByText("Create Key").first()
     await createBtn.waitFor({ state: "visible", timeout: 10_000 })

--- a/e2e/staging/usage-tracking.test.ts
+++ b/e2e/staging/usage-tracking.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page } from "@playwright/test"
-import { makeTestUser, signUpAndUpgradeToPro } from "./helpers"
+import { homeComposerInput, makeTestUser, signUpAndUpgradeToPro } from "./helpers"
 
 /**
  * Usage Tracking E2E Tests (USD pricing)
@@ -58,7 +58,7 @@ test.describe("Usage Tracking", () => {
     await page.goto("/")
     await page.waitForSelector("text=What's on your mind", { timeout: 10_000 })
 
-    const input = page.getByPlaceholder("Ask Shogo to ...")
+    const input = homeComposerInput(page)
     await input.click()
     await input.fill("Quick usage tracking test")
     await page.waitForTimeout(500)


### PR DESCRIPTION
## Summary

First of a 5-PR stack that fixes the hosted-env Playwright suite
(\`e2e/staging/\`) after the v1.5.0 release.

Running \`STAGING_URL=https://studio.shogo.ai bun run test:e2e:staging\`
against prod reported **5 passed / 10 failed / 10 skipped / 85 did-not-run** —
every single non-expected failure traced back to a UI change that shipped
in v1.5.0 without a matching test update.

This PR is **test code only** — no app-side changes.

### What changed

1. **Home composer animated placeholder** (unblocks 6 tests)
   The composer now uses a typewriter placeholder (\`Ask Shogo to \` +
   rotating suggestion), so \`getByPlaceholder("Ask Shogo to ...")\`
   never matches. \`CompactChatInput\` already renders a stable
   \`accessibilityLabel="Describe the agent you want to build"\`, so
   a new \`homeComposerInput(page)\` helper targets that instead.
2. **API Keys page redesign** (unblocks 3 tests)
   \`/api-keys\` was rebuilt in v1.5.0: "Devices" is primary, manual
   workspace API keys live behind a collapsed \`Manual API keys (N) ·
   advanced\` accordion. New \`expandManualApiKeys(page)\` helper clicks
   the accordion before looking for the \"Create Key\" button. Called
   from \`composio-cloud-proxy\`, \`remote-control\`, \`streaming-latency\`.
3. **v1.5.0 pricing assertions** (unblocks 1 test + 1 skipped case)
   - \`billing-upgrade\`: \`three pricing tiers displayed\` → renamed to
     \"per-seat pricing tiers displayed (v1.5.0 USD)\", asserts Basic
     \$8, Pro \$20, Business \$40, plus \`/seat\` copy.
   - \`billing-upgrade\`: Stripe Checkout \"\$25.00\" → \"\$20.00\".

### Why not app-side changes

PR 2 adds \`testID\`s to the home composer, api-keys page, and billing
plan cards so we never have to chase copy changes again. This PR keeps
the blast radius small — test code only, revertable in one click.

## Expected impact

Runs \`STAGING_URL=https://studio.shogo.ai bun run test:e2e:staging\`
should jump from ~5/110 to ~80/110 passing. The remaining ~20 are
either \`test.skip()\`d upstream (post-Stripe-checkout payment flows)
or the two test-card-vs-live-Stripe tests fixed in PR 3.

## Test plan

- [ ] \`STAGING_URL=https://studio.staging.shogo.ai bun run test:e2e:staging\` — should be green.
- [ ] \`STAGING_URL=https://studio.shogo.ai bun run test:e2e:staging\` — should be ~80 passing, only Stripe-live-card + 10 pre-skipped tests remaining.
- [ ] \`bun run typecheck\` + \`bun run lint\` stay green.

## Follow-ups (in-stack)

- PR 2 — add \`testID\`s in the app + switch tests to \`getByTestId\`
- PR 3 — env-aware skip for Stripe-test-card flow when target is live prod
- PR 4 — move local-mode test out of \`e2e/staging/\`, rename \`STAGING_URL\` → \`E2E_TARGET_URL\`, add nightly CI + cleanup script
- PR 5 — API-side e2e subscription bootstrap backdoor (gated)

Made with [Cursor](https://cursor.com)