### PR TITLE
test(e2e): stable testIDs on composer, API keys, plan cards (PR 2/5)

### DIFF
--- a/apps/mobile/app/(app)/api-keys.tsx
+++ b/apps/mobile/app/(app)/api-keys.tsx
@@ -279,6 +279,7 @@ export default observer(function ApiKeysPage() {
 
         {/* Manual API keys (advanced) */}
         <Pressable
+          testID="manual-api-keys-toggle"
           onPress={() => setShowManualKeys((v) => !v)}
           className="flex-row items-center gap-2 mb-3 py-1"
           accessibilityRole="button"
@@ -304,7 +305,11 @@ export default observer(function ApiKeysPage() {
               sign in via the desktop app instead.
             </Text>
             <View className="flex-row justify-end mb-3">
-              <Button size="sm" onPress={() => setShowCreateModal(true)}>
+              <Button
+                size="sm"
+                testID="create-api-key-btn"
+                onPress={() => setShowCreateModal(true)}
+              >
                 <View className="flex-row items-center gap-1.5">
                   <Plus size={14} color="#fff" />
                   <Text className="text-sm font-medium text-primary-foreground">Create Key</Text>
@@ -465,6 +470,7 @@ export default observer(function ApiKeysPage() {
                     Cancel
                   </Button>
                   <Button
+                    testID="create-api-key-submit"
                     onPress={handleCreate}
                     disabled={isCreating || !newKeyName.trim()}
                     className="flex-1"

--- a/apps/mobile/app/(app)/billing.tsx
+++ b/apps/mobile/app/(app)/billing.tsx
@@ -413,9 +413,9 @@ export default observer(function BillingPage() {
       </View>
 
       {/* Plan Cards — md row: equal-height columns; tier slot reserves space so CTAs align */}
-      <View className="gap-6 md:flex-row md:items-stretch">
+      <View className="gap-6 md:flex-row md:items-stretch" testID="plan-cards-row">
         {/* Basic Plan */}
-        <View className="md:flex-1 md:w-0 flex flex-col">
+        <View className="md:flex-1 md:w-0 flex flex-col" testID="plan-card-basic">
           <View className="hidden md:block md:min-h-8" />
           <Card className="md:flex-1 flex flex-col">
             <CardContent className="md:flex-1 flex flex-col p-5 gap-5">
@@ -469,7 +469,7 @@ export default observer(function BillingPage() {
         </View>
 
         {/* Pro Plan */}
-        <View className="md:flex-1 md:w-0 flex flex-col">
+        <View className="md:flex-1 md:w-0 flex flex-col" testID="plan-card-pro">
           <View className="hidden md:block md:min-h-8" />
           <Card className="md:flex-1 flex flex-col">
             <CardContent className="md:flex-1 flex flex-col p-5 gap-5">
@@ -535,7 +535,7 @@ export default observer(function BillingPage() {
         </View>
 
         {/* Business Plan */}
-        <View className="md:flex-1 md:w-0 flex flex-col">
+        <View className="md:flex-1 md:w-0 flex flex-col" testID="plan-card-business">
           <View className="min-h-8 items-center justify-center px-1">
             <Badge className="bg-primary">
               <Text className="text-xs text-primary-foreground font-medium">Most Popular</Text>
@@ -602,7 +602,7 @@ export default observer(function BillingPage() {
         </View>
 
         {/* Enterprise Plan */}
-        <View className="md:flex-1 md:w-0 flex flex-col">
+        <View className="md:flex-1 md:w-0 flex flex-col" testID="plan-card-enterprise">
           <View className="hidden md:block md:min-h-8" />
           <Card className="md:flex-1 flex flex-col">
             <CardContent className="md:flex-1 flex flex-col p-5 gap-5">

--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -553,6 +553,7 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
 
           <TextInput
             ref={textInputRef}
+            testID="home-composer-input"
             placeholder={placeholderText}
             placeholderTextColor="#9ca3af"
             accessibilityLabel="Describe the agent you want to build"

--- a/e2e/staging/billing-upgrade.test.ts
+++ b/e2e/staging/billing-upgrade.test.ts
@@ -105,16 +105,28 @@ test.describe("Billing & Upgrade Flow", () => {
 
     // v1.5.0 pricing: Basic $8/mo, Pro $20/seat, Business $40/seat, Enterprise custom.
     // Source: apps/mobile/app/(app)/billing.tsx → PLAN_PRICING.
-    await expect(page.getByText("Basic", { exact: true }).first()).toBeVisible()
-    await expect(page.getByText("Pro").first()).toBeVisible()
-    await expect(page.getByText("Business", { exact: true }).first()).toBeVisible()
-    await expect(page.getByText("Enterprise", { exact: true }).first()).toBeVisible()
+    // Each plan Card is wrapped in a View with a stable testID; fall back
+    // to role/name matching if the app predates the testIDs.
+    const basicCard = page.getByTestId("plan-card-basic")
+    const proCard = page.getByTestId("plan-card-pro")
+    const businessCard = page.getByTestId("plan-card-business")
+    const enterpriseCard = page.getByTestId("plan-card-enterprise")
+
+    await expect(basicCard.or(page.getByText("Basic", { exact: true }).first())).toBeVisible()
+    await expect(proCard.or(page.getByText("Pro").first())).toBeVisible()
+    await expect(businessCard.or(page.getByText("Business", { exact: true }).first())).toBeVisible()
+    await expect(enterpriseCard.or(page.getByText("Enterprise", { exact: true }).first())).toBeVisible()
     await expect(page.getByText("Custom", { exact: true })).toBeVisible()
-    // The per-seat dollar labels appear on each plan card; each tier
-    // exposes its price in a "$X/seat" or "$X" badge.
-    await expect(page.getByText("$8").first()).toBeVisible()
-    await expect(page.getByText("$20").first()).toBeVisible()
-    await expect(page.getByText("$40").first()).toBeVisible()
+    // Dollar labels live inside each plan card (prefer testID scoping).
+    await expect(
+      basicCard.getByText("$8").first().or(page.getByText("$8").first()),
+    ).toBeVisible()
+    await expect(
+      proCard.getByText("$20").first().or(page.getByText("$20").first()),
+    ).toBeVisible()
+    await expect(
+      businessCard.getByText("$40").first().or(page.getByText("$40").first()),
+    ).toBeVisible()
     await expect(page.getByText(/\/seat/).first()).toBeVisible()
   })
 

--- a/e2e/staging/composio-cloud-proxy.test.ts
+++ b/e2e/staging/composio-cloud-proxy.test.ts
@@ -1,7 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page, type APIRequestContext } from "@playwright/test"
-import { expandManualApiKeys, homeComposerInput, makeTestUser, signUpAndOnboard } from "./helpers"
+import {
+  createApiKeyButton,
+  createApiKeySubmitButton,
+  expandManualApiKeys,
+  homeComposerInput,
+  makeTestUser,
+  signUpAndOnboard,
+} from "./helpers"
 
 /**
  * API Key Feature — Full E2E Tests
@@ -105,7 +112,7 @@ test.describe("API Key Feature — Full E2E", () => {
     // v1.5.0: "Create Key" lives behind the "Manual API keys" accordion on /api-keys
     await expandManualApiKeys(page)
 
-    const createBtn = page.getByText("Create Key").first()
+    const createBtn = createApiKeyButton(page)
     await createBtn.waitFor({ state: "visible", timeout: 10_000 })
     await createBtn.click()
 
@@ -123,7 +130,7 @@ test.describe("API Key Feature — Full E2E", () => {
     // Click "Create Key" in the modal dialog
     const modal = page.getByRole("dialog", { name: "Create API Key" })
     await modal.waitFor({ state: "visible", timeout: 5_000 })
-    await modal.getByText("Create Key", { exact: true }).click()
+    await createApiKeySubmitButton(page).click()
 
     // Wait for the key to be created — the modal shows "API Key Created"
     await page.waitForSelector("text=API Key Created", { timeout: 15_000 })

--- a/e2e/staging/helpers.ts
+++ b/e2e/staging/helpers.ts
@@ -160,21 +160,48 @@ export async function signUpAndOnboardWithAppTemplate(
  * `"Manual API keys (N) · advanced"` accordion. Tests that need to create
  * a manual key must expand the accordion first.
  *
+ * Prefers the stable `testID="manual-api-keys-toggle"` and falls back to
+ * role-based matching for revisions that predate the testID.
+ *
  * See apps/mobile/app/(app)/api-keys.tsx — the `showManualKeys` state.
  */
 export async function expandManualApiKeys(page: Page) {
-  const toggle = page.getByRole("button", { name: /Manual API keys/ })
+  const toggle = page
+    .getByTestId("manual-api-keys-toggle")
+    .or(page.getByRole("button", { name: /Manual API keys/ }))
+    .first()
   await toggle.waitFor({ state: "visible", timeout: 10_000 })
-  // Avoid re-collapsing if the accordion is already open.
   const expanded = await toggle.getAttribute("aria-expanded").catch(() => null)
   if (expanded !== "true") {
     await toggle.click()
   }
   // "Create Key" only renders after the accordion animates open.
-  await page
-    .getByText("Create Key")
+  const createBtn = page
+    .getByTestId("create-api-key-btn")
+    .or(page.getByText("Create Key").first())
     .first()
-    .waitFor({ state: "visible", timeout: 10_000 })
+  await createBtn.waitFor({ state: "visible", timeout: 10_000 })
+}
+
+/**
+ * Returns the "Create Key" button inside the expanded Manual API keys
+ * section, preferring the stable testID.
+ */
+export function createApiKeyButton(page: Page) {
+  return page
+    .getByTestId("create-api-key-btn")
+    .or(page.getByText("Create Key").first())
+    .first()
+}
+
+/**
+ * Returns the "Create Key" submit button inside the Create API Key modal.
+ */
+export function createApiKeySubmitButton(page: Page) {
+  return page
+    .getByTestId("create-api-key-submit")
+    .or(page.getByRole("dialog", { name: "Create API Key" }).getByText("Create Key", { exact: true }))
+    .first()
 }
 
 // ── Interaction mode helpers ─────────────────────────────────────────────────
@@ -223,16 +250,21 @@ export async function selectInteractionMode(page: Page, mode: "Agent" | "Plan" |
  * The home composer uses an animated typewriter placeholder
  * (`"Ask Shogo to " + rotating suggestion`), so the old
  * `getByPlaceholder("Ask Shogo to ...")` selector never matches.
- * `CompactChatInput` renders a stable `accessibilityLabel` we can target
- * regardless of interaction mode and placeholder churn.
+ * `CompactChatInput` exposes a stable `testID="home-composer-input"` we
+ * can target regardless of interaction mode and placeholder churn.
  *
- * See apps/mobile/components/chat/CompactChatInput.tsx — the TextInput
- * label "Describe the agent you want to build".
+ * Falls back to `accessibilityLabel` matching for revisions that predate
+ * the testID (e.g. long-lived staging sessions) so this helper works on
+ * any prod/staging tag.
+ *
+ * See apps/mobile/components/chat/CompactChatInput.tsx.
  */
 export function homeComposerInput(page: Page) {
-  return page.getByRole("textbox", {
-    name: "Describe the agent you want to build",
-  })
+  return page.getByTestId("home-composer-input").or(
+    page.getByRole("textbox", {
+      name: "Describe the agent you want to build",
+    }),
+  )
 }
 
 export async function sendChatMessage(page: Page, text: string) {

--- a/e2e/staging/remote-control.test.ts
+++ b/e2e/staging/remote-control.test.ts
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page, type APIRequestContext } from "@playwright/test"
-import { expandManualApiKeys, makeTestUser, signUpAndOnboard } from "./helpers"
+import {
+  createApiKeyButton,
+  createApiKeySubmitButton,
+  expandManualApiKeys,
+  makeTestUser,
+  signUpAndOnboard,
+} from "./helpers"
 
 /**
  * Remote Control — E2E Tests
@@ -86,14 +92,14 @@ test.describe("Remote Control — E2E", () => {
     // v1.5.0: "Create Key" lives behind the "Manual API keys" accordion on /api-keys
     await expandManualApiKeys(page)
 
-    const createBtn = page.getByText("Create Key").first()
+    const createBtn = createApiKeyButton(page)
     await createBtn.waitFor({ state: "visible", timeout: 10_000 })
     await createBtn.click()
 
     await page.waitForSelector("text=Create API Key", { timeout: 5_000 })
     const modal = page.getByRole("dialog", { name: "Create API Key" })
     await modal.waitFor({ state: "visible", timeout: 5_000 })
-    await modal.getByText("Create Key", { exact: true }).click()
+    await createApiKeySubmitButton(page).click()
 
     await page.waitForSelector("text=API Key Created", { timeout: 15_000 })
 

--- a/e2e/staging/streaming-latency.test.ts
+++ b/e2e/staging/streaming-latency.test.ts
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page, type APIRequestContext } from "@playwright/test"
-import { expandManualApiKeys, makeTestUser, signUpAndOnboard } from "./helpers"
+import {
+  createApiKeyButton,
+  createApiKeySubmitButton,
+  expandManualApiKeys,
+  makeTestUser,
+  signUpAndOnboard,
+} from "./helpers"
 
 /**
  * Streaming Relay Latency — E2E Tests
@@ -147,14 +153,14 @@ test.describe("Streaming Relay Latency — E2E", () => {
     // v1.5.0: "Create Key" lives behind the "Manual API keys" accordion on /api-keys
     await expandManualApiKeys(page)
 
-    const createBtn = page.getByText("Create Key").first()
+    const createBtn = createApiKeyButton(page)
     await createBtn.waitFor({ state: "visible", timeout: 10_000 })
     await createBtn.click()
 
     await page.waitForSelector("text=Create API Key", { timeout: 5_000 })
     const modal = page.getByRole("dialog", { name: "Create API Key" })
     await modal.waitFor({ state: "visible", timeout: 5_000 })
-    await modal.getByText("Create Key", { exact: true }).click()
+    await createApiKeySubmitButton(page).click()
 
     await page.waitForSelector("text=API Key Created", { timeout: 15_000 })
     const createdDialog = page.getByRole("dialog", { name: "API Key Created" })

--- a/packages/shared-ui/src/primitives/Button.tsx
+++ b/packages/shared-ui/src/primitives/Button.tsx
@@ -39,6 +39,9 @@ export interface ButtonProps {
   disabled?: boolean
   onPress?: () => void
   children: React.ReactNode
+  /** Forwarded to the underlying Pressable so tests can use `getByTestId`. */
+  testID?: string
+  accessibilityLabel?: string
 }
 
 export function Button({
@@ -48,9 +51,13 @@ export function Button({
   disabled,
   onPress,
   children,
+  testID,
+  accessibilityLabel,
 }: ButtonProps) {
   return (
     <Pressable
+      testID={testID}
+      accessibilityLabel={accessibilityLabel}
       className={cn(
         'flex-row items-center justify-center rounded-md',
         variantStyles[variant],


### PR DESCRIPTION
## Summary

PR 2 of 5. Stacked on #482 (PR 1).

PR 1 got the hosted-env suite working again by reaching for the stable
\`accessibilityLabel\`s and roles that already existed. This PR locks
those selectors in with \`testID\`s so we don't have to chase future copy
and layout changes.

### App-side additions (no behavior change)

- \`apps/mobile/components/chat/CompactChatInput.tsx\` — TextInput
  \`testID=\"home-composer-input\"\`
- \`apps/mobile/app/(app)/api-keys.tsx\`:
  - Manual API keys accordion → \`testID=\"manual-api-keys-toggle\"\`
  - \"Create Key\" page button → \`testID=\"create-api-key-btn\"\`
  - \"Create Key\" modal submit button → \`testID=\"create-api-key-submit\"\`
- \`apps/mobile/app/(app)/billing.tsx\` — each plan card wrapper gets
  \`testID=\"plan-card-{basic,pro,business,enterprise}\"\`
- \`packages/shared-ui/src/primitives/Button.tsx\` now forwards \`testID\`
  and \`accessibilityLabel\` to the underlying Pressable so the new
  testIDs actually propagate to the DOM on React Native Web.

### Test-side updates (belt-and-suspenders)

All the helpers and tests now prefer \`getByTestId(...)\` and fall back to
the PR 1 role/text selectors via \`.or(...)\`. That way this PR passes on
deployments that predate the testIDs (useful during the rollout window)
and stays passing after they land.

- \`homeComposerInput\` — testID + accessibilityLabel fallback
- \`expandManualApiKeys\` — testID toggle + regex role fallback
- new \`createApiKeyButton\` / \`createApiKeySubmitButton\` helpers
- \`billing-upgrade\` pricing test scopes each dollar assertion inside
  its plan card by testID

## Risks

- \`shared-ui/Button\` prop addition is additive only. Existing call sites
  without \`testID\` are unaffected.
- No change to any app user flow — only props added to underlying
  \`Pressable\` / \`TextInput\`.

## Test plan

- [ ] \`bun run typecheck\` stays green across mobile + shared-ui.
- [ ] \`STAGING_URL=https://studio.staging.shogo.ai bun run test:e2e:staging\`
      stays green (fallback selectors still work before the testIDs
      deploy).
- [ ] After this + PR 1 merge to main and deploy to staging, rerun the
      suite to confirm testID path is exercised (inspect a successful
      trace to verify).

Made with [Cursor](https://cursor.com)