### PR TITLE
test(e2e): skip Stripe-hosted-checkout tests on live Stripe env (PR 3/5)

### DIFF
--- a/apps/mobile/app/(app)/api-keys.tsx
+++ b/apps/mobile/app/(app)/api-keys.tsx
@@ -279,6 +279,7 @@ export default observer(function ApiKeysPage() {
 
         {/* Manual API keys (advanced) */}
         <Pressable
+          testID="manual-api-keys-toggle"
           onPress={() => setShowManualKeys((v) => !v)}
           className="flex-row items-center gap-2 mb-3 py-1"
           accessibilityRole="button"
@@ -304,7 +305,11 @@ export default observer(function ApiKeysPage() {
               sign in via the desktop app instead.
             </Text>
             <View className="flex-row justify-end mb-3">
-              <Button size="sm" onPress={() => setShowCreateModal(true)}>
+              <Button
+                size="sm"
+                testID="create-api-key-btn"
+                onPress={() => setShowCreateModal(true)}
+              >
                 <View className="flex-row items-center gap-1.5">
                   <Plus size={14} color="#fff" />
                   <Text className="text-sm font-medium text-primary-foreground">Create Key</Text>
@@ -465,6 +470,7 @@ export default observer(function ApiKeysPage() {
                     Cancel
                   </Button>
                   <Button
+                    testID="create-api-key-submit"
                     onPress={handleCreate}
                     disabled={isCreating || !newKeyName.trim()}
                     className="flex-1"

--- a/apps/mobile/app/(app)/billing.tsx
+++ b/apps/mobile/app/(app)/billing.tsx
@@ -413,9 +413,9 @@ export default observer(function BillingPage() {
       </View>
 
       {/* Plan Cards — md row: equal-height columns; tier slot reserves space so CTAs align */}
-      <View className="gap-6 md:flex-row md:items-stretch">
+      <View className="gap-6 md:flex-row md:items-stretch" testID="plan-cards-row">
         {/* Basic Plan */}
-        <View className="md:flex-1 md:w-0 flex flex-col">
+        <View className="md:flex-1 md:w-0 flex flex-col" testID="plan-card-basic">
           <View className="hidden md:block md:min-h-8" />
           <Card className="md:flex-1 flex flex-col">
             <CardContent className="md:flex-1 flex flex-col p-5 gap-5">
@@ -469,7 +469,7 @@ export default observer(function BillingPage() {
         </View>
 
         {/* Pro Plan */}
-        <View className="md:flex-1 md:w-0 flex flex-col">
+        <View className="md:flex-1 md:w-0 flex flex-col" testID="plan-card-pro">
           <View className="hidden md:block md:min-h-8" />
           <Card className="md:flex-1 flex flex-col">
             <CardContent className="md:flex-1 flex flex-col p-5 gap-5">
@@ -535,7 +535,7 @@ export default observer(function BillingPage() {
         </View>
 
         {/* Business Plan */}
-        <View className="md:flex-1 md:w-0 flex flex-col">
+        <View className="md:flex-1 md:w-0 flex flex-col" testID="plan-card-business">
           <View className="min-h-8 items-center justify-center px-1">
             <Badge className="bg-primary">
               <Text className="text-xs text-primary-foreground font-medium">Most Popular</Text>
@@ -602,7 +602,7 @@ export default observer(function BillingPage() {
         </View>
 
         {/* Enterprise Plan */}
-        <View className="md:flex-1 md:w-0 flex flex-col">
+        <View className="md:flex-1 md:w-0 flex flex-col" testID="plan-card-enterprise">
           <View className="hidden md:block md:min-h-8" />
           <Card className="md:flex-1 flex flex-col">
             <CardContent className="md:flex-1 flex flex-col p-5 gap-5">

--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -553,6 +553,7 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
 
           <TextInput
             ref={textInputRef}
+            testID="home-composer-input"
             placeholder={placeholderText}
             placeholderTextColor="#9ca3af"
             accessibilityLabel="Describe the agent you want to build"

--- a/e2e/staging/billing-upgrade.test.ts
+++ b/e2e/staging/billing-upgrade.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page } from "@playwright/test"
-import { makeTestUser, signUpAndOnboard } from "./helpers"
+import { homeComposerInput, makeTestUser, signUpAndOnboard } from "./helpers"
 
 /**
  * Billing & Upgrade Flow E2E Tests (USD pricing)
@@ -100,15 +100,22 @@ test.describe("Billing & Upgrade Flow", () => {
     ).toBeVisible()
   })
 
-  test("free plan: three pricing tiers displayed", async () => {
+  test("free plan: per-seat pricing tiers displayed (v1.5.0 USD)", async () => {
     await navigateToBilling(page)
 
+    // v1.5.0 pricing: Basic $8/mo, Pro $20/seat, Business $40/seat, Enterprise custom.
+    // Source: apps/mobile/app/(app)/billing.tsx → PLAN_PRICING.
+    await expect(page.getByText("Basic", { exact: true }).first()).toBeVisible()
     await expect(page.getByText("Pro").first()).toBeVisible()
-    await expect(page.getByText("$25")).toBeVisible()
     await expect(page.getByText("Business", { exact: true }).first()).toBeVisible()
-    await expect(page.getByText("$365")).toBeVisible()
     await expect(page.getByText("Enterprise", { exact: true }).first()).toBeVisible()
     await expect(page.getByText("Custom", { exact: true })).toBeVisible()
+    // The per-seat dollar labels appear on each plan card; each tier
+    // exposes its price in a "$X/seat" or "$X" badge.
+    await expect(page.getByText("$8").first()).toBeVisible()
+    await expect(page.getByText("$20").first()).toBeVisible()
+    await expect(page.getByText("$40").first()).toBeVisible()
+    await expect(page.getByText(/\/seat/).first()).toBeVisible()
   })
 
   // ── Phase 3: Stripe Checkout (Reach-Only) ────────────────────────
@@ -130,7 +137,9 @@ test.describe("Billing & Upgrade Flow", () => {
     expect(page.url()).toContain("checkout.stripe.com")
 
     await expect(page.getByText("Subscribe to Pro")).toBeVisible({ timeout: 15_000 })
-    await expect(page.getByText("$25.00")).toBeVisible()
+    // v1.5.0: Pro is $20/seat/month. The exact label on Stripe Checkout
+    // is "$20.00 per seat / month" so a partial "$20.00" match is enough.
+    await expect(page.getByText("$20.00")).toBeVisible()
   })
 
   // ── Phase 4: Post-Upgrade UI (skipped) ───────────────────────────
@@ -182,7 +191,7 @@ test.describe("Billing & Upgrade Flow", () => {
     await page.goto("/")
     await page.waitForSelector("text=What's on your mind", { timeout: 10_000 })
 
-    const input = page.getByPlaceholder("Ask Shogo to ...")
+    const input = homeComposerInput(page)
     await input.click()
     await input.fill("Test model gating for Pro plan")
     await page.waitForTimeout(500)

--- a/e2e/staging/billing-upgrade.test.ts
+++ b/e2e/staging/billing-upgrade.test.ts
@@ -105,16 +105,28 @@ test.describe("Billing & Upgrade Flow", () => {
 
     // v1.5.0 pricing: Basic $8/mo, Pro $20/seat, Business $40/seat, Enterprise custom.
     // Source: apps/mobile/app/(app)/billing.tsx → PLAN_PRICING.
-    await expect(page.getByText("Basic", { exact: true }).first()).toBeVisible()
-    await expect(page.getByText("Pro").first()).toBeVisible()
-    await expect(page.getByText("Business", { exact: true }).first()).toBeVisible()
-    await expect(page.getByText("Enterprise", { exact: true }).first()).toBeVisible()
+    // Each plan Card is wrapped in a View with a stable testID; fall back
+    // to role/name matching if the app predates the testIDs.
+    const basicCard = page.getByTestId("plan-card-basic")
+    const proCard = page.getByTestId("plan-card-pro")
+    const businessCard = page.getByTestId("plan-card-business")
+    const enterpriseCard = page.getByTestId("plan-card-enterprise")
+
+    await expect(basicCard.or(page.getByText("Basic", { exact: true }).first())).toBeVisible()
+    await expect(proCard.or(page.getByText("Pro").first())).toBeVisible()
+    await expect(businessCard.or(page.getByText("Business", { exact: true }).first())).toBeVisible()
+    await expect(enterpriseCard.or(page.getByText("Enterprise", { exact: true }).first())).toBeVisible()
     await expect(page.getByText("Custom", { exact: true })).toBeVisible()
-    // The per-seat dollar labels appear on each plan card; each tier
-    // exposes its price in a "$X/seat" or "$X" badge.
-    await expect(page.getByText("$8").first()).toBeVisible()
-    await expect(page.getByText("$20").first()).toBeVisible()
-    await expect(page.getByText("$40").first()).toBeVisible()
+    // Dollar labels live inside each plan card (prefer testID scoping).
+    await expect(
+      basicCard.getByText("$8").first().or(page.getByText("$8").first()),
+    ).toBeVisible()
+    await expect(
+      proCard.getByText("$20").first().or(page.getByText("$20").first()),
+    ).toBeVisible()
+    await expect(
+      businessCard.getByText("$40").first().or(page.getByText("$40").first()),
+    ).toBeVisible()
     await expect(page.getByText(/\/seat/).first()).toBeVisible()
   })
 

--- a/e2e/staging/chat-file-upload.test.ts
+++ b/e2e/staging/chat-file-upload.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page } from "@playwright/test"
-import { makeTestUser, signUpAndOnboard } from "./helpers"
+import { homeComposerInput, makeTestUser, signUpAndOnboard } from "./helpers"
 import * as path from "path"
 import * as fs from "fs"
 import * as os from "os"
@@ -41,7 +41,7 @@ async function createProjectAndWait(page: Page, prompt: string) {
   await page.goto("/")
   await page.waitForSelector("text=What's on your mind", { timeout: 15_000 })
 
-  const input = page.getByPlaceholder("Ask Shogo to ...")
+  const input = homeComposerInput(page)
   await input.click()
   await input.fill(prompt)
   await page.waitForTimeout(500)

--- a/e2e/staging/composio-cloud-proxy.test.ts
+++ b/e2e/staging/composio-cloud-proxy.test.ts
@@ -1,7 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page, type APIRequestContext } from "@playwright/test"
-import { expandManualApiKeys, homeComposerInput, makeTestUser, signUpAndOnboard } from "./helpers"
+import {
+  createApiKeyButton,
+  createApiKeySubmitButton,
+  expandManualApiKeys,
+  homeComposerInput,
+  makeTestUser,
+  signUpAndOnboard,
+} from "./helpers"
 
 /**
  * API Key Feature — Full E2E Tests
@@ -105,7 +112,7 @@ test.describe("API Key Feature — Full E2E", () => {
     // v1.5.0: "Create Key" lives behind the "Manual API keys" accordion on /api-keys
     await expandManualApiKeys(page)
 
-    const createBtn = page.getByText("Create Key").first()
+    const createBtn = createApiKeyButton(page)
     await createBtn.waitFor({ state: "visible", timeout: 10_000 })
     await createBtn.click()
 
@@ -123,7 +130,7 @@ test.describe("API Key Feature — Full E2E", () => {
     // Click "Create Key" in the modal dialog
     const modal = page.getByRole("dialog", { name: "Create API Key" })
     await modal.waitFor({ state: "visible", timeout: 5_000 })
-    await modal.getByText("Create Key", { exact: true }).click()
+    await createApiKeySubmitButton(page).click()
 
     // Wait for the key to be created — the modal shows "API Key Created"
     await page.waitForSelector("text=API Key Created", { timeout: 15_000 })

--- a/e2e/staging/composio-cloud-proxy.test.ts
+++ b/e2e/staging/composio-cloud-proxy.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page, type APIRequestContext } from "@playwright/test"
-import { makeTestUser, signUpAndOnboard } from "./helpers"
+import { expandManualApiKeys, homeComposerInput, makeTestUser, signUpAndOnboard } from "./helpers"
 
 /**
  * API Key Feature — Full E2E Tests
@@ -102,7 +102,9 @@ test.describe("API Key Feature — Full E2E", () => {
     }).catch(() => {})
     await page.waitForTimeout(500)
 
-    // Click "Create Key" button
+    // v1.5.0: "Create Key" lives behind the "Manual API keys" accordion on /api-keys
+    await expandManualApiKeys(page)
+
     const createBtn = page.getByText("Create Key").first()
     await createBtn.waitFor({ state: "visible", timeout: 10_000 })
     await createBtn.click()
@@ -188,7 +190,7 @@ test.describe("API Key Feature — Full E2E", () => {
     await page.goto("/")
     await page.waitForSelector("text=What's on your mind", { timeout: 15_000 })
 
-    const input = page.getByPlaceholder("Ask Shogo to ...")
+    const input = homeComposerInput(page)
     await input.click()
     await input.fill("Test project for API key E2E")
     await page.waitForTimeout(500)

--- a/e2e/staging/composio-integrations.test.ts
+++ b/e2e/staging/composio-integrations.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect } from "@playwright/test"
-import { makeTestUser, signUpAndOnboard } from "./helpers"
+import { homeComposerInput, makeTestUser, signUpAndOnboard } from "./helpers"
 
 /**
  * Composio Integration E2E Tests
@@ -50,7 +50,7 @@ test.describe("Composio Integrations", () => {
   })
 
   test("MCP catalog includes composio authType fields", async () => {
-    const input = page.getByPlaceholder("Ask Shogo to ...")
+    const input = homeComposerInput(page)
     await input.click()
     await input.fill("Test composio integrations")
     await page.waitForTimeout(500)

--- a/e2e/staging/helpers.ts
+++ b/e2e/staging/helpers.ts
@@ -152,6 +152,31 @@ export async function signUpAndOnboardWithAppTemplate(
  *
  * Leaves the browser on the app after the Stripe redirect.
  */
+// ── API Keys page helpers ────────────────────────────────────────────────────
+
+/**
+ * The `/api-keys` page was redesigned in v1.5.0: the "Devices" section is
+ * primary, and manual workspace API keys live behind a collapsed
+ * `"Manual API keys (N) · advanced"` accordion. Tests that need to create
+ * a manual key must expand the accordion first.
+ *
+ * See apps/mobile/app/(app)/api-keys.tsx — the `showManualKeys` state.
+ */
+export async function expandManualApiKeys(page: Page) {
+  const toggle = page.getByRole("button", { name: /Manual API keys/ })
+  await toggle.waitFor({ state: "visible", timeout: 10_000 })
+  // Avoid re-collapsing if the accordion is already open.
+  const expanded = await toggle.getAttribute("aria-expanded").catch(() => null)
+  if (expanded !== "true") {
+    await toggle.click()
+  }
+  // "Create Key" only renders after the accordion animates open.
+  await page
+    .getByText("Create Key")
+    .first()
+    .waitFor({ state: "visible", timeout: 10_000 })
+}
+
 // ── Interaction mode helpers ─────────────────────────────────────────────────
 
 export async function selectInteractionMode(page: Page, mode: "Agent" | "Plan" | "Ask") {
@@ -194,8 +219,24 @@ export async function selectInteractionMode(page: Page, mode: "Agent" | "Plan" |
   await page.waitForTimeout(300)
 }
 
+/**
+ * The home composer uses an animated typewriter placeholder
+ * (`"Ask Shogo to " + rotating suggestion`), so the old
+ * `getByPlaceholder("Ask Shogo to ...")` selector never matches.
+ * `CompactChatInput` renders a stable `accessibilityLabel` we can target
+ * regardless of interaction mode and placeholder churn.
+ *
+ * See apps/mobile/components/chat/CompactChatInput.tsx — the TextInput
+ * label "Describe the agent you want to build".
+ */
+export function homeComposerInput(page: Page) {
+  return page.getByRole("textbox", {
+    name: "Describe the agent you want to build",
+  })
+}
+
 export async function sendChatMessage(page: Page, text: string) {
-  const chatInput = page.getByPlaceholder(/Ask Shogo|Describe what|Ask a question/)
+  const chatInput = homeComposerInput(page)
   await chatInput.click()
   await chatInput.fill(text)
   await page.waitForTimeout(300)
@@ -221,7 +262,7 @@ export async function createProjectAndWait(page: Page, prompt: string) {
   await page.goto("/")
   await page.waitForSelector("text=What's on your mind", { timeout: 15_000 })
 
-  const input = page.getByPlaceholder("Ask Shogo to ...")
+  const input = homeComposerInput(page)
   await input.click()
   await input.fill(prompt)
   await page.waitForTimeout(500)

--- a/e2e/staging/helpers.ts
+++ b/e2e/staging/helpers.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
-import type { Page } from "@playwright/test"
+import { test, type Page } from "@playwright/test"
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -316,7 +316,46 @@ export async function createProjectAndWait(page: Page, prompt: string) {
   await page.waitForTimeout(1000)
 }
 
+/**
+ * Returns true when the Playwright suite is pointed at a live-Stripe
+ * environment (production). Live Stripe rejects the test card
+ * `4242424242424242`, so any test that drives hosted Checkout with a
+ * test card must skip when this returns true.
+ *
+ * Detection priority:
+ *   1. Explicit opt-in/opt-out via `E2E_STRIPE_MODE` (`live` | `test`).
+ *   2. URL heuristic — anything that looks like *.staging.shogo.ai or
+ *      localhost is test-mode; everything else is live.
+ *
+ * Override when needed with:
+ *   E2E_STRIPE_MODE=test npx playwright test ...     # force test mode
+ *   E2E_STRIPE_MODE=live npx playwright test ...     # force live mode
+ */
+export function isLiveStripeEnv(): boolean {
+  const explicit = process.env.E2E_STRIPE_MODE?.toLowerCase()
+  if (explicit === "live") return true
+  if (explicit === "test") return false
+
+  const url = process.env.STAGING_URL || process.env.E2E_TARGET_URL || ""
+  if (!url) return false
+  if (url.includes("localhost") || url.includes("127.0.0.1")) return false
+  if (url.includes("staging.shogo.ai")) return false
+  if (url.includes("shogo.ai")) return true
+  return false
+}
+
 export async function signUpAndUpgradeToPro(page: Page, user: TestUser): Promise<void> {
+  // Hosted Stripe Checkout against live keys rejects test cards, so tests
+  // that rely on this helper can't run end-to-end against production.
+  // Skip cleanly with a message so the run is green instead of red —
+  // PR 5 adds an API-side bootstrap backdoor that removes this gap.
+  test.skip(
+    isLiveStripeEnv(),
+    "signUpAndUpgradeToPro drives Stripe hosted Checkout with a test " +
+      "card, which live Stripe rejects. Run against staging, or set " +
+      "E2E_STRIPE_MODE=test to override.",
+  )
+
   await signUpAndOnboard(page, user)
 
   await page.goto("/billing")

--- a/e2e/staging/helpers.ts
+++ b/e2e/staging/helpers.ts
@@ -160,21 +160,48 @@ export async function signUpAndOnboardWithAppTemplate(
  * `"Manual API keys (N) · advanced"` accordion. Tests that need to create
  * a manual key must expand the accordion first.
  *
+ * Prefers the stable `testID="manual-api-keys-toggle"` and falls back to
+ * role-based matching for revisions that predate the testID.
+ *
  * See apps/mobile/app/(app)/api-keys.tsx — the `showManualKeys` state.
  */
 export async function expandManualApiKeys(page: Page) {
-  const toggle = page.getByRole("button", { name: /Manual API keys/ })
+  const toggle = page
+    .getByTestId("manual-api-keys-toggle")
+    .or(page.getByRole("button", { name: /Manual API keys/ }))
+    .first()
   await toggle.waitFor({ state: "visible", timeout: 10_000 })
-  // Avoid re-collapsing if the accordion is already open.
   const expanded = await toggle.getAttribute("aria-expanded").catch(() => null)
   if (expanded !== "true") {
     await toggle.click()
   }
   // "Create Key" only renders after the accordion animates open.
-  await page
-    .getByText("Create Key")
+  const createBtn = page
+    .getByTestId("create-api-key-btn")
+    .or(page.getByText("Create Key").first())
     .first()
-    .waitFor({ state: "visible", timeout: 10_000 })
+  await createBtn.waitFor({ state: "visible", timeout: 10_000 })
+}
+
+/**
+ * Returns the "Create Key" button inside the expanded Manual API keys
+ * section, preferring the stable testID.
+ */
+export function createApiKeyButton(page: Page) {
+  return page
+    .getByTestId("create-api-key-btn")
+    .or(page.getByText("Create Key").first())
+    .first()
+}
+
+/**
+ * Returns the "Create Key" submit button inside the Create API Key modal.
+ */
+export function createApiKeySubmitButton(page: Page) {
+  return page
+    .getByTestId("create-api-key-submit")
+    .or(page.getByRole("dialog", { name: "Create API Key" }).getByText("Create Key", { exact: true }))
+    .first()
 }
 
 // ── Interaction mode helpers ─────────────────────────────────────────────────
@@ -223,16 +250,21 @@ export async function selectInteractionMode(page: Page, mode: "Agent" | "Plan" |
  * The home composer uses an animated typewriter placeholder
  * (`"Ask Shogo to " + rotating suggestion`), so the old
  * `getByPlaceholder("Ask Shogo to ...")` selector never matches.
- * `CompactChatInput` renders a stable `accessibilityLabel` we can target
- * regardless of interaction mode and placeholder churn.
+ * `CompactChatInput` exposes a stable `testID="home-composer-input"` we
+ * can target regardless of interaction mode and placeholder churn.
  *
- * See apps/mobile/components/chat/CompactChatInput.tsx — the TextInput
- * label "Describe the agent you want to build".
+ * Falls back to `accessibilityLabel` matching for revisions that predate
+ * the testID (e.g. long-lived staging sessions) so this helper works on
+ * any prod/staging tag.
+ *
+ * See apps/mobile/components/chat/CompactChatInput.tsx.
  */
 export function homeComposerInput(page: Page) {
-  return page.getByRole("textbox", {
-    name: "Describe the agent you want to build",
-  })
+  return page.getByTestId("home-composer-input").or(
+    page.getByRole("textbox", {
+      name: "Describe the agent you want to build",
+    }),
+  )
 }
 
 export async function sendChatMessage(page: Page, text: string) {

--- a/e2e/staging/pro-feature-gating.test.ts
+++ b/e2e/staging/pro-feature-gating.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page } from "@playwright/test"
-import { makeTestUser, signUpAndUpgradeToPro } from "./helpers"
+import { homeComposerInput, makeTestUser, signUpAndUpgradeToPro } from "./helpers"
 
 /**
  * Pro Feature Gating E2E Tests
@@ -63,7 +63,7 @@ test.describe("Pro Feature Gating", () => {
     await page.goto("/")
     await page.waitForSelector("text=What's on your mind", { timeout: 15_000 })
 
-    const input = page.getByPlaceholder("Ask Shogo to ...")
+    const input = homeComposerInput(page)
     await input.click()
     await input.fill("Test model gating")
     await page.waitForTimeout(500)

--- a/e2e/staging/remote-control.test.ts
+++ b/e2e/staging/remote-control.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page, type APIRequestContext } from "@playwright/test"
-import { makeTestUser, signUpAndOnboard } from "./helpers"
+import { expandManualApiKeys, makeTestUser, signUpAndOnboard } from "./helpers"
 
 /**
  * Remote Control — E2E Tests
@@ -82,6 +82,9 @@ test.describe("Remote Control — E2E", () => {
       .waitForSelector("text=Loading API keys...", { state: "hidden", timeout: 15_000 })
       .catch(() => {})
     await page.waitForTimeout(500)
+
+    // v1.5.0: "Create Key" lives behind the "Manual API keys" accordion on /api-keys
+    await expandManualApiKeys(page)
 
     const createBtn = page.getByText("Create Key").first()
     await createBtn.waitFor({ state: "visible", timeout: 10_000 })

--- a/e2e/staging/remote-control.test.ts
+++ b/e2e/staging/remote-control.test.ts
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page, type APIRequestContext } from "@playwright/test"
-import { expandManualApiKeys, makeTestUser, signUpAndOnboard } from "./helpers"
+import {
+  createApiKeyButton,
+  createApiKeySubmitButton,
+  expandManualApiKeys,
+  makeTestUser,
+  signUpAndOnboard,
+} from "./helpers"
 
 /**
  * Remote Control — E2E Tests
@@ -86,14 +92,14 @@ test.describe("Remote Control — E2E", () => {
     // v1.5.0: "Create Key" lives behind the "Manual API keys" accordion on /api-keys
     await expandManualApiKeys(page)
 
-    const createBtn = page.getByText("Create Key").first()
+    const createBtn = createApiKeyButton(page)
     await createBtn.waitFor({ state: "visible", timeout: 10_000 })
     await createBtn.click()
 
     await page.waitForSelector("text=Create API Key", { timeout: 5_000 })
     const modal = page.getByRole("dialog", { name: "Create API Key" })
     await modal.waitFor({ state: "visible", timeout: 5_000 })
-    await modal.getByText("Create Key", { exact: true }).click()
+    await createApiKeySubmitButton(page).click()
 
     await page.waitForSelector("text=API Key Created", { timeout: 15_000 })
 

--- a/e2e/staging/streaming-latency.test.ts
+++ b/e2e/staging/streaming-latency.test.ts
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page, type APIRequestContext } from "@playwright/test"
-import { expandManualApiKeys, makeTestUser, signUpAndOnboard } from "./helpers"
+import {
+  createApiKeyButton,
+  createApiKeySubmitButton,
+  expandManualApiKeys,
+  makeTestUser,
+  signUpAndOnboard,
+} from "./helpers"
 
 /**
  * Streaming Relay Latency — E2E Tests
@@ -147,14 +153,14 @@ test.describe("Streaming Relay Latency — E2E", () => {
     // v1.5.0: "Create Key" lives behind the "Manual API keys" accordion on /api-keys
     await expandManualApiKeys(page)
 
-    const createBtn = page.getByText("Create Key").first()
+    const createBtn = createApiKeyButton(page)
     await createBtn.waitFor({ state: "visible", timeout: 10_000 })
     await createBtn.click()
 
     await page.waitForSelector("text=Create API Key", { timeout: 5_000 })
     const modal = page.getByRole("dialog", { name: "Create API Key" })
     await modal.waitFor({ state: "visible", timeout: 5_000 })
-    await modal.getByText("Create Key", { exact: true }).click()
+    await createApiKeySubmitButton(page).click()
 
     await page.waitForSelector("text=API Key Created", { timeout: 15_000 })
     const createdDialog = page.getByRole("dialog", { name: "API Key Created" })

--- a/e2e/staging/streaming-latency.test.ts
+++ b/e2e/staging/streaming-latency.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page, type APIRequestContext } from "@playwright/test"
-import { makeTestUser, signUpAndOnboard } from "./helpers"
+import { expandManualApiKeys, makeTestUser, signUpAndOnboard } from "./helpers"
 
 /**
  * Streaming Relay Latency — E2E Tests
@@ -143,6 +143,9 @@ test.describe("Streaming Relay Latency — E2E", () => {
       .waitForSelector("text=Loading API keys...", { state: "hidden", timeout: 15_000 })
       .catch(() => {})
     await page.waitForTimeout(500)
+
+    // v1.5.0: "Create Key" lives behind the "Manual API keys" accordion on /api-keys
+    await expandManualApiKeys(page)
 
     const createBtn = page.getByText("Create Key").first()
     await createBtn.waitFor({ state: "visible", timeout: 10_000 })

--- a/e2e/staging/usage-tracking.test.ts
+++ b/e2e/staging/usage-tracking.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { test, expect, type Page } from "@playwright/test"
-import { makeTestUser, signUpAndUpgradeToPro } from "./helpers"
+import { homeComposerInput, makeTestUser, signUpAndUpgradeToPro } from "./helpers"
 
 /**
  * Usage Tracking E2E Tests (USD pricing)
@@ -58,7 +58,7 @@ test.describe("Usage Tracking", () => {
     await page.goto("/")
     await page.waitForSelector("text=What's on your mind", { timeout: 10_000 })
 
-    const input = page.getByPlaceholder("Ask Shogo to ...")
+    const input = homeComposerInput(page)
     await input.click()
     await input.fill("Quick usage tracking test")
     await page.waitForTimeout(500)

--- a/packages/shared-ui/src/primitives/Button.tsx
+++ b/packages/shared-ui/src/primitives/Button.tsx
@@ -39,6 +39,9 @@ export interface ButtonProps {
   disabled?: boolean
   onPress?: () => void
   children: React.ReactNode
+  /** Forwarded to the underlying Pressable so tests can use `getByTestId`. */
+  testID?: string
+  accessibilityLabel?: string
 }
 
 export function Button({
@@ -48,9 +51,13 @@ export function Button({
   disabled,
   onPress,
   children,
+  testID,
+  accessibilityLabel,
 }: ButtonProps) {
   return (
     <Pressable
+      testID={testID}
+      accessibilityLabel={accessibilityLabel}
       className={cn(
         'flex-row items-center justify-center rounded-md',
         variantStyles[variant],


### PR DESCRIPTION
## Summary

PR 3 of 5. Stacked on #483 (PR 2).

When the suite is pointed at production (\`STAGING_URL=https://studio.shogo.ai\`),
Stripe Checkout runs against live keys which reject the
\`4242424242424242\` test card. This caused
\`pro-feature-gating.test.ts\` and \`usage-tracking.test.ts\` to fail at the
card-fill step on prod — a known platform limitation, not a regression.

This PR adds a small heuristic in \`signUpAndUpgradeToPro\` so those two
tests \`test.skip(...)\` with a clear message when we're in live-Stripe
territory, and otherwise run normally against staging.

### Detection logic

\`isLiveStripeEnv()\` in priority order:

1. Explicit override: \`E2E_STRIPE_MODE=live|test\` env var.
2. URL heuristic:
   - \`localhost\` / \`127.0.0.1\` → test
   - \`*.staging.shogo.ai\` → test
   - Anything else containing \`shogo.ai\` → live
   - Empty / unknown → test (safe default)

## Effect on the run

| Target | Before | After |
|---|---|---|
| \`studio.staging.shogo.ai\` | Upgrade tests run, pass | Same — no change |
| \`studio.shogo.ai\` | Upgrade tests run, fail at card fill | Upgrade tests \`test.skip\` with message |

PR 5 adds an API-side bootstrap backdoor that removes this gap and
restores full upgrade-path coverage against prod too.

## Test plan

- [ ] \`STAGING_URL=https://studio.staging.shogo.ai bun run test:e2e:staging\` — upgrade tests still run + pass.
- [ ] \`STAGING_URL=https://studio.shogo.ai bun run test:e2e:staging\` — upgrade tests skip with clear reason. Suite should now be fully green (0 failed) against prod.
- [ ] \`E2E_STRIPE_MODE=test STAGING_URL=https://studio.shogo.ai bun run test:e2e:staging billing-upgrade\` — override works, tests attempt live Checkout anyway (for debugging).

Made with [Cursor](https://cursor.com)