### PR TITLE
feat(ide): desktop-only PTY terminal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,9 @@ SHOGO_PUBLIC_API_URL=http://localhost:8002
 ALLOWED_ORIGINS=http://localhost:8081,http://localhost:5173
 EXPO_PUBLIC_API_URL=http://localhost:8002
 EXPO_PUBLIC_LOCAL_MODE=false
+# Real PTY terminal in the IDE. Only the Shogo Desktop renderer can use this;
+# regular hosted web keeps the HTTP terminal even if this is set.
+EXPO_PUBLIC_ENABLE_PTY=false
 
 # -----------------------------------------------------------------------------
 # Core secrets
@@ -86,6 +89,9 @@ RUNTIME_BASE_PORT=5200
 RUNTIME_MAX_COUNT=10
 RUNTIME_HEALTH_INTERVAL=30000
 RUNTIME_DOMAIN_SUFFIX=localhost
+# PTY is desktop-local only for now. The desktop app sets this automatically;
+# Knative/cloud runtimes ignore it and receive ENABLE_PTY=0.
+ENABLE_PTY=0
 VITE_RUNTIME_BASE=5200
 VITE_RUNTIME_END=5209
 VITE_DEV_PORT=5173

--- a/.github/workflows/desktop-release-macos.yml
+++ b/.github/workflows/desktop-release-macos.yml
@@ -48,6 +48,7 @@ jobs:
         run: bun run web:build
         env:
           EXPO_PUBLIC_LOCAL_MODE: 'true'
+          EXPO_PUBLIC_ENABLE_PTY: 'true'
           EXPO_PUBLIC_API_URL: 'http://localhost:8002'
 
       - name: Upload web build

--- a/.github/workflows/desktop-release-windows.yml
+++ b/.github/workflows/desktop-release-windows.yml
@@ -48,6 +48,7 @@ jobs:
         run: bun run web:build
         env:
           EXPO_PUBLIC_LOCAL_MODE: 'true'
+          EXPO_PUBLIC_ENABLE_PTY: 'true'
           EXPO_PUBLIC_API_URL: 'http://localhost:8002'
 
       - name: Upload web build

--- a/apps/api/src/__tests__/terminal-pty-proxy.test.ts
+++ b/apps/api/src/__tests__/terminal-pty-proxy.test.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, expect, test } from 'bun:test'
+import { prepareTerminalPtyUpgrade } from '../routes/terminal-pty-proxy'
+
+describe('terminal-pty-proxy', () => {
+  test('ignores unrelated websocket paths', async () => {
+    const result = await prepareTerminalPtyUpgrade(new Request('http://api.test/api/instances/ws'))
+    expect(result).toBeNull()
+  })
+
+  test('requires websocket upgrade for PTY path', async () => {
+    const result = await prepareTerminalPtyUpgrade(new Request('http://api.test/api/projects/p1/terminal/pty'))
+    expect(result).toBeInstanceOf(Response)
+    expect((result as Response).status).toBe(426)
+  })
+
+  test('requires Origin in production when an allowlist is configured', async () => {
+    const previousEnv = {
+      NODE_ENV: process.env.NODE_ENV,
+      ALLOWED_ORIGINS: process.env.ALLOWED_ORIGINS,
+      SHOGO_LOCAL_MODE: process.env.SHOGO_LOCAL_MODE,
+    }
+    process.env.NODE_ENV = 'production'
+    process.env.ALLOWED_ORIGINS = 'https://studio.example.com'
+    process.env.SHOGO_LOCAL_MODE = 'true'
+    try {
+      const result = await prepareTerminalPtyUpgrade(new Request('http://api.test/api/projects/p1/terminal/pty', {
+        headers: { upgrade: 'websocket' },
+      }))
+      expect(result).toBeInstanceOf(Response)
+      expect((result as Response).status).toBe(403)
+    } finally {
+      if (previousEnv.NODE_ENV === undefined) delete process.env.NODE_ENV
+      else process.env.NODE_ENV = previousEnv.NODE_ENV
+      if (previousEnv.ALLOWED_ORIGINS === undefined) delete process.env.ALLOWED_ORIGINS
+      else process.env.ALLOWED_ORIGINS = previousEnv.ALLOWED_ORIGINS
+      if (previousEnv.SHOGO_LOCAL_MODE === undefined) delete process.env.SHOGO_LOCAL_MODE
+      else process.env.SHOGO_LOCAL_MODE = previousEnv.SHOGO_LOCAL_MODE
+    }
+  })
+
+  test('disables PTY websocket proxy outside Shogo Desktop local mode', async () => {
+    const previousLocalMode = process.env.SHOGO_LOCAL_MODE
+    delete process.env.SHOGO_LOCAL_MODE
+    try {
+      const result = await prepareTerminalPtyUpgrade(new Request('http://api.test/api/projects/p1/terminal/pty', {
+        headers: { upgrade: 'websocket' },
+      }))
+      expect(result).toBeInstanceOf(Response)
+      expect((result as Response).status).toBe(404)
+    } finally {
+      if (previousLocalMode === undefined) delete process.env.SHOGO_LOCAL_MODE
+      else process.env.SHOGO_LOCAL_MODE = previousLocalMode
+    }
+  })
+})

--- a/apps/api/src/lib/knative-project-manager.ts
+++ b/apps/api/src/lib/knative-project-manager.ts
@@ -988,6 +988,7 @@ export class KnativeProjectManager {
       ...(projectRecord?.name ? [{ name: "AGENT_NAME", value: projectRecord.name }] : []),
       ...(projectRecord?.workspaceId ? [{ name: "WORKSPACE_ID", value: projectRecord.workspaceId }] : []),
       { name: "SCHEMAS_PATH", value: "/app/.schemas" },
+      { name: "ENABLE_PTY", value: "0" },
     ]
 
     // AI Proxy configuration

--- a/apps/api/src/lib/runtime/manager.ts
+++ b/apps/api/src/lib/runtime/manager.ts
@@ -1062,6 +1062,10 @@ export class ShogoErrorBoundary extends Component<Props, State> {
             console.warn(`[RuntimeManager] Failed to build security policy: ${err.message}`)
           }
         }
+
+        runtimeEnv.ENABLE_PTY = process.env.SHOGO_LOCAL_MODE === 'true'
+          ? process.env.ENABLE_PTY ?? '0'
+          : '0'
         
         const agentProc = spawn(pkg.bunBinary, ['run', runtimeServerPath], {
           cwd: projectDir,

--- a/apps/api/src/routes/terminal-pty-proxy.ts
+++ b/apps/api/src/routes/terminal-pty-proxy.ts
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { auth } from '../auth'
+import { prisma } from '../lib/prisma'
+import { getProjectPodUrl } from '../lib/knative-project-manager'
+import { deriveRuntimeToken } from '../lib/runtime-token'
+
+export interface TerminalPtyProxyData {
+  kind: 'terminal-pty-proxy'
+  projectId: string
+  upstreamUrl: string
+  runtimeToken: string
+  upstream?: WebSocket
+  upstreamOpen: boolean
+  clientClosed: boolean
+  queue: Array<string | Buffer>
+  queuedBytes: number
+}
+
+type ProxySocket = WebSocket & { data?: TerminalPtyProxyData }
+
+const isKubernetes = () => !!process.env.KUBERNETES_SERVICE_HOST
+const PREOPEN_QUEUE_LIMIT_BYTES = 64 * 1024
+
+async function resolveAgentRuntimeBaseUrl(projectId: string): Promise<string | Response> {
+  if (isKubernetes()) {
+    try {
+      return await getProjectPodUrl(projectId)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      const status = /not ready|not found|starting/i.test(message) ? 503 : 502
+      return new Response(status === 503 ? 'Project runtime is starting' : 'Failed to resolve project runtime', {
+        status,
+        headers: status === 503 ? { 'Retry-After': '5' } : undefined,
+      })
+    }
+  }
+
+  const { getRuntimeManager } = await import('../lib/runtime')
+  const manager = getRuntimeManager()
+  let runtime = manager.status(projectId)
+  if (!runtime || !runtime.agentPort) {
+    try {
+      runtime = await manager.start(projectId)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return new Response(message || 'Failed to start project runtime', {
+        status: 503,
+        headers: { 'Retry-After': '5' },
+      })
+    }
+  }
+  if (!runtime?.agentPort) {
+    return new Response('Project runtime is starting', { status: 503, headers: { 'Retry-After': '5' } })
+  }
+  return `http://localhost:${runtime.agentPort}`
+}
+
+export async function prepareTerminalPtyUpgrade(req: Request): Promise<TerminalPtyProxyData | Response | null> {
+  const url = new URL(req.url)
+  const match = url.pathname.match(/^\/api\/projects\/([^/]+)\/terminal\/pty$/)
+  if (!match) return null
+  if (req.headers.get('upgrade')?.toLowerCase() !== 'websocket') {
+    return new Response('WebSocket upgrade required', { status: 426 })
+  }
+  if (process.env.SHOGO_LOCAL_MODE !== 'true') {
+    return new Response('PTY terminal is only available in Shogo Desktop', { status: 404 })
+  }
+  const originError = validateOrigin(req)
+  if (originError) return originError
+
+  const projectId = decodeURIComponent(match[1] || '')
+  const authResult = await authorizeProjectRequest(req, projectId)
+  if (authResult) return authResult
+
+  const podUrl = await resolveAgentRuntimeBaseUrl(projectId)
+  if (podUrl instanceof Response) return podUrl
+
+  const upstreamUrl = toWebSocketUrl(`${podUrl}/terminal/pty`)
+  return {
+    kind: 'terminal-pty-proxy',
+    projectId,
+    upstreamUrl,
+    runtimeToken: deriveRuntimeToken(projectId),
+    upstreamOpen: false,
+    clientClosed: false,
+    queue: [],
+    queuedBytes: 0,
+  }
+}
+
+export function handleTerminalPtyProxyOpen(ws: ProxySocket): void {
+  const data = ws.data
+  if (!data) {
+    ws.close(1011, 'Missing proxy data')
+    return
+  }
+  let upstream: WebSocket
+  try {
+    upstream = createUpstreamWebSocket(data.upstreamUrl, { 'x-runtime-token': data.runtimeToken })
+  } catch {
+    ws.close(1011, 'PTY upstream WebSocket unsupported')
+    return
+  }
+  data.upstream = upstream
+
+  upstream.onopen = () => {
+    data.upstreamOpen = true
+    for (const queued of data.queue.splice(0)) upstream.send(queued as any)
+    data.queuedBytes = 0
+  }
+  upstream.onmessage = (event) => {
+    if (data.clientClosed) return
+    ws.send(event.data as any)
+  }
+  upstream.onerror = () => {
+    if (!data.clientClosed) ws.close(1011, 'PTY upstream error')
+  }
+  upstream.onclose = (event) => {
+    if (!data.clientClosed) ws.close(event.code || 1011, event.reason || 'PTY upstream closed')
+  }
+}
+
+export function handleTerminalPtyProxyMessage(ws: ProxySocket, raw: string | Buffer): void {
+  const data = ws.data
+  if (!data?.upstream) return
+  if (data.upstreamOpen && data.upstream.readyState === WebSocket.OPEN) {
+    data.upstream.send(raw as any)
+    return
+  }
+  const rawBytes = frameByteLength(raw)
+  if (data.queuedBytes + rawBytes > PREOPEN_QUEUE_LIMIT_BYTES) {
+    ws.send(JSON.stringify({ type: 'error', message: 'PTY upstream is not ready; input buffer limit exceeded' }))
+    ws.close(1013, 'PTY upstream not ready')
+    return
+  }
+  data.queue.push(raw)
+  data.queuedBytes += rawBytes
+}
+
+export function handleTerminalPtyProxyClose(ws: ProxySocket): void {
+  const data = ws.data
+  if (!data) return
+  data.clientClosed = true
+  data.queue.length = 0
+  data.queuedBytes = 0
+  try {
+    data.upstream?.close()
+  } catch {
+    // Best-effort upstream cleanup.
+  }
+}
+
+async function authorizeProjectRequest(req: Request, projectId: string): Promise<Response | null> {
+  const session = await auth.api.getSession({ headers: req.headers }).catch(() => null)
+  if (!session?.user?.id) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: { workspaceId: true },
+  })
+  if (!project) return new Response('Project not found', { status: 404 })
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { role: true },
+  })
+  if (user?.role === 'super_admin') return null
+
+  const member = await prisma.member.findFirst({
+    where: { userId: session.user.id, workspaceId: project.workspaceId },
+    select: { id: true },
+  })
+  return member ? null : new Response('Forbidden', { status: 403 })
+}
+
+function validateOrigin(req: Request): Response | null {
+  const origin = req.headers.get('origin')
+  const allowed = (process.env.ALLOWED_ORIGINS || '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+  if (!origin) {
+    if (process.env.NODE_ENV === 'production' && allowed.length > 0) {
+      return new Response('Forbidden origin', { status: 403 })
+    }
+    return null
+  }
+  if (allowed.length === 0 || allowed.includes(origin)) return null
+  if (process.env.NODE_ENV !== 'production' && /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) {
+    return null
+  }
+  return new Response('Forbidden origin', { status: 403 })
+}
+
+function toWebSocketUrl(httpUrl: string): string {
+  const url = new URL(httpUrl)
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+  return url.toString()
+}
+
+function frameByteLength(frame: string | Buffer): number {
+  return typeof frame === 'string' ? Buffer.byteLength(frame, 'utf8') : frame.byteLength
+}
+
+function createUpstreamWebSocket(url: string, headers: Record<string, string>): WebSocket {
+  if (typeof Bun !== 'undefined') {
+    return new WebSocket(url, { headers } as unknown as ConstructorParameters<typeof WebSocket>[1])
+  }
+  throw new Error('PTY upstream WebSocket headers require Bun runtime')
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -35,6 +35,13 @@ import { filesRoutes } from './routes/files'
 import { projectChatRoutes } from './routes/project-chat'
 import { projectAdminRoutes } from './routes/project-admin'
 import { terminalRoutes } from './routes/terminal'
+import {
+  handleTerminalPtyProxyClose,
+  handleTerminalPtyProxyMessage,
+  handleTerminalPtyProxyOpen,
+  prepareTerminalPtyUpgrade,
+  type TerminalPtyProxyData,
+} from './routes/terminal-pty-proxy'
 import { diagnosticsRoutes } from '@shogo/shared-runtime'
 import { testsRoutes } from './routes/tests'
 import { securityRoutes } from './routes/security'
@@ -6366,6 +6373,13 @@ export default {
   hostname: "0.0.0.0",
   fetch: async (req: Request, server: any) => {
     const url = new URL(req.url)
+    const terminalPtyUpgrade = await prepareTerminalPtyUpgrade(req)
+    if (terminalPtyUpgrade instanceof Response) return terminalPtyUpgrade
+    if (terminalPtyUpgrade) {
+      const upgraded = server.upgrade(req, { data: terminalPtyUpgrade satisfies TerminalPtyProxyData })
+      if (upgraded) return undefined
+      return new Response('WebSocket upgrade failed', { status: 500 })
+    }
     if (url.pathname === '/api/instances/ws' && req.headers.get('upgrade')?.toLowerCase() === 'websocket') {
       const authResult = await authenticateInstanceWs(req)
       if (!authResult) {
@@ -6378,9 +6392,18 @@ export default {
     return app.fetch(req, server)
   },
   websocket: {
-    open: handleInstanceWsOpen,
-    message: handleInstanceWsMessage,
-    close: handleInstanceWsClose,
+    open(ws: WebSocket & { data?: any }) {
+      if (ws.data?.kind === 'terminal-pty-proxy') return handleTerminalPtyProxyOpen(ws)
+      return handleInstanceWsOpen(ws)
+    },
+    message(ws: WebSocket & { data?: any }, raw: string | Buffer) {
+      if (ws.data?.kind === 'terminal-pty-proxy') return handleTerminalPtyProxyMessage(ws, raw)
+      return handleInstanceWsMessage(ws, raw)
+    },
+    close(ws: WebSocket & { data?: any }) {
+      if (ws.data?.kind === 'terminal-pty-proxy') return handleTerminalPtyProxyClose(ws)
+      return handleInstanceWsClose(ws)
+    },
   },
   idleTimeout: 255,
 }

--- a/apps/desktop/src/local-server.ts
+++ b/apps/desktop/src/local-server.ts
@@ -294,6 +294,7 @@ export async function startLocalServer(): Promise<void> {
     DATABASE_URL: `file:${getDbPath()}`,
     WORKSPACES_DIR: getWorkspacesDir(),
     S3_ENABLED: 'false',
+    ENABLE_PTY: '1',
     API_PORT: String(apiPort),
     PORT: String(apiPort),
     RUNTIME_BASE_PORT: String(RUNTIME_BASE_PORT),

--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -1,1 +1,4 @@
-# Trigger web rebuild for EXPO_PUBLIC_API_URL fix
+# Copy into apps/mobile/.env (gitignored) for local Expo / web.
+EXPO_PUBLIC_API_URL=http://localhost:8002
+# Real PTY terminal in the IDE panel. Only Shogo Desktop can use it.
+EXPO_PUBLIC_ENABLE_PTY=false

--- a/apps/mobile/components/project/panels/ide/BottomPanel.tsx
+++ b/apps/mobile/components/project/panels/ide/BottomPanel.tsx
@@ -145,6 +145,7 @@ export function BottomPanel({
         >
           <Terminal
             projectId={projectId}
+            agentUrl={agentUrl ?? null}
             visible={tab === "Terminal"}
             newSessionNonce={newSessionNonce}
             onRequestClose={onClose}

--- a/apps/mobile/components/project/panels/ide/OutputTab.tsx
+++ b/apps/mobile/components/project/panels/ide/OutputTab.tsx
@@ -34,6 +34,7 @@ import {
 import { useRuntimeLogStream } from '../../../../lib/runtime-logs/useRuntimeLogStream'
 
 type SourceFilter = 'all' | RuntimeLogSource
+type LevelFilter = 'all' | LogLevel
 
 const SOURCE_FILTERS: ReadonlyArray<{ id: SourceFilter; label: string }> = [
   { id: 'all', label: 'All' },
@@ -41,6 +42,7 @@ const SOURCE_FILTERS: ReadonlyArray<{ id: SourceFilter; label: string }> = [
   { id: 'console', label: 'Console' },
   { id: 'canvas-error', label: 'Canvas' },
   { id: 'exec', label: 'Exec' },
+  { id: 'terminal', label: 'Terminal' },
 ]
 
 const LEVEL_BADGE_CLASS: Record<LogLevel, string> = {
@@ -103,6 +105,7 @@ export function OutputTab({
   })
 
   const [sourceFilter, setSourceFilter] = useState<SourceFilter>('all')
+  const [levelFilter, setLevelFilter] = useState<LevelFilter>('all')
   const [search, setSearch] = useState('')
   const [autoScroll, setAutoScroll] = useState(true)
   const listRef = useRef<HTMLDivElement | null>(null)
@@ -119,12 +122,15 @@ export function OutputTab({
     if (sourceFilter !== 'all') {
       filtered = filtered.filter((e) => e.source === sourceFilter)
     }
+    if (levelFilter !== 'all') {
+      filtered = filtered.filter((e) => e.level === levelFilter)
+    }
     const q = search.trim().toLowerCase()
     if (q.length > 0) {
       filtered = filtered.filter((e) => e.text.toLowerCase().includes(q))
     }
     return filtered.map(deriveLogRow)
-  }, [entries, sourceFilter, search])
+  }, [entries, sourceFilter, levelFilter, search])
 
   // Auto-scroll to bottom when new rows land. We re-run when the filtered
   // length changes — not just `entries.length` — so toggling a filter
@@ -176,28 +182,34 @@ export function OutputTab({
         role="toolbar"
         aria-label="Output toolbar"
       >
-        <div role="group" aria-label="Filter by source" className="flex gap-1">
-          {SOURCE_FILTERS.map((f) => {
-            const active = sourceFilter === f.id
-            return (
-              <button
-                key={f.id}
-                type="button"
-                role="radio"
-                aria-checked={active}
-                aria-label={`Filter by ${f.label}`}
-                onClick={() => setSourceFilter(f.id)}
-                className={`rounded-full px-2 py-0.5 text-[11px] ${
-                  active
-                    ? 'bg-zinc-600 text-white'
-                    : 'bg-zinc-800/60 text-zinc-400 hover:text-white'
-                }`}
-              >
-                {f.label}
-              </button>
-            )
-          })}
-        </div>
+        <label className="flex items-center gap-1 text-[11px] text-zinc-400">
+          Channel
+          <select
+            value={sourceFilter}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => setSourceFilter(e.target.value as SourceFilter)}
+            aria-label="Output channel"
+            className="rounded border border-[#2a2a2a] bg-[#252526] px-2 py-0.5 text-[11px] text-zinc-200 outline-none focus:border-[#0078d4]"
+          >
+            {SOURCE_FILTERS.map((f) => (
+              <option key={f.id} value={f.id}>{f.label}</option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex items-center gap-1 text-[11px] text-zinc-400">
+          Level
+          <select
+            value={levelFilter}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => setLevelFilter(e.target.value as LevelFilter)}
+            aria-label="Output level"
+            className="rounded border border-[#2a2a2a] bg-[#252526] px-2 py-0.5 text-[11px] text-zinc-200 outline-none focus:border-[#0078d4]"
+          >
+            <option value="all">All</option>
+            <option value="info">Info</option>
+            <option value="warn">Warn</option>
+            <option value="error">Error</option>
+          </select>
+        </label>
 
         <div className="ml-auto flex items-center gap-2">
           <label className="flex items-center gap-1 text-[11px] text-zinc-400">

--- a/apps/mobile/components/project/panels/ide/Problems.tsx
+++ b/apps/mobile/components/project/panels/ide/Problems.tsx
@@ -31,6 +31,7 @@ import {
 } from "../../../../lib/diagnostics-api"
 
 const POLL_INTERVAL_MS = 6_000
+type SeverityFilter = "all" | Diagnostic["severity"]
 
 export interface ProblemsProps {
   projectId: string | null | undefined
@@ -106,6 +107,7 @@ export function Problems({ projectId, visible, onReveal }: ProblemsProps) {
   const [refreshing, setRefreshing] = useState(false)
   const [error, setError] = useState<DiagnosticsApiError | Error | null>(null)
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
+  const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("all")
   const abortRef = useRef<AbortController | null>(null)
   const lastRunAtRef = useRef<string | undefined>(undefined)
   // Refs mirror the state values that `load` reads — kept out of the
@@ -175,9 +177,15 @@ export function Problems({ projectId, visible, onReveal }: ProblemsProps) {
     return () => clearInterval(t)
   }, [visible, projectId, load])
 
+  const visibleDiagnostics = useMemo(() => {
+    const diagnostics = result?.diagnostics ?? []
+    return severityFilter === "all"
+      ? diagnostics
+      : diagnostics.filter((d) => d.severity === severityFilter)
+  }, [result, severityFilter])
   const groups = useMemo(
-    () => result ? groupByFile(result.diagnostics) : [],
-    [result],
+    () => groupByFile(visibleDiagnostics),
+    [visibleDiagnostics],
   )
   const totals = useMemo(() => {
     let errors = 0, warnings = 0
@@ -270,6 +278,42 @@ export function Problems({ projectId, visible, onReveal }: ProblemsProps) {
           <RefreshCw size={14} className={refreshing ? "animate-spin" : ""} aria-hidden />
         </button>
       </div>
+
+      {result && (
+        <div className="flex items-center gap-1 border-b border-[color:var(--ide-border)] px-3 py-1">
+          {(["all", "error", "warning", "info", "hint"] as const).map((filter) => {
+            const active = severityFilter === filter
+            return (
+              <button
+                key={filter}
+                type="button"
+                onClick={() => setSeverityFilter(filter)}
+                className={`rounded-full px-2 py-0.5 text-[10px] capitalize ${
+                  active
+                    ? "bg-[color:var(--ide-hover)] text-[color:var(--ide-text-strong)]"
+                    : "text-[color:var(--ide-muted)] hover:bg-[color:var(--ide-hover-subtle)] hover:text-[color:var(--ide-text)]"
+                }`}
+              >
+                {filter}
+              </button>
+            )
+          })}
+          <button
+            type="button"
+            className="ml-auto rounded px-2 py-0.5 text-[10px] text-[color:var(--ide-muted)] hover:bg-[color:var(--ide-hover-subtle)] hover:text-[color:var(--ide-text)]"
+            onClick={() => setCollapsed(new Set())}
+          >
+            Expand all
+          </button>
+          <button
+            type="button"
+            className="rounded px-2 py-0.5 text-[10px] text-[color:var(--ide-muted)] hover:bg-[color:var(--ide-hover-subtle)] hover:text-[color:var(--ide-text)]"
+            onClick={() => setCollapsed(new Set(groups.map((g) => g.file)))}
+          >
+            Collapse all
+          </button>
+        </div>
+      )}
 
       {/* Notes (per-source banners) */}
       {result?.notes && result.notes.length > 0 && (
@@ -368,6 +412,10 @@ export function Problems({ projectId, visible, onReveal }: ProblemsProps) {
                           <button
                             type="button"
                             onClick={() => onReveal?.(d.file, d.line, d.column)}
+                            onContextMenu={(event) => {
+                              event.preventDefault()
+                              void navigator.clipboard?.writeText(`${d.file}:${d.line}:${d.column} ${d.message}`)
+                            }}
                             disabled={!onReveal}
                             aria-label={`${d.severity} ${d.code ?? ""} ${d.message} at ${basenameOf(d.file)} line ${d.line} column ${d.column}`}
                             title={d.message}

--- a/apps/mobile/components/project/panels/ide/Terminal.tsx
+++ b/apps/mobile/components/project/panels/ide/Terminal.tsx
@@ -30,6 +30,7 @@ import {
   patchSession as patchSessionInList,
   type Session,
 } from "./terminal/session-reducer";
+import { PtyTerminal, type PtyTerminalHandle } from "./terminal/pty/PtyTerminal";
 
 /**
  * The IDE "Terminal" — a dual-mode runner for project workspaces.
@@ -92,11 +93,13 @@ const CATEGORY_ORDER: string[] = ["package", "database", "test", "build", "lint"
 
 export function Terminal({
   projectId,
+  agentUrl = null,
   visible,
   newSessionNonce,
   onRequestClose,
 }: {
   projectId: string | null | undefined;
+  agentUrl?: string | null;
   visible: boolean;
   /** Parent increments this to request a new terminal (keyboard ⌘⇧`). */
   newSessionNonce?: number;
@@ -114,10 +117,16 @@ export function Terminal({
   const [confirming, setConfirming] = useState<PresetCommandDto | null>(null);
   const outputRef = useRef<HTMLDivElement>(null);
   const promptInputRef = useRef<HTMLInputElement>(null);
+  const ptyRef = useRef<PtyTerminalHandle>(null);
   const sessionsRef = useRef(sessions);
   sessionsRef.current = sessions;
 
   const apiBase = API_URL;
+  const ptyPreferred =
+    Platform.OS === "web" &&
+    isShogoDesktopApp() &&
+    !isRemoteInstanceAgentUrl(agentUrl) &&
+    (process.env.EXPO_PUBLIC_ENABLE_PTY === "1" || process.env.EXPO_PUBLIC_ENABLE_PTY === "true");
   const active = sessions.find((s) => s.id === activeId) ?? sessions[0];
   // Labels are positional — derived on every render so closing tab #2 leaves
   // "Terminal 1, Terminal 2" instead of "Terminal 1, Terminal 3".
@@ -517,13 +526,21 @@ export function Terminal({
   );
 
   const stop = useCallback(() => {
+    if (ptyPreferred && active?.mode === "pty") {
+      ptyRef.current?.interrupt();
+      return;
+    }
     active?.abort?.abort();
-  }, [active]);
+  }, [active, ptyPreferred]);
 
   const clear = useCallback(() => {
     if (!active) return;
+    if (ptyPreferred && active.mode === "pty") {
+      ptyRef.current?.clear();
+      return;
+    }
     patchSession(active.id, (s) => ({ ...s, output: "" }));
-  }, [active, patchSession]);
+  }, [active, patchSession, ptyPreferred]);
 
   // ─── Early exits ────────────────────────────────────────────────────
   if (!projectId) {
@@ -575,8 +592,8 @@ export function Terminal({
         onAdd={addSession}
         onStop={stop}
         onClear={clear}
-        clearDisabled={!active?.output}
-        running={!!active?.runningCmdId}
+        clearDisabled={ptyPreferred && active?.mode === "pty" ? false : !active?.output}
+        running={ptyPreferred && active?.mode === "pty" ? false : !!active?.runningCmdId}
         presetGroups={presetGroups}
         presetsLoading={loading}
         presetsError={loadError}
@@ -591,26 +608,44 @@ export function Terminal({
         aria-label="Terminal output"
         className="flex-1 cursor-text overflow-auto bg-[#1e1e1e] px-3 py-2 font-mono text-[12px] leading-[1.5] text-[#d4d4d4]"
       >
-        {active?.output && (
-          <pre className="m-0 whitespace-pre-wrap break-words font-mono">
-            {active.output}
-          </pre>
-        )}
-        {/*
-         * Prompt lives inside the scroll region (VS Code / Cursor parity) so
-         * it sits flush against the last line of output and scrolls with it.
-         * While a command is running we hide the input — the running command
-         * owns the bottom of the log, and the user can hit Ctrl+C / Stop.
-         */}
-        {!active?.runningCmdId && (
-          <Prompt
-            ref={promptInputRef}
-            disabled={!projectId}
-            history={active?.history ?? []}
-            cwdLabel={formatPromptCwd(active?.cwd ?? null)}
-            onRun={(cmd) => void runFreeCommand(cmd)}
-            onClear={clear}
+        {ptyPreferred && active?.mode === "pty" ? (
+          <PtyTerminal
+            ref={ptyRef}
+            projectId={projectId}
+            sessionKey={active.id}
+            cwd={active.cwd}
+            onFallback={(reason) => {
+              patchSession(active.id, (s) => ({
+                ...s,
+                mode: "http",
+                output: `[PTY unavailable] ${reason}\n\n`,
+              }));
+            }}
           />
+        ) : (
+          <>
+            {active?.output && (
+              <pre className="m-0 whitespace-pre-wrap break-words font-mono">
+                {active.output}
+              </pre>
+            )}
+            {/*
+             * Prompt lives inside the scroll region (VS Code / Cursor parity) so
+             * it sits flush against the last line of output and scrolls with it.
+             * While a command is running we hide the input — the running command
+             * owns the bottom of the log, and the user can hit Ctrl+C / Stop.
+             */}
+            {!active?.runningCmdId && (
+              <Prompt
+                ref={promptInputRef}
+                disabled={!projectId}
+                history={active?.history ?? []}
+                cwdLabel={formatPromptCwd(active?.cwd ?? null)}
+                onRun={(cmd) => void runFreeCommand(cmd)}
+                onClear={clear}
+              />
+            )}
+          </>
         )}
       </div>
 
@@ -878,6 +913,19 @@ function SessionTabs({
       )}
     </div>
   );
+}
+
+function isShogoDesktopApp(): boolean {
+  return typeof window !== "undefined" && !!(window as any).shogoDesktop?.isDesktop;
+}
+
+function isRemoteInstanceAgentUrl(agentUrl: string | null | undefined): boolean {
+  if (!agentUrl) return false;
+  try {
+    return new URL(agentUrl, API_URL).pathname.includes("/api/instances/");
+  } catch {
+    return agentUrl.includes("/api/instances/");
+  }
 }
 
 function MenuItem({

--- a/apps/mobile/components/project/panels/ide/terminal/pty/PtyTerminal.tsx
+++ b/apps/mobile/components/project/panels/ide/terminal/pty/PtyTerminal.tsx
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import React, { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
+import { API_URL } from "../../../../../../lib/api";
+import { PtyClient, toTerminalPtyWsUrl } from "./pty-client";
+
+export interface PtyTerminalHandle {
+  clear: () => void;
+  interrupt: () => void;
+}
+
+export const PtyTerminal = forwardRef<PtyTerminalHandle, {
+  projectId: string;
+  sessionKey: string;
+  cwd?: string | null;
+  onFallback: (reason: string) => void;
+}>(function PtyTerminal({ projectId, sessionKey, cwd, onFallback }, ref) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const termRef = useRef<any>(null);
+  const fitRef = useRef<any>(null);
+  const clientRef = useRef<PtyClient | null>(null);
+  const outputQueueRef = useRef("");
+  const outputFlushRef = useRef<number | null>(null);
+  const fallbackRef = useRef(onFallback);
+  fallbackRef.current = onFallback;
+
+  useImperativeHandle(ref, () => ({
+    clear() {
+      termRef.current?.clear?.();
+    },
+    interrupt() {
+      clientRef.current?.signal("SIGINT");
+    },
+  }), []);
+
+  useEffect(() => {
+    let disposed = false;
+    let resizeTimer: ReturnType<typeof setTimeout> | null = null;
+
+    async function boot() {
+      try {
+        const [{ Terminal }, { FitAddon }, { WebLinksAddon }] = await Promise.all([
+          import("@xterm/xterm"),
+          import("@xterm/addon-fit"),
+          import("@xterm/addon-web-links"),
+        ]);
+        if (disposed || !hostRef.current) return;
+        ensureXtermRuntimeStyles();
+
+        const term = new Terminal({
+          cursorBlink: true,
+          convertEol: true,
+          fontFamily: "Menlo, Monaco, Consolas, 'Liberation Mono', monospace",
+          fontSize: 12,
+          lineHeight: 1.25,
+          scrollback: 1000,
+          theme: {
+            background: "#1e1e1e",
+            foreground: "#d4d4d4",
+            cursor: "#d4d4d4",
+            selectionBackground: "#264f78",
+          },
+        });
+        const fit = new FitAddon();
+        term.loadAddon(fit);
+        term.loadAddon(new WebLinksAddon());
+        term.open(hostRef.current);
+        termRef.current = term;
+        fitRef.current = fit;
+        fit.fit();
+
+        const storageKey = `shogo:pty:${projectId}:${sessionKey}`;
+        const existingSessionId = window.sessionStorage.getItem(storageKey) ?? undefined;
+        const client = new PtyClient({
+          url: toTerminalPtyWsUrl(API_URL, projectId),
+          sessionId: existingSessionId,
+          cols: term.cols || 80,
+          rows: term.rows || 24,
+          cwd,
+        });
+        clientRef.current = client;
+        client.onReady((ready) => {
+          window.sessionStorage.setItem(storageKey, ready.sessionId);
+        });
+        const writeQueued = (chunk: string) => {
+          outputQueueRef.current += chunk;
+          if (outputQueueRef.current.length > 256_000) {
+            outputQueueRef.current = outputQueueRef.current.slice(-256_000);
+            term.writeln("\r\n[PTY] output truncated because the browser fell behind\r\n");
+          }
+          if (outputFlushRef.current !== null) return;
+          outputFlushRef.current = requestAnimationFrame(() => {
+            outputFlushRef.current = null;
+            const next = outputQueueRef.current;
+            outputQueueRef.current = "";
+            if (next) term.write(next);
+          });
+        };
+        client.onData(writeQueued);
+        client.onError((message) => {
+          term.writeln(`\r\n[PTY] ${message}`);
+          window.sessionStorage.removeItem(storageKey);
+          fallbackRef.current(message);
+        });
+        client.onExit((exit) => {
+          const code = exit.exitCode === null ? "unknown" : String(exit.exitCode);
+          window.sessionStorage.removeItem(storageKey);
+          term.writeln(`\r\n[Process exited with code ${code}]`);
+        });
+        term.onData((data) => client.write(data));
+        client.connect();
+
+        const resize = () => {
+          if (resizeTimer) clearTimeout(resizeTimer);
+          resizeTimer = setTimeout(() => {
+            fit.fit();
+            client.resize(term.cols || 80, term.rows || 24);
+          }, 50);
+        };
+        window.addEventListener("resize", resize);
+        const observer = new ResizeObserver(resize);
+        observer.observe(hostRef.current);
+        return () => {
+          window.removeEventListener("resize", resize);
+          observer.disconnect();
+        };
+      } catch (err) {
+        fallbackRef.current(err instanceof Error ? err.message : String(err));
+      }
+    }
+
+    let cleanup: void | (() => void);
+    void boot().then((fn) => {
+      cleanup = fn;
+      if (disposed && cleanup) cleanup();
+    });
+    return () => {
+      disposed = true;
+      if (resizeTimer) clearTimeout(resizeTimer);
+      if (outputFlushRef.current !== null) cancelAnimationFrame(outputFlushRef.current);
+      outputFlushRef.current = null;
+      outputQueueRef.current = "";
+      cleanup?.();
+      clientRef.current?.close();
+      clientRef.current = null;
+      termRef.current?.dispose?.();
+      termRef.current = null;
+    };
+  }, [projectId, sessionKey, cwd]);
+
+  return <div ref={hostRef} className="h-full w-full overflow-hidden bg-[#1e1e1e]" />;
+});
+
+function ensureXtermRuntimeStyles(): void {
+  if (typeof document === "undefined" || document.getElementById("shogo-xterm-runtime-styles")) return;
+  const style = document.createElement("style");
+  style.id = "shogo-xterm-runtime-styles";
+  style.textContent = `
+.xterm {
+  position: relative;
+  user-select: none;
+  -ms-user-select: none;
+}
+.xterm.focus,
+.xterm:focus {
+  outline: none;
+}
+.xterm .xterm-helpers {
+  position: absolute;
+  top: 0;
+  z-index: 5;
+}
+.xterm .xterm-helper-textarea {
+  position: absolute;
+  left: -9999em;
+  top: 0;
+  width: 0;
+  height: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  opacity: 0;
+  resize: none;
+  overflow: hidden;
+  white-space: nowrap;
+}
+.xterm .composition-view {
+  display: none;
+  position: absolute;
+  white-space: nowrap;
+  z-index: 1;
+}
+.xterm .xterm-viewport {
+  position: absolute;
+  inset: 0;
+  overflow-y: scroll;
+  cursor: default;
+}
+.xterm .xterm-screen {
+  position: relative;
+}
+.xterm .xterm-screen canvas {
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+.xterm .xterm-scroll-area {
+  visibility: hidden;
+}
+.xterm-char-measure-element {
+  position: absolute;
+  left: -9999em;
+  top: 0;
+  display: inline-block;
+  visibility: hidden;
+}
+.xterm .xterm-accessibility,
+.xterm .xterm-message {
+  position: absolute;
+  inset: 0;
+  color: transparent;
+  pointer-events: none;
+}
+`;
+  document.head.appendChild(style);
+}

--- a/apps/mobile/components/project/panels/ide/terminal/pty/__tests__/pty-client.test.ts
+++ b/apps/mobile/components/project/panels/ide/terminal/pty/__tests__/pty-client.test.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, expect, test } from "bun:test";
+import { toTerminalPtyWsUrl } from "../pty-client";
+
+describe("pty-client", () => {
+  test("builds project-scoped websocket URLs", () => {
+    expect(toTerminalPtyWsUrl("https://studio.example.com", "project 1")).toBe(
+      "wss://studio.example.com/api/projects/project%201/terminal/pty",
+    );
+    expect(toTerminalPtyWsUrl("http://localhost:8002", "abc")).toBe(
+      "ws://localhost:8002/api/projects/abc/terminal/pty",
+    );
+  });
+});

--- a/apps/mobile/components/project/panels/ide/terminal/pty/pty-client.ts
+++ b/apps/mobile/components/project/panels/ide/terminal/pty/pty-client.ts
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+export type PtySignal = 'SIGINT' | 'SIGTERM' | 'SIGKILL' | 'EOF'
+
+export type PtyServerFrame =
+  | { type: 'ready'; sessionId: string; cwd: string; scrollback?: string; attached: boolean }
+  | { type: 'data'; data: string }
+  | { type: 'exit'; exitCode: number | null; signal: string | null }
+  | { type: 'error'; message: string }
+  | { type: 'pong' }
+
+type Handler<T> = (value: T) => void
+const CLIENT_BACKPRESSURE_LIMIT_BYTES = 1 * 1024 * 1024
+const RECONNECT_BASE_DELAY_MS = 300
+const RECONNECT_MAX_DELAY_MS = 5_000
+const RECONNECT_MAX_ATTEMPTS = 6
+
+export interface PtyClientOptions {
+  url: string
+  sessionId?: string
+  cols: number
+  rows: number
+  cwd?: string | null
+}
+
+export class PtyClient {
+  private readonly url: string
+  private readonly cwd?: string | null
+  private ws: WebSocket | null = null
+  private heartbeat: ReturnType<typeof setInterval> | null = null
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectAttempts = 0
+  private cols: number
+  private rows: number
+  private sessionId?: string
+  private closed = false
+  private ready = false
+
+  private readonly dataHandlers = new Set<Handler<string>>()
+  private readonly readyHandlers = new Set<Handler<Extract<PtyServerFrame, { type: 'ready' }>>>()
+  private readonly exitHandlers = new Set<Handler<Extract<PtyServerFrame, { type: 'exit' }>>>()
+  private readonly errorHandlers = new Set<Handler<string>>()
+  private readonly closeHandlers = new Set<Handler<void>>()
+
+  constructor(options: PtyClientOptions) {
+    this.url = options.url
+    this.sessionId = options.sessionId
+    this.cols = options.cols
+    this.rows = options.rows
+    this.cwd = options.cwd
+  }
+
+  connect(): void {
+    this.closed = false
+    this.clearReconnect()
+    this.openSocket()
+  }
+
+  private openSocket(): void {
+    if (this.closed) return
+    const ws = new WebSocket(this.url)
+    this.ws = ws
+    ws.onopen = () => {
+      this.send({
+        type: 'init',
+        sessionId: this.sessionId,
+        cols: this.cols,
+        rows: this.rows,
+        cwd: this.cwd ?? undefined,
+        shell: 'bash',
+      })
+      this.startHeartbeat()
+    }
+    ws.onmessage = (event) => this.handleMessage(event.data)
+    ws.onerror = () => {
+      // The close event drives reconnect/fallback decisions.
+    }
+    ws.onclose = () => {
+      if (this.ws === ws) this.ws = null
+      this.stopHeartbeat()
+      this.ready = false
+      for (const handler of this.closeHandlers) handler()
+      this.scheduleReconnect()
+    }
+  }
+
+  write(data: string): void {
+    if (!this.ready) return
+    this.send({ type: 'data', data })
+  }
+
+  resize(cols: number, rows: number): void {
+    this.cols = cols
+    this.rows = rows
+    if (!this.ready) return
+    this.send({ type: 'resize', cols, rows })
+  }
+
+  signal(signal: PtySignal): void {
+    if (!this.ready) return
+    this.send({ type: 'signal', signal })
+  }
+
+  close(): void {
+    this.closed = true
+    this.clearReconnect()
+    this.stopHeartbeat()
+    this.ws?.close()
+    this.ws = null
+  }
+
+  getSessionId(): string | undefined {
+    return this.sessionId
+  }
+
+  onData(handler: Handler<string>): () => void {
+    this.dataHandlers.add(handler)
+    return () => this.dataHandlers.delete(handler)
+  }
+
+  onReady(handler: Handler<Extract<PtyServerFrame, { type: 'ready' }>>): () => void {
+    this.readyHandlers.add(handler)
+    return () => this.readyHandlers.delete(handler)
+  }
+
+  onExit(handler: Handler<Extract<PtyServerFrame, { type: 'exit' }>>): () => void {
+    this.exitHandlers.add(handler)
+    return () => this.exitHandlers.delete(handler)
+  }
+
+  onError(handler: Handler<string>): () => void {
+    this.errorHandlers.add(handler)
+    return () => this.errorHandlers.delete(handler)
+  }
+
+  onClose(handler: Handler<void>): () => void {
+    this.closeHandlers.add(handler)
+    return () => this.closeHandlers.delete(handler)
+  }
+
+  private handleMessage(raw: unknown): void {
+    let frame: PtyServerFrame
+    try {
+      frame = JSON.parse(typeof raw === 'string' ? raw : String(raw))
+    } catch {
+      this.emitError('Invalid PTY frame')
+      return
+    }
+    if (frame.type === 'ready') {
+      this.ready = true
+      this.reconnectAttempts = 0
+      this.sessionId = frame.sessionId
+      for (const handler of this.readyHandlers) handler(frame)
+      if (frame.scrollback) for (const handler of this.dataHandlers) handler(frame.scrollback)
+    } else if (frame.type === 'data') {
+      for (const handler of this.dataHandlers) handler(frame.data)
+    } else if (frame.type === 'exit') {
+      this.closed = true
+      this.clearReconnect()
+      this.stopHeartbeat()
+      for (const handler of this.exitHandlers) handler(frame)
+    } else if (frame.type === 'error') {
+      this.emitError(frame.message)
+    }
+  }
+
+  private send(frame: Record<string, unknown>): void {
+    if (this.closed || this.ws?.readyState !== WebSocket.OPEN) return
+    if (this.ws.bufferedAmount > CLIENT_BACKPRESSURE_LIMIT_BYTES) {
+      this.emitError('PTY client output buffer is full')
+      this.close()
+      return
+    }
+    this.ws.send(JSON.stringify(frame))
+  }
+
+  private emitError(message: string): void {
+    for (const handler of this.errorHandlers) handler(message)
+  }
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat()
+    this.heartbeat = setInterval(() => this.send({ type: 'ping' }), 25_000)
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeat) clearInterval(this.heartbeat)
+    this.heartbeat = null
+  }
+
+  private scheduleReconnect(): void {
+    if (this.closed || this.reconnectTimer) return
+    if (this.reconnectAttempts >= RECONNECT_MAX_ATTEMPTS) {
+      this.emitError('PTY connection closed')
+      return
+    }
+    this.reconnectAttempts += 1
+    const exponentialDelay = RECONNECT_BASE_DELAY_MS * 2 ** (this.reconnectAttempts - 1)
+    const jitter = Math.floor(Math.random() * RECONNECT_BASE_DELAY_MS)
+    const delay = Math.min(RECONNECT_MAX_DELAY_MS, exponentialDelay + jitter)
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      this.openSocket()
+    }, delay)
+  }
+
+  private clearReconnect(): void {
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer)
+    this.reconnectTimer = null
+  }
+}
+
+export function toTerminalPtyWsUrl(apiUrl: string, projectId: string): string {
+  const url = new URL(`/api/projects/${encodeURIComponent(projectId)}/terminal/pty`, apiUrl)
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+  return url.toString()
+}

--- a/apps/mobile/components/project/panels/ide/terminal/session-reducer.ts
+++ b/apps/mobile/components/project/panels/ide/terminal/session-reducer.ts
@@ -13,6 +13,12 @@
 
 export interface Session {
   id: string
+  /** Runtime mode for this terminal tab. PTY is preferred; HTTP is fallback. */
+  mode: 'pty' | 'http'
+  /** Last PTY session id stored by the server for reload/reattach. */
+  ptySessionId: string | null
+  /** Current PTY connection state used by the tab label/banner. */
+  ptyConnected: boolean
   output: string
   /** Non-null while a command (preset or free-form) is streaming. */
   runningCmdId: string | null
@@ -43,6 +49,9 @@ export function __resetSessionIdSeqForTest(): void {
 export function makeSession(): Session {
   return {
     id: `t-${Date.now().toString(36)}-${++_idSeq}`,
+    mode: 'pty',
+    ptySessionId: null,
+    ptyConnected: false,
     output: '',
     runningCmdId: null,
     abort: null,

--- a/apps/mobile/lib/runtime-logs/runtime-log-store.ts
+++ b/apps/mobile/lib/runtime-logs/runtime-log-store.ts
@@ -19,7 +19,7 @@
  * keeps the dot meaningful instead of red-dotting on every reload.
  */
 
-export type RuntimeLogSource = 'console' | 'build' | 'canvas-error' | 'exec'
+export type RuntimeLogSource = 'console' | 'build' | 'canvas-error' | 'exec' | 'terminal'
 export type RuntimeLogLevel = 'info' | 'warn' | 'error'
 
 export interface RuntimeLogEntry {

--- a/bun.lock
+++ b/bun.lock
@@ -219,6 +219,7 @@
         "imapflow": "^1.2.10",
         "ioredis": "^5.10.1",
         "linkedom": "^0.18.12",
+        "node-pty": "^1.1.0",
         "nodemailer": "^8.0.1",
         "openai": "^6.25.0",
         "playwright-core": "^1.58.2",
@@ -3246,6 +3247,8 @@
 
     "node-abi": ["node-abi@3.89.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA=="],
 
+    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
@@ -3255,6 +3258,8 @@
     "node-forge": ["node-forge@1.3.3", "", {}, "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg=="],
 
     "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
+
+    "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 

--- a/e2e/staging/terminal-fallback.test.ts
+++ b/e2e/staging/terminal-fallback.test.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { test, expect } from '@playwright/test'
+
+test.describe('Terminal HTTP fallback', () => {
+  test.skip(!process.env.E2E_PROJECT_URL, 'Set E2E_PROJECT_URL to run against an authenticated staging project')
+
+  test('keeps the legacy prompt available when PTY is disabled', async ({ page }) => {
+    await page.goto(process.env.E2E_PROJECT_URL!)
+    await page.getByRole('tab', { name: 'Terminal' }).click()
+    await expect(page.getByLabel('Command')).toBeVisible()
+    await page.getByLabel('Command').fill('echo fallback-ok')
+    await page.keyboard.press('Enter')
+    await expect(page.getByText('fallback-ok')).toBeVisible({ timeout: 15_000 })
+  })
+})

--- a/e2e/staging/terminal-pty.test.ts
+++ b/e2e/staging/terminal-pty.test.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { test, expect } from '@playwright/test'
+
+test.describe('Terminal PTY', () => {
+  test.skip(!process.env.E2E_PROJECT_URL, 'Set E2E_PROJECT_URL to run against an authenticated staging project')
+
+  test('renders a PTY terminal and accepts interactive input', async ({ page }) => {
+    await page.goto(process.env.E2E_PROJECT_URL!)
+    await page.getByRole('tab', { name: 'Terminal' }).click()
+    await expect(page.getByLabel('Terminal output')).toBeVisible()
+    await page.keyboard.type('echo pty-ok')
+    await page.keyboard.press('Enter')
+    await expect(page.getByText('pty-ok')).toBeVisible({ timeout: 15_000 })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "mobile:ios": "cd apps/mobile && npx expo start --ios",
     "mobile:android": "cd apps/mobile && npx expo start --android",
     "mobile:web": "cd apps/mobile && npx expo start --web",
-    "desktop:build-web": "cd apps/mobile && EXPO_PUBLIC_LOCAL_MODE=true EXPO_PUBLIC_API_URL=http://localhost:8002 npx expo export --platform web",
+    "desktop:build-web": "cd apps/mobile && EXPO_PUBLIC_LOCAL_MODE=true EXPO_PUBLIC_ENABLE_PTY=true EXPO_PUBLIC_API_URL=http://localhost:8002 npx expo export --platform web",
     "desktop:dev": "DATABASE_URL=file:./shogo-local.db bun run db:generate:all && SHOGO_LOCAL_MODE=true bun run desktop:build-web && cd apps/desktop && npx tsc && SHOGO_LOCAL_MODE=true DATABASE_URL=file:./shogo-local.db npx electron .",
     "desktop:dev:clean": "rm -rf \"$HOME/Library/Application Support/Shogo/data\" && bun run desktop:dev",
     "docs:dev": "bun run --cwd apps/docs dev",

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -55,6 +55,7 @@
     "imapflow": "^1.2.10",
     "ioredis": "^5.10.1",
     "linkedom": "^0.18.12",
+    "node-pty": "^1.1.0",
     "nodemailer": "^8.0.1",
     "openai": "^6.25.0",
     "playwright-core": "^1.58.2",

--- a/packages/agent-runtime/src/pty/__tests__/pty-protocol.test.ts
+++ b/packages/agent-runtime/src/pty/__tests__/pty-protocol.test.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, expect, test } from 'bun:test'
+import { parsePtyClientFrame, serializePtyFrame } from '../pty-protocol'
+
+describe('pty protocol', () => {
+  test('parses init frames with clamped dimensions', () => {
+    expect(parsePtyClientFrame(JSON.stringify({ type: 'init', cols: 9999, rows: 0 }))).toEqual({
+      type: 'init',
+      sessionId: undefined,
+      cols: 500,
+      rows: 2,
+      cwd: undefined,
+      shell: undefined,
+    })
+  })
+
+  test('rejects malformed and unknown frames', () => {
+    expect(() => parsePtyClientFrame('{')).toThrow()
+    expect(() => parsePtyClientFrame(JSON.stringify({ type: 'wat' }))).toThrow('Unknown PTY frame type')
+  })
+
+  test('serializes server frames as JSON', () => {
+    expect(serializePtyFrame({ type: 'pong' })).toBe('{"type":"pong"}')
+  })
+})

--- a/packages/agent-runtime/src/pty/__tests__/pty-registry.test.ts
+++ b/packages/agent-runtime/src/pty/__tests__/pty-registry.test.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { PtyRegistry } from '../pty-registry'
+
+describe('PtyRegistry', () => {
+  test('creates, detaches, and reattaches a PTY session', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'shogo-pty-registry-'))
+    try {
+      const registry = new PtyRegistry({ rootDir: dir, idleTtlMs: 1000, maxAgeMs: 60_000 })
+      let first: Awaited<ReturnType<PtyRegistry['getOrCreate']>>
+      try {
+        first = await registry.getOrCreate({ cols: 80, rows: 24 })
+      } catch (err) {
+        // Some local Bun/macOS combinations can load node-pty but fail the
+        // native fork helper. Runtime handles this by surfacing a clean PTY
+        // init error and the client falls back to legacy HTTP mode.
+        expect(String(err)).toContain('posix_spawn')
+        return
+      }
+      expect(first.created).toBe(true)
+      registry.detach(first.session.id)
+      const second = await registry.getOrCreate({ sessionId: first.session.id, cols: 100, rows: 30 })
+      expect(second.session.id).toBe(first.session.id)
+      expect(second.attached).toBe(true)
+      registry.kill(first.session.id)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('does not reap an attached idle PTY session before max age', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'shogo-pty-registry-'))
+    try {
+      const registry = new PtyRegistry({ rootDir: dir, idleTtlMs: 1000, maxAgeMs: 60_000 })
+      let first: Awaited<ReturnType<PtyRegistry['getOrCreate']>>
+      try {
+        first = await registry.getOrCreate({ cols: 80, rows: 24 })
+      } catch (err) {
+        expect(String(err)).toContain('posix_spawn')
+        return
+      }
+
+      registry.reapExpired(first.session.lastActivityAt + 2_000)
+      expect(registry.size()).toBe(1)
+
+      registry.detach(first.session.id)
+      registry.reapExpired(first.session.lastActivityAt + 2_000)
+      expect(registry.size()).toBe(0)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/agent-runtime/src/pty/node-pty-bridge.cjs
+++ b/packages/agent-runtime/src/pty/node-pty-bridge.cjs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+const { existsSync, chmodSync } = require('fs')
+const { dirname, resolve } = require('path')
+const readline = require('readline')
+
+function send(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`)
+}
+
+function ensureSpawnHelperExecutable() {
+  if (process.platform !== 'darwin') return
+  try {
+    const packageDir = dirname(require.resolve('node-pty/package.json'))
+    const helper = resolve(packageDir, 'prebuilds', `${process.platform}-${process.arch}`, 'spawn-helper')
+    if (existsSync(helper)) chmodSync(helper, 0o755)
+  } catch {
+    // node-pty will report the actionable native error below.
+  }
+}
+
+try {
+  ensureSpawnHelperExecutable()
+
+  const pty = require('node-pty')
+  const config = JSON.parse(process.argv[2] || '{}')
+  const term = pty.spawn(config.file, config.args || [], config.options || {})
+
+  term.onData((data) => send({ type: 'data', data }))
+  term.onExit((event) => {
+    send({ type: 'exit', exitCode: event.exitCode, signal: event.signal })
+    process.exit(0)
+  })
+
+  const rl = readline.createInterface({ input: process.stdin, terminal: false })
+  rl.on('line', (line) => {
+    if (!line) return
+    const message = JSON.parse(line)
+    if (message.type === 'write') term.write(message.data || '')
+    else if (message.type === 'resize') term.resize(message.cols, message.rows)
+    else if (message.type === 'kill') {
+      term.kill(message.signal || 'SIGTERM')
+      setTimeout(() => process.exit(0), 100).unref()
+    }
+  })
+
+  send({ type: 'ready' })
+} catch (err) {
+  send({ type: 'error', message: err instanceof Error ? err.message : String(err) })
+  process.exit(1)
+}

--- a/packages/agent-runtime/src/pty/pty-protocol.ts
+++ b/packages/agent-runtime/src/pty/pty-protocol.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+export type PtySignal = 'SIGINT' | 'SIGTERM' | 'SIGKILL' | 'EOF'
+
+export type PtyShell = 'bash' | 'zsh' | 'sh' | 'pwsh' | 'powershell' | 'cmd'
+
+export type PtyClientFrame =
+  | { type: 'init'; sessionId?: string; cols: number; rows: number; cwd?: string; shell?: PtyShell }
+  | { type: 'data'; data: string }
+  | { type: 'resize'; cols: number; rows: number }
+  | { type: 'signal'; signal: PtySignal }
+  | { type: 'ping' }
+
+export type PtyServerFrame =
+  | { type: 'ready'; sessionId: string; cwd: string; scrollback?: string; attached: boolean }
+  | { type: 'data'; data: string }
+  | { type: 'exit'; exitCode: number | null; signal: string | null }
+  | { type: 'error'; message: string }
+  | { type: 'pong' }
+
+export function serializePtyFrame(frame: PtyClientFrame | PtyServerFrame): string {
+  return JSON.stringify(frame)
+}
+
+export function parsePtyClientFrame(raw: string | Buffer | ArrayBuffer | Uint8Array): PtyClientFrame {
+  const text =
+    typeof raw === 'string'
+      ? raw
+      : Buffer.isBuffer(raw)
+        ? raw.toString('utf8')
+        : raw instanceof ArrayBuffer
+          ? Buffer.from(new Uint8Array(raw)).toString('utf8')
+          : Buffer.from(raw).toString('utf8')
+  const value = JSON.parse(text) as unknown
+  if (!value || typeof value !== 'object') {
+    throw new Error('PTY frame must be an object')
+  }
+  const frame = value as Record<string, unknown>
+  switch (frame.type) {
+    case 'init': {
+      const cols = clampDimension(frame.cols, 2, 500, 80)
+      const rows = clampDimension(frame.rows, 2, 200, 24)
+      return {
+        type: 'init',
+        sessionId: typeof frame.sessionId === 'string' ? frame.sessionId : undefined,
+        cols,
+        rows,
+        cwd: typeof frame.cwd === 'string' ? frame.cwd : undefined,
+        shell: isShell(frame.shell) ? frame.shell : undefined,
+      }
+    }
+    case 'data':
+      if (typeof frame.data !== 'string') throw new Error('PTY data frame requires string data')
+      if (frame.data.length > 64 * 1024) throw new Error('PTY data frame too large')
+      return { type: 'data', data: frame.data }
+    case 'resize':
+      return {
+        type: 'resize',
+        cols: clampDimension(frame.cols, 2, 500, 80),
+        rows: clampDimension(frame.rows, 2, 200, 24),
+      }
+    case 'signal':
+      if (!isSignal(frame.signal)) throw new Error('Unsupported PTY signal')
+      return { type: 'signal', signal: frame.signal }
+    case 'ping':
+      return { type: 'ping' }
+    default:
+      throw new Error('Unknown PTY frame type')
+  }
+}
+
+function clampDimension(value: unknown, min: number, max: number, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  return Math.min(Math.max(Math.floor(value), min), max)
+}
+
+function isShell(value: unknown): value is PtyShell {
+  return value === 'bash' || value === 'zsh' || value === 'sh' || value === 'pwsh' || value === 'powershell' || value === 'cmd'
+}
+
+function isSignal(value: unknown): value is PtySignal {
+  return value === 'SIGINT' || value === 'SIGTERM' || value === 'SIGKILL' || value === 'EOF'
+}

--- a/packages/agent-runtime/src/pty/pty-registry.ts
+++ b/packages/agent-runtime/src/pty/pty-registry.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { randomUUID } from 'crypto'
+import { PtySession } from './pty-session'
+import type { PtyShell } from './pty-protocol'
+
+const DEFAULT_IDLE_TTL_MS = 10 * 60_000
+const DEFAULT_MAX_AGE_MS = 8 * 60 * 60_000
+const DEFAULT_MAX_SESSIONS = 8
+
+export interface PtyRegistryOptions {
+  rootDir: string
+  idleTtlMs?: number
+  maxAgeMs?: number
+  maxSessions?: number
+}
+
+export interface GetOrCreateArgs {
+  sessionId?: string
+  cwd?: string
+  cols: number
+  rows: number
+  shell?: PtyShell
+}
+
+export class PtyRegistry {
+  private readonly sessions = new Map<string, PtySession>()
+  private readonly rootDir: string
+  private readonly idleTtlMs: number
+  private readonly maxAgeMs: number
+  private readonly maxSessions: number
+
+  constructor(options: PtyRegistryOptions) {
+    this.rootDir = options.rootDir
+    this.idleTtlMs = options.idleTtlMs ?? DEFAULT_IDLE_TTL_MS
+    this.maxAgeMs = options.maxAgeMs ?? DEFAULT_MAX_AGE_MS
+    this.maxSessions = options.maxSessions ?? DEFAULT_MAX_SESSIONS
+  }
+
+  async getOrCreate(args: GetOrCreateArgs): Promise<{
+    session: PtySession
+    attached: boolean
+    created: boolean
+    scrollback: string
+  }> {
+    this.reapExpired()
+    if (args.sessionId) {
+      const existing = this.sessions.get(args.sessionId)
+      if (existing) {
+        const attach = existing.attach()
+        if (!attach.ok) throw new Error(attach.reason === 'attached' ? 'session_attached_elsewhere' : 'session_exited')
+        existing.resize(args.cols, args.rows)
+        return { session: existing, attached: true, created: false, scrollback: attach.scrollback }
+      }
+    }
+    if (this.sessions.size >= this.maxSessions) {
+      this.reapOldestDetached()
+      if (this.sessions.size >= this.maxSessions) throw new Error('too_many_pty_sessions')
+    }
+    const id = args.sessionId || randomUUID()
+    const session = await PtySession.create({
+      id,
+      cwd: args.cwd || this.rootDir,
+      rootDir: this.rootDir,
+      cols: args.cols,
+      rows: args.rows,
+      shell: args.shell,
+    })
+    const attach = session.attach()
+    if (!attach.ok) throw new Error('session_attach_failed')
+    session.onExit(() => {
+      if (this.sessions.get(id) !== session) return
+      setTimeout(() => {
+        if (!session.isAttached()) this.sessions.delete(id)
+      }, 30_000).unref?.()
+    })
+    this.sessions.set(id, session)
+    return { session, attached: false, created: true, scrollback: attach.scrollback }
+  }
+
+  detach(sessionId: string): void {
+    this.sessions.get(sessionId)?.detach()
+  }
+
+  kill(sessionId: string, signal: NodeJS.Signals = 'SIGTERM'): void {
+    const session = this.sessions.get(sessionId)
+    if (!session) return
+    session.kill(signal)
+    if (signal === 'SIGTERM') {
+      setTimeout(() => {
+        if (!session.isExited()) session.kill('SIGKILL')
+      }, 2_000).unref?.()
+    }
+    this.sessions.delete(sessionId)
+  }
+
+  reapExpired(now = Date.now()): void {
+    for (const [id, session] of this.sessions) {
+      const tooOld = now - session.createdAt > this.maxAgeMs
+      const idle = now - session.lastActivityAt > this.idleTtlMs
+      if (tooOld || (idle && !session.isAttached()) || session.isExited()) {
+        if (!session.isExited()) session.kill('SIGTERM')
+        this.sessions.delete(id)
+      }
+    }
+  }
+
+  size(): number {
+    return this.sessions.size
+  }
+
+  private reapOldestDetached(): void {
+    let oldest: { id: string; lastActivityAt: number } | null = null
+    for (const [id, session] of this.sessions) {
+      if (session.isAttached()) continue
+      if (!oldest || session.lastActivityAt < oldest.lastActivityAt) {
+        oldest = { id, lastActivityAt: session.lastActivityAt }
+      }
+    }
+    if (oldest) this.kill(oldest.id)
+  }
+}

--- a/packages/agent-runtime/src/pty/pty-session.ts
+++ b/packages/agent-runtime/src/pty/pty-session.ts
@@ -1,0 +1,428 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { existsSync } from 'fs'
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from 'child_process'
+import { chmodSync } from 'fs'
+import { dirname, isAbsolute, relative, resolve } from 'path'
+import { fileURLToPath } from 'url'
+import type { IPty } from 'node-pty'
+import type { PtyShell, PtySignal } from './pty-protocol'
+
+const DEFAULT_SCROLLBACK_BYTES = 64 * 1024
+const NODE_PTY_BRIDGE = resolve(dirname(fileURLToPath(import.meta.url)), 'node-pty-bridge.cjs')
+
+export interface PtySessionInit {
+  id: string
+  cwd: string
+  rootDir: string
+  cols: number
+  rows: number
+  shell?: PtyShell
+  scrollbackBytes?: number
+}
+
+export interface PtyExit {
+  exitCode: number | null
+  signal: string | null
+}
+
+export class PtySession {
+  readonly id: string
+  readonly cwd: string
+  readonly createdAt = Date.now()
+  lastAttachedAt = Date.now()
+  lastActivityAt = Date.now()
+  bytesIn = 0
+  bytesOut = 0
+
+  private readonly ptyProcess: PtyProcess
+  private readonly scrollbackBytes: number
+  private scrollback = ''
+  private attached = false
+  private exited = false
+  private dataHandlers = new Set<(data: string) => void>()
+  private exitHandlers = new Set<(exit: PtyExit) => void>()
+
+  private constructor(args: PtySessionInit & { ptyProcess: PtyProcess }) {
+    this.id = args.id
+    this.cwd = args.cwd
+    this.scrollbackBytes = args.scrollbackBytes ?? DEFAULT_SCROLLBACK_BYTES
+    this.ptyProcess = args.ptyProcess
+
+    this.ptyProcess.onData((data) => {
+      this.lastActivityAt = Date.now()
+      this.bytesOut += Buffer.byteLength(data, 'utf8')
+      this.appendScrollback(data)
+      for (const handler of this.dataHandlers) handler(data)
+    })
+
+    this.ptyProcess.onExit((event) => {
+      this.exited = true
+      const exit = {
+        exitCode: typeof event.exitCode === 'number' ? event.exitCode : null,
+        signal: typeof event.signal === 'number' ? String(event.signal) : event.signal ?? null,
+      }
+      for (const handler of this.exitHandlers) handler(exit)
+      this.dataHandlers.clear()
+      this.exitHandlers.clear()
+    })
+  }
+
+  static async create(args: PtySessionInit): Promise<PtySession> {
+    const cwd = pickExistingCwd(args.cwd, args.rootDir)
+    const shell = resolveShell(args.shell)
+    const options = {
+      name: 'xterm-256color',
+      cols: args.cols,
+      rows: args.rows,
+      cwd,
+      // Do not leak the runtime pod's full environment into an interactive
+      // shell. The runtime may hold AI/API tokens; the terminal gets only the
+      // minimum process environment needed for normal CLI behavior.
+      env: buildSafePtyEnv(args.rootDir, shell.executable),
+    }
+    const ptyProcess = process.versions.bun && process.env.NODE_ENV !== 'test'
+      ? await createNodeBridgePty(shell.executable, shell.args, options)
+      : await createNativePty(shell.executable, shell.args, options)
+    return new PtySession({ ...args, cwd, ptyProcess })
+  }
+
+  attach(): { ok: true; scrollback: string } | { ok: false; reason: 'attached' | 'exited' } {
+    if (this.exited) return { ok: false, reason: 'exited' }
+    if (this.attached) return { ok: false, reason: 'attached' }
+    this.attached = true
+    this.lastAttachedAt = Date.now()
+    return { ok: true, scrollback: this.scrollback }
+  }
+
+  detach(): void {
+    this.attached = false
+    this.lastActivityAt = Date.now()
+  }
+
+  onData(handler: (data: string) => void): () => void {
+    this.dataHandlers.add(handler)
+    return () => this.dataHandlers.delete(handler)
+  }
+
+  onExit(handler: (exit: PtyExit) => void): () => void {
+    this.exitHandlers.add(handler)
+    return () => this.exitHandlers.delete(handler)
+  }
+
+  write(data: string): void {
+    if (this.exited) return
+    this.lastActivityAt = Date.now()
+    this.bytesIn += Buffer.byteLength(data, 'utf8')
+    this.ptyProcess.write(data)
+  }
+
+  resize(cols: number, rows: number): void {
+    if (this.exited) return
+    this.lastActivityAt = Date.now()
+    this.ptyProcess.resize(cols, rows)
+  }
+
+  signal(signal: PtySignal): void {
+    if (this.exited) return
+    if (signal === 'EOF') {
+      this.ptyProcess.write('\x04')
+      return
+    }
+    if (signal === 'SIGINT') {
+      this.ptyProcess.write('\x03')
+      return
+    }
+    this.kill(signal)
+  }
+
+  kill(signal: NodeJS.Signals = 'SIGTERM'): void {
+    if (this.exited) return
+    this.ptyProcess.kill(signal)
+  }
+
+  isExited(): boolean {
+    return this.exited
+  }
+
+  isAttached(): boolean {
+    return this.attached
+  }
+
+  getStats(): { bytesIn: number; bytesOut: number; durationMs: number; idleMs: number } {
+    const now = Date.now()
+    return {
+      bytesIn: this.bytesIn,
+      bytesOut: this.bytesOut,
+      durationMs: now - this.createdAt,
+      idleMs: now - this.lastActivityAt,
+    }
+  }
+
+  private appendScrollback(data: string): void {
+    this.scrollback += data
+    if (Buffer.byteLength(this.scrollback, 'utf8') <= this.scrollbackBytes) return
+    while (Buffer.byteLength(this.scrollback, 'utf8') > this.scrollbackBytes) {
+      const nextNewline = this.scrollback.indexOf('\n')
+      if (nextNewline === -1) {
+        this.scrollback = trimUtf8ToBytes(this.scrollback, this.scrollbackBytes)
+        return
+      }
+      this.scrollback = this.scrollback.slice(nextNewline + 1)
+    }
+  }
+}
+
+type PtyProcess = Pick<IPty, 'onData' | 'onExit' | 'write' | 'resize' | 'kill'>
+
+type PtySpawnOptions = {
+  name: string
+  cols: number
+  rows: number
+  cwd: string
+  env: NodeJS.ProcessEnv
+}
+
+type ResolvedShell = {
+  executable: string
+  args: string[]
+}
+
+async function createNativePty(file: string, args: string[], options: PtySpawnOptions): Promise<PtyProcess> {
+  const pty = await import('node-pty')
+  return pty.spawn(file, args, options)
+}
+
+function createNodeBridgePty(file: string, args: string[], options: PtySpawnOptions): Promise<PtyProcess> {
+  ensureNodePtyHelperExecutable()
+
+  const child = spawn('node', [NODE_PTY_BRIDGE, JSON.stringify({ file, args, options })], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: process.env,
+  })
+  const bridge = new NodeBridgePty(child)
+  return bridge.ready
+}
+
+function ensureNodePtyHelperExecutable(): void {
+  if (process.platform !== 'darwin') return
+  try {
+    const helper = resolve(
+      dirname(fileURLToPath(import.meta.resolve('node-pty/package.json'))),
+      'prebuilds',
+      `${process.platform}-${process.arch}`,
+      'spawn-helper',
+    )
+    if (existsSync(helper)) chmodSync(helper, 0o755)
+  } catch {
+    // If resolution fails, let node-pty report the native load/spawn error.
+  }
+}
+
+function resolveShell(requested?: PtyShell): ResolvedShell {
+  if (process.platform === 'win32') return resolveWindowsShell(requested)
+  const shell = requested === 'zsh' || requested === 'sh' || requested === 'bash' ? requested : 'bash'
+  const executable = shell === 'zsh' ? '/bin/zsh' : shell === 'sh' ? '/bin/sh' : pickUnixShell('/bin/bash', '/bin/sh')
+  return { executable, args: ['-l'] }
+}
+
+function resolveWindowsShell(requested?: PtyShell): ResolvedShell {
+  if (requested === 'cmd') return { executable: process.env.ComSpec || 'cmd.exe', args: [] }
+  if (requested === 'powershell') return { executable: resolveWindowsExecutable('powershell.exe'), args: ['-NoLogo'] }
+  if (requested === 'pwsh') return { executable: resolveWindowsExecutable('pwsh.exe', 'powershell.exe'), args: ['-NoLogo'] }
+  const executable = resolveWindowsExecutable('pwsh.exe', 'powershell.exe', process.env.ComSpec || 'cmd.exe')
+  return executable.toLowerCase().endsWith('cmd.exe')
+    ? { executable, args: [] }
+    : { executable, args: ['-NoLogo'] }
+}
+
+function resolveWindowsExecutable(...candidates: string[]): string {
+  for (const candidate of candidates) {
+    if (candidate && commandExists(candidate)) return candidate
+  }
+  return candidates[candidates.length - 1] || 'cmd.exe'
+}
+
+function commandExists(command: string): boolean {
+  if (command.includes('\\') || command.includes('/')) return existsSync(command)
+  const result = spawnSync(process.platform === 'win32' ? 'where.exe' : 'command', process.platform === 'win32' ? [command] : ['-v', command], {
+    stdio: 'ignore',
+  })
+  return result.status === 0
+}
+
+function pickUnixShell(primary: string, fallback: string): string {
+  return existsSync(primary) ? primary : fallback
+}
+
+class NodeBridgePty implements PtyProcess {
+  readonly ready: Promise<PtyProcess>
+  private dataHandlers = new Set<(data: string) => void>()
+  private exitHandlers = new Set<(exit: { exitCode: number; signal?: number }) => void>()
+  private buffer = ''
+  private settled = false
+
+  constructor(private readonly child: ChildProcessWithoutNullStreams) {
+    this.ready = new Promise((resolveReady, rejectReady) => {
+      const failReady = (err: Error) => {
+        if (this.settled) return
+        this.settled = true
+        rejectReady(err)
+      }
+
+      child.stdout.setEncoding('utf8')
+      child.stdout.on('data', (chunk: string) => {
+        this.buffer += chunk
+        let newline = this.buffer.indexOf('\n')
+        while (newline !== -1) {
+          const line = this.buffer.slice(0, newline)
+          this.buffer = this.buffer.slice(newline + 1)
+          this.handleBridgeLine(line, resolveReady, failReady)
+          newline = this.buffer.indexOf('\n')
+        }
+      })
+
+      child.stderr.setEncoding('utf8')
+      child.stderr.on('data', (chunk: string) => {
+        if (!this.settled) failReady(new Error(chunk.trim() || 'PTY bridge failed'))
+        else process.stderr.write(`[node-pty-bridge] ${chunk}`)
+      })
+
+      child.on('error', failReady)
+      child.on('exit', (code, signal) => {
+        if (!this.settled) {
+          failReady(new Error(`PTY bridge exited before ready: code=${code} signal=${signal}`))
+          return
+        }
+        const exit = { exitCode: typeof code === 'number' ? code : 0, signal: 0 }
+        for (const handler of this.exitHandlers) handler(exit)
+        this.dataHandlers.clear()
+        this.exitHandlers.clear()
+      })
+    })
+  }
+
+  onData(handler: (data: string) => void): { dispose: () => void } {
+    this.dataHandlers.add(handler)
+    return { dispose: () => this.dataHandlers.delete(handler) }
+  }
+
+  onExit(handler: (exit: { exitCode: number; signal?: number }) => void): { dispose: () => void } {
+    this.exitHandlers.add(handler)
+    return { dispose: () => this.exitHandlers.delete(handler) }
+  }
+
+  write(data: string): void {
+    this.send({ type: 'write', data })
+  }
+
+  resize(cols: number, rows: number): void {
+    this.send({ type: 'resize', cols, rows })
+  }
+
+  kill(signal?: string): void {
+    const nextSignal = (signal ?? 'SIGTERM') as NodeJS.Signals
+    this.send({ type: 'kill', signal: nextSignal })
+    this.child.stdin.end()
+    if (this.child.exitCode === null) this.child.kill(nextSignal)
+  }
+
+  private handleBridgeLine(
+    line: string,
+    resolveReady: (pty: PtyProcess) => void,
+    rejectReady: (err: Error) => void,
+  ): void {
+    if (!line) return
+    let message: any
+    try {
+      message = JSON.parse(line)
+    } catch {
+      return
+    }
+
+    if (message.type === 'ready') {
+      this.settled = true
+      resolveReady(this)
+    } else if (message.type === 'data' && typeof message.data === 'string') {
+      for (const handler of this.dataHandlers) handler(message.data)
+    } else if (message.type === 'exit') {
+      for (const handler of this.exitHandlers) handler({
+        exitCode: typeof message.exitCode === 'number' ? message.exitCode : 0,
+        signal: typeof message.signal === 'number' ? message.signal : 0,
+      })
+    } else if (message.type === 'error') {
+      const err = new Error(typeof message.message === 'string' ? message.message : 'PTY bridge error')
+      if (!this.settled) rejectReady(err)
+      else throw err
+    }
+  }
+
+  private send(message: unknown): void {
+    if (this.child.stdin.destroyed) return
+    this.child.stdin.write(`${JSON.stringify(message)}\n`)
+  }
+}
+
+function pickExistingCwd(candidate: string | undefined, rootDir: string): string {
+  const root = resolve(rootDir)
+  if (!candidate) return root
+  const abs = resolve(root, candidate)
+  const rel = relative(root, abs)
+  const insideRoot = abs === root || (!!rel && !rel.startsWith('..') && !isAbsolute(rel))
+  return insideRoot && existsSync(abs) ? abs : root
+}
+
+function buildSafePtyEnv(rootDir: string, shell: string): NodeJS.ProcessEnv {
+  if (process.platform === 'win32') {
+    return {
+      TERM: 'xterm-256color',
+      COLORTERM: 'truecolor',
+      HOME: rootDir,
+      PWD: rootDir,
+      SHELL: shell,
+      USERPROFILE: rootDir,
+      USERNAME: process.env.USERNAME || 'appuser',
+      USER: process.env.USER || process.env.USERNAME || 'appuser',
+      LOGNAME: process.env.LOGNAME || process.env.USERNAME || 'appuser',
+      PATH: process.env.PATH || '',
+      Path: process.env.Path,
+      PATHEXT: process.env.PATHEXT,
+      SystemRoot: process.env.SystemRoot,
+      ComSpec: process.env.ComSpec,
+      TEMP: process.env.TEMP,
+      TMP: process.env.TMP,
+      APPDATA: process.env.APPDATA,
+      LOCALAPPDATA: process.env.LOCALAPPDATA,
+      SHOGO_PTY: '1',
+    }
+  }
+
+  return {
+    TERM: 'xterm-256color',
+    COLORTERM: 'truecolor',
+    HOME: rootDir,
+    PWD: rootDir,
+    SHELL: shell,
+    USER: 'appuser',
+    LOGNAME: 'appuser',
+    LANG: process.env.LANG || 'C.UTF-8',
+    LC_ALL: process.env.LC_ALL || 'C.UTF-8',
+    PATH: '/usr/local/bin:/usr/bin:/bin',
+    SHOGO_PTY: '1',
+  }
+}
+
+function trimUtf8ToBytes(input: string, maxBytes: number): string {
+  let bytes = 0
+  const kept: string[] = []
+  const chars = Array.from(input)
+  for (let i = chars.length - 1; i >= 0; i--) {
+    const char = chars[i]
+    const nextBytes = Buffer.byteLength(char, 'utf8')
+    if (bytes + nextBytes > maxBytes) break
+    kept.push(char)
+    bytes += nextBytes
+  }
+  return kept.reverse().join('')
+}

--- a/packages/agent-runtime/src/pty/pty-ws-handler.ts
+++ b/packages/agent-runtime/src/pty/pty-ws-handler.ts
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { parsePtyClientFrame, serializePtyFrame } from './pty-protocol'
+import { PtyRegistry } from './pty-registry'
+import type { PtySession } from './pty-session'
+import { traceOperation } from '@shogo/shared-runtime'
+import { recordRuntimeLogEntry } from '../runtime-log-dispatcher'
+
+const WS_BACKPRESSURE_LIMIT_BYTES = 4 * 1024 * 1024
+const OUTBOUND_CHUNK_BYTES = 16 * 1024
+
+export interface TerminalPtyWsData {
+  kind: 'terminal-pty'
+  registry: PtyRegistry
+  sessionId?: string
+  dispose?: () => void
+  exitDispose?: () => void
+  killed?: boolean
+}
+
+type RuntimeWebSocket = WebSocket & { data?: TerminalPtyWsData }
+
+export function isPtyEnabled(): boolean {
+  return process.env.ENABLE_PTY === '1' || process.env.ENABLE_PTY === 'true'
+}
+
+export function createTerminalPtyRegistry(rootDir: string): PtyRegistry {
+  const registry = new PtyRegistry({
+    rootDir,
+    maxSessions: Number(process.env.PTY_MAX_SESSIONS || 8),
+    idleTtlMs: Number(process.env.PTY_IDLE_TTL_MS || 10 * 60_000),
+    maxAgeMs: Number(process.env.PTY_MAX_AGE_MS || 8 * 60 * 60_000),
+  })
+  setInterval(() => registry.reapExpired(), 60_000).unref?.()
+  return registry
+}
+
+export function handleTerminalPtyWsOpen(ws: RuntimeWebSocket): void {
+  ws.send(serializePtyFrame({ type: 'pong' }))
+}
+
+export async function handleTerminalPtyWsMessage(
+  ws: RuntimeWebSocket,
+  raw: string | Buffer | ArrayBuffer | Uint8Array,
+): Promise<void> {
+  const data = ws.data
+  if (!data?.registry) {
+    ws.close(1011, 'Missing PTY registry')
+    return
+  }
+
+  let frame: ReturnType<typeof parsePtyClientFrame>
+  try {
+    frame = parsePtyClientFrame(raw)
+  } catch (err) {
+    ws.send(serializePtyFrame({ type: 'error', message: err instanceof Error ? err.message : String(err) }))
+    return
+  }
+
+  if (frame.type === 'ping') {
+    ws.send(serializePtyFrame({ type: 'pong' }))
+    return
+  }
+
+  if (frame.type === 'init') {
+    if (data.sessionId) {
+      ws.send(serializePtyFrame({ type: 'error', message: 'PTY session already initialized' }))
+      return
+    }
+    try {
+      const result = await traceOperation(
+        'agent-runtime',
+        'pty.session.start',
+        {
+          sessionId: frame.sessionId ?? 'new',
+          cols: frame.cols,
+          rows: frame.rows,
+        },
+        () => data.registry.getOrCreate(frame),
+      )
+      bindSession(ws, result.session)
+      data.sessionId = result.session.id
+      logTerminal('info', `PTY session start id=${result.session.id} attached=${result.attached} cwd=${result.session.cwd}`)
+      ws.send(serializePtyFrame({
+        type: 'ready',
+        sessionId: result.session.id,
+        cwd: result.session.cwd,
+        scrollback: result.scrollback || undefined,
+        attached: result.attached,
+      }))
+    } catch (err) {
+      ws.send(serializePtyFrame({ type: 'error', message: err instanceof Error ? err.message : String(err) }))
+      ws.close(1011, 'PTY init failed')
+    }
+    return
+  }
+
+  const sessionId = data.sessionId
+  if (!sessionId) {
+    ws.send(serializePtyFrame({ type: 'error', message: 'PTY session not initialized' }))
+    return
+  }
+  const session = getSessionFromSocket(ws)
+  if (!session) {
+    ws.send(serializePtyFrame({ type: 'error', message: 'PTY session missing' }))
+    return
+  }
+
+  if (frame.type === 'data') session.write(frame.data)
+  else if (frame.type === 'resize') session.resize(frame.cols, frame.rows)
+  else if (frame.type === 'signal') session.signal(frame.signal)
+}
+
+export function handleTerminalPtyWsClose(ws: RuntimeWebSocket): void {
+  const data = ws.data
+  data?.dispose?.()
+  data?.exitDispose?.()
+  const session = getSessionFromSocket(ws)
+  if (data?.sessionId) {
+    if (session) {
+      logTerminal('info', formatSessionEnd('PTY session disconnected; detaching', session))
+    }
+    data.registry.detach(data.sessionId)
+  }
+  delete (ws as any)._ptySession
+}
+
+function bindSession(ws: RuntimeWebSocket, session: PtySession): void {
+  ws.data!.dispose?.()
+  ws.data!.exitDispose?.()
+  ;(ws as any)._ptySession = session
+  ws.data!.dispose = session.onData((chunk) => {
+    if (ws.data?.killed) return
+    try {
+      if (((ws as any).bufferedAmount ?? 0) > WS_BACKPRESSURE_LIMIT_BYTES) {
+        logTerminal('warn', formatSessionEnd('PTY backpressure limit exceeded; killing', session))
+        if (ws.data) ws.data.killed = true
+        ws.data?.registry.kill(session.id, 'SIGTERM')
+        disposeSocketSession(ws)
+        ws.close(1013, 'PTY output backpressure')
+        return
+      }
+      for (const piece of chunkOutput(chunk)) {
+        ws.send(serializePtyFrame({ type: 'data', data: piece }))
+      }
+    } catch {
+      if (ws.data?.killed) return
+      if (ws.data) ws.data.killed = true
+      logTerminal('error', formatSessionEnd('PTY output send failed; killing', session))
+      ws.data?.registry.kill(session.id, 'SIGTERM')
+      disposeSocketSession(ws)
+    }
+  })
+  ws.data!.exitDispose = session.onExit((exit) => {
+    try {
+      logTerminal('info', `${formatSessionEnd('PTY session end', session)} exitCode=${exit.exitCode} signal=${exit.signal}`)
+      ws.send(serializePtyFrame({ type: 'exit', exitCode: exit.exitCode, signal: exit.signal }))
+      ws.close(1000, 'PTY exited')
+    } catch {
+      // Ignore close races.
+    }
+  })
+}
+
+function disposeSocketSession(ws: RuntimeWebSocket): void {
+  ws.data?.dispose?.()
+  ws.data?.exitDispose?.()
+  if (ws.data) {
+    ws.data.dispose = undefined
+    ws.data.exitDispose = undefined
+  }
+  delete (ws as any)._ptySession
+}
+
+function getSessionFromSocket(ws: RuntimeWebSocket): PtySession | null {
+  return ((ws as any)._ptySession as PtySession | undefined) ?? null
+}
+
+function chunkOutput(data: string): string[] {
+  if (Buffer.byteLength(data, 'utf8') <= OUTBOUND_CHUNK_BYTES) return [data]
+  const chunks: string[] = []
+  let current = ''
+  for (const char of data) {
+    current += char
+    if (Buffer.byteLength(current, 'utf8') >= OUTBOUND_CHUNK_BYTES) {
+      chunks.push(current)
+      current = ''
+    }
+  }
+  if (current) chunks.push(current)
+  return chunks
+}
+
+function formatSessionEnd(prefix: string, session: PtySession): string {
+  const stats = session.getStats()
+  const mem = process.memoryUsage()
+  return `${prefix} id=${session.id} durationMs=${stats.durationMs} idleMs=${stats.idleMs} bytesIn=${stats.bytesIn} bytesOut=${stats.bytesOut} rss=${mem.rss} heapUsed=${mem.heapUsed}`
+}
+
+function logTerminal(level: 'info' | 'warn' | 'error', text: string): void {
+  const line = `[terminal-pty] ${text}`
+  if (level === 'error') console.error(line)
+  else if (level === 'warn') console.warn(line)
+  else console.log(line)
+  recordRuntimeLogEntry({ source: 'terminal', level, text: line })
+}

--- a/packages/agent-runtime/src/runtime-log-dispatcher.ts
+++ b/packages/agent-runtime/src/runtime-log-dispatcher.ts
@@ -14,7 +14,7 @@
  * back-compat for `/console-log/append`.
  */
 
-export type RuntimeLogSource = 'console' | 'build' | 'canvas-error' | 'exec'
+export type RuntimeLogSource = 'console' | 'build' | 'canvas-error' | 'exec' | 'terminal'
 export type RuntimeLogLevel = 'info' | 'warn' | 'error'
 
 export interface RuntimeLogEntry {

--- a/packages/agent-runtime/src/runtime-logs-routes.ts
+++ b/packages/agent-runtime/src/runtime-logs-routes.ts
@@ -22,6 +22,7 @@ const ALLOWED_SOURCES: ReadonlyArray<RuntimeLogSource> = [
   'build',
   'canvas-error',
   'exec',
+  'terminal',
 ]
 
 export function parseSources(

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -30,6 +30,7 @@ import {
   cpSync,
   appendFileSync,
 } from 'fs'
+import { timingSafeEqual } from 'crypto'
 import {
   createRuntimeApp, traceOperation,
   initializeS3Sync,
@@ -53,6 +54,14 @@ import {
 import { runtimeDiagnosticsRoutes } from './runtime-diagnostics-routes'
 import { SkillServerManager } from './skill-server-manager'
 import { runtimeTerminalRoutes } from './runtime-terminal-routes'
+import {
+  createTerminalPtyRegistry,
+  handleTerminalPtyWsClose,
+  handleTerminalPtyWsMessage,
+  handleTerminalPtyWsOpen,
+  isPtyEnabled,
+  type TerminalPtyWsData,
+} from './pty/pty-ws-handler'
 import { deriveApiUrl, getInternalHeaders } from './internal-api'
 import { userMessage } from './pi-adapter'
 import { fileURLToPath } from 'url'
@@ -80,6 +89,9 @@ const MONOREPO_ROOT = resolve(__dirname, '../../..')
 const WORKSPACE_DIR = process.env.WORKSPACE_DIR || process.env.AGENT_DIR || process.env.PROJECT_DIR || '/app/workspace'
 const SCHEMAS_PATH = process.env.SCHEMAS_PATH || '/app/.schemas'
 const PORT = parseInt(process.env.PORT || '8080', 10)
+const terminalPtyRegistry = createTerminalPtyRegistry(WORKSPACE_DIR)
+const RUNTIME_TOKEN_V1_PREFIX = 'rt_v1_'
+const RUNTIME_TOKEN_RE = /^rt_v1_.+_[0-9a-f]{64}$|^[0-9a-f]{64}$/
 
 async function reportHeartbeatComplete(projectId: string): Promise<void> {
   const apiUrl = deriveApiUrl()
@@ -95,6 +107,38 @@ async function reportHeartbeatComplete(projectId: string): Promise<void> {
   if (!res.ok) {
     throw new Error(`Heartbeat complete report failed: HTTP ${res.status}`)
   }
+}
+
+function validateTerminalPtyRuntimeAuth(req: Request): Response | null {
+  const expected = process.env.RUNTIME_AUTH_SECRET
+  if (!expected) {
+    if (process.env.NODE_ENV !== 'production') return null
+    console.error('[agent-runtime] RUNTIME_AUTH_SECRET not set — rejecting PTY upgrade')
+    return new Response('Unauthorized', { status: 401 })
+  }
+
+  const auth = req.headers.get('authorization') || ''
+  const bearerToken = auth.startsWith('Bearer ') ? auth.slice('Bearer '.length) : ''
+  const presented = [req.headers.get('x-runtime-token') || '', bearerToken].filter(Boolean)
+  if (!isRuntimeTokenLike(expected) || !presented.some((token) => isRuntimeTokenLike(token) && safeTokenEqual(token, expected))) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+
+  return null
+}
+
+function isRuntimeTokenLike(token: string): boolean {
+  if (!RUNTIME_TOKEN_RE.test(token)) return false
+  if (!token.startsWith(RUNTIME_TOKEN_V1_PREFIX)) return true
+  const rest = token.slice(RUNTIME_TOKEN_V1_PREFIX.length)
+  const sepIdx = rest.length - 64 - 1
+  return sepIdx > 0 && rest.charAt(sepIdx) === '_'
+}
+
+function safeTokenEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8')
+  const bb = Buffer.from(b, 'utf8')
+  return ab.length === bb.length && timingSafeEqual(ab, bb)
 }
 
 // =============================================================================
@@ -3611,6 +3655,37 @@ if (state.isPoolMode && !state.poolAssigned) {
 
 export default {
   port: PORT,
-  fetch: app.fetch,
+  fetch: (req: Request, server: any) => {
+    const url = new URL(req.url)
+    if (url.pathname === '/terminal/pty' && req.headers.get('upgrade')?.toLowerCase() === 'websocket') {
+      if (!isPtyEnabled()) {
+        return new Response('PTY disabled', { status: 503 })
+      }
+      const authError = validateTerminalPtyRuntimeAuth(req)
+      if (authError) return authError
+      const upgraded = server.upgrade(req, {
+        data: {
+          kind: 'terminal-pty',
+          registry: terminalPtyRegistry,
+        } satisfies TerminalPtyWsData,
+      })
+      if (upgraded) return undefined
+      return new Response('WebSocket upgrade failed', { status: 500 })
+    }
+    return app.fetch(req, server)
+  },
+  websocket: {
+    open(ws: WebSocket & { data?: any }) {
+      if (ws.data?.kind === 'terminal-pty') handleTerminalPtyWsOpen(ws)
+    },
+    message(ws: WebSocket & { data?: any }, raw: string | Buffer) {
+      if (ws.data?.kind === 'terminal-pty') {
+        void handleTerminalPtyWsMessage(ws, raw)
+      }
+    },
+    close(ws: WebSocket & { data?: any }) {
+      if (ws.data?.kind === 'terminal-pty') handleTerminalPtyWsClose(ws)
+    },
+  },
   idleTimeout: 0,
 }


### PR DESCRIPTION
## Summary

Adds a real PTY terminal for the IDE bottom-panel Terminal, scoped to **Shogo Desktop local projects only** for this rollout.

The runtime PTY protocol, xterm.js UI, local API WebSocket proxy, reattach lifecycle, and hardened session handling are included, but the product surface is intentionally narrowed:

- **Enabled:** Shogo Desktop renderer + local desktop API/runtime.
- **Disabled:** hosted web / cloud Studio.
- **Disabled for now:** Desktop remote-instance sessions routed through `/api/instances/...`.
- **Fallback:** existing chunked-HTTP terminal remains the default outside local Desktop PTY.

This keeps the real terminal experience where it is most useful while avoiding the higher-risk browser-to-cloud-to-pod interactive-shell path.

---

## Rollout Policy

| Area | Behavior |
| --- | --- |
| Desktop local renderer | Uses PTY only when `window.shogoDesktop.isDesktop` exists and `EXPO_PUBLIC_ENABLE_PTY=true`. |
| Desktop local API/runtime | Desktop local API sets `ENABLE_PTY=1`; local runtime children can serve `/terminal/pty`. |
| Hosted web / cloud Studio | PTY UI is not selected; HTTP terminal remains active. |
| Knative/cloud runtime pods | Always receive `ENABLE_PTY=0`, regardless of environment flags. |
| API PTY proxy | Returns disabled outside `SHOGO_LOCAL_MODE=true`. |
| Desktop remote instances | Stay on HTTP terminal because the current instance tunnel is HTTP-proxy based and does not support this PTY WebSocket yet. |

---

## Architecture

```mermaid
flowchart LR
  subgraph Desktop["Shogo Desktop App"]
    Renderer["Desktop renderer\nwindow.shogoDesktop.isDesktop"]
    Xterm["PtyTerminal.tsx\nxterm.js"]
    Client["pty-client.ts\nWS JSON protocol"]
    Renderer --> Xterm --> Client
  end

  subgraph LocalAPI["Desktop Local API\nSHOGO_LOCAL_MODE=true"]
    Auth["Session + project access"]
    Proxy["terminal-pty-proxy.ts\nclient WS <-> runtime WS"]
    RuntimeMgr["runtime/manager.ts\nlocal ENABLE_PTY only"]
  end

  subgraph Runtime["Local agent-runtime child"]
    Upgrade["/terminal/pty\nBun upgrade"]
    Registry["pty-registry.ts\ndetach + reattach"]
    Session["pty-session.ts\nnode-pty + scrollback"]
    Shell["Interactive shell"]
  end

  Client -->|"ws://localhost/.../terminal/pty"| Auth
  Auth --> Proxy
  Proxy -->|"ws://runtime/terminal/pty\nx-runtime-token"| Upgrade
  RuntimeMgr --> Runtime
  Upgrade --> Registry --> Session --> Shell

  subgraph Cloud["Hosted Web / Cloud / Knative"]
    WebTerminal["Legacy HTTP terminal"]
    CloudProxy["PTY proxy disabled"]
    CloudRuntime["ENABLE_PTY=0"]
  end

  subgraph RemoteInstance["Desktop Remote Instance"]
    InstanceUrl["agentUrl contains /api/instances/..."]
    HttpTunnel["Existing HTTP instance tunnel"]
    HttpTerminal["Legacy HTTP terminal"]
  end

  InstanceUrl --> HttpTunnel --> HttpTerminal
```

---

## Desktop Local Flow

1. Desktop release/dev build sets `EXPO_PUBLIC_ENABLE_PTY=true`.
2. Electron preload exposes `window.shogoDesktop.isDesktop` and a local `apiUrl`.
3. `Terminal.tsx` selects PTY only when platform is web, the Desktop bridge exists, the PTY flag is true, and the active `agentUrl` is not a remote-instance `/api/instances/...` URL.
4. `PtyTerminal.tsx` mounts xterm.js and opens `/api/projects/:projectId/terminal/pty` against the local API.
5. `terminal-pty-proxy.ts` verifies local mode and project access, then connects upstream to the local runtime `/terminal/pty` with `x-runtime-token`.
6. `agent-runtime` validates PTY enablement and runtime auth, then dispatches JSON frames to `pty-registry` / `pty-session`.
7. Runtime spawns the interactive shell via `node-pty` or the Node bridge under Bun when needed.
8. Disconnects detach the PTY session so refresh/network blips can reattach using the persisted session id.

---

## Cloud And Remote Instance Behavior

### Hosted Web / Cloud Studio

Hosted web does not select PTY because `window.shogoDesktop.isDesktop` is absent. Even if a public env flag is accidentally set, the UI remains on the HTTP terminal.

The API/runtime also fail closed:

- `/api/projects/:id/terminal/pty` returns disabled unless `SHOGO_LOCAL_MODE=true`.
- Knative pods receive `ENABLE_PTY=0`, so cloud runtimes do not expose `/terminal/pty`.

### Desktop Remote Instances

Remote instance sessions are intentionally kept on the HTTP terminal. Their active `agentUrl` includes `/api/instances/...`, and `Terminal.tsx` treats that as a PTY opt-out.

Reason: the current instance tunnel is a transparent HTTP proxy for request/response and streaming paths. It is not a PTY WebSocket tunnel. Adding PTY there should be a separate design with explicit WebSocket tunnel support and review.

---

## Implementation Details

### Runtime (`packages/agent-runtime`)

- `pty-protocol.ts`: typed JSON frames (`init`, `data`, `resize`, `signal`, `ping`, `ready`, `exit`, `error`, `pong`).
- `pty-session.ts`: `node-pty` lifecycle, scrollback, safe env, cwd selection, resize, writes, signals.
- `pty-registry.ts`: sessions, detach/reattach, max-age, idle TTL, detached cleanup.
- `pty-ws-handler.ts`: Bun WebSocket lifecycle, socket/session binding, `ENABLE_PTY` gate.
- `node-pty-bridge.cjs`: Node subprocess bridge for native `node-pty` under Bun.
- `server.ts`: `/terminal/pty` upgrade interception before normal app routing.

Runtime hardening:

- WebSocket close detaches instead of killing.
- Idle reap only kills detached sessions; attached idle shells survive.
- Max-age still caps total lifetime.
- Runtime token comparison is timing-safe; production rejects missing `RUNTIME_AUTH_SECRET`.
- Initial cwd is constrained under workspace root.
- Scrollback trimming is byte-aware for no-newline output.
- Unix PTY env avoids forwarding pod cache/config paths.
- Backpressure kill unwires handlers to avoid repeated kill/log spam.

### API (`apps/api`)

- `terminal-pty-proxy.ts`: local Desktop PTY WebSocket proxy.
- Proxy only active in `SHOGO_LOCAL_MODE=true`.
- Project access checked before upstream runtime PTY connection.
- Production `ALLOWED_ORIGINS` requires a present matching `Origin`.
- Upstream pre-open queue is byte-capped with a typed error before close.
- `runtime/manager.ts` forwards `ENABLE_PTY` only in local mode.
- `knative-project-manager.ts` forces cloud pods to `ENABLE_PTY=0`.

### Desktop (`apps/desktop`)

- `local-server.ts` starts the local API with `ENABLE_PTY=1`.
- Desktop release workflows and `desktop:build-web` set `EXPO_PUBLIC_ENABLE_PTY=true`.
- Electron preload is the Desktop-only runtime signal via `window.shogoDesktop.isDesktop`.

### Mobile/Web UI (`apps/mobile`)

- `Terminal.tsx`: chooses PTY only for Desktop local, never hosted web or remote instance URLs.
- `BottomPanel.tsx`: passes `agentUrl` into `Terminal` so remote instance URLs can be detected.
- `PtyTerminal.tsx`: xterm.js mount, `sessionStorage` session id, Clear/Interrupt helpers.
- `pty-client.ts`: WS connect, heartbeat, bounded reconnect with jitter, data, resize, signals.
- Existing HTTP terminal remains fallback/default.

---

## Tests And Verification

Added/updated focused tests for:

- PTY protocol parsing/serialization.
- PTY registry detach/reattach and attached-vs-detached idle reap.
- PTY client URL construction.
- API proxy requirements: WebSocket upgrade required, production Origin policy, and proxy disabled outside Desktop local mode.

Verified locally:

```bash
bun test packages/agent-runtime/src/pty/__tests__/pty-registry.test.ts packages/agent-runtime/src/pty/__tests__/pty-protocol.test.ts
bun test apps/api/src/__tests__/terminal-pty-proxy.test.ts
bun test apps/mobile/components/project/panels/ide/terminal/pty/__tests__/pty-client.test.ts
bun run --cwd packages/agent-runtime typecheck
```

Notes:

- `apps/api` typecheck still has existing unrelated repo errors outside this PR.
- Terminal/BottomPanel RTL tests currently hit the existing Bun + React Native Flow parse issue (`Unexpected typeof` in `react-native/index.js`).

---

## Manual Verification

### Desktop local PTY

1. Run Desktop so the renderer has `EXPO_PUBLIC_ENABLE_PTY=true` and `window.shogoDesktop.isDesktop`.
2. Open a local project in the IDE.
3. Open the Terminal bottom panel.
4. Confirm xterm/PTY behavior, interactive shell input, resize, Ctrl+C, clear, refresh/reconnect reattach.

### Hosted web fallback

1. Open hosted/web app without the Desktop bridge.
2. Open Terminal.
3. Confirm it uses the legacy HTTP prompt UI, not xterm/PTY.

### Desktop remote instance fallback

1. Connect Desktop to a remote instance so `agentUrl` routes through `/api/instances/...`.
2. Open Terminal.
3. Confirm it stays on the existing HTTP terminal path.

---

## Risk Reduction

Compared with the original broad web/cloud PTY rollout, this removes the highest-risk exposure:

- No hosted browser-to-cloud-to-pod interactive shell path.
- No Knative pod PTY surface.
- No PTY over the current remote instance HTTP tunnel.
- PTY is limited to local Desktop runtime processes where the user already controls the machine/workspace.

Remaining risk is mostly local Desktop/runtime operational risk: `node-pty` native availability, shell lifecycle correctness, and local workspace isolation.