### PR TITLE
fix(infra): use cert-covered regional tunnel hosts

### DIFF
--- a/k8s/overlays/production-eu/api-service.yaml
+++ b/k8s/overlays/production-eu/api-service.yaml
@@ -127,7 +127,7 @@ spec:
             # api-tunnel-ingress.yaml so the WS Upgrade bypasses the
             # DomainMapping loopback.
             - name: SHOGO_TUNNEL_WS_URL
-              value: "wss://eu.tunnel.shogo.ai"
+              value: "wss://eu-tunnel.shogo.ai"
             - name: REDIS_URL
               value: "redis://redis-master.shogo-production-system:6379"
             - name: DATABASE_URL

--- a/k8s/overlays/production-eu/api-tunnel-ingress.yaml
+++ b/k8s/overlays/production-eu/api-tunnel-ingress.yaml
@@ -3,13 +3,17 @@
 # =============================================================================
 # See k8s/overlays/staging/api-tunnel-ingress.yaml for the full rationale.
 #
-# Routes `eu.tunnel.shogo.ai` → the EU api ksvc revision pods' queue-proxy
+# Routes `eu-tunnel.shogo.ai` → the EU api ksvc revision pods' queue-proxy
 # port, bypassing the Knative DomainMapping that drops WebSocket Upgrade.
 #
 # The regional hostname is intentional: the desktop must reach the same
 # region whose API issued its heartbeat, so each region advertises its own
 # SHOGO_TUNNEL_WS_URL (see api-service.yaml). Cloudflare resolves
-# `eu.tunnel.shogo.ai` to the Frankfurt OCI LB only.
+# `eu-tunnel.shogo.ai` to the Frankfurt OCI LB only.
+#
+# NOTE: A single-label subdomain (eu-tunnel) is used instead of a
+# two-label one (eu.tunnel) so that the existing `*.shogo.ai` Cloudflare
+# wildcard certificate covers it. Wildcards only match a single label.
 # =============================================================================
 
 apiVersion: v1
@@ -48,7 +52,7 @@ spec:
   httpOption: Enabled
   rules:
     - hosts:
-        - eu.tunnel.shogo.ai
+        - eu-tunnel.shogo.ai
       visibility: ExternalIP
       http:
         paths:

--- a/k8s/overlays/production-india/api-service.yaml
+++ b/k8s/overlays/production-india/api-service.yaml
@@ -127,7 +127,7 @@ spec:
             # api-tunnel-ingress.yaml so the WS Upgrade bypasses the
             # DomainMapping loopback.
             - name: SHOGO_TUNNEL_WS_URL
-              value: "wss://india.tunnel.shogo.ai"
+              value: "wss://india-tunnel.shogo.ai"
             - name: REDIS_URL
               value: "redis://redis-master.shogo-production-system:6379"
             - name: DATABASE_URL

--- a/k8s/overlays/production-india/api-tunnel-ingress.yaml
+++ b/k8s/overlays/production-india/api-tunnel-ingress.yaml
@@ -3,14 +3,18 @@
 # =============================================================================
 # See k8s/overlays/staging/api-tunnel-ingress.yaml for the full rationale.
 #
-# Routes `india.tunnel.shogo.ai` → the India api ksvc revision pods'
+# Routes `india-tunnel.shogo.ai` → the India api ksvc revision pods'
 # queue-proxy port, bypassing the Knative DomainMapping that drops
 # WebSocket Upgrade.
 #
 # The regional hostname is intentional: the desktop must reach the same
 # region whose API issued its heartbeat, so each region advertises its own
 # SHOGO_TUNNEL_WS_URL (see api-service.yaml). Cloudflare resolves
-# `india.tunnel.shogo.ai` to the Mumbai OCI LB only.
+# `india-tunnel.shogo.ai` to the Mumbai OCI LB only.
+#
+# NOTE: A single-label subdomain (india-tunnel) is used instead of a
+# two-label one (india.tunnel) so that the existing `*.shogo.ai` Cloudflare
+# wildcard certificate covers it. Wildcards only match a single label.
 # =============================================================================
 
 apiVersion: v1
@@ -49,7 +53,7 @@ spec:
   httpOption: Enabled
   rules:
     - hosts:
-        - india.tunnel.shogo.ai
+        - india-tunnel.shogo.ai
       visibility: ExternalIP
       http:
         paths:

--- a/terraform/environments/production-global/main.tf
+++ b/terraform/environments/production-global/main.tf
@@ -174,6 +174,12 @@ resource "cloudflare_record" "india_studio" {
 # passthrough; the Knative Ingress (api-tunnel) inside each cluster routes
 # to the api revision pods' queue-proxy port 8012 and bypasses the
 # DomainMapping loopback that drops WS Upgrade.
+#
+# IMPORTANT: Regional tunnel hostnames use a single label (`eu-tunnel`,
+# `india-tunnel`) instead of nested subdomains (`eu.tunnel`, `india.tunnel`)
+# so that the existing `*.shogo.ai` Cloudflare wildcard certificate covers
+# them. SSL wildcards only match a single DNS label, so two-label hosts
+# like `eu.tunnel.shogo.ai` would fail the TLS handshake at the edge.
 
 resource "cloudflare_record" "us_tunnel" {
   zone_id = var.cloudflare_zone_id
@@ -185,7 +191,7 @@ resource "cloudflare_record" "us_tunnel" {
 
 resource "cloudflare_record" "eu_tunnel" {
   zone_id = var.cloudflare_zone_id
-  name    = "eu.tunnel"
+  name    = "eu-tunnel"
   content = var.eu_lb_ip
   type    = "A"
   proxied = true
@@ -193,7 +199,7 @@ resource "cloudflare_record" "eu_tunnel" {
 
 resource "cloudflare_record" "india_tunnel" {
   zone_id = var.cloudflare_zone_id
-  name    = "india.tunnel"
+  name    = "india-tunnel"
   content = var.india_lb_ip
   type    = "A"
   proxied = true


### PR DESCRIPTION
## Summary

Fixes production EU and India desktop tunnel WebSocket failures by renaming regional tunnel hosts from nested subdomains to single-label subdomains covered by the existing Cloudflare `*.shogo.ai` wildcard certificate.

Closes #489

## RCA

US production worked because `tunnel.shogo.ai` is a single-label subdomain and matches the existing `*.shogo.ai` Cloudflare wildcard certificate.

EU and India failed because their tunnel hosts were nested subdomains:

- `eu.tunnel.shogo.ai`
- `india.tunnel.shogo.ai`

A wildcard certificate for `*.shogo.ai` only matches one DNS label. It does not match `eu.tunnel` or `india.tunnel`, so TLS failed at Cloudflare edge during SNI/certificate selection. The connection never reached OCI LB, Knative/Kourier, or the API pods, which is why SigNoz/API logs did not show failed WebSocket requests.

## Detailed Implementation

This PR updates all layers that must agree on the advertised tunnel hostname:

- Terraform Cloudflare DNS records now create `eu-tunnel.shogo.ai` and `india-tunnel.shogo.ai` as proxied A records pointing to the existing regional OCI load balancer IPs.
- Production EU and India API services now advertise `wss://eu-tunnel.shogo.ai` and `wss://india-tunnel.shogo.ai` through `SHOGO_TUNNEL_WS_URL`.
- Production EU and India `api-tunnel` Knative ingress rules now accept the new hostnames and continue routing directly to `api-tunnel-direct` on the queue-proxy path that preserves WebSocket Upgrade.
- Added comments in Terraform and regional ingress manifests documenting why single-label tunnel hostnames are required.

## Architecture Diagram

```mermaid
flowchart LR
  Desktop[Desktop App] -->|POST heartbeat| Studio[studio.shogo.ai]
  Studio -->|returns wsUrl from SHOGO_TUNNEL_WS_URL| Desktop

  subgraph BrokenBefore[Before: EU and India]
    Desktop -->|wss://india.tunnel.shogo.ai| CF1[Cloudflare Edge]
    CF1 -->|TLS fails: *.shogo.ai does not match india.tunnel| Drop[Connection drops before API]
  end

  subgraph FixedAfter[After: EU and India]
    Desktop -->|wss://india-tunnel.shogo.ai| CF2[Cloudflare Edge]
    CF2 -->|TLS OK: *.shogo.ai matches india-tunnel| LB[Regional OCI Load Balancer]
    LB --> Kourier[Knative/Kourier Ingress]
    Kourier --> TunnelSvc[api-tunnel-direct Service]
    TunnelSvc --> API[API pod queue-proxy / WS handler]
  end
```

## Regional Hostnames After This PR

| Region | Tunnel host | Certificate coverage |
| --- | --- | --- |
| US | `tunnel.shogo.ai` | covered by `*.shogo.ai` |
| EU | `eu-tunnel.shogo.ai` | covered by `*.shogo.ai` |
| India | `india-tunnel.shogo.ai` | covered by `*.shogo.ai` |

## Test Plan

- [x] Verified PR diff only includes the regional tunnel TLS fix files.
- [x] Verified the branch is based on `origin/main` and contains one commit.
- [ ] Apply Terraform in `terraform/environments/production-global` to create/update Cloudflare DNS records.
- [ ] Deploy production EU and India K8s overlays.
- [ ] Verify TLS succeeds for `eu-tunnel.shogo.ai` and `india-tunnel.shogo.ai` using `openssl s_client`.
- [ ] Verify unauthenticated API probes return `401` from both tunnel hosts, proving traffic reaches the API.
- [ ] Restart or wait for desktop heartbeat and confirm affected regional instances become online.

Made with [Cursor](https://cursor.com)