### PR TITLE
fix(cloud-login): prevent auto-signout when cloud rejects API key

### DIFF
--- a/apps/api/src/__tests__/cloud-login-e2e.test.ts
+++ b/apps/api/src/__tests__/cloud-login-e2e.test.ts
@@ -868,25 +868,62 @@ describe('Cloud Login E2E', () => {
       expect(res.status).toBe(401)
     })
 
-    test('remote revoke: heartbeat against a revoked key wipes local config', async () => {
+    test('remote revoke: heartbeat returns cloudKeyRejected but never wipes local config', async () => {
       await signInHelper()
       // Simulate cloud-side revocation (via Devices UI)
       const deviceRow = [...apiKeys.values()].find((r) => r.kind === 'device')!
       deviceRow.revokedAt = new Date()
 
+      // Multiple heartbeats with a revoked key should never wipe local credentials.
+      // The user stays signed in; the UI shows a warning banner instead.
+      for (let i = 0; i < 5; i++) {
+        const res = await app.request('/api/local/cloud-login/heartbeat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        })
+        expect(res.status).toBe(401)
+        const data = await res.json()
+        expect(data.cloudKeyRejected).toBe(true)
+        // Key is NEVER auto-deleted — only explicit sign-out wipes it
+        expect(localConfig.has('SHOGO_API_KEY')).toBe(true)
+        expect(localConfig.has('SHOGO_KEY_INFO')).toBe(true)
+        expect(process.env.SHOGO_API_KEY).toBeDefined()
+      }
+
+      // Status still reports signed in, with the rejection flag
+      const statusRes = await app.request('/api/local/cloud-login/status')
+      const status = await statusRes.json()
+      expect(status.signedIn).toBe(true)
+      expect(status.cloudKeyRejected).toBe(true)
+    })
+
+    test('cloudKeyRejected clears when heartbeat succeeds again', async () => {
+      await signInHelper()
+      const deviceRow = [...apiKeys.values()].find((r) => r.kind === 'device')!
+
+      // Trigger a rejection
+      deviceRow.revokedAt = new Date()
+      await app.request('/api/local/cloud-login/heartbeat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      })
+
+      // Cloud recovers (un-revoked)
+      deviceRow.revokedAt = null
       const res = await app.request('/api/local/cloud-login/heartbeat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({}),
       })
-      expect(res.status).toBe(401)
-      const data = await res.json()
-      expect(data.revoked).toBe(true)
+      expect(res.status).toBe(200)
 
-      // Local credentials are wiped so the UI flips to signed-out on next poll.
-      expect(localConfig.has('SHOGO_API_KEY')).toBe(false)
-      expect(localConfig.has('SHOGO_KEY_INFO')).toBe(false)
-      expect(process.env.SHOGO_API_KEY).toBeUndefined()
+      // Status should no longer show rejection
+      const statusRes = await app.request('/api/local/cloud-login/status')
+      const status = await statusRes.json()
+      expect(status.signedIn).toBe(true)
+      expect(status.cloudKeyRejected).toBe(false)
     })
   })
 })

--- a/apps/api/src/routes/local-auth.ts
+++ b/apps/api/src/routes/local-auth.ts
@@ -56,6 +56,11 @@ interface PendingState {
  * so a Map is sufficient — we don't want to persist unused nonces to disk. */
 const pendingStates = new Map<string, PendingState>()
 
+/** Tracks whether the cloud has rejected our key so the UI can show a
+ * degraded-connection banner without wiping credentials. Only an explicit
+ * user-initiated sign-out deletes the stored key. */
+let cloudKeyRejected = false
+
 function purgeExpiredStates(): void {
   const now = Date.now()
   for (const [state, record] of pendingStates) {
@@ -226,6 +231,7 @@ export function localAuthRoutes() {
     ])
 
     process.env.SHOGO_API_KEY = body.key
+    cloudKeyRejected = false
 
     // Restart the instance tunnel with the new key so inbound cloud-driven
     // remote control picks up fresh credentials immediately.
@@ -276,6 +282,7 @@ export function localAuthRoutes() {
       localDb.localConfig.deleteMany({ where: { key: 'SHOGO_KEY_INFO' } }),
     ])
     delete process.env.SHOGO_API_KEY
+    cloudKeyRejected = false
 
     import('../lib/instance-tunnel').then(({ stopInstanceTunnel }) => {
       stopInstanceTunnel()
@@ -306,18 +313,17 @@ export function localAuthRoutes() {
       })
       const data = await res.json().catch(() => ({} as any))
       if (!res.ok || data?.ok === false) {
-        // A 401 from cloud means our key was revoked (probably via the cloud
-        // Devices UI). Wipe locally so the UI flips to signed-out and the
-        // user is prompted to re-login.
         if (res.status === 401) {
-          await Promise.all([
-            localDb.localConfig.deleteMany({ where: { key: 'SHOGO_API_KEY' } }),
-            localDb.localConfig.deleteMany({ where: { key: 'SHOGO_KEY_INFO' } }),
-          ])
-          delete process.env.SHOGO_API_KEY
+          cloudKeyRejected = true
+          console.warn('[CloudLogin] Cloud rejected API key (401) — key may be revoked or expired. User must re-sign-in.')
         }
-        return c.json({ ok: false, error: data?.error || `HTTP ${res.status}`, revoked: res.status === 401 }, res.status as any)
+        return c.json({
+          ok: false,
+          error: data?.error || `HTTP ${res.status}`,
+          cloudKeyRejected: res.status === 401,
+        }, res.status as any)
       }
+      cloudKeyRejected = false
       return c.json({ ok: true })
     } catch (err: any) {
       return c.json({ ok: false, error: err?.message || 'Heartbeat failed' }, 502)
@@ -338,6 +344,7 @@ export function localAuthRoutes() {
       workspace: info?.workspace || null,
       deviceId: info?.deviceId || null,
       keyPrefix: storedKey.slice(0, 16),
+      cloudKeyRejected,
     })
   })
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -35,6 +35,7 @@ interface CloudLoginBody {
   workspace?: string
   authUrl?: string
   revoked?: boolean
+  cloudKeyRejected?: boolean
 }
 
 // --- Persistent file logging ---
@@ -211,9 +212,11 @@ function notifyRendererLoginResult(payload: { ok: boolean; error?: string; email
 // Keep the cloud-minted device key fresh by pinging the local heartbeat
 // endpoint periodically. The local API forwards this to the cloud
 // `/api/api-keys/heartbeat`, which updates `lastSeenAt` / `deviceAppVersion`
-// for the Devices UI, and tells us to sign out if the key was revoked
-// remotely. The AI proxy also updates `lastSeenAt` on every authenticated
-// call, so this only matters when the device is idle.
+// for the Devices UI. If the cloud rejects the key (revoked / expired),
+// we push `cloudKeyRejected` to the renderer so Settings can show a
+// warning banner — but we never auto-sign the user out. The AI proxy
+// also updates `lastSeenAt` on every authenticated call, so this only
+// matters when the device is idle.
 const HEARTBEAT_INTERVAL_MS = 5 * 60_000
 let heartbeatTimer: NodeJS.Timeout | null = null
 
@@ -226,13 +229,17 @@ function startCloudLoginHeartbeat(): void {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ deviceAppVersion: app.getVersion() }),
       })
-      if (!res.ok) return
       const body = (await res.json().catch(() => ({}))) as CloudLoginBody
-      if (body?.revoked) {
-        console.warn('[Desktop] Cloud key was revoked remotely, signing out')
-        notifyRendererLoginResult({
-          ok: false,
-          error: 'Signed out from Shogo Cloud (key revoked)',
+      if (body?.cloudKeyRejected) {
+        console.warn('[Desktop] Cloud rejected API key — notifying renderer of connection issue')
+      }
+      // Push current cloud-connection health to the renderer so the
+      // Settings UI can show a warning banner without signing out.
+      for (const win of BrowserWindow.getAllWindows()) {
+        win.webContents.send('cloud-connection-status', {
+          connected: body?.ok === true,
+          cloudKeyRejected: !!body?.cloudKeyRejected,
+          error: body?.error,
         })
       }
     } catch {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -226,4 +226,12 @@ contextBridge.exposeInMainWorld('shogoDesktop', {
   removeCloudLoginListener: () => {
     ipcRenderer.removeAllListeners('cloud-login-result')
   },
+  onCloudConnectionStatus: (
+    callback: (status: { connected: boolean; cloudKeyRejected: boolean; error?: string }) => void,
+  ) => {
+    ipcRenderer.on('cloud-connection-status', (_event, status) => callback(status))
+  },
+  removeCloudConnectionStatusListener: () => {
+    ipcRenderer.removeAllListeners('cloud-connection-status')
+  },
 })

--- a/apps/mobile/app/(admin)/general.tsx
+++ b/apps/mobile/app/(admin)/general.tsx
@@ -55,6 +55,7 @@ export default function AdminGeneralPage() {
   const [loginStatus, setLoginStatus] = useState<'idle' | 'connecting' | 'error'>('idle')
   const [loginError, setLoginError] = useState('')
   const [isDisconnecting, setIsDisconnecting] = useState(false)
+  const [cloudKeyRejected, setCloudKeyRejected] = useState(false)
   // Cloud URL is read-only; it reflects the API server's `SHOGO_CLOUD_URL`
   // env var (default https://studio.shogo.ai) and is not user-editable.
   const [cloudUrl, setCloudUrl] = useState(SHOGO_CLOUD_URL_DEFAULT)
@@ -85,6 +86,7 @@ export default function AdminGeneralPage() {
       setShogoEmail(status.email || '')
       setShogoWorkspaceName(status.workspace?.name || '')
       setShogoKeyMask(status.keyPrefix ? `${status.keyPrefix}…` : '')
+      setCloudKeyRejected(!!status.cloudKeyRejected)
       if (status.cloudUrl) {
         setCloudUrl(status.cloudUrl)
       }
@@ -132,9 +134,19 @@ export default function AdminGeneralPage() {
       }
     })
 
+    // Listen for periodic cloud-connection health updates from the
+    // desktop heartbeat. This surfaces key-rejected warnings without
+    // signing the user out.
+    const desktopExt = desktop as any
+    desktopExt?.onCloudConnectionStatus?.((status: { connected: boolean; cloudKeyRejected: boolean; error?: string }) => {
+      if (cancelled) return
+      setCloudKeyRejected(status.cloudKeyRejected)
+    })
+
     return () => {
       cancelled = true
       desktop?.removeCloudLoginListener?.()
+      desktopExt?.removeCloudConnectionStatusListener?.()
     }
   }, [platform, fetchInstanceInfo, loadStatus])
 
@@ -238,6 +250,7 @@ export default function AdminGeneralPage() {
       setShogoKeyMask('')
       setShogoWorkspaceName('')
       setShogoEmail('')
+      setCloudKeyRejected(false)
       setLoginStatus('idle')
       setInstanceInfo(null)
     } catch (err) {
@@ -295,8 +308,15 @@ export default function AdminGeneralPage() {
         >
           {shogoKeyConnected ? (
             <View className="gap-3">
-              <View className="flex-row items-center gap-2 bg-green-500/10 rounded-lg p-3">
-                <CheckCircle size={16} className="text-green-500" />
+              <View className={cn(
+                'flex-row items-center gap-2 rounded-lg p-3',
+                cloudKeyRejected ? 'bg-orange-500/10 border border-orange-500/20' : 'bg-green-500/10',
+              )}>
+                {cloudKeyRejected ? (
+                  <AlertTriangle size={16} className="text-orange-500" />
+                ) : (
+                  <CheckCircle size={16} className="text-green-500" />
+                )}
                 <View className="flex-1">
                   <Text className="text-sm font-medium text-foreground">
                     Signed in{shogoEmail ? ` as ${shogoEmail}` : ''}
@@ -308,6 +328,20 @@ export default function AdminGeneralPage() {
                   ) : null}
                 </View>
               </View>
+              {cloudKeyRejected && (
+                <View className="flex-row items-start gap-2 bg-orange-500/10 border border-orange-500/20 rounded-lg p-3">
+                  <AlertTriangle size={16} className="text-orange-500 mt-0.5" />
+                  <View className="flex-1">
+                    <Text className="text-sm font-medium text-foreground">
+                      Cloud connection issue
+                    </Text>
+                    <Text className="text-xs text-muted-foreground mt-0.5">
+                      Your API key may have been revoked or expired on the cloud.
+                      Sign out and sign in again to refresh your connection.
+                    </Text>
+                  </View>
+                </View>
+              )}
               <View className="flex-row items-center gap-2">
                 {shogoKeyMask ? (
                   <Text className="text-xs text-muted-foreground font-mono flex-1">

--- a/packages/sdk/src/platform/index.ts
+++ b/packages/sdk/src/platform/index.ts
@@ -137,6 +137,10 @@ export interface CloudLoginStatus {
   workspace?: { id?: string; name?: string; slug?: string } | null
   deviceId?: string | null
   keyPrefix?: string
+  /** True when the cloud has rejected the stored API key (revoked / expired).
+   * The user remains signed in locally; the UI should show a warning banner
+   * prompting them to sign out and sign in again. */
+  cloudKeyRejected?: boolean
 }
 
 export interface ShogoKeyStatus {


### PR DESCRIPTION
## Summary

Fixes #491

The desktop app was automatically signing users out of Shogo Cloud mid-chat when the heartbeat received a 401 from the cloud. This PR replaces the auto-wipe behaviour with a degraded-connection warning that preserves the user's signed-in state.

**Core principle: once signed in, the user is never automatically signed out. Only an explicit "Sign out" button press clears credentials.**

## Root Cause

Three bugs across three layers combined:

1. **Aggressive key wiping** (`local-auth.ts`): The heartbeat endpoint deleted `SHOGO_API_KEY` from SQLite and `process.env` on a single 401 — instantly breaking AI proxying mid-chat.
2. **Silent heartbeat failure** (`main.ts`): `if (!res.ok) return` prevented reading the response body, so the renderer was never notified.
3. **Stale UI state** (`general.tsx`): No status refresh on heartbeat errors left the UI showing "Signed in" until the key was already gone.

## Implementation

### Architecture: Before vs After

**Before (broken):**
```
Cloud 401 → local-auth DELETES key → main.ts skips body → renderer stale
         → AI proxy breaks immediately → user sees "Sign in" mid-chat
```

**After (fixed):**
```
Cloud 401 → local-auth sets cloudKeyRejected flag (key preserved)
         → main.ts reads body, sends cloud-connection-status IPC
         → renderer shows orange warning banner
         → user stays signed in, can sign out manually if needed
         → next successful heartbeat auto-clears the flag (self-healing)
```

### Data Flow Diagram

```
┌──────────────────────────────────────────────────────────────┐
│                 ELECTRON MAIN PROCESS (main.ts)              │
│                                                              │
│  startCloudLoginHeartbeat() — every 5 min                    │
│  ┌──────────────────────────────────────────────┐            │
│  │ POST /api/local/cloud-login/heartbeat        │            │
│  │                  │                           │            │
│  │                  ▼                           │            │
│  │  ┌────────────────────────────────┐          │            │
│  │  │   LOCAL API (local-auth.ts)    │          │            │
│  │  │                                │          │            │
│  │  │  Read key from SQLite          │          │            │
│  │  │  Forward to cloud heartbeat    │          │            │
│  │  │         │                      │          │            │
│  │  │    ┌────┴────┐                 │          │            │
│  │  │    │  CLOUD   │                │          │            │
│  │  │    │ 200 / 401│                │          │            │
│  │  │    └────┬────┘                 │          │            │
│  │  │         │                      │          │            │
│  │  │    200: cloudKeyRejected=false │          │            │
│  │  │    401: cloudKeyRejected=true  │          │            │
│  │  │    (KEY NEVER DELETED)         │          │            │
│  │  └────────────────────────────────┘          │            │
│  │                  │                           │            │
│  │  Always read response body                   │            │
│  └──────────────────┬───────────────────────────┘            │
│                     │                                        │
│  IPC: cloud-connection-status                                │
│  { connected: bool, cloudKeyRejected: bool, error?: string } │
│                     │                                        │
└─────────────────────┼────────────────────────────────────────┘
                      │
                      ▼
┌──────────────────────────────────────────────────────────────┐
│              RENDERER PROCESS (general.tsx)                   │
│                                                              │
│  onCloudConnectionStatus listener                            │
│         │                                                    │
│    ┌────┴────────────────┐                                   │
│    │ cloudKeyRejected?   │                                   │
│    ├─── false ───────────┼──► Green "Signed in as X" card    │
│    │                     │    Workspace: Y                   │
│    ├─── true ────────────┼──► Orange "Signed in as X" card   │
│    │                     │    + Warning: "Cloud connection    │
│    │                     │      issue — sign out & sign in   │
│    │                     │      to refresh"                  │
│    └─────────────────────┘                                   │
│                                                              │
│  Sign-out: ONLY via explicit button press                    │
│  → handleDisconnectShogoKey() → clears all state             │
└──────────────────────────────────────────────────────────────┘
```

### State Lifecycle of `cloudKeyRejected`

```
false (initial)
  │
  ├── Heartbeat 401 ──────────► true  (warning banner shown)
  │                               │
  │                               ├── Heartbeat 200 ──► false (self-healed)
  │                               ├── User signs out ──► false (reset)
  │                               └── User signs in  ──► false (reset)
  │
  ├── Heartbeat 200 ──────────► false (stays healthy)
  ├── Heartbeat 502/timeout ──► false (transient, not rejection)
  └── API process restart ────► false (in-memory, fresh start)
```

## Changes by File

| File | What Changed |
|---|---|
| `apps/api/src/routes/local-auth.ts` | Removed auto-wipe on 401. Added in-memory `cloudKeyRejected` flag. Reset on sign-out, sign-in (complete), and successful heartbeat. Exposed in `/status` response. |
| `apps/desktop/src/main.ts` | Removed `if (!res.ok) return` — always reads response body. Sends new `cloud-connection-status` IPC instead of triggering sign-out. Updated comments to reflect "never auto-sign-out" intent. |
| `apps/desktop/src/preload.ts` | Exposed `onCloudConnectionStatus` and `removeCloudConnectionStatusListener` via `contextBridge`. |
| `apps/mobile/app/(admin)/general.tsx` | Listens to new IPC. Shows orange warning banner below identity card when `cloudKeyRejected` is true. Clears `cloudKeyRejected` on explicit sign-out. User email/workspace always visible. |
| `packages/sdk/src/platform/index.ts` | Added `cloudKeyRejected?: boolean` to `CloudLoginStatus` interface with JSDoc. |
| `apps/api/src/__tests__/cloud-login-e2e.test.ts` | Updated revocation test: key is never wiped after 5 consecutive 401s. Added test: `cloudKeyRejected` self-heals when heartbeat succeeds. |

## Edge Cases

| Scenario | Handling |
|---|---|
| Single 401 from cloud | Flag set, key kept, self-heals on next 200 |
| Multiple consecutive 401s | Flag stays true, key never wiped |
| Transient network error (502, timeout) | `cloudKeyRejected` NOT set — only 401 triggers it |
| Cloud 500/503 | Not treated as key rejection |
| Sign-out → Sign-in cycle | Flag reset on both operations, no stale state |
| API process restart | In-memory flag resets to false; next heartbeat re-evaluates |
| Non-desktop (Metro/browser) path | `cloudKeyRejected` served via HTTP `/status` on page load |
| Warning banner UX | Always shows email + workspace; warning is additive, not replacing |

## User Experience

| Scenario | Before | After |
|---|---|---|
| Cloud hiccup during chat | Key wiped, "Not configured" screen, chat breaks | User stays signed in, chat continues. Warning in Settings if key rejected. |
| Key revoked from cloud Devices UI | Silent wipe, confusing UX | Warning banner: "Cloud connection issue." Identity still visible. |
| Temporary cloud outage | Key wiped on first 401 | Nothing visible. Self-heals when cloud recovers. |
| User wants to sign out | Happened automatically at worst time | Explicit button only. User controls when. |

## Test Plan

- [x] `bun test cloud-login-e2e` — all 24 tests pass including new revocation + self-heal tests
- [x] Lint check — zero errors across all changed files
- [ ] Manual: Sign in → revoke key from cloud Devices UI → verify orange warning shows, user stays signed in
- [ ] Manual: After warning shows → next heartbeat succeeds → verify warning disappears
- [ ] Manual: Sign out → sign back in → verify no stale warning flash

Made with [Cursor](https://cursor.com)