### PR TITLE
fix(chat): allow mode and model pickers while assistant streams

### DIFF
--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -276,11 +276,11 @@ export function ChatInput({
   )
 
   const cycleInteractionMode = useCallback(() => {
-    if (disabled || isStreaming) return
+    if (disabled) return
     const currentIndex = INTERACTION_MODE_ORDER.indexOf(interactionMode)
     const nextIndex = (currentIndex + 1) % INTERACTION_MODE_ORDER.length
     handleInteractionModeChange(INTERACTION_MODE_ORDER[nextIndex])
-  }, [disabled, handleInteractionModeChange, interactionMode, isStreaming])
+  }, [disabled, handleInteractionModeChange, interactionMode])
 
   const currentInteractionConfig = useMemo(
     () => INTERACTION_MODES.find((m) => m.id === interactionMode) || INTERACTION_MODES[0],
@@ -957,7 +957,7 @@ export function ChatInput({
               trigger={(triggerProps) => (
                 <Pressable
                   {...triggerProps}
-                  disabled={disabled || isStreaming}
+                  disabled={disabled}
                   className={cn(
                     "h-[22px] flex-row items-center gap-1 rounded-md px-1.5",
                     interactionMode === "agent" && "bg-muted/50",
@@ -1079,7 +1079,7 @@ export function ChatInput({
                 trigger={(triggerProps) => (
                   <Pressable
                     {...triggerProps}
-                    disabled={disabled || isStreaming}
+                    disabled={disabled}
                     className={cn(
                       "h-[22px] flex-row items-center gap-1 rounded-md px-1.5",
                       quickActionsOpen
@@ -1155,7 +1155,7 @@ export function ChatInput({
               trigger={(triggerProps) => (
                 <Pressable
                   {...triggerProps}
-                  disabled={disabled || isStreaming}
+                  disabled={disabled}
                   className="h-[22px] flex-row items-center gap-1 rounded-md px-1.5"
                 >
                   <Text className="text-xs text-muted-foreground">

--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -591,7 +591,7 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
                 trigger={(triggerProps) => (
                   <Pressable
                     {...triggerProps}
-                    disabled={disabled || isLoading}
+                    disabled={disabled}
                     className={cn(
                       "h-[22px] flex-row items-center gap-1 rounded-md px-1.5",
                       interactionMode === "agent" && "bg-muted/50",
@@ -714,7 +714,7 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
                 trigger={(triggerProps) => (
                   <Pressable
                     {...triggerProps}
-                    disabled={disabled || isLoading}
+                    disabled={disabled}
                     className="h-[22px] flex-row items-center gap-1 rounded-md px-1.5"
                   >
                     <Text className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Related issue

Closes #493

## Problem

The chat composer disabled **Agent / Plan / Ask**, **Quick actions**, and **model** popover triggers whenever `isStreaming` (full `ChatInput`) or `isLoading` (compact composer) was true. Users could not adjust preferences while watching a long streamed response.

## Solution (implementation)

| File | Change |
|------|--------|
| [`apps/mobile/components/chat/ChatInput.tsx`](apps/mobile/components/chat/ChatInput.tsx) | **Interaction mode** popover trigger, **Quick actions** trigger, and **model** popover trigger: `Pressable` `disabled` is now **`disabled` only** (removed `\|\| isStreaming`). **`cycleInteractionMode`** (web **Shift+Tab**): removed `isStreaming` early return and dependency. |
| [`apps/mobile/components/chat/CompactChatInput.tsx`](apps/mobile/components/chat/CompactChatInput.tsx) | **Interaction mode** and **model** triggers: `disabled` is **`disabled` only** (removed `\|\| isLoading`). |

**Not changed in this PR:** streaming-specific UI (stop button, optional queue send), attach button rules, text-input `editable` logic, and `EnvironmentPicker` props—only the three toolbar popover triggers called out above (plus mode cycle guard in `ChatInput`).

## Architecture

`ChatPanel` still computes `isStreaming` from chat status; it continues to pass `isStreaming` into `ChatInput` for stop/queue behavior. The difference is that **preference controls** (mode / model / quick actions) no longer consume that flag for `Pressable.disabled`.

```mermaid
flowchart LR
  subgraph ChatPanel
    IS[isStreaming]
  end

  subgraph ChatInput
    T1[Mode popover trigger]
    T2[Model popover trigger]
    T3[Quick actions trigger]
    STOP[Stop / queue UI]
  end

  IS --> STOP
  IS -.->|removed| T1
  IS -.->|removed| T2
  IS -.->|removed| T3

  D[disabled prop] --> T1
  D --> T2
  D --> T3
```

```mermaid
sequenceDiagram
  participant U as User
  participant In as ChatInput
  participant P as ChatPanel

  P->>In: isStreaming=true during reply
  U->>In: Open model menu, select model
  In->>P: onModelChange
  Note over P: selectedModel updated for next message
  U->>In: Shift+Tab (web)
  In->>P: onInteractionModeChange
```

## Branch scope

Single-purpose branch **`fix/chat-compose-mode-model-while-streaming`** off **`main`**, containing only the two files above.

## How to verify

1. Start a chat turn that streams for several seconds.
2. While streaming, open **Agent / Plan / Ask** and change mode; open **model** and pick another model; on full composer with quick actions, open **Actions**.
3. On web, with focus in the composer, press **Shift+Tab** and confirm the mode cycles.
4. Confirm **Stop** still appears and works as before.
