### PR TITLE
fix(api/knative): healthCheck resolves warm-pool service URL via DB

### DIFF
--- a/apps/api/src/lib/knative-project-manager.ts
+++ b/apps/api/src/lib/knative-project-manager.ts
@@ -822,10 +822,21 @@ export class KnativeProjectManager {
    * Perform an active health check on a project's pod.
    * Returns true if the pod is responding and ready to handle requests.
    * Uses /ready endpoint which verifies the project directory exists.
+   *
+   * Resolves the actual Knative Service via the DB so warm-pool-promoted
+   * projects (whose service name is `warm-pool-*`, not `project-{id}`) are
+   * probed at the correct hostname. Using the legacy `project-{id}`
+   * convention here causes NXDOMAIN and waitForReady() loops until timeout.
    */
   async healthCheck(projectId: string): Promise<boolean> {
+    let url: string
     try {
-      const url = this.getProjectPodUrl(projectId)
+      url = await this.resolveProjectPodUrl(projectId)
+    } catch (error: any) {
+      console.warn(`[KnativeProjectManager] healthCheck: failed to resolve pod URL for ${projectId}: ${error?.message || error}`)
+      return false
+    }
+    try {
       const response = await fetch(`${url}/ready`, {
         method: "GET",
         signal: AbortSignal.timeout(5000), // 5 second timeout


### PR DESCRIPTION
## Summary

Fixes preview iframes appearing as 404s in production by repairing the runtime health probe that the studio uses to gate iframe mount.

`KnativeProjectManager.healthCheck()` was using the synchronous `getProjectPodUrl()`, which hardcodes the legacy `project-{id}.{ns}.svc.cluster.local` hostname. In current production, every project is served by a **claimed warm-pool** service (`warm-pool-*`) — there are no `project-{id}` ksvcs left — so the probe hits a host with no DNS entry, fetch fails in <15ms, and `waitForReady()` spins for the full 180s before throwing.

User-visible effects this resolves:

- `GET /api/projects/:id/runtime/status` returning `{ status: 'starting', ready: false }` indefinitely → studio iframe never mounts.
- `GET /api/projects/:id/sandbox/url` cold-start path returning 503 `pod_unavailable` after 180s → studio renders the legacy proxy URL response as a 404.
- Spam in api logs: `[KnativeProjectManager] Project … reports ready but health check failed (5ms), retrying...` x ~177 polls per affected request.

## Diagnosis (kubectl evidence)

Checked from inside an api pod:

```
$ wget http://project-474f8645-...svc.cluster.local/ready
wget: bad address           ← NXDOMAIN — what healthCheck() was hitting

$ wget http://warm-pool-27baf967.shogo-production-workspaces.svc.cluster.local/ready
{"ready":true,"gateway":true,"poolMode":false}    ← what it should have been hitting
```

The DomainMapping for the affected project's preview URL correctly points at `warm-pool-27baf967`, and `Project.knativeServiceName` in Postgres is also set to that value — only `healthCheck()` failed to consult the DB.

## Fix

Use `resolveProjectPodUrl()` (already exists in this file at line 273): DB-mapped name first, legacy `project-{id}` fallback for backwards compatibility. Resolution errors are caught and return `false`, matching the existing fail-soft contract.

`healthCheck()` was already `async` and its only callers (`waitForReady()` in the same file and `/api/projects/:projectId/runtime/status` in `apps/api/src/server.ts`) already `await` it — no caller changes required.

## Test plan

- [ ] Deploy to `production-us`, then load the previously-broken project (https://studio.shogo.ai/projects/474f8645-16ec-4300-83bd-52b80237f670) and confirm:
  - [ ] `[KnativeProjectManager] Project … reports ready but health check failed` log spam stops.
  - [ ] `/api/projects/:id/runtime/status` returns `ready: true` immediately after Knative reports ready.
  - [ ] `/api/projects/:id/sandbox/url` returns 200 with a preview URL on the first request after cold start (no 180s wait).
  - [ ] Studio iframe mounts and shows the preview app.
- [ ] Verify a fresh project (cold start, no prior warm-pool claim) also resolves: warm pool is claimed, DomainMapping created, and the healthcheck targets `warm-pool-*` not `project-{id}`.
- [ ] No regression for legacy `project-{id}` projects: `resolveProjectPodUrl()` still falls back to the legacy convention when `Project.knativeServiceName` is null.

Made with [Cursor](https://cursor.com)