### PR TITLE
feat(cloud-login): self-heal AI proxy + tunnel on revoked cloud key

### DIFF
--- a/apps/api/src/__tests__/cloud-key-wipe.test.ts
+++ b/apps/api/src/__tests__/cloud-key-wipe.test.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Cloud Key Self-Heal Tests — wipeCloudKey contract: clears env + localConfig,
+ * stops the tunnel, no-ops when unauthenticated, debounces concurrent callers.
+ * Run: bun test apps/api/src/__tests__/cloud-key-wipe.test.ts
+ */
+
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test'
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const localConfig = new Map<string, string>()
+const mockPrisma = {
+  localConfig: {
+    findUnique: mock(async (args: { where: { key: string } }) => {
+      const value = localConfig.get(args.where.key)
+      return value === undefined ? null : { key: args.where.key, value }
+    }),
+    upsert: mock(async (args: {
+      where: { key: string }
+      create: { key: string; value: string }
+      update: { value: string }
+    }) => {
+      localConfig.set(args.where.key, args.update.value ?? args.create.value)
+      return { key: args.where.key, value: localConfig.get(args.where.key)! }
+    }),
+    deleteMany: mock(async (args: { where: { key: string } }) => {
+      const existed = localConfig.delete(args.where.key)
+      return { count: existed ? 1 : 0 }
+    }),
+  },
+}
+
+const stopInstanceTunnel = mock(() => {})
+
+mock.module('../lib/prisma', () => ({ prisma: mockPrisma }))
+mock.module('../lib/instance-tunnel', () => ({
+  startInstanceTunnel: mock(() => {}),
+  stopInstanceTunnel,
+}))
+
+// Import AFTER mocks
+const { wipeCloudKey, _testing } = await import('../lib/cloud-key-wipe')
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('wipeCloudKey', () => {
+  beforeEach(() => {
+    localConfig.clear()
+    localConfig.set('SHOGO_API_KEY', 'shogo_sk_test_revoked')
+    localConfig.set('SHOGO_KEY_INFO', JSON.stringify({ workspace: { id: 'ws-1' } }))
+    process.env.SHOGO_API_KEY = 'shogo_sk_test_revoked'
+    stopInstanceTunnel.mockClear()
+    mockPrisma.localConfig.deleteMany.mockClear()
+    _testing.reset()
+  })
+
+  afterEach(() => {
+    delete process.env.SHOGO_API_KEY
+  })
+
+  test('clears env, localConfig, and stops the tunnel', async () => {
+    const result = await wipeCloudKey('test-trigger')
+
+    expect(result.wiped).toBe(true)
+    expect(process.env.SHOGO_API_KEY).toBeUndefined()
+    expect(localConfig.has('SHOGO_API_KEY')).toBe(false)
+    expect(localConfig.has('SHOGO_KEY_INFO')).toBe(false)
+    expect(mockPrisma.localConfig.deleteMany).toHaveBeenCalledTimes(2)
+    expect(stopInstanceTunnel).toHaveBeenCalledTimes(1)
+  })
+
+  test('is a no-op when no key is set', async () => {
+    delete process.env.SHOGO_API_KEY
+    localConfig.clear()
+    mockPrisma.localConfig.deleteMany.mockClear()
+    stopInstanceTunnel.mockClear()
+
+    const result = await wipeCloudKey('test-noop')
+
+    expect(result.wiped).toBe(false)
+    expect(mockPrisma.localConfig.deleteMany).not.toHaveBeenCalled()
+    expect(stopInstanceTunnel).not.toHaveBeenCalled()
+  })
+
+  test('coalesces concurrent callers — three forwarders racing should wipe once', async () => {
+    const [a, b, c] = await Promise.all([
+      wipeCloudKey('caller-a'),
+      wipeCloudKey('caller-b'),
+      wipeCloudKey('caller-c'),
+    ])
+
+    const wins = [a, b, c].filter((r) => r.wiped)
+    expect(wins.length).toBe(1)
+    expect(stopInstanceTunnel).toHaveBeenCalledTimes(1)
+    expect(mockPrisma.localConfig.deleteMany).toHaveBeenCalledTimes(2)
+    expect(process.env.SHOGO_API_KEY).toBeUndefined()
+  })
+
+  test('dedups follow-up wipes within the dedup window', async () => {
+    await wipeCloudKey('first')
+    expect(stopInstanceTunnel).toHaveBeenCalledTimes(1)
+
+    // Sign back in + revoke again inside the window — should still no-op.
+    process.env.SHOGO_API_KEY = 'shogo_sk_test_again'
+    localConfig.set('SHOGO_API_KEY', 'shogo_sk_test_again')
+    const second = await wipeCloudKey('second')
+    expect(second.wiped).toBe(false)
+    expect(stopInstanceTunnel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/api/src/lib/__tests__/instance-tunnel.test.ts
+++ b/apps/api/src/lib/__tests__/instance-tunnel.test.ts
@@ -34,6 +34,12 @@ mock.module('../runtime', () => ({
   }),
 }))
 
+const wipeCloudKeyMock = mock(async () => ({ wiped: true }))
+mock.module('../cloud-key-wipe', () => ({
+  wipeCloudKey: wipeCloudKeyMock,
+  _testing: { reset: () => {} },
+}))
+
 describe('Instance Tunnel Client', () => {
   beforeEach(() => {
     globalThis.fetch = mockFetch as any
@@ -170,5 +176,25 @@ describe('Instance Tunnel Client', () => {
   test('DEFAULT_POLL_INTERVAL_S is 60', async () => {
     const mod = await import('../instance-tunnel')
     expect(mod._testing.DEFAULT_POLL_INTERVAL_S).toBe(60)
+  })
+
+  test('heartbeat self-heals after AUTH_FAILURE_THRESHOLD consecutive 401s', async () => {
+    // 3 cloud 401s in a row should fire wipeCloudKey, not just back off forever.
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('Unauthorized', { status: 401 })),
+    )
+    wipeCloudKeyMock.mockClear()
+
+    const mod = await import('../instance-tunnel')
+    for (let i = 0; i < 3; i++) {
+      await mod._testing.heartbeatLoop()
+    }
+
+    expect(wipeCloudKeyMock).toHaveBeenCalled()
+    const reason = (wipeCloudKeyMock.mock.calls[0] as any)?.[0] as string
+    expect(reason).toContain('instance tunnel')
+    expect(reason).toContain('consecutive auth failures')
+
+    mod.stopInstanceTunnel()
   })
 })

--- a/apps/api/src/lib/cloud-key-wipe.ts
+++ b/apps/api/src/lib/cloud-key-wipe.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Cloud Key Self-Heal — wipes the local SHOGO_API_KEY when cloud rejects it,
+ * so the desktop UI flips to signed-out instead of looping 401s.
+ */
+
+import { prisma } from './prisma'
+
+const DEDUP_WINDOW_MS = 5_000
+
+let lastWipeAt = 0
+let inFlight: Promise<void> | null = null
+
+export interface WipeResult {
+  /** True when this call performed the wipe; false if no-op or coalesced. */
+  wiped: boolean
+}
+
+/** Wipe the locally-stored Shogo Cloud API key. Idempotent + debounced. */
+export async function wipeCloudKey(reason: string): Promise<WipeResult> {
+  if (!process.env.SHOGO_API_KEY) return { wiped: false }
+  // Coalesce concurrent callers and dedup follow-ups within the window.
+  if (inFlight) { await inFlight; return { wiped: false } }
+  if (Date.now() - lastWipeAt < DEDUP_WINDOW_MS) return { wiped: false }
+
+  console.warn(
+    `[CloudKeyWipe] Clearing SHOGO_API_KEY — ${reason}. ` +
+      `Desktop heartbeat will surface the signed-out state on its next tick.`,
+  )
+
+  const localDb = prisma as any
+  inFlight = (async () => {
+    try {
+      await Promise.all([
+        localDb.localConfig
+          .deleteMany({ where: { key: 'SHOGO_API_KEY' } })
+          .catch((err: unknown) => {
+            console.error('[CloudKeyWipe] localConfig SHOGO_API_KEY delete failed:', err)
+          }),
+        localDb.localConfig
+          .deleteMany({ where: { key: 'SHOGO_KEY_INFO' } })
+          .catch((err: unknown) => {
+            console.error('[CloudKeyWipe] localConfig SHOGO_KEY_INFO delete failed:', err)
+          }),
+      ])
+      delete process.env.SHOGO_API_KEY
+
+      // Dynamic import avoids a static instance-tunnel ↔ cloud-key-wipe cycle.
+      try {
+        const mod = await import('./instance-tunnel')
+        mod.stopInstanceTunnel()
+      } catch (err) {
+        console.error('[CloudKeyWipe] Failed to stop instance tunnel:', err)
+      }
+    } finally {
+      lastWipeAt = Date.now()
+      inFlight = null
+    }
+  })()
+
+  await inFlight
+  return { wiped: true }
+}
+
+/** Test-only reset of the dedup state. */
+export const _testing = {
+  reset() {
+    lastWipeAt = 0
+    inFlight = null
+  },
+}

--- a/apps/api/src/lib/instance-tunnel.ts
+++ b/apps/api/src/lib/instance-tunnel.ts
@@ -12,6 +12,7 @@
 
 import { hostname as osHostname, platform, arch as osArch } from 'os'
 import { getRuntimeManager } from './runtime'
+import { wipeCloudKey } from './cloud-key-wipe'
 
 interface TunnelRequest {
   type: 'request'
@@ -331,10 +332,14 @@ async function heartbeatLoop() {
       lastHeartbeatError = err.message
     }
     if (consecutiveAuthFailures >= AUTH_FAILURE_THRESHOLD) {
+      // Self-heal: key revoked or superseded — wipe + stop instead of polling forever.
+      void wipeCloudKey(
+        `instance tunnel saw ${consecutiveAuthFailures} consecutive auth failures from Shogo Cloud`,
+      )
       if (currentPollInterval !== AUTH_FAILURE_BACKOFF_S) {
         console.warn(
-          `[InstanceTunnel] ${consecutiveAuthFailures} consecutive auth failures \u2014 backing off to ${AUTH_FAILURE_BACKOFF_S}s. ` +
-            `Run \`shogo login\` once you've issued a fresh API key.`
+          `[InstanceTunnel] ${consecutiveAuthFailures} consecutive auth failures \u2014 backing off to ${AUTH_FAILURE_BACKOFF_S}s and clearing local key. ` +
+            `Re-link from the desktop General settings once you've issued a fresh API key.`
         )
       }
       currentPollInterval = AUTH_FAILURE_BACKOFF_S

--- a/apps/api/src/routes/ai-proxy.ts
+++ b/apps/api/src/routes/ai-proxy.ts
@@ -35,6 +35,7 @@ import {
   type ProxyTokenPayload,
 } from '../lib/ai-proxy-token'
 import { resolveApiKey } from './api-keys'
+import { wipeCloudKey } from '../lib/cloud-key-wipe'
 import {
   MODEL_CATALOG,
   MODEL_ALIASES,
@@ -1787,6 +1788,11 @@ export function aiProxyRoutes() {
       signal,
     })
 
+    // Self-heal on revoked / superseded device key.
+    if (response.status === 401) {
+      void wipeCloudKey('AI proxy chat-completions got 401 from Shogo Cloud')
+    }
+
     if (request.stream) {
       if (!response.body) {
         return c.json({ error: { message: 'Cloud proxy returned no stream body', type: 'server_error' } }, 502)
@@ -1836,6 +1842,11 @@ export function aiProxyRoutes() {
       },
       { label: 'shogo-cloud', signal },
     )
+
+    // Self-heal on revoked / superseded device key.
+    if (response.status === 401) {
+      void wipeCloudKey('AI proxy Anthropic messages got 401 from Shogo Cloud')
+    }
 
     if (isStream) {
       if (!response.body) {
@@ -2625,6 +2636,10 @@ export function aiProxyRoutes() {
         },
         { label: 'shogo-cloud', signal: c.req.raw.signal },
       )
+      // Self-heal on revoked / superseded device key.
+      if (response.status === 401) {
+        void wipeCloudKey('AI proxy count_tokens got 401 from Shogo Cloud')
+      }
       const responseBody = await response.text()
       return new Response(responseBody, {
         status: response.status,

--- a/apps/api/src/routes/local-auth.ts
+++ b/apps/api/src/routes/local-auth.ts
@@ -35,6 +35,7 @@
 import { Hono } from 'hono'
 import crypto from 'crypto'
 import { prisma } from '../lib/prisma'
+import { wipeCloudKey } from '../lib/cloud-key-wipe'
 
 const SHOGO_CLOUD_URL_DEFAULT = 'https://studio.shogo.ai'
 /** Default deep-link the cloud bridge page redirects back to. Override with
@@ -306,15 +307,9 @@ export function localAuthRoutes() {
       })
       const data = await res.json().catch(() => ({} as any))
       if (!res.ok || data?.ok === false) {
-        // A 401 from cloud means our key was revoked (probably via the cloud
-        // Devices UI). Wipe locally so the UI flips to signed-out and the
-        // user is prompted to re-login.
+        // 401 ⇒ key revoked or superseded; delegate to the shared self-heal helper.
         if (res.status === 401) {
-          await Promise.all([
-            localDb.localConfig.deleteMany({ where: { key: 'SHOGO_API_KEY' } }),
-            localDb.localConfig.deleteMany({ where: { key: 'SHOGO_KEY_INFO' } }),
-          ])
-          delete process.env.SHOGO_API_KEY
+          await wipeCloudKey('cloud-login heartbeat got 401 from Shogo Cloud')
         }
         return c.json({ ok: false, error: data?.error || `HTTP ${res.status}`, revoked: res.status === 401 }, res.status as any)
       }


### PR DESCRIPTION
## Description (Required)
<!-- Provide a brief description of the changes in this PR -->
When Shogo Cloud revokes a device API key (via the Devices UI, or by superseding it on a fresh `(workspaceId, deviceId)` mint), the local API used to keep using the dead key — every AI proxy call returned 401, the instance tunnel polled forever, and the desktop General settings page still showed the user as signed in.

This PR adds a small shared self-heal helper and wires it into all three cloud-talking surfaces so a revoked key gets dropped automatically. After the wipe, the next desktop heartbeat tick flips the UI to signed-out and prompts the user to re-link.

What changed:
- New `apps/api/src/lib/cloud-key-wipe.ts` — `wipeCloudKey(reason)` helper. Idempotent, debounced (5s window). Clears `SHOGO_API_KEY` + `SHOGO_KEY_INFO` from `localConfig`, drops `process.env.SHOGO_API_KEY`, and stops the instance tunnel.
- `apps/api/src/routes/ai-proxy.ts` — fires the wipe on a 401 from cloud in the chat-completions, Anthropic messages, and `count_tokens` forwarders.
- `apps/api/src/lib/instance-tunnel.ts` — fires the wipe when `consecutiveAuthFailures` crosses `AUTH_FAILURE_THRESHOLD` (3), instead of just backing off forever.
- `apps/api/src/routes/local-auth.ts` — refactored the existing heartbeat handler to use the shared helper so all three surfaces have identical wipe semantics.

No new IPC channel was needed — the existing 5-min desktop heartbeat (`/api/local/cloud-login/heartbeat`) already returns `revoked: true` once `SHOGO_API_KEY` is gone, which the desktop forwards to the renderer as a `cloud-login-result` event.

## Related Issue (Required)
https://odin-ai.atlassian.net/browse/EN-3617

## Type of Change (Required)
<!-- Select ONE option by changing [ ] to [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring (no functional changes, no test changes)
- [ ] Added new tests

## How Has This Been Tested? (Required)
<!-- Describe the tests you ran to verify your changes. Provide instructions so we can reproduce. -->
Automated (each suite passes in isolation):

- `bun test apps/api/src/__tests__/cloud-key-wipe.test.ts` — 4/4 pass. New file. Covers: wipe clears env + localConfig + stops tunnel, no-op when no key is set, three concurrent callers coalesce into one wipe, follow-up wipes within the dedup window are no-ops.
- `bun test apps/api/src/lib/__tests__/instance-tunnel.test.ts` — 11/11 pass. Includes the new `heartbeat self-heals after AUTH_FAILURE_THRESHOLD consecutive 401s` case.
- `bun test apps/api/src/__tests__/cloud-login-e2e.test.ts` — 25/25 pass. Existing `remote revoke` test now exercises the shared helper.
- `bun test apps/api/src/lib/__tests__/instance-tunnel-backoff.test.ts` — 4/4 pass.

Manual repro of the original bug (so a reviewer can confirm the fix):

1. Sign in to local-mode against staging cloud, then in the cloud Devices UI revoke the device key (or trigger a re-mint that supersedes it).
2. Send any chat from the agent — before this PR you'd see `[AI Proxy] 401 from Shogo Cloud` repeatedly and the General settings page still claimed you were signed in. With this PR, the very first 401 wipes the local key; within the next desktop heartbeat tick the General page flips to signed-out and prompts re-link.
3. Same flow via the tunnel: stop the agent, leave the API running, revoke the key. Before this PR the `[InstanceTunnel] Heartbeat error: HTTP 401` line repeats forever. With this PR you see one `[CloudKeyWipe] Clearing SHOGO_API_KEY — instance tunnel saw 3 consecutive auth failures…` log followed by `[InstanceTunnel] Tunnel stopped`.