### PR TITLE
feat(chat): auto-grow textarea height based on content like ChatGPT

### DIFF
--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -230,6 +230,17 @@ export function ChatInput({
   // the same clipboard event, which would create duplicate chips.
   const pasteHandledRef = useRef(false)
 
+  const INPUT_MIN_HEIGHT = 60
+  const INPUT_MAX_HEIGHT = 200
+  const [inputHeight, setInputHeight] = useState(INPUT_MIN_HEIGHT)
+
+  const handleContentSizeChange = useCallback((e: any) => {
+    const contentHeight = e?.nativeEvent?.contentSize?.height
+    if (contentHeight) {
+      setInputHeight(Math.min(Math.max(contentHeight, INPUT_MIN_HEIGHT), INPUT_MAX_HEIGHT))
+    }
+  }, [])
+
   const [inputValue, setInputValue] = useState("")
   const [pendingFiles, setPendingFiles] = useState<AttachedFile[]>([])
   const [fileError, setFileError] = useState<string | null>(null)
@@ -579,6 +590,7 @@ export function ChatInput({
 
     onSubmit(trimmedContent, fileData, currentModelId)
     setInputValue("")
+    setInputHeight(INPUT_MIN_HEIGHT)
     setPendingFiles([])
     setPastedTexts([])
     setViewingPastedId(null)
@@ -921,6 +933,7 @@ export function ChatInput({
           ref={textInputRef}
           value={voiceInput.isRecording && voiceInput.liveTranscript ? voiceInput.liveTranscript : inputValue}
           onChangeText={handleChangeText}
+          onContentSizeChange={handleContentSizeChange}
           onSubmitEditing={handleSubmit}
           onKeyPress={(e: any) => {
             if (Platform.OS === "web" && e.nativeEvent.key === "Tab" && e.nativeEvent.shiftKey) {
@@ -938,9 +951,11 @@ export function ChatInput({
           accessibilityLabel="Chat message input"
           editable={!disabled && !voiceInput.isRecording}
           multiline
+          scrollEnabled={inputHeight >= INPUT_MAX_HEIGHT}
           blurOnSubmit={false}
+          style={{ height: inputHeight }}
           className={cn(
-            "min-h-[60px] max-h-[200px] w-full",
+            "w-full",
             "bg-transparent",
             "px-4 pt-4 text-xs text-foreground",
             disabled && dimWhenDisabled && "opacity-50",

--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -147,6 +147,17 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
     const textInputRef = useRef<TextInput>(null)
     const pasteHandledRef = useRef(false)
 
+    const INPUT_MIN_HEIGHT = 80
+    const INPUT_MAX_HEIGHT = 200
+    const [inputHeight, setInputHeight] = useState(INPUT_MIN_HEIGHT)
+
+    const handleContentSizeChange = useCallback((e: any) => {
+      const contentHeight = e?.nativeEvent?.contentSize?.height
+      if (contentHeight) {
+        setInputHeight(Math.min(Math.max(contentHeight, INPUT_MIN_HEIGHT), INPUT_MAX_HEIGHT))
+      }
+    }, [])
+
     const [pendingFiles, setPendingFiles] = useState<AttachedFile[]>([])
     const [fileError, setFileError] = useState<string | null>(null)
     const [attachSheetOpen, setAttachSheetOpen] = useState(false)
@@ -415,6 +426,7 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
         return
       }
       setValue("")
+      setInputHeight(INPUT_MIN_HEIGHT)
       setPendingFiles([])
       setFileError(null)
       setPastedTexts([])
@@ -559,6 +571,7 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
             accessibilityLabel="Describe the agent you want to build"
             value={voiceInput.isRecording && voiceInput.liveTranscript ? voiceInput.liveTranscript : value}
             onChangeText={handleChangeText}
+            onContentSizeChange={handleContentSizeChange}
             onSubmitEditing={handleSubmit}
             onKeyPress={(e: any) => {
               if (Platform.OS === "web" && e.nativeEvent.key === "Enter" && !e.nativeEvent.shiftKey) {
@@ -568,9 +581,11 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
             }}
             editable={!disabled && !isLoading && !voiceInput.isRecording}
             multiline
+            scrollEnabled={inputHeight >= INPUT_MAX_HEIGHT}
             blurOnSubmit={false}
+            style={{ height: inputHeight }}
             className={cn(
-              "min-h-[80px] max-h-[200px] w-full",
+              "w-full",
               "px-4 pt-4 text-xs text-foreground",
               disabled && dimWhenDisabled && "opacity-50",
               Platform.OS === "web" && "outline-none no-focus-ring"


### PR DESCRIPTION
## Summary
- Chat input textarea now dynamically expands its height as the user types, matching ChatGPT's behavior
- Grows from a minimum height (60px for ChatInput, 80px for CompactChatInput) up to a max of 200px, then becomes scrollable
- Height resets back to minimum after sending a message
<img width="764" height="913" alt="image" src="https://github.com/user-attachments/assets/58ca0826-6aca-4971-9ac4-b1476dec5d00" />


## Test plan
- [ ] Open a chat and type a short message — input stays at minimum height
- [ ] Type a multi-line message — input grows with each new line
- [ ] Type enough to exceed ~200px — input stops growing and becomes scrollable
- [ ] Send the message — input shrinks back to minimum height
- [ ] Verify on both the project chat page (ChatInput) and home page (CompactChatInput)


Made with [Cursor](https://cursor.com)