### PR TITLE
fix(desktop): bundle FFmpeg in installer so users don't need to insta…

### DIFF
--- a/apps/api/src/services/diarization.service.ts
+++ b/apps/api/src/services/diarization.service.ts
@@ -55,7 +55,8 @@ export function isDiarizationAvailable(): boolean {
 
 function whichSync(cmd: string): string | null {
   try {
-    return execSync(`which ${cmd}`, { encoding: 'utf-8' }).trim() || null
+    const lookup = process.platform === 'win32' ? `where ${cmd}` : `which ${cmd}`
+    return execSync(lookup, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim().split(/\r?\n/)[0] || null
   } catch {
     return null
   }
@@ -155,7 +156,12 @@ async function ensureResampled(audioPath: string): Promise<string> {
   } catch { /* proceed to resample */ }
 
   if (!whichSync('ffmpeg')) {
-    throw new Error('ffmpeg is required for diarization (audio resampling). Install it with: brew install ffmpeg')
+    throw new Error(
+      'ffmpeg is required for diarization (audio resampling). ' +
+      (process.platform === 'win32'
+        ? 'Install it with: winget install Gyan.FFmpeg'
+        : 'Install it with: brew install ffmpeg'),
+    )
   }
 
   const resampledPath = audioPath.replace(/\.wav$/, '-16k.wav')

--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -20,6 +20,7 @@ const extraResourceCandidates = [
   './resources/vm-helper',
   './resources/sherpa-onnx',
   './resources/shogo-sysaudio',
+  './resources/ffmpeg',
   './resources/seed.db',
   './resources/package.json',
   './prisma',

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,6 +16,7 @@
     "publish": "electron-forge publish",
     "download-bun": "node scripts/download-bun.mjs",
     "download-sherpa": "node scripts/download-sherpa.mjs",
+    "download-ffmpeg": "node scripts/download-ffmpeg.mjs",
     "build-sysaudio": "cd native/shogo-sysaudio && make build",
     "generate-install-gif": "node scripts/generate-install-gif.mjs"
   },

--- a/apps/desktop/scripts/download-ffmpeg.mjs
+++ b/apps/desktop/scripts/download-ffmpeg.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+/**
+ * Downloads FFmpeg binaries for the current (or specified) platform and places
+ * them into apps/desktop/resources/ffmpeg so they are bundled with the Electron
+ * app via extraResource in forge.config.ts.
+ *
+ * Usage:
+ *   node scripts/download-ffmpeg.mjs                    # Current platform
+ *   node scripts/download-ffmpeg.mjs --platform win32   # Windows
+ *   node scripts/download-ffmpeg.mjs --platform darwin  # macOS
+ */
+
+import { execSync } from 'child_process'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const RESOURCES_DIR = path.join(__dirname, '..', 'resources')
+
+// gyan.dev essentials build for Windows (well-known, trusted community builds).
+// macOS / Linux users already have ffmpeg via Homebrew / apt — we only need to
+// bundle on Windows where users are least likely to have it pre-installed and
+// the installer error is the most confusing.
+const FFMPEG_VERSION = process.env.FFMPEG_VERSION || '8.1.1'
+
+const DOWNLOADS = {
+  'win32-x64': {
+    url: `https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-${FFMPEG_VERSION}-essentials_build.zip`,
+    extractDir: `ffmpeg-${FFMPEG_VERSION}-essentials_build`,
+    binDir: 'bin',
+    binaries: ['ffmpeg.exe', 'ffprobe.exe'],
+  },
+  'darwin-arm64': {
+    url: 'https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip',
+    extractDir: null,
+    binDir: '.',
+    binaries: ['ffmpeg'],
+  },
+  'darwin-x64': {
+    url: 'https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip',
+    extractDir: null,
+    binDir: '.',
+    binaries: ['ffmpeg'],
+  },
+}
+
+function getTargetKey() {
+  const args = process.argv.slice(2)
+  const platformIdx = args.indexOf('--platform')
+  const archIdx = args.indexOf('--arch')
+
+  const platform = platformIdx >= 0 ? args[platformIdx + 1] : process.platform
+  const arch = archIdx >= 0 ? args[archIdx + 1] : process.arch
+
+  return `${platform}-${arch}`
+}
+
+function main() {
+  const targetKey = getTargetKey()
+  const config = DOWNLOADS[targetKey]
+
+  if (!config) {
+    console.error(`Unsupported platform for FFmpeg download: ${targetKey}`)
+    console.error(`Supported: ${Object.keys(DOWNLOADS).join(', ')}`)
+    process.exit(1)
+  }
+
+  const isWindows = targetKey.startsWith('win32')
+  const outputDir = path.join(RESOURCES_DIR, 'ffmpeg')
+  const primaryBin = isWindows ? 'ffmpeg.exe' : 'ffmpeg'
+
+  if (fs.existsSync(path.join(outputDir, primaryBin))) {
+    console.log(`FFmpeg binary already exists at ${path.join(outputDir, primaryBin)}`)
+    return
+  }
+
+  fs.mkdirSync(outputDir, { recursive: true })
+
+  const archivePath = path.join(outputDir, 'ffmpeg-download.zip')
+
+  console.log(`Downloading FFmpeg for ${targetKey} from ${config.url}...`)
+  execSync(`curl -fSL -o "${archivePath}" "${config.url}"`, { stdio: 'inherit' })
+
+  console.log('Extracting...')
+  const tempDir = path.join(outputDir, '_extract')
+  fs.mkdirSync(tempDir, { recursive: true })
+
+  if (isWindows) {
+    execSync(
+      `powershell -Command "Expand-Archive -Path '${archivePath}' -DestinationPath '${tempDir}' -Force"`,
+    )
+  } else {
+    execSync(`unzip -o "${archivePath}" -d "${tempDir}"`)
+  }
+
+  // Locate the extracted bin directory
+  let binSourceDir = tempDir
+  if (config.extractDir) {
+    binSourceDir = path.join(tempDir, config.extractDir, config.binDir)
+  }
+
+  // Copy binaries to the output directory
+  for (const file of config.binaries) {
+    const src = path.join(binSourceDir, file)
+    const dest = path.join(outputDir, file)
+    if (fs.existsSync(src)) {
+      fs.copyFileSync(src, dest)
+      if (!isWindows) fs.chmodSync(dest, 0o755)
+      console.log(`Saved: ${dest}`)
+    } else {
+      console.warn(`Warning: expected file not found: ${src}`)
+    }
+  }
+
+  // On Windows, also copy any DLLs that ffmpeg.exe depends on
+  if (isWindows && fs.existsSync(binSourceDir)) {
+    const dlls = fs.readdirSync(binSourceDir).filter((f) => f.endsWith('.dll'))
+    for (const dll of dlls) {
+      fs.copyFileSync(path.join(binSourceDir, dll), path.join(outputDir, dll))
+      console.log(`Saved DLL: ${dll}`)
+    }
+  }
+
+  // Cleanup temp files
+  fs.rmSync(tempDir, { recursive: true, force: true })
+  fs.rmSync(archivePath, { force: true })
+
+  console.log(`FFmpeg binaries saved to ${outputDir}`)
+}
+
+main()

--- a/apps/desktop/src/local-server.ts
+++ b/apps/desktop/src/local-server.ts
@@ -284,10 +284,21 @@ export async function startLocalServer(): Promise<void> {
   const bunDir = path.dirname(bunPath)
   const pathSep = isWindows ? ';' : ':'
   const defaultPath = isWindows ? '' : '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
+
+  // Bundled FFmpeg directory — so the API subprocess can find ffmpeg without
+  // the user needing to install it system-wide.
+  const ffmpegDir = IS_DEV
+    ? path.join(projectRoot, 'apps', 'desktop', 'resources', 'ffmpeg')
+    : path.join(projectRoot, 'ffmpeg')
+  const hasBundledFfmpeg = existsSync(ffmpegDir)
+  if (hasBundledFfmpeg) {
+    console.log(`[Desktop] Bundled FFmpeg found at ${ffmpegDir}`)
+  }
+
   const { app } = require('electron') as typeof import('electron')
   const env: Record<string, string> = {
     ...process.env as Record<string, string>,
-    PATH: `${bunDir}${pathSep}${process.env.PATH || defaultPath}`,
+    PATH: [bunDir, ...(hasBundledFfmpeg ? [ffmpegDir] : []), process.env.PATH || defaultPath].join(pathSep),
     HOME: process.env.HOME || process.env.USERPROFILE || os.homedir(),
     SHOGO_LOCAL_MODE: 'true',
     APP_VERSION: app.getVersion(),


### PR DESCRIPTION
<img width="1596" height="423" alt="image" src="https://github.com/user-attachments/assets/936bb5b1-bf50-441e-aa93-39c7fe92b036" />
<img width="876" height="628" alt="image" src="https://github.com/user-attachments/assets/41e4ae27-94c6-4d06-8e1f-fc764c45b04c" />
<img width="1492" height="344" alt="image" src="https://github.com/user-attachments/assets/e6e6d65d-47e0-456c-8a03-88dcc67ccee1" />


## Summary

Bundle **FFmpeg** with Shogo Desktop so Windows users are not required to install FFmpeg system-wide. This addresses the confusing **`ffmpeg.dll` was not found** / generic installer failure when FFmpeg is missing from the machine.

## Problem

- Installing Shogo Desktop could fail or show an opaque Windows error about **`ffmpeg.dll`** / **`ffmpeg`** not being found.
- End users should not need **`winget install ffmpeg`** (or similar) for a normal desktop install.

## Solution

1. **`download-ffmpeg.mjs`** — Downloads platform FFmpeg binaries into `apps/desktop/resources/ffmpeg` (same pattern as `download-bun.mjs`).
2. **`forge.config.ts`** — Adds `./resources/ffmpeg` to `extraResourceCandidates` so Electron Forge ships it next to the app.
3. **`local-server.ts`** — Prepends the bundled `ffmpeg` directory to **`PATH`** when spawning the local API process so **`ffmpeg`** is discoverable without a global install.
4. **`diarization.service.ts`** — Uses **`where`** on Windows instead of **`which`**, and a **platform-aware** error message if FFmpeg is still missing.

## How to test (for maintainers)

- Run `node apps/desktop/scripts/download-ffmpeg.mjs` (or ensure `resources/ffmpeg` is populated before package).
- `bun run build` and `bun run package` in `apps/desktop`.
- Confirm packaged layout includes:  
  `out/Shogo-win32-x64/resources/ffmpeg/ffmpeg.exe`
- Run `ffmpeg.exe -version` from that path (exit 0).
- Optional: `bun run make` and install `out/make/squirrel.windows/x64/Shogo-Setup.exe`; verify `resources/ffmpeg` exists under the installed app.

## Validation done for this PR

- **`electron-forge package`**: confirmed **`ffmpeg.exe`** at  
  `apps/desktop/out/Shogo-win32-x64/resources/ffmpeg/ffmpeg.exe`
- Ran **`ffmpeg -version`** on that binary — **8.1.1**, exit code **0**
- **`electron-forge make`** completed; installer produced under **`out/make/squirrel.windows/x64/`**
**Yes, fully validated.** Here's what you proved at each layer:

| Step | Result |
|------|--------|
| `download-ffmpeg.mjs` | Downloads FFmpeg 8.1.1 into `resources/ffmpeg/` |
| `bun run package` | Forge copies `resources/ffmpeg/` into `out/Shogo-win32-x64/resources/ffmpeg/` |
| `ffmpeg.exe -version` (from packaged output) | Runs, exits 0 |
| `bun run make` | Produces `Shogo-Setup.exe` successfully |
| Install `Shogo-Setup.exe` | Installs without any **`ffmpeg.dll`** error |
| Installed app directory | `%LOCALAPPDATA%\Shogo\app-1.2.20\resources\ffmpeg\ffmpeg.exe` exists (101 MB) |
