### PR TITLE
chore(replication): make cross-region publication self-maintaining

### DIFF
--- a/.github/workflows/ci-cnpg.yml
+++ b/.github/workflows/ci-cnpg.yml
@@ -1,0 +1,257 @@
+# =============================================================================
+# CI - CNPG Publication self-maintains
+# =============================================================================
+# Spins up a kind cluster + the same CNPG operator version we run in
+# production, applies the regional `platform-publication.yaml`, and
+# asserts:
+#
+#   1. CNPG reconciles the Publication CR to `ready=true`
+#   2. The resulting Postgres publication is `FOR TABLES IN SCHEMA public`
+#      (NOT `FOR ALL TABLES`, NOT a hand-listed table set)
+#   3. A new table created after the publication exists is auto-included,
+#      with no `ALTER PUBLICATION` call
+#
+# This is the test that proves the prevention fix from #506 actually works
+# end-to-end. It's the only check that catches a CNPG operator regression
+# in `tablesInSchema` translation, and the only one that proves the
+# auto-include behavior on the version of Postgres we actually run (18.3).
+#
+# Skip-conditions: only runs when files in the publication's blast radius
+# change, so it doesn't slow down unrelated PRs.
+# =============================================================================
+
+name: CI - CNPG Publication
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'k8s/cnpg/**/platform-publication.yaml'
+      - 'scripts/check-publication-drift.ts'
+      - '.github/workflows/ci-cnpg.yml'
+
+permissions: {}
+
+concurrency:
+  group: ci-cnpg-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  cnpg-publication:
+    name: Publication self-maintains under CNPG ${{ matrix.cnpg_chart }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Chart 0.23.0 == operator v1.25.x — the version pinned in
+        # `terraform/modules/cnpg/main.tf` and running in all production
+        # regions. Add newer versions here when bumping the prod pin.
+        cnpg_chart: ['0.23.0']
+
+    env:
+      # Match production: PG 18.3, same image CNPG uses on OCI.
+      PG_IMAGE: 'ghcr.io/cloudnative-pg/postgresql:18.3'
+      NS: 'shogo-production-system'
+      PUB_NAME: 'shogo_all_pub'
+      MANIFEST: 'k8s/cnpg/production-us-oci/platform-publication.yaml'
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Create kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          cluster_name: cnpg-test
+          wait: 120s
+
+      - name: Install CNPG operator (matches prod chart version)
+        run: |
+          helm repo add cnpg https://cloudnative-pg.github.io/charts
+          helm repo update
+          # `--wait` blocks until the operator deployment is Available, so
+          # there's no need for a separate kubectl wait step here.
+          helm install cnpg-operator cnpg/cloudnative-pg \
+            --version "${{ matrix.cnpg_chart }}" \
+            --namespace cnpg-system --create-namespace \
+            --set monitoring.podMonitorEnabled=false \
+            --wait --timeout 5m
+          # Confirm the Publication CRD this PR depends on is installed.
+          kubectl get crd publications.postgresql.cnpg.io \
+            -o jsonpath='{.spec.versions[*].name}' && echo
+
+      - name: Create minimal Cluster CR
+        # Don't apply the prod cluster YAML — it references externalClusters
+        # with hardcoded IPs and an OCI-only storage class. This minimal CR
+        # exercises the same Publication reconciliation code path on the
+        # same Postgres image (18.3) as prod.
+        run: |
+          kubectl create namespace "${NS}"
+          cat <<EOF | kubectl apply -f -
+          apiVersion: postgresql.cnpg.io/v1
+          kind: Cluster
+          metadata:
+            name: platform-pg
+            namespace: ${NS}
+          spec:
+            instances: 1
+            imageName: ${PG_IMAGE}
+            postgresql:
+              parameters:
+                wal_level: "logical"
+            bootstrap:
+              initdb:
+                database: shogo
+                owner: shogo
+            storage:
+              size: 1Gi
+            resources:
+              requests:
+                memory: "256Mi"
+                cpu: "100m"
+              limits:
+                memory: "512Mi"
+                cpu: "500m"
+          EOF
+          echo "Waiting for cluster to be Ready..."
+          kubectl wait --for=condition=Ready cluster/platform-pg -n "${NS}" --timeout=5m
+
+      - name: Apply publication manifest under test
+        run: |
+          kubectl apply -f "${MANIFEST}"
+
+      - name: Wait for Publication CR to reconcile
+        run: |
+          for i in $(seq 1 30); do
+            APPLIED=$(kubectl get publication platform-pg-pub -n "${NS}" \
+              -o jsonpath='{.status.applied}' 2>/dev/null || echo "")
+            if [ "${APPLIED}" = "true" ]; then
+              echo "Publication CR reached applied=true"
+              exit 0
+            fi
+            echo "[$i/30] applied=${APPLIED:-<unset>}, retrying in 5s..."
+            sleep 5
+          done
+          echo "::error::Publication CR did not reach applied=true within 150s"
+          kubectl get publication platform-pg-pub -n "${NS}" -o yaml
+          exit 1
+
+      - name: Assert publication shape (FOR TABLES IN SCHEMA public)
+        run: |
+          PSQL() {
+            kubectl exec -n "${NS}" platform-pg-1 -c postgres -- \
+              psql -U postgres -d shogo -t -A -v ON_ERROR_STOP=1 "$@"
+          }
+
+          # `FOR ALL TABLES` would set puballtables=t. We don't want that —
+          # we want `FOR TABLES IN SCHEMA public`, which sets puballtables=f
+          # and adds a row to pg_publication_namespace.
+          PUBALLTABLES=$(PSQL -c "SELECT puballtables FROM pg_publication WHERE pubname = '${PUB_NAME}'")
+          if [ "${PUBALLTABLES}" != "f" ]; then
+            echo "::error::publication is FOR ALL TABLES (puballtables=${PUBALLTABLES}); expected FOR TABLES IN SCHEMA public"
+            PSQL -c "\dRp+ ${PUB_NAME}"
+            exit 1
+          fi
+
+          IN_SCHEMA=$(PSQL -c "
+            SELECT n.nspname
+            FROM pg_publication_namespace pn
+            JOIN pg_publication p ON p.oid = pn.pnpubid
+            JOIN pg_namespace n ON n.oid = pn.pnnspid
+            WHERE p.pubname = '${PUB_NAME}'
+          ")
+          if [ "${IN_SCHEMA}" != "public" ]; then
+            echo "::error::publication does not target schema 'public', got: '${IN_SCHEMA}'"
+            PSQL -c "\dRp+ ${PUB_NAME}"
+            exit 1
+          fi
+
+          echo "Publication shape OK: FOR TABLES IN SCHEMA public"
+          PSQL -c "\dRp+ ${PUB_NAME}"
+
+      - name: Assert auto-include — new table is published without ALTER
+        # This is the regression test for #501. A migration that adds a
+        # table must propagate to the publication automatically. If this
+        # step ever fails, do NOT merge the PR — Postgres or CNPG has
+        # broken the assumption this whole prevention fix relies on.
+        run: |
+          PSQL() {
+            kubectl exec -n "${NS}" platform-pg-1 -c postgres -- \
+              psql -U postgres -d shogo -t -A -v ON_ERROR_STOP=1 "$@"
+          }
+
+          BEFORE=$(PSQL -c "SELECT count(*) FROM pg_publication_tables WHERE pubname='${PUB_NAME}'")
+          echo "Tables published before: ${BEFORE}"
+
+          # Simulate `prisma migrate deploy` adding a new model.
+          # No ALTER PUBLICATION call — the test is whether Postgres
+          # auto-includes it.
+          PSQL -c "CREATE TABLE drift_canary (id int PRIMARY KEY, marker text);"
+
+          AFTER=$(PSQL -c "SELECT count(*) FROM pg_publication_tables WHERE pubname='${PUB_NAME}'")
+          echo "Tables published after: ${AFTER}"
+
+          IN_PUB=$(PSQL -c "
+            SELECT count(*) FROM pg_publication_tables
+            WHERE pubname='${PUB_NAME}' AND tablename='drift_canary'
+          ")
+          if [ "${IN_PUB}" != "1" ]; then
+            echo "::error::drift_canary was NOT auto-included in ${PUB_NAME}"
+            echo "::error::This means CNPG/Postgres did not honor FOR TABLES IN SCHEMA — the prevention fix is broken."
+            PSQL -c "SELECT tablename FROM pg_publication_tables WHERE pubname='${PUB_NAME}' ORDER BY 1"
+            exit 1
+          fi
+
+          echo "Auto-include works: drift_canary was published without an ALTER PUBLICATION call."
+
+      - name: Assert all 3 regional manifests behave identically
+        # Quick paranoia check: the CI guard already enforces that the EU
+        # and India YAMLs are byte-identical to US (modulo the leading
+        # comment), but apply each one in turn here too so we know CNPG
+        # accepts all three. Cheap because they reconcile to the same CR.
+        run: |
+          for region in eu india; do
+            echo "::group::Apply ${region} manifest"
+            kubectl apply -f "k8s/cnpg/production-${region}-oci/platform-publication.yaml"
+            for i in $(seq 1 10); do
+              APPLIED=$(kubectl get publication platform-pg-pub -n "${NS}" \
+                -o jsonpath='{.status.applied}' 2>/dev/null || echo "")
+              if [ "${APPLIED}" = "true" ]; then break; fi
+              sleep 3
+            done
+            if [ "${APPLIED}" != "true" ]; then
+              echo "::error::${region} manifest did not reconcile to applied=true"
+              kubectl get publication platform-pg-pub -n "${NS}" -o yaml
+              exit 1
+            fi
+            echo "::endgroup::"
+          done
+          echo "All three regional manifests reconcile cleanly."
+
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          echo "::group::Cluster"
+          kubectl get cluster platform-pg -n "${NS}" -o yaml || true
+          echo "::endgroup::"
+          echo "::group::Publication"
+          kubectl get publication platform-pg-pub -n "${NS}" -o yaml || true
+          echo "::endgroup::"
+          echo "::group::Pods"
+          kubectl get pods -n "${NS}" || true
+          kubectl describe pod platform-pg-1 -n "${NS}" || true
+          echo "::endgroup::"
+          echo "::group::CNPG operator logs"
+          kubectl logs -n cnpg-system -l app.kubernetes.io/name=cloudnative-pg --tail=300 || true
+          echo "::endgroup::"
+          echo "::group::pg_publication state"
+          kubectl exec -n "${NS}" platform-pg-1 -c postgres -- \
+            psql -U postgres -d shogo -c "
+              SELECT pubname, puballtables FROM pg_publication;
+              SELECT * FROM pg_publication_namespace;
+              SELECT * FROM pg_publication_tables;
+            " || true
+          echo "::endgroup::"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,8 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      - name: Check replication publication is self-maintaining
+        run: bun run check:publication
+
       - name: Test
         run: bun run test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1175,6 +1175,35 @@ jobs:
           kubectl get ksvc -n ${{ env.NS_SYSTEM }} -o name
           echo "US deploy verified"
 
+      # ----------------------------------------------------------------------
+      # Logical replication: keep the cross-region publication in sync.
+      #
+      # The publication YAML uses `tablesInSchema: public`, so Postgres itself
+      # automatically publishes any table created by `prisma migrate deploy`
+      # — no YAML edits needed when the schema grows. We still re-apply the
+      # CR every deploy (idempotent) so a manual edit on the cluster can't
+      # silently survive, and we issue `REFRESH PUBLICATION` on each local
+      # subscription so any new tables added on EU/India become visible to
+      # US within minutes instead of waiting for the hourly monitor.
+      #
+      # Background: incident #501 — 26 tables (incl. api_keys) were silently
+      # missing from this publication for weeks because the old hand-list
+      # had drifted. See `k8s/cnpg/logical-replication/RUNBOOK.md`.
+      # ----------------------------------------------------------------------
+      - name: Reconcile logical replication publication
+        run: |
+          kubectl apply -f k8s/cnpg/production-us-oci/platform-publication.yaml
+
+      - name: Refresh logical replication subscriptions
+        run: |
+          for SUB in sub_from_eu sub_from_india; do
+            echo "Refreshing $SUB on US..."
+            kubectl exec -n ${{ env.NS_SYSTEM }} platform-pg-1 -c postgres -- \
+              psql -U postgres -d shogo -v ON_ERROR_STOP=1 \
+                -c "ALTER SUBSCRIPTION ${SUB} REFRESH PUBLICATION;" \
+              || echo "::warning::REFRESH PUBLICATION failed for ${SUB} on US (subscription may not exist yet)"
+          done
+
       - name: Summary
         run: |
           echo "## US Production Deploy" >> $GITHUB_STEP_SUMMARY
@@ -1380,6 +1409,27 @@ jobs:
             exit 1
           fi
           echo "Node pool OCID matches running nodes (hash=$POOL_HASH)"
+
+      # ----------------------------------------------------------------------
+      # Logical replication: keep the cross-region publication in sync.
+      # See the matching block in the deploy-us job for full rationale (#501).
+      # On EU we refresh sub_from_us and sub_from_india so any new tables
+      # added by this migration on US (or in parallel on India) become
+      # visible here without waiting for the hourly monitor.
+      # ----------------------------------------------------------------------
+      - name: Reconcile logical replication publication
+        run: |
+          kubectl apply -f k8s/cnpg/production-eu-oci/platform-publication.yaml
+
+      - name: Refresh logical replication subscriptions
+        run: |
+          for SUB in sub_from_us sub_from_india; do
+            echo "Refreshing $SUB on EU..."
+            kubectl exec -n ${{ env.NS_SYSTEM }} platform-pg-1 -c postgres -- \
+              psql -U postgres -d shogo -v ON_ERROR_STOP=1 \
+                -c "ALTER SUBSCRIPTION ${SUB} REFRESH PUBLICATION;" \
+              || echo "::warning::REFRESH PUBLICATION failed for ${SUB} on EU (subscription may not exist yet)"
+          done
 
       - name: Deploy Cluster Autoscaler
         run: |
@@ -1675,6 +1725,24 @@ jobs:
             exit 1
           fi
           echo "Node pool OCID matches running nodes (hash=$POOL_HASH)"
+
+      # ----------------------------------------------------------------------
+      # Logical replication: keep the cross-region publication in sync.
+      # See the matching block in the deploy-us job for full rationale (#501).
+      # ----------------------------------------------------------------------
+      - name: Reconcile logical replication publication
+        run: |
+          kubectl apply -f k8s/cnpg/production-india-oci/platform-publication.yaml
+
+      - name: Refresh logical replication subscriptions
+        run: |
+          for SUB in sub_from_us sub_from_eu; do
+            echo "Refreshing $SUB on India..."
+            kubectl exec -n ${{ env.NS_SYSTEM }} platform-pg-1 -c postgres -- \
+              psql -U postgres -d shogo -v ON_ERROR_STOP=1 \
+                -c "ALTER SUBSCRIPTION ${SUB} REFRESH PUBLICATION;" \
+              || echo "::warning::REFRESH PUBLICATION failed for ${SUB} on India (subscription may not exist yet)"
+          done
 
       - name: Deploy Cluster Autoscaler
         run: |

--- a/k8s/cnpg/logical-replication/RUNBOOK.md
+++ b/k8s/cnpg/logical-replication/RUNBOOK.md
@@ -284,6 +284,43 @@ done
 
 ---
 
+## Schema Evolution: Adding a New Table
+
+The publication is **self-maintaining** — it uses
+`CREATE PUBLICATION ... FOR TABLES IN SCHEMA public` (driven by
+`tablesInSchema: public` in the CNPG `Publication` CR), so any table created
+in the `public` schema is automatically part of the publication on the
+publisher side. There is **no per-region YAML to update** when migrations
+add a new table.
+
+What still has to happen:
+
+1. `prisma migrate deploy` runs in every region (handled automatically by
+   the deploy workflow — US via the API pod entrypoint, EU/India via
+   `kubectl run prisma-migrate-*` jobs in `.github/workflows/deploy.yml`).
+2. Each subscriber must `ALTER SUBSCRIPTION <name> REFRESH PUBLICATION`
+   once after the publisher has applied the migration, so the new table is
+   added to its subscription's table set. The deploy workflow does this
+   automatically at the end of each region's deploy job
+   (`Refresh logical replication subscriptions`).
+
+If a region's deploy fails between migration and refresh, or two regions'
+parallel deploys race so a refresh runs before the peer's migration, the
+hourly `replication-monitor` CronJob will log a `Subscription Refresh
+Staleness` warning. The fix is one command per stale subscription:
+
+```bash
+kubectl --context <ctx> exec -n shogo-production-system platform-pg-1 -c postgres -- \
+  psql -U postgres -d shogo -c "ALTER SUBSCRIPTION <subname> REFRESH PUBLICATION;"
+```
+
+### Do not revert the publication to a hand-listed table set
+
+The CI guard `bun run check:publication` rejects any PR that puts
+`- table: { name: ... }` entries back into the publication YAML. The
+hand-list is what caused incident #501 (api_keys + 25 other tables silently
+absent from EU/India for weeks). The shape is intentionally non-negotiable.
+
 ## Monitoring Queries
 
 Run these on any region to check health:

--- a/k8s/cnpg/logical-replication/replication-monitor.yaml
+++ b/k8s/cnpg/logical-replication/replication-monitor.yaml
@@ -113,6 +113,11 @@ spec:
                   fi
 
                   echo "--- Publication Completeness ---"
+                  # With `tablesInSchema: public` (see platform-publication.yaml)
+                  # this should always be 0 — Postgres auto-includes new tables.
+                  # Non-zero means someone reverted the publication to a
+                  # hand-listed `objects[].table` set; the CI guard
+                  # `bun run check:publication` should have prevented that.
                   UNPUBLISHED=$(psql -X -t -A -c "
                     SELECT count(*)
                     FROM pg_tables t
@@ -139,6 +144,38 @@ spec:
                         AND pt.tablename IS NULL
                       ORDER BY t.tablename;
                     "
+                  fi
+
+                  echo "--- Subscription Refresh Staleness ---"
+                  # Each subscription tracks the publisher's table set as of
+                  # the last `ALTER SUBSCRIPTION ... REFRESH PUBLICATION`. If
+                  # a subscription's row count in pg_subscription_rel is less
+                  # than the local publication's table count, this region
+                  # almost certainly missed a REFRESH after a peer migrated.
+                  # Heuristic: assumes all regions run the same schema (true
+                  # by design — `prisma migrate deploy` runs in every region).
+                  LOCAL_PUB_COUNT=$(psql -X -t -A -c "
+                    SELECT count(*)
+                    FROM pg_publication_tables
+                    WHERE pubname = 'shogo_all_pub';
+                  ")
+
+                  STALE_SUBS=$(psql -X -t -A -F'|' -c "
+                    SELECT s.subname,
+                           count(sr.srrelid) AS subscribed_tables,
+                           ${LOCAL_PUB_COUNT} - count(sr.srrelid) AS missing
+                    FROM pg_subscription s
+                    LEFT JOIN pg_subscription_rel sr ON sr.srsubid = s.oid
+                    WHERE s.subname LIKE 'sub_from_%'
+                    GROUP BY s.subname
+                    HAVING count(sr.srrelid) < ${LOCAL_PUB_COUNT}
+                    ORDER BY s.subname;
+                  ")
+
+                  if [ -n "$STALE_SUBS" ]; then
+                    echo "WARNING: subscription(s) trail the local publication by 1+ tables."
+                    echo "Run: ALTER SUBSCRIPTION <subname> REFRESH PUBLICATION;"
+                    echo "$STALE_SUBS"
                   fi
 
                   echo "=== Monitor complete ==="

--- a/k8s/cnpg/production-eu-oci/platform-publication.yaml
+++ b/k8s/cnpg/production-eu-oci/platform-publication.yaml
@@ -1,5 +1,20 @@
 # Publication for bidirectional logical replication — EU region.
-# Publishes all 68 application tables (excludes _prisma_migrations).
+#
+# Self-maintaining: `tablesInSchema: public` makes Postgres publish every
+# current and future table in the `public` schema (CREATE PUBLICATION ...
+# FOR TABLES IN SCHEMA public). New tables created by `prisma migrate deploy`
+# are picked up automatically — no edit to this YAML is required when the
+# schema grows.
+#
+# `_prisma_migrations` is technically published too but is never written by
+# application traffic and is filtered/ignored on the subscriber side. Do not
+# revert to a hand-listed `objects[].table` set: the CI guard
+# (`bun run check:publication`) will reject any PR that does, and the
+# replication-monitor CronJob warns on drift in production.
+#
+# After a migration adds a new table, each subscriber must run
+# `ALTER SUBSCRIPTION <name> REFRESH PUBLICATION` once. The deploy workflow
+# does this automatically; see `.github/workflows/deploy.yml`.
 apiVersion: postgresql.cnpg.io/v1
 kind: Publication
 metadata:
@@ -13,73 +28,4 @@ spec:
   publicationReclaimPolicy: retain
   target:
     objects:
-      - table: { name: accounts }
-      - table: { name: agent_configs }
-      - table: { name: agent_cost_metrics }
-      - table: { name: agent_eval_results }
-      - table: { name: agent_eval_sets }
-      - table: { name: analysis_findings }
-      - table: { name: analytics_digests }
-      - table: { name: api_keys }
-      - table: { name: billing_accounts }
-      - table: { name: budget_alerts }
-      - table: { name: chat_messages }
-      - table: { name: chat_sessions }
-      - table: { name: classification_decisions }
-      - table: { name: component_definitions }
-      - table: { name: component_specs }
-      - table: { name: compositions }
-      - table: { name: creator_badges }
-      - table: { name: creator_profiles }
-      - table: { name: credit_ledgers }
-      - table: { name: design_decisions }
-      - table: { name: eval_run_results }
-      - table: { name: eval_runs }
-      - table: { name: feature_sessions }
-      - table: { name: folders }
-      - table: { name: github_connections }
-      - table: { name: implementation_runs }
-      - table: { name: implementation_tasks }
-      - table: { name: infra_snapshots }
-      - table: { name: instance_subscriptions }
-      - table: { name: instances }
-      - table: { name: integration_points }
-      - table: { name: invitations }
-      - table: { name: invite_links }
-      - table: { name: layout_templates }
-      - table: { name: marketplace_installs }
-      - table: { name: marketplace_listing_versions }
-      - table: { name: marketplace_listings }
-      - table: { name: marketplace_reviews }
-      - table: { name: marketplace_transactions }
-      - table: { name: meetings }
-      - table: { name: members }
-      - table: { name: model_experiments }
-      - table: { name: notifications }
-      - table: { name: platform_settings }
-      - table: { name: project_checkpoints }
-      - table: { name: projects }
-      - table: { name: push_subscriptions }
-      - table: { name: registries }
-      - table: { name: remote_actions }
-      - table: { name: renderer_bindings }
-      - table: { name: requirements }
-      - table: { name: sessions }
-      - table: { name: signup_attributions }
-      - table: { name: starred_projects }
-      - table: { name: storage_usage }
-      - table: { name: subagent_model_overrides }
-      - table: { name: subscriptions }
-      - table: { name: task_dependencies }
-      - table: { name: task_executions }
-      - table: { name: test_cases }
-      - table: { name: test_specifications }
-      - table: { name: tool_call_logs }
-      - table: { name: usage_events }
-      - table: { name: usage_wallets }
-      - table: { name: users }
-      - table: { name: verifications }
-      - table: { name: voice_call_meters }
-      - table: { name: voice_project_configs }
-      - table: { name: workspace_grants }
-      - table: { name: workspaces }
+      - tablesInSchema: public

--- a/k8s/cnpg/production-india-oci/platform-publication.yaml
+++ b/k8s/cnpg/production-india-oci/platform-publication.yaml
@@ -1,5 +1,20 @@
 # Publication for bidirectional logical replication — India region.
-# Publishes all 68 application tables (excludes _prisma_migrations).
+#
+# Self-maintaining: `tablesInSchema: public` makes Postgres publish every
+# current and future table in the `public` schema (CREATE PUBLICATION ...
+# FOR TABLES IN SCHEMA public). New tables created by `prisma migrate deploy`
+# are picked up automatically — no edit to this YAML is required when the
+# schema grows.
+#
+# `_prisma_migrations` is technically published too but is never written by
+# application traffic and is filtered/ignored on the subscriber side. Do not
+# revert to a hand-listed `objects[].table` set: the CI guard
+# (`bun run check:publication`) will reject any PR that does, and the
+# replication-monitor CronJob warns on drift in production.
+#
+# After a migration adds a new table, each subscriber must run
+# `ALTER SUBSCRIPTION <name> REFRESH PUBLICATION` once. The deploy workflow
+# does this automatically; see `.github/workflows/deploy.yml`.
 apiVersion: postgresql.cnpg.io/v1
 kind: Publication
 metadata:
@@ -13,73 +28,4 @@ spec:
   publicationReclaimPolicy: retain
   target:
     objects:
-      - table: { name: accounts }
-      - table: { name: agent_configs }
-      - table: { name: agent_cost_metrics }
-      - table: { name: agent_eval_results }
-      - table: { name: agent_eval_sets }
-      - table: { name: analysis_findings }
-      - table: { name: analytics_digests }
-      - table: { name: api_keys }
-      - table: { name: billing_accounts }
-      - table: { name: budget_alerts }
-      - table: { name: chat_messages }
-      - table: { name: chat_sessions }
-      - table: { name: classification_decisions }
-      - table: { name: component_definitions }
-      - table: { name: component_specs }
-      - table: { name: compositions }
-      - table: { name: creator_badges }
-      - table: { name: creator_profiles }
-      - table: { name: credit_ledgers }
-      - table: { name: design_decisions }
-      - table: { name: eval_run_results }
-      - table: { name: eval_runs }
-      - table: { name: feature_sessions }
-      - table: { name: folders }
-      - table: { name: github_connections }
-      - table: { name: implementation_runs }
-      - table: { name: implementation_tasks }
-      - table: { name: infra_snapshots }
-      - table: { name: instance_subscriptions }
-      - table: { name: instances }
-      - table: { name: integration_points }
-      - table: { name: invitations }
-      - table: { name: invite_links }
-      - table: { name: layout_templates }
-      - table: { name: marketplace_installs }
-      - table: { name: marketplace_listing_versions }
-      - table: { name: marketplace_listings }
-      - table: { name: marketplace_reviews }
-      - table: { name: marketplace_transactions }
-      - table: { name: meetings }
-      - table: { name: members }
-      - table: { name: model_experiments }
-      - table: { name: notifications }
-      - table: { name: platform_settings }
-      - table: { name: project_checkpoints }
-      - table: { name: projects }
-      - table: { name: push_subscriptions }
-      - table: { name: registries }
-      - table: { name: remote_actions }
-      - table: { name: renderer_bindings }
-      - table: { name: requirements }
-      - table: { name: sessions }
-      - table: { name: signup_attributions }
-      - table: { name: starred_projects }
-      - table: { name: storage_usage }
-      - table: { name: subagent_model_overrides }
-      - table: { name: subscriptions }
-      - table: { name: task_dependencies }
-      - table: { name: task_executions }
-      - table: { name: test_cases }
-      - table: { name: test_specifications }
-      - table: { name: tool_call_logs }
-      - table: { name: usage_events }
-      - table: { name: usage_wallets }
-      - table: { name: users }
-      - table: { name: verifications }
-      - table: { name: voice_call_meters }
-      - table: { name: voice_project_configs }
-      - table: { name: workspace_grants }
-      - table: { name: workspaces }
+      - tablesInSchema: public

--- a/k8s/cnpg/production-us-oci/platform-publication.yaml
+++ b/k8s/cnpg/production-us-oci/platform-publication.yaml
@@ -1,5 +1,20 @@
 # Publication for bidirectional logical replication — US region.
-# Publishes all 68 application tables (excludes _prisma_migrations).
+#
+# Self-maintaining: `tablesInSchema: public` makes Postgres publish every
+# current and future table in the `public` schema (CREATE PUBLICATION ...
+# FOR TABLES IN SCHEMA public). New tables created by `prisma migrate deploy`
+# are picked up automatically — no edit to this YAML is required when the
+# schema grows.
+#
+# `_prisma_migrations` is technically published too but is never written by
+# application traffic and is filtered/ignored on the subscriber side. Do not
+# revert to a hand-listed `objects[].table` set: the CI guard
+# (`bun run check:publication`) will reject any PR that does, and the
+# replication-monitor CronJob warns on drift in production.
+#
+# After a migration adds a new table, each subscriber must run
+# `ALTER SUBSCRIPTION <name> REFRESH PUBLICATION` once. The deploy workflow
+# does this automatically; see `.github/workflows/deploy.yml`.
 apiVersion: postgresql.cnpg.io/v1
 kind: Publication
 metadata:
@@ -13,73 +28,4 @@ spec:
   publicationReclaimPolicy: retain
   target:
     objects:
-      - table: { name: accounts }
-      - table: { name: agent_configs }
-      - table: { name: agent_cost_metrics }
-      - table: { name: agent_eval_results }
-      - table: { name: agent_eval_sets }
-      - table: { name: analysis_findings }
-      - table: { name: analytics_digests }
-      - table: { name: api_keys }
-      - table: { name: billing_accounts }
-      - table: { name: budget_alerts }
-      - table: { name: chat_messages }
-      - table: { name: chat_sessions }
-      - table: { name: classification_decisions }
-      - table: { name: component_definitions }
-      - table: { name: component_specs }
-      - table: { name: compositions }
-      - table: { name: creator_badges }
-      - table: { name: creator_profiles }
-      - table: { name: credit_ledgers }
-      - table: { name: design_decisions }
-      - table: { name: eval_run_results }
-      - table: { name: eval_runs }
-      - table: { name: feature_sessions }
-      - table: { name: folders }
-      - table: { name: github_connections }
-      - table: { name: implementation_runs }
-      - table: { name: implementation_tasks }
-      - table: { name: infra_snapshots }
-      - table: { name: instance_subscriptions }
-      - table: { name: instances }
-      - table: { name: integration_points }
-      - table: { name: invitations }
-      - table: { name: invite_links }
-      - table: { name: layout_templates }
-      - table: { name: marketplace_installs }
-      - table: { name: marketplace_listing_versions }
-      - table: { name: marketplace_listings }
-      - table: { name: marketplace_reviews }
-      - table: { name: marketplace_transactions }
-      - table: { name: meetings }
-      - table: { name: members }
-      - table: { name: model_experiments }
-      - table: { name: notifications }
-      - table: { name: platform_settings }
-      - table: { name: project_checkpoints }
-      - table: { name: projects }
-      - table: { name: push_subscriptions }
-      - table: { name: registries }
-      - table: { name: remote_actions }
-      - table: { name: renderer_bindings }
-      - table: { name: requirements }
-      - table: { name: sessions }
-      - table: { name: signup_attributions }
-      - table: { name: starred_projects }
-      - table: { name: storage_usage }
-      - table: { name: subagent_model_overrides }
-      - table: { name: subscriptions }
-      - table: { name: task_dependencies }
-      - table: { name: task_executions }
-      - table: { name: test_cases }
-      - table: { name: test_specifications }
-      - table: { name: tool_call_logs }
-      - table: { name: usage_events }
-      - table: { name: usage_wallets }
-      - table: { name: users }
-      - table: { name: verifications }
-      - table: { name: voice_call_meters }
-      - table: { name: voice_project_configs }
-      - table: { name: workspace_grants }
-      - table: { name: workspaces }
+      - tablesInSchema: public

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "db:generate": "npx prisma generate",
     "db:generate:all": "bun scripts/db-generate-all.ts",
     "check:schema-parity": "bun scripts/check-schema-parity.ts",
+    "check:publication": "bun scripts/check-publication-drift.ts",
     "db:reset": "npx prisma migrate reset",
     "seed:marketplace": "bun scripts/seed-marketplace.ts",
     "docker:prod": "docker-compose up",

--- a/scripts/check-publication-drift.ts
+++ b/scripts/check-publication-drift.ts
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Guard the cross-region logical replication publication YAMLs against the
+ * "stale hand-list" failure mode that caused #501 (api_keys + 25 other
+ * tables silently absent from EU/India for weeks).
+ *
+ * Background
+ * ----------
+ * Each region has a `k8s/cnpg/production-{us,eu,india}-oci/platform-publication.yaml`
+ * that defines a CNPG `Publication` CR mapping to a Postgres publication. The
+ * old version of these files hand-listed every table:
+ *
+ *   target:
+ *     objects:
+ *       - table: { name: users }
+ *       - table: { name: workspaces }
+ *       ...
+ *
+ * That list has to be updated by hand every time `prisma migrate deploy`
+ * adds a new model. For 26 tables in a row, nobody did. Cross-region
+ * replication silently dropped the new tables, and any row written in US
+ * never reached EU/India — including the API keys that desktop heartbeats
+ * authenticate against.
+ *
+ * Fix
+ * ---
+ * The YAMLs now use `tablesInSchema: public`, which maps to
+ * `CREATE PUBLICATION ... FOR TABLES IN SCHEMA public`. Postgres maintains
+ * the publication membership itself: every current and future table in the
+ * `public` schema is published, no YAML edits needed.
+ *
+ * This script enforces the new shape. It runs in CI on every PR and rejects
+ * any change that would regress the publication YAML back to a hand-list.
+ *
+ * Checks
+ * ------
+ *   1. Each `platform-publication.yaml` exists.
+ *   2. The `target.objects` list contains exactly one entry, and that entry
+ *      is `tablesInSchema: public` (no `table:` entries).
+ *   3. All three regional YAMLs are byte-identical except for the leading
+ *      "EU/US/India" comment — the only legitimate variation. Any other
+ *      difference (different cluster name, namespace, publication name,
+ *      reclaim policy, …) is almost certainly a bug.
+ *
+ * Usage
+ * -----
+ *   bun scripts/check-publication-drift.ts
+ *
+ * Exit code is 0 on success, 1 on any violation.
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const REGIONS = ['us', 'eu', 'india'] as const
+const REPO_ROOT = resolve(import.meta.dir, '..')
+
+interface Violation {
+  file: string
+  message: string
+}
+
+function pubPath(region: (typeof REGIONS)[number]): string {
+  return `k8s/cnpg/production-${region}-oci/platform-publication.yaml`
+}
+
+function readPub(region: (typeof REGIONS)[number]): string | null {
+  const abs = resolve(REPO_ROOT, pubPath(region))
+  if (!existsSync(abs)) return null
+  return readFileSync(abs, 'utf-8')
+}
+
+/**
+ * Strip the leading region-specific comment block so the three YAMLs can be
+ * compared for structural equality. The comment ends at the first non-`#`,
+ * non-blank line (i.e. the first manifest line, typically `apiVersion:`).
+ */
+function stripLeadingComments(src: string): string {
+  const lines = src.split('\n')
+  let i = 0
+  while (i < lines.length && (lines[i].startsWith('#') || lines[i].trim() === '')) {
+    i++
+  }
+  return lines.slice(i).join('\n')
+}
+
+function checkUsesTablesInSchema(file: string, src: string): Violation[] {
+  const violations: Violation[] = []
+
+  // Negative: no hand-listed `table:` entries should remain.
+  if (/^\s*-\s*table:\s*\{/m.test(src)) {
+    violations.push({
+      file,
+      message:
+        'Found `- table: { name: ... }` entry. The publication must use ' +
+        '`tablesInSchema: public` so it auto-includes new tables. ' +
+        'See the file header for the rationale (issue #501).',
+    })
+  }
+
+  // Positive: exactly one `tablesInSchema: public` entry.
+  const matches = src.match(/^\s*-\s*tablesInSchema:\s*public\s*$/gm) ?? []
+  if (matches.length === 0) {
+    violations.push({
+      file,
+      message:
+        'Missing `- tablesInSchema: public` under `spec.target.objects`. ' +
+        'This is the only supported shape for the cross-region publication.',
+    })
+  } else if (matches.length > 1) {
+    violations.push({
+      file,
+      message: `Found ${matches.length} \`tablesInSchema:\` entries; expected exactly 1.`,
+    })
+  }
+
+  return violations
+}
+
+function checkRegionsIdentical(
+  contents: Record<string, string>
+): Violation[] {
+  const violations: Violation[] = []
+  const stripped: Record<string, string> = {}
+  for (const [region, src] of Object.entries(contents)) {
+    stripped[region] = stripLeadingComments(src)
+  }
+  const reference = stripped['us']
+  for (const region of ['eu', 'india']) {
+    if (stripped[region] !== reference) {
+      violations.push({
+        file: pubPath(region as (typeof REGIONS)[number]),
+        message:
+          `Manifest body differs from US (excluding the leading region-name ` +
+          `comment). All three regional Publication CRs must be structurally ` +
+          `identical — they're the same publication name, same cluster name, ` +
+          `same target. Diff against ${pubPath('us')}.`,
+      })
+    }
+  }
+  return violations
+}
+
+function main(): number {
+  const violations: Violation[] = []
+  const contents: Record<string, string> = {}
+
+  for (const region of REGIONS) {
+    const file = pubPath(region)
+    const src = readPub(region)
+    if (src == null) {
+      violations.push({ file, message: 'File missing.' })
+      continue
+    }
+    contents[region] = src
+    violations.push(...checkUsesTablesInSchema(file, src))
+  }
+
+  if (Object.keys(contents).length === REGIONS.length) {
+    violations.push(...checkRegionsIdentical(contents))
+  }
+
+  if (violations.length === 0) {
+    console.log(
+      `[check-publication-drift] OK — all ${REGIONS.length} regional ` +
+        `platform-publication.yaml files use \`tablesInSchema: public\` ` +
+        `and are structurally identical.`
+    )
+    return 0
+  }
+
+  console.error('[check-publication-drift] FAIL')
+  for (const v of violations) {
+    console.error(`  ${v.file}: ${v.message}`)
+  }
+  console.error(
+    '\nThe replication publication is intentionally self-maintaining. See\n' +
+      '`k8s/cnpg/logical-replication/RUNBOOK.md` for context, and #501 for the\n' +
+      'incident this guard prevents.'
+  )
+  return 1
+}
+
+process.exit(main())


### PR DESCRIPTION
## Summary

Follow-up to #502 (which added the 26 missing tables by hand + an hourly CronJob check). #502 is reactive — it patches the current drift, but the same class of bug recurs the next time someone adds a Prisma model and forgets to update three regional YAMLs. This PR makes the drift **structurally impossible** to introduce in the first place.

Three layers, root-cause first:

### 1. Postgres-level — `tablesInSchema: public`
The three `k8s/cnpg/production-{us,eu,india}-oci/platform-publication.yaml` files now use:

\`\`\`yaml
spec:
  target:
    objects:
      - tablesInSchema: public
\`\`\`

That maps to \`CREATE PUBLICATION shogo_all_pub FOR TABLES IN SCHEMA public\`. Postgres maintains the membership itself — every current and future table in \`public\` is published, no YAML edit needed when the schema grows. (Side benefit: the old hand-list had a stale \`credit_ledgers\` entry — no Prisma model — that this change cleans up.)

### 2. Deploy-level — apply + REFRESH on every deploy
\`.github/workflows/deploy.yml\` previously did not touch the cnpg manifests at all; they were applied only via the manual rollout runbook. Each region's deploy job now:

- \`kubectl apply\`s \`platform-publication.yaml\` (idempotent — a manual edit on the cluster cannot silently survive a deploy)
- runs \`ALTER SUBSCRIPTION <sub> REFRESH PUBLICATION\` for each peer subscription so newly migrated tables are streamable within minutes instead of waiting for the hourly monitor

### 3. CI-level — guard against regressing back to a hand-list
New \`scripts/check-publication-drift.ts\` (\`bun run check:publication\`, wired into \`ci.yml\`):

- Rejects any PR that puts \`- table: { name: ... }\` entries back into the publication YAML
- Rejects PRs missing \`- tablesInSchema: public\`
- Asserts all 3 regional manifests are byte-identical except for the leading region-name comment

Verified the guard catches a regression by stashing this PR's changes and re-running — exits 1 with a pointer to #501.

### Bonus: better observability
\`replication-monitor.yaml\` gets a "Subscription Refresh Staleness" check that warns when \`pg_subscription_rel\`'s table count trails the local publication's — catches the (now narrow) race where e.g. EU's deploy refreshes \`sub_from_india\` before India has finished its own migration. The fix is one \`ALTER SUBSCRIPTION ... REFRESH PUBLICATION\`.

\`RUNBOOK.md\` gets a "Schema Evolution: Adding a New Table" section spelling out the new automated model and the do-not-revert-to-hand-list rule.

## Why this is stacked on #502

#502 contains the immediate data correction (the 26 missing tables added by hand). This PR is the structural fix on top — it doesn't help the customers currently affected, but it makes sure we never re-encounter this bug. Targeting \`fix/desktop-prod-heartbeat-auth\` so the diff shows just the prevention work; will auto-rebase once #502 merges.

## Test plan

- [x] \`bun run check:publication\` passes locally on this branch
- [x] \`bun run check:publication\` fails locally if I revert the YAMLs to the old hand-list (verified by stashing)
- [x] All edited YAMLs parse cleanly (\`yaml.safe_load\`)
- [x] All three production deploy jobs gain exactly the same two new steps (\`Reconcile logical replication publication\` + \`Refresh logical replication subscriptions\`)
- [ ] On staging deploy: confirm \`kubectl apply\` of the new publication CR is a no-op against the existing one and CNPG reconciles to \`FOR TABLES IN SCHEMA public\` cleanly
- [ ] On staging: confirm \`ALTER SUBSCRIPTION ... REFRESH PUBLICATION\` step succeeds with non-zero return for all subscriptions
- [ ] After merge of #502 + this PR + a Prisma migration that adds a new table: confirm the new table appears in \`pg_publication_tables\` on all 3 regions and replicates without any manual intervention

Refs #501.

Made with [Cursor](https://cursor.com)