### PR TITLE
eat(mobile): auto-expand chat composer height (ChatGPT-style)

### DIFF
--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -230,6 +230,30 @@ export function ChatInput({
   // the same clipboard event, which would create duplicate chips.
   const pasteHandledRef = useRef(false)
 
+  const MIN_INPUT_HEIGHT = 60
+  const MAX_INPUT_VH = 40
+
+  const getDOMNode = useCallback(() => {
+    const ref = textInputRef.current as any
+    return ref?._node || ref?.getHostNode?.() || ref
+  }, [])
+
+  const resizeTextarea = useCallback(() => {
+    if (Platform.OS !== "web") return
+    const node = getDOMNode()
+    if (!node?.style) return
+
+    const maxPx = Math.min(window.innerHeight * (MAX_INPUT_VH / 100), 230)
+    node.style.height = "auto"
+    const scrollH = node.scrollHeight
+    const newHeight = Math.max(MIN_INPUT_HEIGHT, Math.min(scrollH, maxPx))
+
+    if (node.style.height !== `${newHeight}px`) {
+      node.style.height = `${newHeight}px`
+    }
+    node.style.overflowY = scrollH > maxPx ? "auto" : "hidden"
+  }, [getDOMNode])
+
   const [inputValue, setInputValue] = useState("")
   const [pendingFiles, setPendingFiles] = useState<AttachedFile[]>([])
   const [fileError, setFileError] = useState<string | null>(null)
@@ -244,6 +268,12 @@ export function ChatInput({
   useEffect(() => {
     inputValueRef.current = inputValue
   }, [inputValue])
+
+  useEffect(() => {
+    if (Platform.OS === "web") {
+      requestAnimationFrame(resizeTextarea)
+    }
+  }, [inputValue, resizeTextarea])
 
   const [internalModel, setInternalModel] = useState<string>(
     effectiveIsPro ? DEFAULT_MODEL_PRO : DEFAULT_MODEL_FREE
@@ -940,7 +970,7 @@ export function ChatInput({
           multiline
           blurOnSubmit={false}
           className={cn(
-            "min-h-[60px] max-h-[200px] w-full",
+            "min-h-[60px] w-full overflow-hidden",
             "bg-transparent",
             "px-4 pt-4 text-xs text-foreground",
             disabled && dimWhenDisabled && "opacity-50",


### PR DESCRIPTION
### Description

The projects chat composer `TextInput` now grows with the typed content instead of staying at a fixed height until internal scrolling kicks in.
<img width="622" height="952" alt="image" src="https://github.com/user-attachments/assets/620e8470-e02d-4296-8741-42f2591013ed" />


**Behavior**
- On web, height follows content via `scrollHeight`, clamped between a minimum (60px) and `min(40vh, 230px)`, then turns vertically scrollable.
- Ref uses a stable DOM lookup (`_node` → `getHostNode()` → ref).
- Resizing runs from one effect tied to `inputValue` and `requestAnimationFrame`, so send/clear, draft restore, voice, paste, and skill flows stay consistent without extra call sites.
- Removed Tailwind `max-h-[200px]` so layout height is driven only by this logic (plus `min-h-[60px]` and default `overflow-hidden`).