### PR TITLE
feat(mobile): auto-close chat/canvas panels when drag-resized too small

### DIFF
--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -128,6 +128,10 @@ const STANDALONE_PANELS = ['ide', 'files', 'capabilities', 'channels', 'agents',
 const DEFAULT_CHAT_PANEL_WIDTH = 480
 const MIN_CHAT_PANEL_WIDTH = 320
 const CHAT_PANEL_WIDTH_STORAGE_KEY = 'shogo:chatPanelWidth'
+const CHAT_AUTO_CLOSE_THRESHOLD = 280
+const CANVAS_AUTO_CLOSE_THRESHOLD = 200
+const DRAG_FLOOR = 100
+const DRAG_CEILING_OFFSET = 100
 
 /** Suppress duplicate "[canvas-error]" toasts within this many ms. */
 const CANVAS_ERROR_DEDUP_MS = 10_000
@@ -462,6 +466,7 @@ export default observer(function ProjectLayout() {
   const [userSelectedSurfaceId, setUserSelectedSurfaceId] = useState<string | null>(null)
   const mountTimeRef = useRef(Date.now())
   const splitRowRef = useRef<View>(null)
+  const chatColumnRef = useRef<View>(null)
 
   // Restore last-viewed surface from AsyncStorage
   useEffect(() => {
@@ -881,7 +886,6 @@ export default observer(function ProjectLayout() {
 
   // Resizable chat panel width (wide split mode only)
   const [chatPanelWidth, setChatPanelWidth] = useState(DEFAULT_CHAT_PANEL_WIDTH)
-  const maxChatPanelWidth = Math.floor(width * 0.5)
   const clampChatWidth = useCallback((w: number) =>
     Math.max(MIN_CHAT_PANEL_WIDTH, Math.min(w, Math.floor(width * 0.5))),
     [width],
@@ -899,6 +903,17 @@ export default observer(function ProjectLayout() {
   const persistChatPanelWidth = useCallback((w: number) => {
     setChatPanelWidth(w)
     AsyncStorage.setItem(CHAT_PANEL_WIDTH_STORAGE_KEY, String(w)).catch(() => {})
+  }, [])
+
+  const [autoCloseHint, setAutoCloseHint] = useState<'chat' | 'canvas' | null>(null)
+
+  const handleAutoCollapseChat = useCallback(() => {
+    setChatCollapsed(true)
+    persistChatPanelWidth(DEFAULT_CHAT_PANEL_WIDTH)
+  }, [persistChatPanelWidth])
+
+  const handleAutoCollapseCanvas = useCallback(() => {
+    setPreviewTab('chat-fullscreen')
   }, [])
 
   const PERSISTABLE_PREVIEW_TABS = useMemo(() => new Set(['dynamic-app', 'chat-fullscreen', 'app-preview']), [])
@@ -1712,6 +1727,7 @@ export default observer(function ProjectLayout() {
             <View className={cn('flex-1', isWide && 'flex-row')} ref={splitRowRef}>
               {/* Chat column — single mount point so ChatPanel never unmounts on mode switch */}
               <View
+                ref={chatColumnRef}
                 className={cn(
                   'flex min-h-0 flex-col',
                   isChatFullscreen
@@ -1721,7 +1737,11 @@ export default observer(function ProjectLayout() {
                       : 'relative flex-1',
                   !isChatFullscreen && chatHidden && 'hidden',
                 )}
-                style={!isChatFullscreen && isWide && !chatHidden ? { width: clampChatWidth(chatPanelWidth) } : undefined}
+                style={!isChatFullscreen && isWide && !chatHidden ? {
+                  width: clampChatWidth(chatPanelWidth),
+                  opacity: autoCloseHint === 'chat' ? 0.4 : 1,
+                  transition: 'opacity 150ms',
+                } as any : undefined}
               >
                 {isChatFullscreen && (
                   <View className="w-[280px] bg-muted/50 dark:bg-black/30">
@@ -1828,11 +1848,12 @@ export default observer(function ProjectLayout() {
               {Platform.OS === 'web' && isWide && !isChatFullscreen && !chatHidden && (
                 <ChatPanelResizeHandle
                   splitRowRef={splitRowRef}
+                  chatColumnRef={chatColumnRef}
                   chatPanelWidth={clampChatWidth(chatPanelWidth)}
-                  minWidth={MIN_CHAT_PANEL_WIDTH}
-                  maxWidth={maxChatPanelWidth}
-                  onResize={setChatPanelWidth}
                   onResizeEnd={persistChatPanelWidth}
+                  onAutoCollapseChat={handleAutoCollapseChat}
+                  onAutoCollapseCanvas={handleAutoCollapseCanvas}
+                  onAutoCloseHintChange={setAutoCloseHint}
                   defaultWidth={DEFAULT_CHAT_PANEL_WIDTH}
                 />
               )}
@@ -1844,6 +1865,10 @@ export default observer(function ProjectLayout() {
               canvasAreaHidden && 'hidden',
               Platform.OS === 'web' && !canvasAreaHidden && 'min-h-0',
             )}
+            style={autoCloseHint === 'canvas' ? {
+              opacity: 0.4,
+              transition: 'opacity 150ms',
+            } as any : undefined}
           >
             <DrawerHost
               projectId={projectId ?? null}
@@ -2066,19 +2091,21 @@ function ShogoAwareChatPanels({ children }: { children: React.ReactNode }) {
 
 function ChatPanelResizeHandle({
   splitRowRef,
+  chatColumnRef,
   chatPanelWidth,
-  minWidth,
-  maxWidth,
-  onResize,
   onResizeEnd,
+  onAutoCollapseChat,
+  onAutoCollapseCanvas,
+  onAutoCloseHintChange,
   defaultWidth,
 }: {
   splitRowRef: React.RefObject<View | null>
+  chatColumnRef: React.RefObject<View | null>
   chatPanelWidth: number
-  minWidth: number
-  maxWidth: number
-  onResize: (w: number) => void
   onResizeEnd: (w: number) => void
+  onAutoCollapseChat: () => void
+  onAutoCollapseCanvas: () => void
+  onAutoCloseHintChange: (hint: 'chat' | 'canvas' | null) => void
   defaultWidth: number
 }) {
   const [dragging, setDragging] = useState(false)
@@ -2092,11 +2119,25 @@ function ChatPanelResizeHandle({
     const container = splitRowRef.current as unknown as HTMLElement | null
     if (!container) return
     const containerRect = container.getBoundingClientRect()
+    const chatCol = chatColumnRef.current as unknown as HTMLElement | null
 
     const onPointerMove = (ev: PointerEvent) => {
-      const newWidth = Math.max(minWidth, Math.min(maxWidth, ev.clientX - containerRect.left))
-      latestWidthRef.current = newWidth
-      onResize(newWidth)
+      const rawWidth = ev.clientX - containerRect.left
+      const clampedWidth = Math.max(
+        DRAG_FLOOR,
+        Math.min(rawWidth, containerRect.width - DRAG_CEILING_OFFSET),
+      )
+      latestWidthRef.current = clampedWidth
+
+      if (chatCol) chatCol.style.width = `${clampedWidth}px`
+
+      if (clampedWidth < CHAT_AUTO_CLOSE_THRESHOLD) {
+        onAutoCloseHintChange('chat')
+      } else if (containerRect.width - clampedWidth < CANVAS_AUTO_CLOSE_THRESHOLD) {
+        onAutoCloseHintChange('canvas')
+      } else {
+        onAutoCloseHintChange(null)
+      }
     }
 
     const onPointerUp = () => {
@@ -2105,14 +2146,28 @@ function ChatPanelResizeHandle({
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
       setDragging(false)
-      onResizeEnd(latestWidthRef.current)
+      onAutoCloseHintChange(null)
+
+      const finalWidth = latestWidthRef.current
+      const containerWidth = containerRect.width
+
+      if (finalWidth < CHAT_AUTO_CLOSE_THRESHOLD) {
+        if (chatCol) chatCol.style.width = ''
+        onAutoCollapseChat()
+      } else if (containerWidth - finalWidth < CANVAS_AUTO_CLOSE_THRESHOLD) {
+        if (chatCol) chatCol.style.width = ''
+        onAutoCollapseCanvas()
+      } else {
+        if (chatCol) chatCol.style.width = ''
+        onResizeEnd(finalWidth)
+      }
     }
 
     document.body.style.cursor = 'col-resize'
     document.body.style.userSelect = 'none'
     document.addEventListener('pointermove', onPointerMove)
     document.addEventListener('pointerup', onPointerUp)
-  }, [splitRowRef, minWidth, maxWidth, onResize, onResizeEnd])
+  }, [splitRowRef, chatColumnRef, onResizeEnd, onAutoCollapseChat, onAutoCollapseCanvas, onAutoCloseHintChange])
 
   const handleDoubleClick = useCallback(() => {
     onResizeEnd(defaultWidth)

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -133,6 +133,16 @@ const CANVAS_AUTO_CLOSE_THRESHOLD = 200
 const DRAG_FLOOR = 100
 const DRAG_CEILING_OFFSET = 100
 
+/**
+ * React Native Web forwards extra CSS properties (like `transition`)
+ * that aren't part of RN's `ViewStyle` type. This narrows the `any` to
+ * a single, documented spot instead of casting inline at every call
+ * site, and is a no-op on native since those keys are simply absent.
+ */
+function withWebTransition<T extends object>(style: T, transition: string): T & { transition?: string } {
+  return Platform.OS === 'web' ? { ...style, transition } : style
+}
+
 /** Suppress duplicate "[canvas-error]" toasts within this many ms. */
 const CANVAS_ERROR_DEDUP_MS = 10_000
 /** How many recent runtime log entries to attach to a debug-with-Shogo prompt. */
@@ -1737,11 +1747,13 @@ export default observer(function ProjectLayout() {
                       : 'relative flex-1',
                   !isChatFullscreen && chatHidden && 'hidden',
                 )}
-                style={!isChatFullscreen && isWide && !chatHidden ? {
-                  width: clampChatWidth(chatPanelWidth),
-                  opacity: autoCloseHint === 'chat' ? 0.4 : 1,
-                  transition: 'opacity 150ms',
-                } as any : undefined}
+                style={!isChatFullscreen && isWide && !chatHidden ? withWebTransition(
+                  {
+                    width: clampChatWidth(chatPanelWidth),
+                    opacity: autoCloseHint === 'chat' ? 0.4 : 1,
+                  },
+                  'opacity 150ms',
+                ) : undefined}
               >
                 {isChatFullscreen && (
                   <View className="w-[280px] bg-muted/50 dark:bg-black/30">
@@ -1865,10 +1877,7 @@ export default observer(function ProjectLayout() {
               canvasAreaHidden && 'hidden',
               Platform.OS === 'web' && !canvasAreaHidden && 'min-h-0',
             )}
-            style={autoCloseHint === 'canvas' ? {
-              opacity: 0.4,
-              transition: 'opacity 150ms',
-            } as any : undefined}
+            style={autoCloseHint === 'canvas' ? withWebTransition({ opacity: 0.4 }, 'opacity 150ms') : undefined}
           >
             <DrawerHost
               projectId={projectId ?? null}


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/b3a202c3-e9a9-43b3-8172-318e79cb284d



- Auto-close the **chat panel** when the user drags the resize handle past a narrow threshold (< 280px), collapsing chat and resetting its width to the default 480px for a clean re-open
- Auto-close the **canvas panel** when the user drags the chat wide enough that the remaining canvas space drops below 200px, switching to chat-fullscreen mode
- Replace per-frame React state updates during drag with **direct DOM style mutation** for smoother resize performance
- Add a **40% opacity fade** visual hint on the panel that will close while the user is dragging in the auto-close zone
- Enforce safe drag bounds (floor: 100px, ceiling offset: 100px) to prevent layout collapse during drag

## How it works

The drag handle now uses relaxed bounds during the drag (100px minimum chat, 100px minimum canvas) instead of the previous hard 320px clamp. On pointer release, the final width is checked against two thresholds:

1. If chat width < 280px -> collapse chat (`chatCollapsed = true`), reset to default width
2. If canvas width < 200px -> hide canvas (`previewTab = 'chat-fullscreen'`)
3. Otherwise -> commit the width normally

Recovery uses existing UI controls: the "Expand chat" sidebar button to restore chat, or the "Canvas" tab to exit fullscreen and restore the split view.

## Test plan

- [ ] Drag the resize handle left until chat becomes very narrow -- verify chat auto-collapses with fade hint
- [ ] Drag the resize handle right until canvas becomes very narrow -- verify canvas auto-hides with fade hint
- [ ] After chat auto-closes, click the "Expand chat" button -- verify chat re-opens at default 480px width
- [ ] After canvas auto-closes, click the "Canvas" tab -- verify split view restores
- [ ] Double-click the resize handle -- verify it resets to default width (unchanged behavior)
- [ ] Normal drag within bounds -- verify resize still works smoothly without auto-close
- [ ] Verify no layout jitter or flicker during/after the auto-close transition