### PR TITLE
fix(deploy): reconcile production api service manifests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1129,20 +1129,42 @@ jobs:
             fi
           }
           patch_ksvc studio "${{ env.NS_SYSTEM }}" shogo-web "$WEB_CHANGED" "$PREV_WEB_IMAGE"
-          patch_ksvc api "${{ env.NS_SYSTEM }}" shogo-api "$API_CHANGED" "$PREV_API_IMAGE"
           patch_ksvc docs "${{ env.NS_SYSTEM }}" shogo-docs "$DOCS_CHANGED" "$PREV_DOCS_IMAGE"
 
-          # Pin RUNTIME_IMAGE on api ksvc to the immutable SHA tag
-          IDX=$(kubectl get ksvc api -n ${{ env.NS_SYSTEM }} -o json | \
-            python3 -c "import sys,json; envs=json.load(sys.stdin)['spec']['template']['spec']['containers'][0]['env']; print(next((i for i,e in enumerate(envs) if e['name']=='RUNTIME_IMAGE'), -1))" 2>/dev/null) || IDX="-1"
-          if [ -n "$IDX" ] && [ "$IDX" != "-1" ]; then
-            CURRENT=$(kubectl get ksvc api -n ${{ env.NS_SYSTEM }} -o jsonpath="{.spec.template.spec.containers[0].env[${IDX}].value}")
-            if [ "$CURRENT" != "$RUNTIME_IMAGE" ]; then
-              kubectl patch ksvc api -n ${{ env.NS_SYSTEM }} --type='json' -p="[
-                {\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/env/${IDX}/value\", \"value\": \"${RUNTIME_IMAGE}\"}
-              ]"
-            fi
+      # -----------------------------------------------------------------------
+      # Declarative reconciliation of the api ksvc + RBAC from the overlay YAML.
+      #
+      # The api-service.yaml is the source of truth for ALL env vars, resource
+      # limits, RBAC, and service topology. We inject the correct image tag and
+      # RUNTIME_IMAGE before applying so there is exactly one revision rollout
+      # and every env var/config change committed to the YAML is automatically
+      # picked up - no more manual `patch_env` per variable.
+      #
+      # Background: incident where SHOGO_TUNNEL_WS_URL was committed to the
+      # YAML but never reached the cluster because the old pipeline only
+      # patched the image tag. This pattern makes that class of bug impossible.
+      # -----------------------------------------------------------------------
+      - name: Reconcile api service from overlay YAML
+        env:
+          OCIR_REGISTRY: ${{ needs.resolve-config.outputs.ocir_registry }}
+          RUNTIME_IMAGE: ${{ steps.runtime-tag.outputs.image }}
+          API_CHANGED: ${{ needs.detect-changes.outputs.api_changed }}
+          PREV_API_IMAGE: ${{ steps.save-images.outputs.api_image }}
+        run: |
+          if [ "$API_CHANGED" = "true" ]; then
+            API_IMAGE="${OCIR_REGISTRY}/shogo/shogo-api:${{ env.IMAGE_TAG }}"
+          elif [ -n "$PREV_API_IMAGE" ]; then
+            API_IMAGE="$PREV_API_IMAGE"
+          else
+            API_IMAGE="${OCIR_REGISTRY}/shogo/shogo-api:${{ env.IMAGE_TAG }}"
           fi
+
+          sed -e "s|image: .*shogo/shogo-api:.*|image: ${API_IMAGE}|" \
+              -e "s|value: \".*shogo/shogo-runtime:production-bootstrap\"|value: \"${RUNTIME_IMAGE}\"|" \
+              k8s/overlays/production-us/api-service.yaml \
+            | kubectl apply --server-side --force-conflicts -f -
+
+          echo "Applied api-service.yaml with image=${API_IMAGE} runtime=${RUNTIME_IMAGE}"
 
       - name: Wait for rollout and health check
         run: |
@@ -1203,6 +1225,12 @@ jobs:
                 -c "ALTER SUBSCRIPTION ${SUB} REFRESH PUBLICATION;" \
               || echo "::warning::REFRESH PUBLICATION failed for ${SUB} on US (subscription may not exist yet)"
           done
+
+      # Tunnel ingress: dedicated route bypassing Knative DomainMapping for
+      # WebSocket Upgrade. See api-tunnel-ingress.yaml for full rationale.
+      - name: Reconcile tunnel ingress
+        run: |
+          kubectl apply -f k8s/overlays/production-us/api-tunnel-ingress.yaml
 
       - name: Summary
         run: |
@@ -1495,20 +1523,35 @@ jobs:
             fi
           }
           patch_ksvc studio "${{ env.NS_SYSTEM }}" shogo-web "$WEB_CHANGED" "$PREV_WEB_IMAGE"
-          patch_ksvc api "${{ env.NS_SYSTEM }}" shogo-api "$API_CHANGED" "$PREV_API_IMAGE"
           patch_ksvc docs "${{ env.NS_SYSTEM }}" shogo-docs "$DOCS_CHANGED" "$PREV_DOCS_IMAGE"
 
-          # Pin RUNTIME_IMAGE on api ksvc to the immutable SHA tag
-          IDX=$(kubectl get ksvc api -n ${{ env.NS_SYSTEM }} -o json | \
-            python3 -c "import sys,json; envs=json.load(sys.stdin)['spec']['template']['spec']['containers'][0]['env']; print(next((i for i,e in enumerate(envs) if e['name']=='RUNTIME_IMAGE'), -1))" 2>/dev/null) || IDX="-1"
-          if [ -n "$IDX" ] && [ "$IDX" != "-1" ]; then
-            CURRENT=$(kubectl get ksvc api -n ${{ env.NS_SYSTEM }} -o jsonpath="{.spec.template.spec.containers[0].env[${IDX}].value}")
-            if [ "$CURRENT" != "$RUNTIME_IMAGE" ]; then
-              kubectl patch ksvc api -n ${{ env.NS_SYSTEM }} --type='json' -p="[
-                {\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/env/${IDX}/value\", \"value\": \"${RUNTIME_IMAGE}\"}
-              ]"
-            fi
+      # Declarative api ksvc reconciliation - see deploy-us for full rationale.
+      - name: Reconcile api service from overlay YAML
+        env:
+          OCIR_REGISTRY: ${{ vars.OCI_REGION }}.ocir.io/${{ vars.OCI_TENANCY_NAMESPACE }}
+          RUNTIME_IMAGE: ${{ steps.runtime-tag.outputs.image }}
+          API_CHANGED: ${{ needs.detect-changes.outputs.api_changed }}
+          PREV_API_IMAGE: ${{ steps.save-images.outputs.api_image }}
+        run: |
+          if [ "$API_CHANGED" = "true" ]; then
+            API_IMAGE="${OCIR_REGISTRY}/shogo/shogo-api:${{ env.IMAGE_TAG }}"
+          elif [ -n "$PREV_API_IMAGE" ]; then
+            API_IMAGE="$PREV_API_IMAGE"
+          else
+            API_IMAGE="${OCIR_REGISTRY}/shogo/shogo-api:${{ env.IMAGE_TAG }}"
           fi
+
+          sed -e "s|image: .*shogo/shogo-api:.*|image: ${API_IMAGE}|" \
+              -e "s|value: \".*shogo/shogo-runtime:production-bootstrap\"|value: \"${RUNTIME_IMAGE}\"|" \
+              k8s/overlays/production-eu/api-service.yaml \
+            | kubectl apply --server-side --force-conflicts -f -
+
+          echo "Applied api-service.yaml with image=${API_IMAGE} runtime=${RUNTIME_IMAGE}"
+
+      # Tunnel ingress - see deploy-us for full rationale.
+      - name: Reconcile tunnel ingress
+        run: |
+          kubectl apply -f k8s/overlays/production-eu/api-tunnel-ingress.yaml
 
       - name: Wait for rollout and health check
         run: |
@@ -1808,20 +1851,35 @@ jobs:
             fi
           }
           patch_ksvc studio "${{ env.NS_SYSTEM }}" shogo-web "$WEB_CHANGED" "$PREV_WEB_IMAGE"
-          patch_ksvc api "${{ env.NS_SYSTEM }}" shogo-api "$API_CHANGED" "$PREV_API_IMAGE"
           patch_ksvc docs "${{ env.NS_SYSTEM }}" shogo-docs "$DOCS_CHANGED" "$PREV_DOCS_IMAGE"
 
-          # Pin RUNTIME_IMAGE on api ksvc to the immutable SHA tag
-          IDX=$(kubectl get ksvc api -n ${{ env.NS_SYSTEM }} -o json | \
-            python3 -c "import sys,json; envs=json.load(sys.stdin)['spec']['template']['spec']['containers'][0]['env']; print(next((i for i,e in enumerate(envs) if e['name']=='RUNTIME_IMAGE'), -1))" 2>/dev/null) || IDX="-1"
-          if [ -n "$IDX" ] && [ "$IDX" != "-1" ]; then
-            CURRENT=$(kubectl get ksvc api -n ${{ env.NS_SYSTEM }} -o jsonpath="{.spec.template.spec.containers[0].env[${IDX}].value}")
-            if [ "$CURRENT" != "$RUNTIME_IMAGE" ]; then
-              kubectl patch ksvc api -n ${{ env.NS_SYSTEM }} --type='json' -p="[
-                {\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/env/${IDX}/value\", \"value\": \"${RUNTIME_IMAGE}\"}
-              ]"
-            fi
+      # Declarative api ksvc reconciliation - see deploy-us for full rationale.
+      - name: Reconcile api service from overlay YAML
+        env:
+          OCIR_REGISTRY: ${{ vars.OCI_REGION }}.ocir.io/${{ vars.OCI_TENANCY_NAMESPACE }}
+          RUNTIME_IMAGE: ${{ steps.runtime-tag.outputs.image }}
+          API_CHANGED: ${{ needs.detect-changes.outputs.api_changed }}
+          PREV_API_IMAGE: ${{ steps.save-images.outputs.api_image }}
+        run: |
+          if [ "$API_CHANGED" = "true" ]; then
+            API_IMAGE="${OCIR_REGISTRY}/shogo/shogo-api:${{ env.IMAGE_TAG }}"
+          elif [ -n "$PREV_API_IMAGE" ]; then
+            API_IMAGE="$PREV_API_IMAGE"
+          else
+            API_IMAGE="${OCIR_REGISTRY}/shogo/shogo-api:${{ env.IMAGE_TAG }}"
           fi
+
+          sed -e "s|image: .*shogo/shogo-api:.*|image: ${API_IMAGE}|" \
+              -e "s|value: \".*shogo/shogo-runtime:production-bootstrap\"|value: \"${RUNTIME_IMAGE}\"|" \
+              k8s/overlays/production-india/api-service.yaml \
+            | kubectl apply --server-side --force-conflicts -f -
+
+          echo "Applied api-service.yaml with image=${API_IMAGE} runtime=${RUNTIME_IMAGE}"
+
+      # Tunnel ingress - see deploy-us for full rationale.
+      - name: Reconcile tunnel ingress
+        run: |
+          kubectl apply -f k8s/overlays/production-india/api-tunnel-ingress.yaml
 
       - name: Wait for rollout and health check
         run: |


### PR DESCRIPTION
Closes #509

## Summary

This fixes the production deploy drift that caused `SHOGO_TUNNEL_WS_URL` to be committed in `api-service.yaml` but never applied to the running clusters.

The production deploy pipeline now reconciles the full regional `api-service.yaml` for US, EU, and India using `kubectl apply --server-side`, while injecting only the deploy-time dynamic values:

- API image tag
- `RUNTIME_IMAGE`

It also applies each region's `api-tunnel-ingress.yaml` so the dedicated tunnel hosts are reconciled automatically during production deploys.

## Root Cause

Why did `SHOGO_TUNNEL_WS_URL` never reach the cluster?

Because the deploy pipeline only patched the image tag. Everything else in `api-service.yaml` was effectively dead after initial cluster setup.

Why did the pipeline only patch the image tag?

Because `patch_ksvc()` was written to do exactly one thing:

```sh
kubectl patch ... /spec/template/spec/containers/0/image
```

When someone later added `SHOGO_TUNNEL_WS_URL` to the YAML, there was no automatic mechanism to deliver it to the running Knative service. The YAML looked correct in Git, but production pods never received the new environment variable.

## Old Fix Pattern

Every time a new env var was needed, someone had to manually add a `patch_env VAR_NAME "value"` line to the pipeline. If that extra pipeline change was missed, the env var silently did not exist in the cluster.

That meant `api-service.yaml` was not the real source of truth. It was documentation plus bootstrap config, while deploys only reconciled a small subset of fields.

## What This Fix Changes

The pipeline now does `kubectl apply --server-side` of the full `api-service.yaml` with image + `RUNTIME_IMAGE` injected via `sed`.

This means:

- Every env var in the YAML is automatically applied, with no manual pipeline update needed.
- RBAC, resource limits, annotations, and service topology are reconciled declaratively.
- The next developer who adds `SHOGO_NEW_FEATURE=xyz` to the YAML does not need to touch `deploy.yml` just to make it real in the cluster.
- The entire class of "committed to YAML but never deployed" bugs is eliminated.

## Why This Fixes The Tunnel Incident

For the desktop tunnel incident, production API pods omitted `SHOGO_TUNNEL_WS_URL`. The desktop heartbeat could not receive the dedicated tunnel WebSocket host and fell back to `wss://studio.shogo.ai/api/instances/ws`.

That path flows through the existing Knative DomainMapping route, where WebSocket Upgrade does not produce the expected 101 response. By reconciling the full API service manifest and tunnel ingress, production deploys now make the committed tunnel config real in the cluster.

## Test Plan

- Ran `git diff --check`.
- Validated all production deploy jobs no longer call `patch_ksvc api`.
- Validated all production deploy jobs include `Reconcile api service from overlay YAML`.
- Validated all production deploy jobs include `Reconcile tunnel ingress`.
- Validated no production deploy job still has individual `Sync SHOGO_TUNNEL_WS_URL` logic.
- Validated all production overlays contain `SHOGO_TUNNEL_WS_URL`, `RUNTIME_IMAGE`, `shogo-runtime:production-bootstrap`, and `shogo-api:`.

Made with [Cursor](https://cursor.com)