### PR TITLE
feat(desktop): export bug reports with logs and optional attachments

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -10,6 +10,7 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "bonjour-service": "^1.2.1",
+        "fflate": "^0.8.2",
         "multicast-dns": "^7.2.5",
         "node-ical": "^0.26.0",
         "ps-list": "^9.0.0"
@@ -3610,6 +3611,12 @@
       "dependencies": {
         "pend": "~1.2.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/filename-reserved-regex": {
       "version": "2.0.0",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "bonjour-service": "^1.2.1",
+    "fflate": "^0.8.2",
     "multicast-dns": "^7.2.5",
     "node-ical": "^0.26.0",
     "ps-list": "^9.0.0"

--- a/apps/desktop/src/bug-report.ts
+++ b/apps/desktop/src/bug-report.ts
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { app } from 'electron'
+import path from 'path'
+import fs from 'fs'
+import os from 'os'
+import { zipSync, strToU8 } from 'fflate'
+import { readConfig, getDeviceInfo, type BugReportConfig } from './config'
+
+export interface BugReportAttachment {
+  name: string
+  dataUrl: string
+}
+
+export interface BugReportPayload {
+  description: string
+  attachments?: BugReportAttachment[]
+  /** @deprecated Use attachments instead */
+  screenshotBase64?: string
+}
+
+export interface SystemInfo {
+  appVersion: string
+  electronVersion: string
+  platform: NodeJS.Platform
+  arch: string
+  osVersion: string
+  nodeVersion: string
+  totalMemoryMB: number
+  freeMemoryMB: number
+  cpuModel: string
+  cpuCores: number
+  deviceId: string
+  deviceName: string
+  uptime: number
+}
+
+function getLogDir(): string {
+  return process.platform === 'win32'
+    ? path.join(app.getPath('userData'), 'logs')
+    : path.join(app.getPath('home'), 'Library', 'Logs', 'Shogo')
+}
+
+function getMainLogPath(): string {
+  return path.join(getLogDir(), 'main.log')
+}
+
+function tailFile(filePath: string, maxLines: number): string {
+  try {
+    if (!fs.existsSync(filePath)) return ''
+    const content = fs.readFileSync(filePath, 'utf-8')
+    const lines = content.split('\n')
+    if (lines.length <= maxLines) return content
+    return lines.slice(-maxLines).join('\n')
+  } catch {
+    return `[Error reading ${filePath}]`
+  }
+}
+
+export function collectSystemInfo(): SystemInfo {
+  const device = getDeviceInfo()
+  const cpus = os.cpus()
+  return {
+    appVersion: app.getVersion(),
+    electronVersion: process.versions.electron,
+    platform: process.platform,
+    arch: process.arch,
+    osVersion: os.release(),
+    nodeVersion: process.versions.node,
+    totalMemoryMB: Math.round(os.totalmem() / 1024 / 1024),
+    freeMemoryMB: Math.round(os.freemem() / 1024 / 1024),
+    cpuModel: cpus[0]?.model || 'unknown',
+    cpuCores: cpus.length,
+    deviceId: device.id,
+    deviceName: device.name,
+    uptime: Math.round(os.uptime()),
+  }
+}
+
+function getRedactedConfig(): Record<string, unknown> {
+  const config = readConfig()
+  const redacted: Record<string, unknown> = { ...config }
+  // Remove any fields that might contain secrets
+  const sensitiveKeys = ['githubToken', 'discordWebhookUrl']
+  if (typeof redacted.bugReport === 'object' && redacted.bugReport !== null) {
+    const br = { ...(redacted.bugReport as Record<string, unknown>) }
+    for (const key of sensitiveKeys) {
+      if (br[key]) br[key] = '[REDACTED]'
+    }
+    redacted.bugReport = br
+  }
+  return redacted
+}
+
+export interface BugReportBundle {
+  zipBuffer: Uint8Array
+  filename: string
+}
+
+export function buildBugReportZip(payload: BugReportPayload, maxLogLines?: number): BugReportBundle {
+  const lines = maxLogLines ?? readConfig().bugReport?.maxLogLines ?? 500
+  const systemInfo = collectSystemInfo()
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+
+  const files: Record<string, Uint8Array> = {}
+
+  // User description
+  files['description.txt'] = strToU8(payload.description || '(no description provided)')
+
+  // System info
+  files['system-info.json'] = strToU8(JSON.stringify(systemInfo, null, 2))
+
+  // Desktop config (redacted)
+  files['config.json'] = strToU8(JSON.stringify(getRedactedConfig(), null, 2))
+
+  // Main process log (tail)
+  const mainLog = tailFile(getMainLogPath(), lines)
+  if (mainLog) {
+    files['logs/main.log'] = strToU8(mainLog)
+  }
+
+  // API server log — check common locations
+  const apiLogCandidates = [
+    path.join(getLogDir(), 'api.log'),
+    path.join(app.getPath('userData'), 'data', 'api.log'),
+  ]
+  for (const candidate of apiLogCandidates) {
+    const apiLog = tailFile(candidate, lines)
+    if (apiLog) {
+      files['logs/api.log'] = strToU8(apiLog)
+      break
+    }
+  }
+
+  // User-attached files (screenshots, videos, etc.)
+  if (payload.attachments && payload.attachments.length > 0) {
+    for (const attachment of payload.attachments) {
+      const match = attachment.dataUrl.match(/^data:[^;]+;base64,(.+)$/)
+      if (match) {
+        files[`attachments/${attachment.name}`] = Buffer.from(match[1], 'base64')
+      }
+    }
+  }
+
+  // Legacy screenshot support
+  if (payload.screenshotBase64) {
+    files['screenshot.png'] = Buffer.from(payload.screenshotBase64, 'base64')
+  }
+
+  const zipBuffer = zipSync(files, { level: 6 })
+  const filename = `shogo-bug-report-${timestamp}.zip`
+
+  return { zipBuffer, filename }
+}
+
+export async function submitToDiscord(
+  webhookUrl: string,
+  payload: BugReportPayload,
+  bundle: BugReportBundle,
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const systemInfo = collectSystemInfo()
+    const embed = {
+      title: 'Bug Report',
+      description: payload.description.slice(0, 2000),
+      color: 0xff3b30,
+      fields: [
+        { name: 'App Version', value: systemInfo.appVersion, inline: true },
+        { name: 'Platform', value: `${systemInfo.platform} (${systemInfo.arch})`, inline: true },
+        { name: 'OS', value: systemInfo.osVersion, inline: true },
+        { name: 'Device', value: systemInfo.deviceName, inline: true },
+      ],
+      timestamp: new Date().toISOString(),
+    }
+
+    const boundary = `----BugReport${Date.now()}`
+    const parts: Buffer[] = []
+
+    // JSON payload part
+    const jsonPart = JSON.stringify({ embeds: [embed] })
+    parts.push(Buffer.from(
+      `--${boundary}\r\nContent-Disposition: form-data; name="payload_json"\r\nContent-Type: application/json\r\n\r\n${jsonPart}\r\n`
+    ))
+
+    // File attachment part
+    parts.push(Buffer.from(
+      `--${boundary}\r\nContent-Disposition: form-data; name="files[0]"; filename="${bundle.filename}"\r\nContent-Type: application/zip\r\n\r\n`
+    ))
+    parts.push(Buffer.from(bundle.zipBuffer))
+    parts.push(Buffer.from(`\r\n--${boundary}--\r\n`))
+
+    const body = Buffer.concat(parts)
+
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}` },
+      body,
+    })
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      return { ok: false, error: `Discord returned HTTP ${res.status}: ${text.slice(0, 200)}` }
+    }
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: (err as Error)?.message || 'Discord submission failed' }
+  }
+}
+
+export async function submitToGitHub(
+  repo: string,
+  token: string,
+  payload: BugReportPayload,
+): Promise<{ ok: boolean; error?: string; issueUrl?: string }> {
+  try {
+    const systemInfo = collectSystemInfo()
+    const body = [
+      '## Description',
+      '',
+      payload.description,
+      '',
+      '## System Info',
+      '',
+      '| Field | Value |',
+      '|-------|-------|',
+      `| App Version | ${systemInfo.appVersion} |`,
+      `| Platform | ${systemInfo.platform} (${systemInfo.arch}) |`,
+      `| OS | ${systemInfo.osVersion} |`,
+      `| Electron | ${systemInfo.electronVersion} |`,
+      `| Memory | ${systemInfo.freeMemoryMB}MB free / ${systemInfo.totalMemoryMB}MB total |`,
+      `| CPU | ${systemInfo.cpuModel} (${systemInfo.cpuCores} cores) |`,
+      `| Device | ${systemInfo.deviceName} |`,
+      '',
+      '_Logs attached in the zip bundle (if exported separately)._',
+    ].join('\n')
+
+    const res = await fetch(`https://api.github.com/repos/${repo}/issues`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      body: JSON.stringify({
+        title: `[Bug Report] ${payload.description.split('\n')[0].slice(0, 80)}`,
+        body,
+        labels: ['bug', 'user-reported'],
+      }),
+    })
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      return { ok: false, error: `GitHub returned HTTP ${res.status}: ${text.slice(0, 200)}` }
+    }
+    const data = (await res.json()) as { html_url?: string }
+    return { ok: true, issueUrl: data.html_url }
+  } catch (err) {
+    return { ok: false, error: (err as Error)?.message || 'GitHub submission failed' }
+  }
+}

--- a/apps/desktop/src/config.ts
+++ b/apps/desktop/src/config.ts
@@ -26,10 +26,18 @@ export interface MeetingConfig {
   useCloudTranscription: boolean
 }
 
+export interface BugReportConfig {
+  discordWebhookUrl?: string
+  githubRepo?: string
+  githubToken?: string
+  maxLogLines?: number
+}
+
 export interface DesktopConfig {
   mode: 'local' | 'cloud'
   vmIsolation: VMIsolationConfig
   meetings: MeetingConfig
+  bugReport?: BugReportConfig
   /** Stable per-machine identifier. Generated on first launch and used so
    * Shogo Cloud can dedupe device-session API keys when the same desktop
    * install signs in multiple times. Treated as non-secret metadata — the
@@ -108,6 +116,9 @@ export function readConfig(): DesktopConfig {
         ? parsed.meetings
         : {}),
     },
+    bugReport: typeof parsed.bugReport === 'object' && parsed.bugReport !== null
+      ? parsed.bugReport
+      : undefined,
     deviceId: existingDeviceId || generateDeviceId(),
   }
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -9,13 +9,14 @@ if (handleSquirrelEvent()) {
   process.exit(0)
 }
 
-import { app, BrowserWindow, protocol, net, session, ipcMain, Menu, shell, Notification } from 'electron'
+import { app, BrowserWindow, protocol, net, session, ipcMain, Menu, shell, Notification, dialog } from 'electron'
 import path from 'path'
 import fs from 'fs'
 import crypto from 'crypto'
 import { startLocalServer, stopLocalServer, getApiUrl, getApiPort } from './local-server'
 import { getWebDir } from './paths'
 import { readConfig, writeConfig, getDeviceInfo, getCloudUrl } from './config'
+import { buildBugReportZip, submitToDiscord, submitToGitHub, collectSystemInfo, type BugReportPayload } from './bug-report'
 import { initAutoUpdater, getIsApplyingUpdate } from './updater'
 import {
   registerRecordingIpcHandlers,
@@ -324,6 +325,26 @@ function buildAppMenu(): void {
         ]),
       ],
     },
+    {
+      label: 'Help',
+      submenu: [
+        {
+          label: 'Documentation',
+          click: () => { shell.openExternal('https://docs.shogo.ai') },
+        },
+        { type: 'separator' },
+        {
+          label: 'Report Bug...',
+          click: () => {
+            if (mainWindow) {
+              if (mainWindow.isMinimized()) mainWindow.restore()
+              mainWindow.focus()
+              mainWindow.webContents.send('navigate', '/settings?tab=support')
+            }
+          },
+        },
+      ],
+    },
   ]
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))
 }
@@ -497,6 +518,82 @@ function registerIpcHandlers(): void {
       return { available: false, currentVersion: null, latestVersion: '' }
     }
   })
+
+  // --- Bug report / log sharing ---
+
+  ipcMain.handle('capture-screenshot', async () => {
+    if (!mainWindow) return { ok: false, error: 'No window available' }
+    try {
+      const image = await mainWindow.webContents.capturePage()
+      return { ok: true, base64: image.toPNG().toString('base64') }
+    } catch (err) {
+      return { ok: false, error: (err as Error)?.message || 'Screenshot capture failed' }
+    }
+  })
+
+  ipcMain.handle('export-bug-report', async (_event, payload: BugReportPayload) => {
+    try {
+      const bundle = buildBugReportZip(payload)
+      const result = await dialog.showSaveDialog({
+        title: 'Save Bug Report',
+        defaultPath: bundle.filename,
+        filters: [{ name: 'Zip Archive', extensions: ['zip'] }],
+      })
+      if (result.canceled || !result.filePath) {
+        return { ok: false, error: 'Cancelled' }
+      }
+      fs.writeFileSync(result.filePath, bundle.zipBuffer)
+      return { ok: true, path: result.filePath }
+    } catch (err) {
+      return { ok: false, error: (err as Error)?.message || 'Export failed' }
+    }
+  })
+
+  ipcMain.handle('submit-bug-report', async (_event, payload: BugReportPayload) => {
+    try {
+      const config = readConfig()
+      const bundle = buildBugReportZip(payload)
+      const results: { discord?: { ok: boolean; error?: string }; github?: { ok: boolean; error?: string; issueUrl?: string } } = {}
+
+      if (config.bugReport?.discordWebhookUrl) {
+        results.discord = await submitToDiscord(config.bugReport.discordWebhookUrl, payload, bundle)
+      }
+
+      if (config.bugReport?.githubRepo && config.bugReport?.githubToken) {
+        results.github = await submitToGitHub(config.bugReport.githubRepo, config.bugReport.githubToken, payload)
+      }
+
+      if (!results.discord && !results.github) {
+        return { ok: false, error: 'No submission targets configured. Use "Export" to save locally.' }
+      }
+
+      const anyFailed = (results.discord && !results.discord.ok) || (results.github && !results.github.ok)
+      if (anyFailed) {
+        const errors = [results.discord?.error, results.github?.error].filter(Boolean).join('; ')
+        return { ok: false, error: errors }
+      }
+      return { ok: true, ...results }
+    } catch (err) {
+      return { ok: false, error: (err as Error)?.message || 'Submission failed' }
+    }
+  })
+
+  ipcMain.handle('get-bug-report-config', () => {
+    const config = readConfig()
+    return {
+      hasDiscord: !!config.bugReport?.discordWebhookUrl,
+      hasGitHub: !!(config.bugReport?.githubRepo && config.bugReport?.githubToken),
+      maxLogLines: config.bugReport?.maxLogLines ?? 500,
+    }
+  })
+
+  ipcMain.handle('set-bug-report-config', (_event, bugReport: { discordWebhookUrl?: string; githubRepo?: string; githubToken?: string; maxLogLines?: number }) => {
+    const current = readConfig()
+    writeConfig({ bugReport: { ...current.bugReport, ...bugReport } })
+    return { ok: true }
+  })
+
+  ipcMain.handle('get-system-info', () => collectSystemInfo())
 }
 
 function createWindow(): void {
@@ -767,6 +864,14 @@ app.whenReady().then(async () => {
 
   if (app.isPackaged) {
     initAutoUpdater()
+  } else {
+    // In dev mode, register no-op handlers so the renderer doesn't crash
+    // when it invokes update-related IPC (initAutoUpdater registers these
+    // only in packaged builds).
+    ipcMain.handle('get-update-status', () => ({ status: 'idle', releaseName: null, availableVersion: null }))
+    ipcMain.handle('download-update', () => ({ ok: false, error: 'Updates disabled in dev mode' }))
+    ipcMain.handle('dismiss-update', () => ({ ok: true }))
+    ipcMain.handle('install-update', () => {})
   }
 
   if (!isCloudMode) {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -241,4 +241,18 @@ contextBridge.exposeInMainWorld('shogoDesktop', {
   removeCloudConnectionStatusListener: () => {
     ipcRenderer.removeAllListeners('cloud-connection-status')
   },
+
+  // Bug report / log sharing
+  captureScreenshot: (): Promise<{ ok: boolean; base64?: string; error?: string }> =>
+    ipcRenderer.invoke('capture-screenshot'),
+  exportBugReport: (payload: { description: string; attachments?: { name: string; dataUrl: string }[] }): Promise<{ ok: boolean; path?: string; error?: string }> =>
+    ipcRenderer.invoke('export-bug-report', payload),
+  submitBugReport: (payload: { description: string; attachments?: { name: string; dataUrl: string }[] }): Promise<{ ok: boolean; error?: string; discord?: { ok: boolean }; github?: { ok: boolean; issueUrl?: string } }> =>
+    ipcRenderer.invoke('submit-bug-report', payload),
+  getBugReportConfig: (): Promise<{ hasDiscord: boolean; hasGitHub: boolean; maxLogLines: number }> =>
+    ipcRenderer.invoke('get-bug-report-config'),
+  setBugReportConfig: (config: { discordWebhookUrl?: string; githubRepo?: string; githubToken?: string; maxLogLines?: number }): Promise<{ ok: boolean }> =>
+    ipcRenderer.invoke('set-bug-report-config', config),
+  getSystemInfo: (): Promise<Record<string, unknown>> =>
+    ipcRenderer.invoke('get-system-info'),
 })

--- a/apps/mobile/app/(app)/settings.tsx
+++ b/apps/mobile/app/(app)/settings.tsx
@@ -47,6 +47,7 @@ import {
   Server,
   Coins,
   Plug,
+  Bug,
 } from 'lucide-react-native'
 import { useAuth } from '../../contexts/auth'
 import {
@@ -66,6 +67,7 @@ import { getIncludedUsdCapacityForDisplay, formatUsd, PLAN_PRICING } from '../..
 import { usePlatformConfig } from '../../lib/platform-config'
 import { SecuritySettingsPanel } from '../../components/security/SecuritySettingsPanel'
 import { ComputeTab } from '../../components/settings/ComputeTab'
+import { BugReportTab } from '../../components/settings/BugReportTab'
 import { IntegrationsTab } from '../../components/settings/IntegrationsTab'
 import {
   type AnalyticsPeriod,
@@ -97,9 +99,9 @@ import { useNotifyOnTurnComplete as useNotifyOnTurnCompletePref } from '../../li
 
 const DOCS_URL = 'https://docs.shogo.ai'
 
-type TabId = 'workspace' | 'people' | 'integrations' | 'account' | 'security' | 'billing' | 'compute' | 'analytics' | 'costs'
+type TabId = 'workspace' | 'people' | 'integrations' | 'account' | 'security' | 'billing' | 'compute' | 'analytics' | 'costs' | 'support'
 
-const ALL_TAB_IDS: TabId[] = ['workspace', 'people', 'integrations', 'account', 'security', 'billing', 'compute', 'analytics', 'costs']
+const ALL_TAB_IDS: TabId[] = ['workspace', 'people', 'integrations', 'account', 'security', 'billing', 'compute', 'analytics', 'costs', 'support']
 
 /** Tablet/desktop split: matches `SettingsPage` `isWide` (sidebar layout). */
 const SETTINGS_WIDE_BREAKPOINT = 768
@@ -128,6 +130,7 @@ const LOCAL_NAV_ITEMS: NavItem[] = [
   { id: 'security', label: 'Security', icon: Shield },
   { id: 'analytics', label: 'Usage', icon: BarChart3 },
   { id: 'costs', label: 'Costs', icon: Coins },
+  { id: 'support', label: 'Report Bug', icon: Bug },
 ]
 
 function TabBar({
@@ -241,6 +244,13 @@ function SettingsSidebar({
         ...(!showBilling ? [{ id: 'security' as TabId, label: 'Security' }] : []),
       ],
     },
+    ...(localMode ? [{
+      id: 'support',
+      label: 'Support',
+      items: [
+        { id: 'support' as TabId, label: 'Report Bug' },
+      ],
+    }] : []),
   ]
 
   return (
@@ -2843,6 +2853,7 @@ const SettingsContent = observer(function SettingsContent({
       {activeTab === 'billing' && !isLocal && <BillingTab />}
       {activeTab === 'analytics' && <WorkspaceAnalyticsTab />}
       {activeTab === 'costs' && <WorkspaceCostTab />}
+      {activeTab === 'support' && <BugReportTab />}
     </>
   )
 })

--- a/apps/mobile/components/settings/BugReportTab.tsx
+++ b/apps/mobile/components/settings/BugReportTab.tsx
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { View, Text, TextInput, ScrollView, ActivityIndicator, Pressable, Platform } from 'react-native'
+import { Download, CheckCircle, AlertCircle, Paperclip, X } from 'lucide-react-native'
+import {
+  Card,
+  CardContent,
+  Button,
+  Checkbox,
+  cn,
+} from '@shogo/shared-ui/primitives'
+
+interface SystemInfo {
+  appVersion: string
+  electronVersion: string
+  platform: string
+  arch: string
+  osVersion: string
+  totalMemoryMB: number
+  freeMemoryMB: number
+  cpuModel: string
+  cpuCores: number
+  deviceName: string
+}
+
+interface AttachedFile {
+  name: string
+  size: number
+  type: string
+  dataUrl: string
+}
+
+function getShogoDesktop() {
+  if (typeof window !== 'undefined' && (window as any).shogoDesktop) {
+    return (window as any).shogoDesktop
+  }
+  return null
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+export function BugReportTab() {
+  const [description, setDescription] = useState('')
+  const [includeLogs, setIncludeLogs] = useState(true)
+  const [includeSystemInfo, setIncludeSystemInfo] = useState(true)
+  const [attachments, setAttachments] = useState<AttachedFile[]>([])
+
+  const [maxLogLines, setMaxLogLines] = useState(500)
+  const [systemInfo, setSystemInfo] = useState<SystemInfo | null>(null)
+  const [isExporting, setIsExporting] = useState(false)
+  const [result, setResult] = useState<{ type: 'success' | 'error'; message: string } | null>(null)
+
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const desktop = getShogoDesktop()
+
+  useEffect(() => {
+    if (!desktop) return
+    desktop.getBugReportConfig().then((cfg: any) => {
+      if (cfg?.maxLogLines) setMaxLogLines(cfg.maxLogLines)
+    })
+    desktop.getSystemInfo().then(setSystemInfo)
+  }, [])
+
+  // Set up hidden file input for web/desktop
+  useEffect(() => {
+    if (Platform.OS !== 'web') return
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.multiple = true
+    input.accept = 'image/*,video/*,.png,.jpg,.jpeg,.gif,.mp4,.webm,.mov'
+    input.style.display = 'none'
+    input.addEventListener('change', () => {
+      const files = input.files
+      if (!files) return
+      Array.from(files).forEach((file) => {
+        if (file.size > 25 * 1024 * 1024) {
+          setResult({ type: 'error', message: `File "${file.name}" exceeds 25MB limit` })
+          return
+        }
+        const reader = new FileReader()
+        reader.onload = () => {
+          setAttachments((prev) => [
+            ...prev,
+            { name: file.name, size: file.size, type: file.type, dataUrl: reader.result as string },
+          ])
+        }
+        reader.readAsDataURL(file)
+      })
+      input.value = ''
+    })
+    document.body.appendChild(input)
+    fileInputRef.current = input
+    return () => { document.body.removeChild(input) }
+  }, [])
+
+  const handleAttach = useCallback(() => {
+    fileInputRef.current?.click()
+  }, [])
+
+  const removeAttachment = useCallback((index: number) => {
+    setAttachments((prev) => prev.filter((_, i) => i !== index))
+  }, [])
+
+  const handleExport = useCallback(async () => {
+    if (!desktop) return
+    setIsExporting(true)
+    setResult(null)
+    try {
+      // Convert attachments to base64 strings for the main process
+      const attachmentData = attachments.map((a) => ({
+        name: a.name,
+        dataUrl: a.dataUrl,
+      }))
+      const res = await desktop.exportBugReport({ description, attachments: attachmentData })
+      if (res.ok) {
+        setResult({ type: 'success', message: `Bug report saved to: ${res.path}` })
+        setDescription('')
+        setAttachments([])
+      } else if (res.error !== 'Cancelled') {
+        setResult({ type: 'error', message: res.error || 'Export failed' })
+      }
+    } catch (err: any) {
+      setResult({ type: 'error', message: err?.message || 'Export failed' })
+    } finally {
+      setIsExporting(false)
+    }
+  }, [desktop, description, attachments])
+
+  if (!desktop) {
+    return (
+      <View className="flex-1 items-center justify-center p-8">
+        <Text className="text-muted-foreground text-center">
+          Bug reporting is only available in the desktop app.
+        </Text>
+      </View>
+    )
+  }
+
+  const isDisabled = !description.trim() || isExporting
+
+  return (
+    <ScrollView className="flex-1" contentContainerStyle={{ padding: 24, gap: 20 }}>
+      <View className="gap-1">
+        <Text className="text-xl font-semibold text-foreground">Report a Bug</Text>
+        <Text className="text-sm text-muted-foreground">
+          Describe the issue and export a .zip with logs and system info to share with the team.
+        </Text>
+      </View>
+
+      {/* Description */}
+      <Card>
+        <CardContent className="p-4 gap-3">
+          <Text className="text-sm font-medium text-foreground">Description</Text>
+          <TextInput
+            className="min-h-[120px] rounded-md border border-input bg-background p-3 text-sm text-foreground"
+            placeholder="What happened? What did you expect to happen?&#10;&#10;Steps to reproduce:&#10;1. &#10;2. &#10;3. "
+            value={description}
+            onChangeText={setDescription}
+            multiline
+            textAlignVertical="top"
+            placeholderTextColor="#9ca3af"
+          />
+        </CardContent>
+      </Card>
+
+      {/* Options */}
+      <Card>
+        <CardContent className="p-4 gap-4">
+          <Text className="text-sm font-medium text-foreground">Include in report</Text>
+          <Checkbox
+            checked={includeLogs}
+            onCheckedChange={setIncludeLogs}
+            label={`Application logs (last ${maxLogLines} lines)`}
+          />
+          <Checkbox
+            checked={includeSystemInfo}
+            onCheckedChange={setIncludeSystemInfo}
+            label="System information (OS, memory, CPU)"
+          />
+        </CardContent>
+      </Card>
+
+      {/* Attachments */}
+      <Card>
+        <CardContent className="p-4 gap-3">
+          <View className="flex-row items-center justify-between">
+            <Text className="text-sm font-medium text-foreground">Attachments</Text>
+            <Pressable
+              onPress={handleAttach}
+              className="flex-row items-center gap-1.5 px-3 py-1.5 rounded-md border border-input"
+            >
+              <Paperclip size={14} color="#6b7280" />
+              <Text className="text-xs text-muted-foreground">Add screenshots or videos</Text>
+            </Pressable>
+          </View>
+          {attachments.length === 0 && (
+            <Text className="text-xs text-muted-foreground">
+              No files attached. Add screenshots or screen recordings to help illustrate the issue.
+            </Text>
+          )}
+          {attachments.length > 0 && (
+            <View className="gap-2">
+              {attachments.map((file, index) => (
+                <View key={`${file.name}-${index}`} className="flex-row items-center gap-2 rounded-md bg-muted px-3 py-2">
+                  <Text className="text-xs text-foreground flex-1" numberOfLines={1}>
+                    {file.name}
+                  </Text>
+                  <Text className="text-xs text-muted-foreground">
+                    {formatFileSize(file.size)}
+                  </Text>
+                  <Pressable onPress={() => removeAttachment(index)} className="p-1">
+                    <X size={12} color="#6b7280" />
+                  </Pressable>
+                </View>
+              ))}
+            </View>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* System info preview */}
+      {includeSystemInfo && systemInfo && (
+        <Card>
+          <CardContent className="p-4 gap-2">
+            <Text className="text-sm font-medium text-foreground">System Info Preview</Text>
+            <View className="rounded-md bg-muted p-3 gap-1">
+              <Text className="text-xs text-muted-foreground font-mono">
+                App: Shogo v{systemInfo.appVersion} (Electron {systemInfo.electronVersion})
+              </Text>
+              <Text className="text-xs text-muted-foreground font-mono">
+                OS: {systemInfo.platform} {systemInfo.osVersion} ({systemInfo.arch})
+              </Text>
+              <Text className="text-xs text-muted-foreground font-mono">
+                Memory: {systemInfo.freeMemoryMB}MB free / {systemInfo.totalMemoryMB}MB total
+              </Text>
+              <Text className="text-xs text-muted-foreground font-mono">
+                CPU: {systemInfo.cpuModel} ({systemInfo.cpuCores} cores)
+              </Text>
+              <Text className="text-xs text-muted-foreground font-mono">
+                Device: {systemInfo.deviceName}
+              </Text>
+            </View>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Result message */}
+      {result && (
+        <View className={cn(
+          'w-full rounded-lg border p-4 flex-row items-start gap-3',
+          result.type === 'success' ? 'bg-background border-border' : 'border-destructive bg-destructive/10'
+        )}>
+          {result.type === 'success' ? (
+            <CheckCircle size={16} color="#22c55e" style={{ marginTop: 2 }} />
+          ) : (
+            <AlertCircle size={16} color="#ef4444" style={{ marginTop: 2 }} />
+          )}
+          <View className="flex-1 gap-0.5">
+            <Text className="font-medium text-foreground">
+              {result.type === 'success' ? 'Done' : 'Error'}
+            </Text>
+            <Text className="text-sm text-muted-foreground">{result.message}</Text>
+          </View>
+        </View>
+      )}
+
+      {/* Export action */}
+      <Button
+        variant="outline"
+        className="flex-row items-center justify-center gap-2"
+        onPress={handleExport}
+        disabled={isDisabled}
+      >
+        {isExporting ? (
+          <ActivityIndicator size="small" />
+        ) : (
+          <Download size={16} color="#6b7280" />
+        )}
+        <Text className={cn('text-sm font-medium', isDisabled ? 'text-muted-foreground' : 'text-foreground')}>
+          Export as .zip
+        </Text>
+      </Button>
+
+      <Text className="text-xs text-muted-foreground text-center">
+        Share the exported .zip file with the team via GitHub Issues, Discord, or email.
+      </Text>
+    </ScrollView>
+  )
+}


### PR DESCRIPTION
<img width="1702" height="1022" alt="image" src="https://github.com/user-attachments/assets/edadd5e7-197d-449e-8fcd-cded20af4fe8" />
<img width="1273" height="416" alt="image" src="https://github.com/user-attachments/assets/0c55d225-4726-4fb1-b041-321299e72626" />
## Summary

Adds a **Report Bug** flow for the **local desktop** app so users can describe an issue and export a **`.zip`** with diagnostics (main log tail, optional API log, system metadata, redacted desktop config, and optional user-selected screenshots/videos). Entry points: **Settings → Support → Report Bug** and **Help → Report Bug…**.

## What changed

- **Electron main**: IPC to build the zip, save via native dialog, collect system info; **Help** menu (Docs + Report Bug); **dev-mode** placeholders for update IPC so the renderer does not hit missing `get-update-status` handlers when not packaged.
- **Preload**: Exposes `exportBugReport`, `getBugReportConfig`, `getSystemInfo`, and related helpers on `window.shogoDesktop`.
- **Bug report module**: Uses **`fflate`** to assemble the archive; attachments land under `attachments/` in the zip.
- **Expo settings**: New **Support** section (local mode) and **`BugReportTab`** UI (description, checkboxes, file picker for media, export button, aligned success/error banner).

## Dependency

- **`fflate`** added under **`apps/desktop`** for zip creation (desktop is not in the root Bun workspace, so the dependency is declared there explicitly).

## How to test

1. Build web bundle for desktop if needed: `npx expo export --platform web` from **`apps/mobile`** (or use `desktop:dev` from repo root per your workflow).
2. Run **`apps/desktop`** (`bun run dev` or equivalent).
3. Open **Settings → Report Bug**, fill description, optionally attach images/video, click **Export as .zip** and confirm the save dialog and archive contents (`description.txt`, `system-info.json`, `logs/…`, `attachments/…` when applicable).


## Related

Addresses internal ask to **let local users share logs and report bugs easily**.