### PR TITLE
 fix(desktop): add Windows support for sherpa-onnx installation and runtim

### DIFF
--- a/apps/api/src/services/diarization.service.ts
+++ b/apps/api/src/services/diarization.service.ts
@@ -21,6 +21,8 @@ export interface DiarizationResult {
 // Path resolution
 // ---------------------------------------------------------------------------
 
+const SHERPA_BIN_EXT = process.platform === 'win32' ? '.exe' : ''
+
 function getSherpaDir(): string {
   const candidates = [
     process.env.SHOGO_SHERPA_DIR,
@@ -29,13 +31,13 @@ function getSherpaDir(): string {
     join((process as any).resourcesPath || '', 'sherpa-onnx'),
   ].filter(Boolean) as string[]
   for (const dir of candidates) {
-    if (existsSync(join(dir, 'bin', 'sherpa-onnx-offline-speaker-diarization'))) return dir
+    if (existsSync(join(dir, 'bin', `sherpa-onnx-offline-speaker-diarization${SHERPA_BIN_EXT}`))) return dir
   }
   return candidates[0]
 }
 
 export function getDiarizationBinaryPath(): string | null {
-  const bin = join(getSherpaDir(), 'bin', 'sherpa-onnx-offline-speaker-diarization')
+  const bin = join(getSherpaDir(), 'bin', `sherpa-onnx-offline-speaker-diarization${SHERPA_BIN_EXT}`)
   return existsSync(bin) ? bin : null
 }
 
@@ -55,7 +57,8 @@ export function isDiarizationAvailable(): boolean {
 
 function whichSync(cmd: string): string | null {
   try {
-    return execSync(`which ${cmd}`, { encoding: 'utf-8' }).trim() || null
+    const whichCmd = process.platform === 'win32' ? 'where' : 'which'
+    return execSync(`${whichCmd} ${cmd}`, { encoding: 'utf-8' }).trim().split('\n')[0] || null
   } catch {
     return null
   }
@@ -103,6 +106,9 @@ export async function diarize(
   const env = { ...process.env }
   if (process.platform === 'darwin') {
     env.DYLD_LIBRARY_PATH = [libDir, env.DYLD_LIBRARY_PATH].filter(Boolean).join(':')
+  } else if (process.platform === 'win32') {
+    const binDir = join(getSherpaDir(), 'bin')
+    env.PATH = [binDir, libDir, env.PATH].filter(Boolean).join(';')
   } else {
     env.LD_LIBRARY_PATH = [libDir, env.LD_LIBRARY_PATH].filter(Boolean).join(':')
   }
@@ -155,7 +161,12 @@ async function ensureResampled(audioPath: string): Promise<string> {
   } catch { /* proceed to resample */ }
 
   if (!whichSync('ffmpeg')) {
-    throw new Error('ffmpeg is required for diarization (audio resampling). Install it with: brew install ffmpeg')
+    const installHint = process.platform === 'win32'
+      ? 'Download from https://ffmpeg.org or install via: winget install ffmpeg'
+      : process.platform === 'darwin'
+        ? 'Install with: brew install ffmpeg'
+        : 'Install with: sudo apt install ffmpeg'
+    throw new Error(`ffmpeg is required for diarization (audio resampling). ${installHint}`)
   }
 
   const resampledPath = audioPath.replace(/\.wav$/, '-16k.wav')

--- a/apps/api/src/services/transcription.service.ts
+++ b/apps/api/src/services/transcription.service.ts
@@ -24,6 +24,8 @@ export interface TranscriptionResult {
 // Path resolution
 // ---------------------------------------------------------------------------
 
+const SHERPA_BIN_EXT = process.platform === 'win32' ? '.exe' : ''
+
 function getSherpaDir(): string {
   const candidates = [
     // Explicit override from desktop local-server (packaged app writable path)
@@ -36,14 +38,14 @@ function getSherpaDir(): string {
     join((process as any).resourcesPath || '', 'sherpa-onnx'),
   ].filter(Boolean) as string[]
   for (const dir of candidates) {
-    if (existsSync(join(dir, 'bin', 'sherpa-onnx-offline'))) return dir
+    if (existsSync(join(dir, 'bin', `sherpa-onnx-offline${SHERPA_BIN_EXT}`))) return dir
   }
   return candidates[0]
 }
 
 export function getSherpaOfflinePath(): string | null {
   const dir = getSherpaDir()
-  const binPath = join(dir, 'bin', 'sherpa-onnx-offline')
+  const binPath = join(dir, 'bin', `sherpa-onnx-offline${SHERPA_BIN_EXT}`)
   return existsSync(binPath) ? binPath : null
 }
 
@@ -102,6 +104,9 @@ export async function transcribeLocal(
   const env = { ...process.env }
   if (process.platform === 'darwin') {
     env.DYLD_LIBRARY_PATH = [libDir, env.DYLD_LIBRARY_PATH].filter(Boolean).join(':')
+  } else if (process.platform === 'win32') {
+    const binDir = join(getSherpaDir(), 'bin')
+    env.PATH = [binDir, libDir, env.PATH].filter(Boolean).join(';')
   } else {
     env.LD_LIBRARY_PATH = [libDir, env.LD_LIBRARY_PATH].filter(Boolean).join(':')
   }

--- a/apps/desktop/scripts/download-sherpa.mjs
+++ b/apps/desktop/scripts/download-sherpa.mjs
@@ -54,6 +54,7 @@ function getPlatformConfig() {
       tarball: `sherpa-onnx-v${VERSION}-osx-arm64-shared-no-tts.tar.bz2`,
       extractDir: `sherpa-onnx-v${VERSION}-osx-arm64-shared-no-tts`,
       libExt: 'dylib',
+      binExt: '',
     }
   }
   if (platform === 'darwin' && arch === 'x64') {
@@ -61,6 +62,7 @@ function getPlatformConfig() {
       tarball: `sherpa-onnx-v${VERSION}-osx-x64-shared-no-tts.tar.bz2`,
       extractDir: `sherpa-onnx-v${VERSION}-osx-x64-shared-no-tts`,
       libExt: 'dylib',
+      binExt: '',
     }
   }
   if (platform === 'linux' && arch === 'x64') {
@@ -68,6 +70,15 @@ function getPlatformConfig() {
       tarball: `sherpa-onnx-v${VERSION}-linux-x64-shared-no-tts.tar.bz2`,
       extractDir: `sherpa-onnx-v${VERSION}-linux-x64-shared-no-tts`,
       libExt: 'so',
+      binExt: '',
+    }
+  }
+  if (platform === 'win32' && arch === 'x64') {
+    return {
+      tarball: `sherpa-onnx-v${VERSION}-win-x64-shared-MD-Release-no-tts.tar.bz2`,
+      extractDir: `sherpa-onnx-v${VERSION}-win-x64-shared-MD-Release-no-tts`,
+      libExt: 'dll',
+      binExt: '.exe',
     }
   }
   throw new Error(`Unsupported platform: ${platform}/${arch}`)
@@ -84,16 +95,17 @@ function downloadFile(url, destPath) {
 }
 
 function downloadBinaries() {
+  const config = getPlatformConfig()
+  const isWin = process.platform === 'win32'
   const binDir = path.join(RESOURCES_DIR, 'bin')
   const libDir = path.join(RESOURCES_DIR, 'lib')
-  const offlineBin = path.join(binDir, 'sherpa-onnx-offline')
+  const offlineBin = path.join(binDir, `sherpa-onnx-offline${config.binExt}`)
 
   if (fs.existsSync(offlineBin)) {
     console.log('Binaries already downloaded.')
     return
   }
 
-  const config = getPlatformConfig()
   const url = `https://github.com/k2-fsa/sherpa-onnx/releases/download/v${VERSION}/${config.tarball}`
   const tmpTar = path.join(RESOURCES_DIR, config.tarball)
 
@@ -112,24 +124,37 @@ function downloadBinaries() {
 
   const requiredBins = ['sherpa-onnx-offline', 'sherpa-onnx-offline-speaker-diarization']
   for (const bin of requiredBins) {
-    const src = path.join(binSrc, bin)
-    const dest = path.join(binDir, bin)
+    const src = path.join(binSrc, `${bin}${config.binExt}`)
+    const dest = path.join(binDir, `${bin}${config.binExt}`)
     if (fs.existsSync(src)) {
       fs.copyFileSync(src, dest)
-      fs.chmodSync(dest, 0o755)
+      if (!isWin) fs.chmodSync(dest, 0o755)
     }
   }
 
-  for (const entry of fs.readdirSync(libSrc)) {
-    const src = path.join(libSrc, entry)
-    const dest = path.join(libDir, entry)
-    const stat = fs.lstatSync(src)
-    if (stat.isSymbolicLink()) {
-      const target = fs.readlinkSync(src)
-      if (fs.existsSync(dest)) fs.unlinkSync(dest)
-      fs.symlinkSync(target, dest)
-    } else {
-      fs.copyFileSync(src, dest)
+  // On Windows, also copy DLLs from bin/ (onnxruntime, sherpa-onnx core, etc.)
+  if (isWin) {
+    for (const entry of fs.readdirSync(binSrc)) {
+      if (entry.endsWith('.dll')) {
+        const src = path.join(binSrc, entry)
+        const dest = path.join(binDir, entry)
+        if (!fs.existsSync(dest)) fs.copyFileSync(src, dest)
+      }
+    }
+  }
+
+  if (fs.existsSync(libSrc)) {
+    for (const entry of fs.readdirSync(libSrc)) {
+      const src = path.join(libSrc, entry)
+      const dest = path.join(libDir, entry)
+      const stat = fs.lstatSync(src)
+      if (!isWin && stat.isSymbolicLink()) {
+        const target = fs.readlinkSync(src)
+        if (fs.existsSync(dest)) fs.unlinkSync(dest)
+        fs.symlinkSync(target, dest)
+      } else if (stat.isFile()) {
+        fs.copyFileSync(src, dest)
+      }
     }
   }
 


### PR DESCRIPTION
Branch pushed successfully. Only the 3 sherpa files were committed; the other changes (updater, onboarding) remain uncommitted as intended.
### Summary

- Add Windows (win32/x64) platform support to the sherpa-onnx download script and runtime services, which previously only supported macOS and Linux
- The Meetings page "Install sherpa-onnx" button now works on Windows, downloading the correct release artifact and handling Windows-specific binary/library conventions
- Fix cross-platform issues in the diarization service (`which` -> `where`, platform-appropriate ffmpeg install hints)

### What changed

| File | Change |
|------|--------|
| `apps/desktop/scripts/download-sherpa.mjs` | Added `win32/x64` platform config pointing to `sherpa-onnx-v1.12.35-win-x64-shared-MD-Release-no-tts.tar.bz2`. Handle `.exe` extensions, copy DLLs from `bin/`, skip `chmod`/symlinks on Windows, guard `libSrc` with `existsSync`. |
| `apps/api/src/services/transcription.service.ts` | Look for `sherpa-onnx-offline.exe` on Windows. Prepend `bin/` and `lib/` to `PATH` (using `;` separator) instead of `LD_LIBRARY_PATH`. |
| `apps/api/src/services/diarization.service.ts` | Same `.exe` and `PATH` handling for the diarization binary. Fix `whichSync` to use `where` on Windows. Show `winget install ffmpeg` hint instead of `brew install ffmpeg`. |

### Test plan

- [ ] On Windows: click "Install sherpa-onnx + models" on the Meetings page -- should download, extract, and show "Transcription ready" + "Speaker diarization ready"
- [ ] On macOS/Linux: verify existing install flow still works (no regressions)
- [ ] Verify local transcription works end-to-end on Windows after installation
- [ ] Verify diarization binary is found and runs correctly on Windows