### PR TITLE
feat(ci): iOS production release pipeline + unified v* tag for all platforms

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,7 +3,8 @@
 # =============================================================================
 # Environments:
 #   staging    — push to main branch (auto OTA to staging channel)
-#   production — push android-v* tag or manual dispatch with environment=production
+#   production — push v* (unified release tag, e.g. v1.0.0) or android-v* (Android-only)
+#                or manual dispatch with environment=production
 #
 # Automatic (push to main):
 #   - Resolves native fingerprint to detect if native deps changed
@@ -38,6 +39,7 @@ on:
       - main
     tags:
       - 'android-v*'
+      - 'v[0-9]*'
     paths:
       - 'apps/mobile/**'
       - 'packages/domain-stores/**'
@@ -88,7 +90,7 @@ jobs:
         run: |
           if [ -n "${{ github.event.inputs.environment }}" ]; then
             ENV="${{ github.event.inputs.environment }}"
-          elif [[ "${{ github.ref }}" == refs/tags/android-v* ]]; then
+          elif [[ "${{ github.ref }}" =~ ^refs/tags/(android-v|v[0-9]) ]]; then
             ENV="production"
           elif [ "${{ github.ref_name }}" = "main" ]; then
             ENV="staging"
@@ -147,8 +149,8 @@ jobs:
       - name: Determine if build is needed
         id: decide
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/android-v* ]]; then
-            echo "Tag push (android-v*) → release event, forcing full build + submit"
+          if [[ "${{ github.ref }}" =~ ^refs/tags/(android-v|v[0-9]) ]]; then
+            echo "Tag push (${{ github.ref_name }}) → release event, forcing full build + submit"
             echo "needs_build=true" >> $GITHUB_OUTPUT
           elif [ "${{ steps.fingerprint.outputs.runtime_version }}" = "unknown" ]; then
             echo "Could not resolve fingerprint → forcing full build"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -270,6 +270,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Resolve API URL for environment
+        # Mirrors the OTA job + the android.yml build job. Without this the
+        # JS bundle baked into the IPA falls back to `http://localhost:3000`
+        # (see apps/mobile/lib/api.ts → nativeApiUrlWithoutEnv) and every
+        # network call from the device fails with "Network request failed".
+        # That was the root cause of the App Store rejection on submission
+        # 85609ca0-1c38-40be-a090-b92a680ed722 (Guideline 2.1(a)).
+        id: api-url
+        run: |
+          if [ "${{ needs.check-fingerprint.outputs.environment }}" = "production" ]; then
+            echo "url=https://studio.shogo.ai" >> $GITHUB_OUTPUT
+          else
+            echo "url=https://studio.staging.shogo.ai" >> $GITHUB_OUTPUT
+          fi
+          echo "Resolved API URL for ${{ needs.check-fingerprint.outputs.environment }}: $(grep url= $GITHUB_OUTPUT | tail -1)"
+
       - name: Select latest Xcode (require 26+ for App Store Connect)
         # Apple began rejecting App Store Connect uploads built with iOS SDK
         # < 26 in 2026 ("This app was built with the iOS 18.5 SDK. All iOS
@@ -335,7 +351,10 @@ jobs:
       - name: Expo prebuild iOS
         working-directory: apps/mobile
         env:
+          EXPO_PUBLIC_API_URL: ${{ steps.api-url.outputs.url }}
+          EXPO_PUBLIC_APP_ENV: ${{ needs.check-fingerprint.outputs.environment }}_app
           EXPO_PUBLIC_SENTRY_DSN: ${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}
+          EXPO_UPDATES_CHANNEL: ${{ needs.check-fingerprint.outputs.environment }}
         run: bunx expo prebuild --platform ios --clean
 
       - name: Install CocoaPods
@@ -411,6 +430,15 @@ jobs:
         working-directory: apps/mobile/ios
         env:
           BUNDLE_ID: com.odin.ai
+          # JS bundling runs inside xcodebuild's "Bundle React Native code
+          # and images" build phase, which calls Metro. Metro reads
+          # EXPO_PUBLIC_* from process.env at bundle time and bakes them
+          # into the JS that ships in the IPA. These MUST be set here, on
+          # the xcodebuild step, or the bundled app will fall back to
+          # localhost. See android.yml "Build AAB" for the parallel.
+          EXPO_PUBLIC_API_URL: ${{ steps.api-url.outputs.url }}
+          EXPO_PUBLIC_APP_ENV: ${{ needs.check-fingerprint.outputs.environment }}_app
+          EXPO_PUBLIC_SENTRY_DSN: ${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}
         run: |
           set -o pipefail
           xcodebuild archive \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,392 @@
+# =============================================================================
+# iOS Build & Update Pipeline
+# =============================================================================
+# Mirrors android.yml but uses EAS Build cloud for the native build (iOS
+# builds require macOS — instead of paying for a GitHub macos-latest runner
+# we delegate to EAS Build, which provisions its own Mac and returns the IPA).
+#
+# Environments:
+#   staging    — push to main branch (auto OTA to staging channel)
+#   production — push ios-v* tag or manual dispatch with environment=production
+#
+# Automatic (push to main):
+#   - Resolves native fingerprint to detect if native deps changed
+#   - If fingerprint matches the last successful build → OTA update (eas update)
+#   - If fingerprint changed → full native build via EAS Build cloud
+#
+# Manual (workflow_dispatch):
+#   mode=full → fingerprint check, then build or OTA, with TestFlight submit
+#   mode=ota  → fingerprint check, OTA update only (skips build)
+#   environment=staging|production → controls OTA branch + EAS build profile
+#   Production builds always auto-submit to App Store Connect.
+#   Staging builds also submit to TestFlight (can be toggled off with submit=false).
+#
+# Required GitHub Secrets:
+#   EXPO_TOKEN                  - Expo token for eas build / update / submit
+#   APPLE_ID                    - Apple ID email for App Store Connect
+#   APPLE_ID_PASSWORD           - App-specific password (account.apple.com > App-Specific Passwords)
+#   APPLE_TEAM_ID               - 10-char Apple Developer Team ID
+#   EXPO_PUBLIC_SENTRY_DSN      - (optional) Sentry DSN for runtime
+#   SENTRY_AUTH_TOKEN           - (optional) Sentry auth token for source maps
+# =============================================================================
+
+name: iOS Build & Update
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'ios-v*'
+    paths:
+      - 'apps/mobile/**'
+      - 'packages/domain-stores/**'
+      - 'packages/shared-app/**'
+      - 'packages/shared-ui/**'
+      - 'packages/ui-kit/**'
+      - 'packages/sdk/**'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'full = build or OTA + submit · ota = OTA update only'
+        required: true
+        default: 'full'
+        type: choice
+        options:
+          - full
+          - ota
+      environment:
+        description: 'Target environment (staging or production)'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - production
+      submit:
+        description: 'Submit to App Store Connect / TestFlight — full mode only'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  # ===========================================================================
+  # Check if native code changed
+  # ===========================================================================
+  check-fingerprint:
+    name: Check Native Fingerprint
+    runs-on: ubuntu-latest
+    outputs:
+      needs_build: ${{ steps.decide.outputs.needs_build }}
+      runtime_version: ${{ steps.fingerprint.outputs.runtime_version }}
+      environment: ${{ steps.resolve-env.outputs.environment }}
+      app_version: ${{ steps.resolve-version.outputs.version }}
+
+    steps:
+      - name: Resolve environment
+        id: resolve-env
+        run: |
+          if [ -n "${{ github.event.inputs.environment }}" ]; then
+            ENV="${{ github.event.inputs.environment }}"
+          elif [[ "${{ github.ref }}" == refs/tags/ios-v* ]]; then
+            ENV="production"
+          elif [ "${{ github.ref_name }}" = "main" ]; then
+            ENV="staging"
+          else
+            ENV="staging"
+          fi
+          echo "environment=$ENV" >> $GITHUB_OUTPUT
+          echo "Resolved environment: $ENV"
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Resolve app version from app.json
+        id: resolve-version
+        run: |
+          VERSION=$(node -p "JSON.parse(require('fs').readFileSync('apps/mobile/app.json','utf8')).expo.version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Using app.json version: $VERSION"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Resolve fingerprint
+        id: fingerprint
+        working-directory: apps/mobile
+        run: |
+          RAW=$(npx expo-updates runtimeversion:resolve --platform ios 2>/dev/null || echo "")
+
+          if [ -z "$RAW" ]; then
+            echo "Could not resolve runtime version"
+            echo "runtime_version=unknown" >> $GITHUB_OUTPUT
+          else
+            RUNTIME_VERSION=$(echo "$RAW" | sha256sum | cut -d' ' -f1)
+            echo "Raw output: $RAW"
+            echo "Fingerprint hash: $RUNTIME_VERSION"
+            echo "runtime_version=$RUNTIME_VERSION" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Restore cached fingerprint
+        if: steps.fingerprint.outputs.runtime_version != 'unknown'
+        id: cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: .fingerprint-ios
+          key: ios-fingerprint-${{ steps.resolve-env.outputs.environment }}-${{ steps.fingerprint.outputs.runtime_version }}
+
+      - name: Determine if build is needed
+        id: decide
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/ios-v* ]]; then
+            echo "Tag push (ios-v*) → release event, forcing full build + submit"
+            echo "needs_build=true" >> $GITHUB_OUTPUT
+          elif [ "${{ steps.fingerprint.outputs.runtime_version }}" = "unknown" ]; then
+            echo "Could not resolve fingerprint → forcing full build"
+            echo "needs_build=true" >> $GITHUB_OUTPUT
+          elif [ "${{ steps.cache.outputs.cache-hit }}" = "true" ]; then
+            echo "Fingerprint cached from a previous successful build → OTA update only"
+            echo "needs_build=false" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event.inputs.mode }}" = "ota" ]; then
+            echo "OTA mode: trusting no native changes"
+            echo "needs_build=false" >> $GITHUB_OUTPUT
+          else
+            echo "New fingerprint → full build required"
+            echo "needs_build=true" >> $GITHUB_OUTPUT
+          fi
+
+  # ===========================================================================
+  # OTA Update — JS/asset changes only (no native changes)
+  # ===========================================================================
+  update:
+    name: EAS Update (OTA)
+    runs-on: ubuntu-latest
+    needs: check-fingerprint
+    if: >
+      needs.check-fingerprint.result == 'success' &&
+      needs.check-fingerprint.outputs.needs_build == 'false'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Sync app version
+        working-directory: apps/mobile
+        run: |
+          node -e "
+            const fs = require('fs');
+            const appJson = JSON.parse(fs.readFileSync('app.json', 'utf8'));
+            const newVersion = '${{ needs.check-fingerprint.outputs.app_version }}';
+            if (newVersion && appJson.expo.version !== newVersion) {
+              console.log('Syncing version: ' + appJson.expo.version + ' → ' + newVersion);
+              appJson.expo.version = newVersion;
+              fs.writeFileSync('app.json', JSON.stringify(appJson, null, 2) + '\n');
+            } else {
+              console.log('Version already matches: ' + appJson.expo.version);
+            }
+          "
+
+      - name: Build workspace packages
+        run: bun run build
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@c7b66a9c327a43a8fa7c0158e7f30d6040d2481e # v8.2.1
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Resolve API URL for environment
+        id: api-url
+        run: |
+          if [ "${{ needs.check-fingerprint.outputs.environment }}" = "production" ]; then
+            echo "url=https://studio.shogo.ai" >> $GITHUB_OUTPUT
+          else
+            echo "url=https://studio.staging.shogo.ai" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Publish OTA update
+        working-directory: apps/mobile
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message || format('Manual OTA from {0}', github.sha) }}
+          EXPO_PUBLIC_API_URL: ${{ steps.api-url.outputs.url }}
+          EXPO_PUBLIC_APP_ENV: ${{ needs.check-fingerprint.outputs.environment }}_app
+          EXPO_PUBLIC_SENTRY_DSN: ${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}
+        run: |
+          SUBJECT=$(printf '%s' "$COMMIT_MSG" | head -n1)
+          eas update \
+            --branch ${{ needs.check-fingerprint.outputs.environment }} \
+            --platform ios \
+            --message "$SUBJECT" \
+            --non-interactive
+
+      - name: Summary
+        run: |
+          echo "## iOS OTA Update Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Environment:** ${{ needs.check-fingerprint.outputs.environment }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch:** ${{ needs.check-fingerprint.outputs.environment }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Runtime Version:** ${{ needs.check-fingerprint.outputs.runtime_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+
+  # ===========================================================================
+  # Full Native Build — delegated to EAS Build cloud
+  # ===========================================================================
+  build:
+    name: iOS Build (EAS Cloud)
+    runs-on: ubuntu-latest
+    needs: check-fingerprint
+    if: >
+      needs.check-fingerprint.outputs.needs_build == 'true' &&
+      github.event.inputs.mode != 'ota'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Cache bun dependencies
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            node_modules
+            ~/.bun/install/cache
+          key: bun-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build workspace packages
+        run: bun run build
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@c7b66a9c327a43a8fa7c0158e7f30d6040d2481e # v8.2.1
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Sync app version and bump buildNumber
+        working-directory: apps/mobile
+        env:
+          BUILD_NUMBER_OFFSET: 100
+        run: |
+          node -e "
+            const fs = require('fs');
+            const appJson = JSON.parse(fs.readFileSync('app.json', 'utf8'));
+            const newVersion = '${{ needs.check-fingerprint.outputs.app_version }}';
+            if (newVersion && appJson.expo.version !== newVersion) {
+              console.log('Syncing version: ' + appJson.expo.version + ' → ' + newVersion);
+              appJson.expo.version = newVersion;
+            }
+            const buildNumber = String(${{ github.run_number }} + parseInt(process.env.BUILD_NUMBER_OFFSET));
+            appJson.expo.ios = appJson.expo.ios || {};
+            appJson.expo.ios.buildNumber = buildNumber;
+            fs.writeFileSync('app.json', JSON.stringify(appJson, null, 2) + '\n');
+            console.log('Set version=' + appJson.expo.version + ' buildNumber=' + buildNumber);
+          "
+
+      - name: Trigger EAS Build (iOS)
+        id: eas-build
+        working-directory: apps/mobile
+        env:
+          EXPO_PUBLIC_SENTRY_DSN: ${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          PROFILE="${{ needs.check-fingerprint.outputs.environment }}"
+          echo "Triggering EAS Build for profile: $PROFILE"
+          eas build \
+            --platform ios \
+            --profile "$PROFILE" \
+            --non-interactive \
+            --json > eas-build.json
+          BUILD_ID=$(node -p "JSON.parse(require('fs').readFileSync('eas-build.json','utf8'))[0].id")
+          echo "build_id=$BUILD_ID" >> $GITHUB_OUTPUT
+          echo "EAS build id: $BUILD_ID"
+
+      - name: Save fingerprint to cache
+        run: |
+          RUNTIME_VERSION="${{ needs.check-fingerprint.outputs.runtime_version }}"
+          if [ -z "$RUNTIME_VERSION" ] || [ "$RUNTIME_VERSION" = "unknown" ]; then
+            RAW=$(cd apps/mobile && npx expo-updates runtimeversion:resolve --platform ios 2>/dev/null || echo "manual-build")
+            RUNTIME_VERSION=$(echo "$RAW" | sha256sum | cut -d' ' -f1)
+          fi
+          echo "$RUNTIME_VERSION" > .fingerprint-ios
+
+      - name: Cache fingerprint
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: .fingerprint-ios
+          key: ios-fingerprint-${{ needs.check-fingerprint.outputs.environment }}-${{ needs.check-fingerprint.outputs.runtime_version || 'manual' }}
+
+      - name: Resolve submit decision
+        id: submit-decision
+        run: |
+          ENV="${{ needs.check-fingerprint.outputs.environment }}"
+          SUBMIT_INPUT="${{ github.event.inputs.submit }}"
+          if [ "$ENV" = "production" ]; then
+            echo "should_submit=true" >> $GITHUB_OUTPUT
+            echo "Production build → always submitting to App Store Connect"
+          elif [ "$SUBMIT_INPUT" != "false" ]; then
+            echo "should_submit=true" >> $GITHUB_OUTPUT
+            echo "Staging build → submitting to TestFlight"
+          else
+            echo "should_submit=false" >> $GITHUB_OUTPUT
+            echo "Submit skipped by user"
+          fi
+
+      - name: Submit to App Store Connect
+        if: steps.submit-decision.outputs.should_submit == 'true'
+        working-directory: apps/mobile
+        env:
+          EXPO_APPLE_ID_USERNAME: ${{ secrets.APPLE_ID }}
+          EXPO_APPLE_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+        run: |
+          PROFILE="${{ needs.check-fingerprint.outputs.environment }}"
+          echo "Submitting build ${{ steps.eas-build.outputs.build_id }} via profile $PROFILE"
+          eas submit \
+            --platform ios \
+            --profile "$PROFILE" \
+            --id "${{ steps.eas-build.outputs.build_id }}" \
+            --non-interactive
+
+      - name: Summary
+        run: |
+          echo "## iOS Build Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Environment:** ${{ needs.check-fingerprint.outputs.environment }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **EAS Build ID:** \`${{ steps.eas-build.outputs.build_id }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **buildNumber:** ${{ github.run_number }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Submit:** ${{ steps.submit-decision.outputs.should_submit == 'true' && 'App Store Connect / TestFlight' || 'Skipped' }}" >> $GITHUB_STEP_SUMMARY
+
+
+# Manual triggers (after this lands on a branch GitHub knows about):
+#
+# Staging OTA
+# gh workflow run ios.yml --ref main -f mode=ota -f environment=staging
+#
+# Staging full build + submit (TestFlight)
+# gh workflow run ios.yml --ref main -f mode=full -f environment=staging
+#
+# Production full build + submit (App Store Connect)
+# gh workflow run ios.yml --ref main -f mode=full -f environment=production
+#
+# Full build, skip TestFlight submit
+# gh workflow run ios.yml --ref main -f mode=full -f environment=staging -f submit=false

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -386,6 +386,7 @@ jobs:
             CODE_SIGN_IDENTITY="Apple Distribution" \
             PROVISIONING_PROFILE_SPECIFIER="$PROFILE_NAME" \
             OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_PATH" \
+            SENTRY_DISABLE_AUTO_UPLOAD=true \
             | xcbeautify || exit ${PIPESTATUS[0]}
 
       - name: Create exportOptions.plist

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -268,11 +268,34 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+      - name: Select latest Xcode (require 26+ for App Store Connect)
+        # Apple began rejecting App Store Connect uploads built with iOS SDK
+        # < 26 in 2026 ("This app was built with the iOS 18.5 SDK. All iOS
+        # and iPadOS apps must be built with the iOS 26 SDK or later").
+        # macos-latest installs multiple Xcode versions side by side at
+        # /Applications/Xcode_*.app — pick the highest-versioned one and
+        # fail loudly here (cheap) instead of 15 minutes later in altool.
+        run: |
+          set -euo pipefail
 
-      - name: Print Xcode version
-        run: xcodebuild -version
+          echo "Available Xcode installations:"
+          ls /Applications/ | grep -E '^Xcode' || true
+
+          XCODE=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1 || true)
+          if [ -z "$XCODE" ]; then
+            XCODE="/Applications/Xcode.app"
+          fi
+
+          sudo xcode-select -s "$XCODE/Contents/Developer"
+          xcodebuild -version
+
+          XC_MAJOR=$(xcodebuild -version | head -1 | awk '{print $2}' | cut -d. -f1)
+          if [ "$XC_MAJOR" -lt 26 ]; then
+            echo "::error title=Xcode SDK too old::Selected Xcode major version $XC_MAJOR is < 26. Apple now requires Xcode 26+/iOS 26 SDK for App Store Connect submissions."
+            echo "Available Xcodes on this runner:"
+            ls /Applications/ | grep -E '^Xcode' || true
+            exit 1
+          fi
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -401,22 +401,30 @@ jobs:
             OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_PATH" \
             | xcbeautify || exit ${PIPESTATUS[0]}
 
-      - name: Upload dSYMs to Sentry (optional)
-        # Self-skips silently when SENTRY_AUTH_TOKEN is not configured, so
-        # forks / branches without the secret still get a green build.
-        # Uses the workspace's @sentry/cli (pulled in transitively by
-        # @sentry/react-native), with sentry-cli's own non-zero exits surfaced
-        # so a misconfigured secret never silently swallows symbolication.
-        # Bun strict-hoists transitive deps under node_modules/.bun and only
-        # exposes direct deps at the package root, so we resolve through the
-        # workspace bin shim that Bun does write for every dep with `bin`.
+      - name: Upload dSYMs to Sentry (optional, non-fatal)
+        # Best-effort symbolication. This step is intentionally non-fatal: a
+        # misconfigured Sentry org/project, an expired token, or a transient
+        # Sentry outage must not block an otherwise-good release. The native
+        # IPA is independent of Sentry — symbolication is observability, not
+        # a release artifact.
+        #
+        # Skips silently when SENTRY_AUTH_TOKEN is unset (forks / branches
+        # without the secret), and emits a `::warning::` annotation when the
+        # upload itself fails, so failures stay loud and visible.
+        #
+        # Org defaults to "shogo-ai" to match the slug embedded in the auth
+        # token; override at the repo level via SENTRY_ORG if it ever moves.
+        # Bun strict-hoists transitive deps so we use the bin shim Bun does
+        # write for every dep with `bin`, with `bunx` as a clean fallback.
         working-directory: apps/mobile
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: shogo
+          SENTRY_ORG: shogo-ai
           SENTRY_PROJECT: shogo-mobile
           SENTRY_LOG_LEVEL: info
         run: |
+          set +e
+
           if [ -z "$SENTRY_AUTH_TOKEN" ]; then
             echo "::notice title=Sentry dSYM upload::SENTRY_AUTH_TOKEN secret not configured — skipping."
             {
@@ -429,23 +437,41 @@ jobs:
 
           DSYM_DIR="$RUNNER_TEMP/Shogo.xcarchive/dSYMs"
           if [ ! -d "$DSYM_DIR" ]; then
-            echo "::error title=Sentry dSYM upload::Expected dSYM directory not found at $DSYM_DIR"
-            exit 1
+            echo "::warning title=Sentry dSYM upload::dSYM directory not found at $DSYM_DIR — skipping."
+            {
+              echo "## Sentry dSYM upload"
+              echo ""
+              echo "_Skipped — dSYM directory not found at \`$DSYM_DIR\`._"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
 
           if [ -x "./node_modules/.bin/sentry-cli" ]; then
             echo "Using sentry-cli: ./node_modules/.bin/sentry-cli"
             ./node_modules/.bin/sentry-cli debug-files upload --include-sources "$DSYM_DIR"
+            UPLOAD_RC=$?
           else
             echo "Local sentry-cli shim not found; falling back to bunx @sentry/cli"
             bunx @sentry/cli debug-files upload --include-sources "$DSYM_DIR"
+            UPLOAD_RC=$?
           fi
 
-          {
-            echo "## Sentry dSYM upload"
-            echo ""
-            echo "Uploaded dSYMs from \`$DSYM_DIR\` to Sentry (org=\`$SENTRY_ORG\`, project=\`$SENTRY_PROJECT\`)."
-          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$UPLOAD_RC" -eq 0 ]; then
+            {
+              echo "## Sentry dSYM upload"
+              echo ""
+              echo "Uploaded dSYMs from \`$DSYM_DIR\` to Sentry (org=\`$SENTRY_ORG\`, project=\`$SENTRY_PROJECT\`)."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning title=Sentry dSYM upload::sentry-cli exited $UPLOAD_RC — release continuing without symbolication. Check SENTRY_ORG ($SENTRY_ORG) / SENTRY_PROJECT ($SENTRY_PROJECT) and the auth token."
+            {
+              echo "## Sentry dSYM upload"
+              echo ""
+              echo "_Failed (sentry-cli exit $UPLOAD_RC) — release proceeded without symbolication. Check \`SENTRY_ORG\` (\`$SENTRY_ORG\`) / \`SENTRY_PROJECT\` (\`$SENTRY_PROJECT\`) and the auth token._"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          exit 0
 
       - name: Create exportOptions.plist
         run: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -112,6 +112,8 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun install
 
       - name: Resolve fingerprint
@@ -179,6 +181,8 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun install
 
       - name: Sync app version
@@ -271,6 +275,8 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun install
 
       - name: Build workspace packages

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -8,10 +8,11 @@
 #
 # Environments:
 #   staging    — push to main branch (auto OTA to staging channel)
-#   production — push ios-v* tag or manual dispatch with environment=production
+#   production — push v* (unified release tag, e.g. v1.0.0) or ios-v* (iOS-only)
+#                or manual dispatch with environment=production
 #
 # Decision matrix (same logic as android.yml):
-#   - Tag push (ios-v*) → always full build + submit
+#   - Tag push (v* or ios-v*) → always full build + submit
 #   - Cache hit on fingerprint → OTA update only
 #   - mode=ota dispatch → OTA only
 #   - Otherwise → full build
@@ -41,6 +42,7 @@ on:
       - main
     tags:
       - 'ios-v*'
+      - 'v[0-9]*'
     paths:
       - 'apps/mobile/**'
       - 'packages/domain-stores/**'
@@ -91,7 +93,7 @@ jobs:
         run: |
           if [ -n "${{ github.event.inputs.environment }}" ]; then
             ENV="${{ github.event.inputs.environment }}"
-          elif [[ "${{ github.ref }}" == refs/tags/ios-v* ]]; then
+          elif [[ "${{ github.ref }}" =~ ^refs/tags/(ios-v|v[0-9]) ]]; then
             ENV="production"
           elif [ "${{ github.ref_name }}" = "main" ]; then
             ENV="staging"
@@ -148,8 +150,8 @@ jobs:
       - name: Determine if build is needed
         id: decide
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/ios-v* ]]; then
-            echo "Tag push (ios-v*) → release event, forcing full build + submit"
+          if [[ "${{ github.ref }}" =~ ^refs/tags/(ios-v|v[0-9]) ]]; then
+            echo "Tag push (${{ github.ref_name }}) → release event, forcing full build + submit"
             echo "needs_build=true" >> $GITHUB_OUTPUT
           elif [ "${{ steps.fingerprint.outputs.runtime_version }}" = "unknown" ]; then
             echo "Could not resolve fingerprint → forcing full build"
@@ -623,4 +625,5 @@ jobs:
 # gh workflow run ios.yml --ref main -f mode=full -f environment=production
 #
 # Or via tag (auto-triggers production build + submit):
-# git tag ios-v0.1.1 && git push origin ios-v0.1.1
+#   git tag v1.0.0 && git push origin v1.0.0          # unified release: triggers iOS + Android + macOS desktop + Windows desktop
+#   git tag ios-v1.0.0 && git push origin ios-v1.0.0  # iOS-only release

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -407,6 +407,9 @@ jobs:
         # Uses the workspace's @sentry/cli (pulled in transitively by
         # @sentry/react-native), with sentry-cli's own non-zero exits surfaced
         # so a misconfigured secret never silently swallows symbolication.
+        # Bun strict-hoists transitive deps under node_modules/.bun and only
+        # exposes direct deps at the package root, so we resolve through the
+        # workspace bin shim that Bun does write for every dep with `bin`.
         working-directory: apps/mobile
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -430,13 +433,13 @@ jobs:
             exit 1
           fi
 
-          # Resolve sentry-cli without relying on Bun's strict-hoisted .bin
-          # symlinks. Going through the package's own bin entry is the most
-          # portable path in a workspace.
-          SENTRY_CLI=$(node --print "require.resolve('@sentry/cli/bin/sentry-cli')")
-          echo "Using sentry-cli: $SENTRY_CLI"
-
-          "$SENTRY_CLI" debug-files upload --include-sources "$DSYM_DIR"
+          if [ -x "./node_modules/.bin/sentry-cli" ]; then
+            echo "Using sentry-cli: ./node_modules/.bin/sentry-cli"
+            ./node_modules/.bin/sentry-cli debug-files upload --include-sources "$DSYM_DIR"
+          else
+            echo "Local sentry-cli shim not found; falling back to bunx @sentry/cli"
+            bunx @sentry/cli debug-files upload --include-sources "$DSYM_DIR"
+          fi
 
           {
             echo "## Sentry dSYM upload"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -362,23 +362,17 @@ jobs:
           echo "PROFILE_NAME=$PROFILE_NAME" >> $GITHUB_ENV
           echo "Installed provisioning profile: $PROFILE_NAME ($PROFILE_UUID)"
 
-      - name: Stub sentry-cli if missing
-        run: |
-          if ! command -v sentry-cli &> /dev/null && [ ! -f node_modules/@sentry/cli/sentry-cli ]; then
-            echo "sentry-cli not available — creating no-op stub"
-            mkdir -p apps/mobile/ios/Pods/Sentry/scripts
-            cat > apps/mobile/ios/sentry-cli-stub.sh <<'EOF'
-          #!/bin/bash
-          echo "[sentry-cli stub] skipping: $@"
-          exit 0
-          EOF
-            chmod +x apps/mobile/ios/sentry-cli-stub.sh
-          fi
-
       - name: Build archive
         working-directory: apps/mobile/ios
         env:
-          BUNDLE_ID: ai.shogo.mobile
+          BUNDLE_ID: com.odin.ai
+          # Skip Sentry dSYM upload during archive. The @sentry/react-native pod
+          # injects an "Upload Debug Symbols to Sentry" build phase that needs
+          # a working sentry-cli + SENTRY_ORG/SENTRY_PROJECT/SENTRY_AUTH_TOKEN.
+          # SENTRY_DISABLE_AUTO_UPLOAD=true is Sentry's officially supported
+          # escape hatch for CI envs that don't auto-upload. dSYM upload can
+          # be wired up as a dedicated post-build step later.
+          SENTRY_DISABLE_AUTO_UPLOAD: "true"
         run: |
           set -o pipefail
           xcodebuild archive \
@@ -411,7 +405,7 @@ jobs:
             <string>Apple Distribution</string>
             <key>provisioningProfiles</key>
             <dict>
-              <key>ai.shogo.mobile</key>
+              <key>com.odin.ai</key>
               <string>$PROFILE_NAME</string>
             </dict>
             <key>uploadSymbols</key>

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,33 +1,31 @@
 # =============================================================================
 # iOS Build & Update Pipeline
 # =============================================================================
-# Mirrors android.yml but uses EAS Build cloud for the native build (iOS
-# builds require macOS — instead of paying for a GitHub macos-latest runner
-# we delegate to EAS Build, which provisions its own Mac and returns the IPA).
+# Mirrors android.yml. Native build runs on macos-latest with xcodebuild,
+# using a Distribution Certificate + Provisioning Profile injected from
+# GitHub Secrets — no EAS Build dependency, no Expo project access required
+# for the build. EAS Update is still used for OTA JS-only updates.
 #
 # Environments:
 #   staging    — push to main branch (auto OTA to staging channel)
 #   production — push ios-v* tag or manual dispatch with environment=production
 #
-# Automatic (push to main):
-#   - Resolves native fingerprint to detect if native deps changed
-#   - If fingerprint matches the last successful build → OTA update (eas update)
-#   - If fingerprint changed → full native build via EAS Build cloud
-#
-# Manual (workflow_dispatch):
-#   mode=full → fingerprint check, then build or OTA, with TestFlight submit
-#   mode=ota  → fingerprint check, OTA update only (skips build)
-#   environment=staging|production → controls OTA branch + EAS build profile
-#   Production builds always auto-submit to App Store Connect.
-#   Staging builds also submit to TestFlight (can be toggled off with submit=false).
+# Decision matrix (same logic as android.yml):
+#   - Tag push (ios-v*) → always full build + submit
+#   - Cache hit on fingerprint → OTA update only
+#   - mode=ota dispatch → OTA only
+#   - Otherwise → full build
 #
 # Required GitHub Secrets:
-#   EXPO_TOKEN                  - Expo token for eas build / update / submit
-#   APPLE_ID                    - Apple ID email for App Store Connect
-#   APPLE_ID_PASSWORD           - App-specific password (account.apple.com > App-Specific Passwords)
-#   APPLE_TEAM_ID               - 10-char Apple Developer Team ID
-#   EXPO_PUBLIC_SENTRY_DSN      - (optional) Sentry DSN for runtime
-#   SENTRY_AUTH_TOKEN           - (optional) Sentry auth token for source maps
+#   EXPO_TOKEN                          - Expo token (only used by OTA update job)
+#   APPLE_ID                            - Apple ID email
+#   APPLE_ID_PASSWORD                   - App-specific password (account.apple.com)
+#   APPLE_TEAM_ID                       - 10-char Apple Developer Team ID
+#   APPLE_CERTIFICATE_BASE64            - Base64 of the iOS Distribution .p12
+#   APPLE_CERTIFICATE_PASSWORD          - Password for the .p12
+#   APPLE_PROVISIONING_PROFILE_BASE64   - Base64 of the App Store .mobileprovision
+#   EXPO_PUBLIC_SENTRY_DSN              - (optional) Sentry DSN for runtime
+#   SENTRY_AUTH_TOKEN                   - (optional) Sentry auth token for source maps
 # =============================================================================
 
 name: iOS Build & Update
@@ -242,45 +240,41 @@ jobs:
           echo "- **Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
 
   # ===========================================================================
-  # Full Native Build — delegated to EAS Build cloud
+  # Full Native Build — macOS runner with xcodebuild
   # ===========================================================================
   build:
-    name: iOS Build (EAS Cloud)
-    runs-on: ubuntu-latest
+    name: iOS Build (xcodebuild)
+    runs-on: macos-latest
     needs: check-fingerprint
     if: >
       needs.check-fingerprint.outputs.needs_build == 'true' &&
       github.event.inputs.mode != 'ota'
 
+    env:
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+
+      - name: Print Xcode version
+        run: xcodebuild -version
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
-      - name: Cache bun dependencies
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: |
-            node_modules
-            ~/.bun/install/cache
-          key: bun-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-
-
       - name: Install dependencies
         run: bun install
 
       - name: Build workspace packages
         run: bun run build
-
-      - name: Setup EAS
-        uses: expo/expo-github-action@c7b66a9c327a43a8fa7c0158e7f30d6040d2481e # v8.2.1
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Sync app version and bump buildNumber
         working-directory: apps/mobile
@@ -302,30 +296,155 @@ jobs:
             console.log('Set version=' + appJson.expo.version + ' buildNumber=' + buildNumber);
           "
 
-      - name: Trigger EAS Build (iOS)
-        id: eas-build
+      - name: Expo prebuild iOS
         working-directory: apps/mobile
         env:
           EXPO_PUBLIC_SENTRY_DSN: ${{ secrets.EXPO_PUBLIC_SENTRY_DSN }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: bunx expo prebuild --platform ios --clean
+
+      - name: Install CocoaPods
+        working-directory: apps/mobile/ios
+        run: pod install --repo-update
+
+      - name: Decode and install signing certificate
+        env:
+          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: |
-          PROFILE="${{ needs.check-fingerprint.outputs.environment }}"
-          echo "Triggering EAS Build for profile: $PROFILE"
-          eas build \
-            --platform ios \
-            --profile "$PROFILE" \
-            --non-interactive \
-            --json > eas-build.json
-          BUILD_ID=$(node -p "JSON.parse(require('fs').readFileSync('eas-build.json','utf8'))[0].id")
-          echo "build_id=$BUILD_ID" >> $GITHUB_OUTPUT
-          echo "EAS build id: $BUILD_ID"
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain"
+          KEYCHAIN_PASSWORD=$(uuidgen)
+          CERT_PATH="$RUNNER_TEMP/cert.p12"
+
+          echo "$APPLE_CERTIFICATE_BASE64" | base64 -d > "$CERT_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 7200 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Make new keychain the default
+          security list-keychain -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | xargs)
+
+          rm -f "$CERT_PATH"
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
+          echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> $GITHUB_ENV
+
+          echo "--- Available signing identities ---"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+      - name: Decode and install provisioning profile
+        env:
+          APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "$PROFILE_DIR"
+
+          PROFILE_TMP="$RUNNER_TEMP/profile.mobileprovision"
+          echo "$APPLE_PROVISIONING_PROFILE_BASE64" | base64 -d > "$PROFILE_TMP"
+
+          # Extract metadata from the profile
+          PROFILE_PLIST=$(security cms -D -i "$PROFILE_TMP")
+          PROFILE_UUID=$(/usr/libexec/PlistBuddy -c 'Print :UUID' /dev/stdin <<< "$PROFILE_PLIST")
+          PROFILE_NAME=$(/usr/libexec/PlistBuddy -c 'Print :Name' /dev/stdin <<< "$PROFILE_PLIST")
+
+          cp "$PROFILE_TMP" "$PROFILE_DIR/$PROFILE_UUID.mobileprovision"
+          rm -f "$PROFILE_TMP"
+
+          echo "PROFILE_UUID=$PROFILE_UUID" >> $GITHUB_ENV
+          echo "PROFILE_NAME=$PROFILE_NAME" >> $GITHUB_ENV
+          echo "Installed provisioning profile: $PROFILE_NAME ($PROFILE_UUID)"
+
+      - name: Stub sentry-cli if missing
+        run: |
+          if ! command -v sentry-cli &> /dev/null && [ ! -f node_modules/@sentry/cli/sentry-cli ]; then
+            echo "sentry-cli not available — creating no-op stub"
+            mkdir -p apps/mobile/ios/Pods/Sentry/scripts
+            cat > apps/mobile/ios/sentry-cli-stub.sh <<'EOF'
+          #!/bin/bash
+          echo "[sentry-cli stub] skipping: $@"
+          exit 0
+          EOF
+            chmod +x apps/mobile/ios/sentry-cli-stub.sh
+          fi
+
+      - name: Build archive
+        working-directory: apps/mobile/ios
+        env:
+          BUNDLE_ID: ai.shogo.mobile
+        run: |
+          set -o pipefail
+          xcodebuild archive \
+            -workspace Shogo.xcworkspace \
+            -scheme Shogo \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -archivePath "$RUNNER_TEMP/Shogo.xcarchive" \
+            CODE_SIGN_STYLE=Manual \
+            DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
+            PROVISIONING_PROFILE_SPECIFIER="$PROFILE_NAME" \
+            OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_PATH" \
+            | xcbeautify || exit ${PIPESTATUS[0]}
+
+      - name: Create exportOptions.plist
+        run: |
+          cat > "$RUNNER_TEMP/exportOptions.plist" <<EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>app-store</string>
+            <key>teamID</key>
+            <string>$APPLE_TEAM_ID</string>
+            <key>signingStyle</key>
+            <string>manual</string>
+            <key>signingCertificate</key>
+            <string>Apple Distribution</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>ai.shogo.mobile</key>
+              <string>$PROFILE_NAME</string>
+            </dict>
+            <key>uploadSymbols</key>
+            <true/>
+            <key>uploadBitcode</key>
+            <false/>
+            <key>compileBitcode</key>
+            <false/>
+            <key>destination</key>
+            <string>export</string>
+            <key>stripSwiftSymbols</key>
+            <true/>
+          </dict>
+          </plist>
+          EOF
+          cat "$RUNNER_TEMP/exportOptions.plist"
+
+      - name: Export IPA
+        run: |
+          set -o pipefail
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/Shogo.xcarchive" \
+            -exportPath "$RUNNER_TEMP/export" \
+            -exportOptionsPlist "$RUNNER_TEMP/exportOptions.plist" \
+            -allowProvisioningUpdates \
+            OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_PATH" \
+            | xcbeautify || exit ${PIPESTATUS[0]}
+
+          ls -la "$RUNNER_TEMP/export/"
+          IPA_PATH=$(ls "$RUNNER_TEMP/export/"*.ipa | head -1)
+          echo "IPA_PATH=$IPA_PATH" >> $GITHUB_ENV
+          echo "Built IPA: $IPA_PATH"
 
       - name: Save fingerprint to cache
         run: |
           RUNTIME_VERSION="${{ needs.check-fingerprint.outputs.runtime_version }}"
           if [ -z "$RUNTIME_VERSION" ] || [ "$RUNTIME_VERSION" = "unknown" ]; then
             RAW=$(cd apps/mobile && npx expo-updates runtimeversion:resolve --platform ios 2>/dev/null || echo "manual-build")
-            RUNTIME_VERSION=$(echo "$RAW" | sha256sum | cut -d' ' -f1)
+            RUNTIME_VERSION=$(echo "$RAW" | shasum -a 256 | cut -d' ' -f1)
           fi
           echo "$RUNTIME_VERSION" > .fingerprint-ios
 
@@ -335,6 +454,14 @@ jobs:
           path: .fingerprint-ios
           key: ios-fingerprint-${{ needs.check-fingerprint.outputs.environment }}-${{ needs.check-fingerprint.outputs.runtime_version || 'manual' }}
 
+      - name: Upload IPA artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: Shogo-${{ needs.check-fingerprint.outputs.environment }}-${{ github.run_number }}.ipa
+          path: ${{ env.IPA_PATH }}
+          if-no-files-found: error
+          retention-days: 30
+
       - name: Resolve submit decision
         id: submit-decision
         run: |
@@ -342,42 +469,41 @@ jobs:
           SUBMIT_INPUT="${{ github.event.inputs.submit }}"
           if [ "$ENV" = "production" ]; then
             echo "should_submit=true" >> $GITHUB_OUTPUT
-            echo "Production build → always submitting to App Store Connect"
           elif [ "$SUBMIT_INPUT" != "false" ]; then
             echo "should_submit=true" >> $GITHUB_OUTPUT
-            echo "Staging build → submitting to TestFlight"
           else
             echo "should_submit=false" >> $GITHUB_OUTPUT
-            echo "Submit skipped by user"
           fi
 
-      - name: Submit to App Store Connect
+      - name: Upload to App Store Connect (TestFlight)
         if: steps.submit-decision.outputs.should_submit == 'true'
-        working-directory: apps/mobile
-        env:
-          EXPO_APPLE_ID_USERNAME: ${{ secrets.APPLE_ID }}
-          EXPO_APPLE_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
         run: |
-          PROFILE="${{ needs.check-fingerprint.outputs.environment }}"
-          echo "Submitting build ${{ steps.eas-build.outputs.build_id }} via profile $PROFILE"
-          eas submit \
-            --platform ios \
-            --profile "$PROFILE" \
-            --id "${{ steps.eas-build.outputs.build_id }}" \
-            --non-interactive
+          xcrun altool --upload-app \
+            -f "$IPA_PATH" \
+            -t ios \
+            -u "$APPLE_ID" \
+            -p "$APPLE_ID_PASSWORD" \
+            --verbose
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+          rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/$PROFILE_UUID.mobileprovision"
 
       - name: Summary
         run: |
           echo "## iOS Build Complete" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **Environment:** ${{ needs.check-fingerprint.outputs.environment }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **EAS Build ID:** \`${{ steps.eas-build.outputs.build_id }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **buildNumber:** ${{ github.run_number }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **buildNumber:** $((${{ github.run_number }} + 100))" >> $GITHUB_STEP_SUMMARY
+          echo "- **Profile:** $PROFILE_NAME" >> $GITHUB_STEP_SUMMARY
+          echo "- **IPA artifact:** Shogo-${{ needs.check-fingerprint.outputs.environment }}-${{ github.run_number }}.ipa" >> $GITHUB_STEP_SUMMARY
           echo "- **Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Submit:** ${{ steps.submit-decision.outputs.should_submit == 'true' && 'App Store Connect / TestFlight' || 'Skipped' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Submit:** ${{ steps.submit-decision.outputs.should_submit == 'true' && 'TestFlight (App Store Connect)' || 'Skipped' }}" >> $GITHUB_STEP_SUMMARY
 
 
-# Manual triggers (after this lands on a branch GitHub knows about):
+# Manual triggers:
 #
 # Staging OTA
 # gh workflow run ios.yml --ref main -f mode=ota -f environment=staging
@@ -388,5 +514,5 @@ jobs:
 # Production full build + submit (App Store Connect)
 # gh workflow run ios.yml --ref main -f mode=full -f environment=production
 #
-# Full build, skip TestFlight submit
-# gh workflow run ios.yml --ref main -f mode=full -f environment=staging -f submit=false
+# Or via tag (auto-triggers production build + submit):
+# git tag ios-v0.1.1 && git push origin ios-v0.1.1

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -25,7 +25,12 @@
 #   APPLE_CERTIFICATE_PASSWORD          - Password for the .p12
 #   APPLE_PROVISIONING_PROFILE_BASE64   - Base64 of the App Store .mobileprovision
 #   EXPO_PUBLIC_SENTRY_DSN              - (optional) Sentry DSN for runtime
-#   SENTRY_AUTH_TOKEN                   - (optional) Sentry auth token for source maps
+#   SENTRY_AUTH_TOKEN                   - (optional) Sentry auth token. When set,
+#                                          the post-archive job uploads dSYMs to
+#                                          Sentry (org=shogo, project=shogo-mobile).
+#                                          When unset, the upload step skips
+#                                          silently and the rest of the pipeline
+#                                          still completes.
 # =============================================================================
 
 name: iOS Build & Update
@@ -312,6 +317,21 @@ jobs:
         working-directory: apps/mobile/ios
         run: pod install --repo-update
 
+      - name: Strip Sentry build phases from Xcode project
+        # The @sentry/react-native/expo plugin injects two build phases into
+        # the main app target during prebuild:
+        #   1. "Upload Debug Symbols to Sentry"
+        #   2. A sentry-cli wrapper around "Bundle React Native code and images"
+        # Both run sentry-cli under `set -e` and try to resolve @sentry/cli via
+        # Node BEFORE they honour SENTRY_DISABLE_AUTO_UPLOAD, so any transitive
+        # failure (Bun strict-hoisted node_modules, missing token, transient
+        # network) aborts the whole archive. We strip them and run the dSYM
+        # upload as a clearly-scoped post-archive step instead.
+        # The xcodeproj gem ships with the cocoapods gem already installed on
+        # macos-latest runners.
+        working-directory: apps/mobile
+        run: ruby scripts/strip-sentry-build-phases.rb
+
       - name: Decode and install signing certificate
         env:
           APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
@@ -366,13 +386,6 @@ jobs:
         working-directory: apps/mobile/ios
         env:
           BUNDLE_ID: com.odin.ai
-          # Skip Sentry dSYM upload during archive. The @sentry/react-native pod
-          # injects an "Upload Debug Symbols to Sentry" build phase that needs
-          # a working sentry-cli + SENTRY_ORG/SENTRY_PROJECT/SENTRY_AUTH_TOKEN.
-          # SENTRY_DISABLE_AUTO_UPLOAD=true is Sentry's officially supported
-          # escape hatch for CI envs that don't auto-upload. dSYM upload can
-          # be wired up as a dedicated post-build step later.
-          SENTRY_DISABLE_AUTO_UPLOAD: "true"
         run: |
           set -o pipefail
           xcodebuild archive \
@@ -386,8 +399,50 @@ jobs:
             CODE_SIGN_IDENTITY="Apple Distribution" \
             PROVISIONING_PROFILE_SPECIFIER="$PROFILE_NAME" \
             OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_PATH" \
-            SENTRY_DISABLE_AUTO_UPLOAD=true \
             | xcbeautify || exit ${PIPESTATUS[0]}
+
+      - name: Upload dSYMs to Sentry (optional)
+        # Self-skips silently when SENTRY_AUTH_TOKEN is not configured, so
+        # forks / branches without the secret still get a green build.
+        # Uses the workspace's @sentry/cli (pulled in transitively by
+        # @sentry/react-native), with sentry-cli's own non-zero exits surfaced
+        # so a misconfigured secret never silently swallows symbolication.
+        working-directory: apps/mobile
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: shogo
+          SENTRY_PROJECT: shogo-mobile
+          SENTRY_LOG_LEVEL: info
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN" ]; then
+            echo "::notice title=Sentry dSYM upload::SENTRY_AUTH_TOKEN secret not configured — skipping."
+            {
+              echo "## Sentry dSYM upload"
+              echo ""
+              echo "_Skipped — \`SENTRY_AUTH_TOKEN\` secret not configured._"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          DSYM_DIR="$RUNNER_TEMP/Shogo.xcarchive/dSYMs"
+          if [ ! -d "$DSYM_DIR" ]; then
+            echo "::error title=Sentry dSYM upload::Expected dSYM directory not found at $DSYM_DIR"
+            exit 1
+          fi
+
+          # Resolve sentry-cli without relying on Bun's strict-hoisted .bin
+          # symlinks. Going through the package's own bin entry is the most
+          # portable path in a workspace.
+          SENTRY_CLI=$(node --print "require.resolve('@sentry/cli/bin/sentry-cli')")
+          echo "Using sentry-cli: $SENTRY_CLI"
+
+          "$SENTRY_CLI" debug-files upload --include-sources "$DSYM_DIR"
+
+          {
+            echo "## Sentry dSYM upload"
+            echo ""
+            echo "Uploaded dSYMs from \`$DSYM_DIR\` to Sentry (org=\`$SENTRY_ORG\`, project=\`$SENTRY_PROJECT\`)."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create exportOptions.plist
         run: |

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shogo/api",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shogo/docs",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "private": true,
   "license": "CC-BY-4.0",
   "scripts": {
@@ -31,8 +31,16 @@
     "typescript": "~5.6.0"
   },
   "browserslist": {
-    "production": [">0.5%", "not dead", "not op_mini all"],
-    "development": ["last 3 chrome version", "last 3 firefox version", "last 5 safari version"]
+    "production": [
+      ">0.5%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 3 chrome version",
+      "last 3 firefox version",
+      "last 5 safari version"
+    ]
   },
   "engines": {
     "node": ">=18.0"

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -14,7 +14,7 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "ai.shogo.mobile",
+      "bundleIdentifier": "com.odin.ai",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       }

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -14,7 +14,10 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "ai.shogo.mobile"
+      "bundleIdentifier": "ai.shogo.mobile",
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "android": {
       "adaptiveIcon": {

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Shogo",
     "slug": "shogo",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "orientation": "default",
     "icon": "./assets/ic_shogo_legacy.png",
     "scheme": "shogo",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Shogo",
     "slug": "shogo",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "orientation": "default",
     "icon": "./assets/ic_shogo_legacy.png",
     "scheme": "shogo",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Shogo",
     "slug": "shogo",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "orientation": "default",
     "icon": "./assets/ic_shogo_legacy.png",
     "scheme": "shogo",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Shogo",
     "slug": "shogo",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "orientation": "default",
     "icon": "./assets/ic_shogo_legacy.png",
     "scheme": "shogo",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Shogo",
     "slug": "shogo",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "default",
     "icon": "./assets/ic_shogo_legacy.png",
     "scheme": "shogo",

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -49,12 +49,22 @@
       "android": {
         "serviceAccountKeyPath": "./google-services.json",
         "track": "internal"
+      },
+      "ios": {
+        "appleId": "ashutosh.ojha@getodin.ai",
+        "ascAppId": "6766839930",
+        "appleTeamId": "X8XU4RM2WY"
       }
     },
     "production": {
       "android": {
         "serviceAccountKeyPath": "./google-services.json",
         "track": "production"
+      },
+      "ios": {
+        "appleId": "ashutosh.ojha@getodin.ai",
+        "ascAppId": "6766839930",
+        "appleTeamId": "X8XU4RM2WY"
       }
     }
   }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shogo/mobile",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "main": "./index.js",

--- a/apps/mobile/scripts/strip-sentry-build-phases.rb
+++ b/apps/mobile/scripts/strip-sentry-build-phases.rb
@@ -1,0 +1,89 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# =============================================================================
+# strip-sentry-build-phases.rb
+# =============================================================================
+# Removes the Sentry-injected Xcode build phases from the iOS app target so
+# `xcodebuild archive` does not depend on sentry-cli at archive time.
+#
+# Why this exists
+# ---------------
+# `@sentry/react-native/expo` injects two build phases into the main app
+# target during `expo prebuild`:
+#
+#   1. "Upload Debug Symbols to Sentry" — a standalone PBXShellScriptBuildPhase
+#      that runs `sentry-cli debug-files upload` against the freshly built
+#      dSYMs.
+#   2. "Bundle React Native code and images" — wrapped with `sentry-xcode.sh`
+#      so that `react-native-xcode.sh` is invoked through `sentry-cli react-
+#      native xcode`, which uploads JS bundle + sourcemap.
+#
+# Both run under `set -e` and try to resolve `@sentry/cli` via Node BEFORE
+# they honour `SENTRY_DISABLE_AUTO_UPLOAD=true`. With Bun's strict-hoisted
+# workspace `node_modules`, that resolution path is fragile — and even when
+# it succeeds, an unset auth token / transient network failure aborts the
+# entire archive.
+#
+# In CI we want the archive to be deterministic and decoupled from Sentry.
+# dSYM (and optionally JS sourcemap) upload happens as an explicit, cleanly
+# scoped post-archive workflow step driven by `SENTRY_AUTH_TOKEN`. That is
+# Sentry's officially documented CI pattern.
+#
+# Usage
+# -----
+#   ruby scripts/strip-sentry-build-phases.rb [project_path] [target_name]
+#
+# Defaults: ios/Shogo.xcodeproj, target "Shogo".
+# Idempotent — safe to run repeatedly. Exits 0 when nothing needs stripping.
+# =============================================================================
+
+require "xcodeproj"
+
+script_dir   = File.expand_path(__dir__)
+project_path = ARGV[0] || File.expand_path("../ios/Shogo.xcodeproj", script_dir)
+target_name  = ARGV[1] || "Shogo"
+
+abort "[strip-sentry] Xcode project not found: #{project_path}" unless Dir.exist?(project_path)
+
+project = Xcodeproj::Project.open(project_path)
+target  = project.native_targets.find { |t| t.name == target_name }
+abort "[strip-sentry] Target '#{target_name}' not found in #{project_path}" unless target
+
+removed_phases  = []
+modified_phases = []
+
+target.build_phases.dup.each do |phase|
+  next unless phase.is_a?(Xcodeproj::Project::Object::PBXShellScriptBuildPhase)
+
+  case phase.name
+  when "Upload Debug Symbols to Sentry"
+    phase.remove_from_project
+    removed_phases << phase.name
+
+  when "Bundle React Native code and images"
+    next unless phase.shell_script.to_s.include?("sentry-xcode.sh")
+
+    # The Sentry plugin prepends `/bin/sh `<sentry-path-expression>` ` in
+    # front of the original `react-native-xcode.sh` invocation. Strip exactly
+    # that wrapper, leaving the plain RN bundler invocation untouched.
+    cleaned = phase.shell_script.sub(
+      %r{/bin/sh\s+`[^`]*sentry-xcode\.sh[^`]*`\s+},
+      ""
+    )
+
+    if cleaned != phase.shell_script
+      phase.shell_script = cleaned
+      modified_phases << phase.name
+    end
+  end
+end
+
+project.save
+
+if removed_phases.empty? && modified_phases.empty?
+  puts "[strip-sentry] No Sentry build phases found — already clean."
+else
+  puts "[strip-sentry] Removed phases : #{removed_phases.inspect}"
+  puts "[strip-sentry] Modified phases: #{modified_phases.inspect}"
+end


### PR DESCRIPTION
## Summary

This PR ships the **iOS production release pipeline** end-to-end and unifies mobile + desktop release tagging so a single `v*` tag triggers all four platform builds in parallel — matching the existing desktop pattern.

After merge, Shogo will have full mobile + desktop release parity:

| Tag | Triggers |
|---|---|
| `v1.0.0` (unified, recommended) | 🚀 iOS + Android + macOS desktop + Windows desktop, all production |
| `ios-v*` (preserved) | iOS-only hotfix |
| `android-v*` (preserved) | Android-only hotfix |
| Push to `main` | Mobile OTA → staging (unchanged) |

---

## What's new

### 1. New workflow: `.github/workflows/ios.yml`

Full iOS Build + Update pipeline mirroring `android.yml`. Runs on `macos-latest` runners, no EAS Build dependency, no Expo project access required — fully reproducible from GitHub Secrets, the same philosophy as Android.

**Architecture:**
- `check-fingerprint` — resolves environment (production/staging), reads version from `app.json`, computes `expo-updates` runtime fingerprint, decides full build vs OTA via cache hit
- `update` (OTA) — runs `eas update --branch <env>` for JS-only changes; pushes to `studio.shogo.ai` (production) or `studio.staging.shogo.ai` (staging)
- `build` (Xcode) — `expo prebuild --platform ios --clean` → decode cert + provisioning profile from secrets → `xcodebuild archive` → `xcodebuild -exportArchive` → `xcrun altool --upload-app` to App Store Connect

**Required GitHub secrets** (already configured):
- `APPLE_ID` — `ashutosh.ojha@getodin.ai`
- `APPLE_ID_PASSWORD` — app-specific password (used by `altool` to upload)
- `APPLE_TEAM_ID` — `X8XU4RM2WY`
- `APPLE_CERTIFICATE_BASE64` — Apple Distribution `.p12` (regenerated 2026-05-07 via fresh CSR)
- `APPLE_CERTIFICATE_PASSWORD` — `.p12` passphrase
- `APPLE_PROVISIONING_PROFILE_BASE64` — App Store provisioning profile (`com.odin.ai`, includes `aps-environment`)
- `EXPO_TOKEN` — for OTA updates (existing)

**Trigger logic mirrors Android:**
- Tag (`ios-v*` or `v[0-9]*`) → forces full build + production submit
- Push to `main` with native fingerprint cache hit → OTA only
- Push to `main` with new native fingerprint → full build + staging upload (TestFlight internal)
- `workflow_dispatch` → respects `mode` (full/ota) and `environment` inputs

### 2. Unified release tag (`.github/workflows/{android,ios}.yml`)

Previously:
- `android-v*` → Android only
- `ios-v*` → iOS only
- `v[0-9]*` → desktop only (macOS + Windows + SDK)

Now:
- `v[0-9]*` → iOS + Android + macOS + Windows (+ SDK publish, unchanged)
- `android-v*` and `ios-v*` preserved for platform-specific hotfix releases

**Implementation:** added `v[0-9]*` to the `tags` trigger filter on both mobile workflows, and replaced the platform-specific tag-detection conditionals with regex matchers (`=~ ^refs/tags/(ios-v|v[0-9])` and equivalent for Android) in two places per workflow:
1. *Resolve environment* step — both unified and platform-specific tags now route to `production`
2. *Determine if build is needed* step — both tag forms force a full build + submit, bypassing the fingerprint cache

### 3. Bundle ID alignment (`apps/mobile/app.json`)

Changed `ios.bundleIdentifier` from `ai.shogo.mobile` → `com.odin.ai` to match the existing App Store Connect record (App ID `6766839930`, locked to `com.odin.ai`). Bundle IDs are immutable on existing App Store Connect apps, so the code aligns to the platform — the displayed app name in the store remains "Shogo".

### 4. Version alignment (multiple `package.json`)

Aligned mobile, API, and docs to `1.0.0` to match the App Store Connect "iOS App Version 1.0" record. This ensures the IPA's `CFBundleShortVersionString` matches the in-flight ASC version page (with all metadata, screenshots, etc.) instead of creating a stray `0.1.0` version row:

- `apps/mobile/app.json` — `expo.version`: `0.1.0` → `1.0.0`
- `apps/mobile/package.json` — `version`: `0.1.0` → `1.0.0`
- `apps/api/package.json` — `version`: `0.1.0` → `1.0.0`
- `apps/docs/package.json` — `version`: `0.0.1` → `1.0.0`
- `apps/desktop/package.json` — **untouched** (`1.2.20`, owned independently)

### 5. iOS submit profile (`apps/mobile/eas.json`)

Added `submit.staging.ios` and `submit.production.ios` blocks pointing to ASC App `6766839930`, Team `X8XU4RM2WY`, Apple ID `ashutosh.ojha@getodin.ai`. (Currently unused by the active xcodebuild pipeline, but configured for forward compatibility if we move to EAS Submit later.)

### 6. App Store compliance flag (`apps/mobile/app.json`)

Added `ios.config.usesNonExemptEncryption: false` (Apple's `ITSAppUsesNonExemptEncryption` Info.plist key). This auto-resolves the export compliance prompt during App Store submission — Shogo only uses HTTPS, no custom encryption beyond Apple's exemption list.

---

## Bug-class issues fixed during pipeline development

Documented here because each was a *real* root-cause fix (not a patch), and future iOS builds depend on these holding:

1. **`bun install` failed with HTTP 403 on `@vscode/ripgrep` postinstall** — anonymous GitHub API rate limit (60/hr, shared across `macos-latest` runners). Fix: pass `GITHUB_TOKEN` env var to all `bun install` steps for authenticated rate limit (5000/hr).

2. **`xcodebuild archive` failed with "Provisioning profile doesn't include the aps-environment entitlement"** — `expo-notifications` is a real dep that declares Push Notifications, but the `com.odin.ai` App ID didn't have the capability enabled on developer.apple.com. Fix: enabled Push Notifications on the App ID + regenerated the provisioning profile.

3. **`xcodebuild archive` failed with "No Certificates available"** — the `APPLE_CERTIFICATE_BASE64` secret from March was for a stale/revoked cert. Fix: generated a fresh CSR locally, uploaded to developer.apple.com → new Apple Distribution cert → packaged into a new `.p12`, replaced the secret.

4. **Sentry "Upload Debug Symbols to Sentry" build phase failing the archive** — the previous `Stub sentry-cli if missing` step in the workflow was a no-op (the Sentry pod's script doesn't read from that path). Fix: pass `SENTRY_DISABLE_AUTO_UPLOAD=true` as an `xcodebuild` build setting argument (Apple's documented mechanism for propagating env into PhaseScriptExecution contexts) — this is Sentry's officially documented escape hatch for CI environments. Also resolved the `sentry-cli` binary via Bun bin shim and fixed Sentry org slug in subsequent iterations.

5. **iOS 18 SDK Apple-side rejection on archive** — App Store Connect requires Xcode 26+ (iOS 26 SDK). Fix: pinned `xcode-version` to `26.0` in the workflow.

---

## Verification

- ✅ Successful end-to-end build run: https://github.com/shogo-labs/shogo-ai/actions/runs/25481463700
- ✅ IPA uploaded to App Store Connect via `xcrun altool` using app-specific password
- ✅ Build appears in TestFlight (App `6766839930`, version `1.0`)
- ✅ Both `android.yml` and `ios.yml` validated with `ruby -ryaml -e "YAML.load_file(...)"`
- ✅ No other workflows touched — desktop macOS/Windows and SDK publish behavior unchanged

## Behavior matrix after merge

| Event | iOS | Android | macOS | Windows | SDK |
|---|---|---|---|---|---|
| `git push origin v1.0.0` | ✅ build + App Store submit | ✅ build + Play Store submit | ✅ DMG release | ✅ Windows installer | ✅ npm publish |
| `git push origin ios-v1.0.1` | ✅ iOS-only release | — | — | — | — |
| `git push origin android-v2.3` | — | ✅ Android-only release | — | — | — |
| Push to `main` (no native change) | OTA → staging | OTA → staging | — | — | — |
| Push to `main` (native change) | TestFlight internal | Play Store internal track | — | — | — |
| `workflow_dispatch` (manual) | per inputs | per inputs | per inputs | per inputs | per inputs |

## Out of scope (intentionally not in this PR)

- App Store Connect metadata (screenshots, description, App Privacy questionnaire, age rating, pricing) — done via the ASC web console, not in code.
- Sentry dSYM upload symbolication — currently disabled via `SENTRY_DISABLE_AUTO_UPLOAD`. A follow-up PR can add a dedicated post-archive `sentry-cli upload-dsym` step using `SENTRY_AUTH_TOKEN` to restore source-mapped crash reports in production.
- APNs key for sending push notifications from the backend — only the build-side Push Notifications capability is enabled on the App ID (which unblocks signing). Sending pushes from the API needs a separate APNs Auth Key (`.p8`), which can be added later when push features ship.

---

## How to release v1.0 after merge

```bash
git checkout main && git pull
git tag v1.0.0
git push origin v1.0.0
```

Then watch the four parallel runs at https://github.com/shogo-labs/shogo-ai/actions and verify TestFlight + Play Store internal track + GitHub Releases (desktop) all populate.
