### PR TITLE
Remove hardcoded EAS iOS submit credentials

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -51,9 +51,9 @@
         "track": "internal"
       },
       "ios": {
-        "appleId": "ashutosh.ojha@getodin.ai",
-        "ascAppId": "6766839930",
-        "appleTeamId": "X8XU4RM2WY"
+        "appleId": "$APPLE_ID",
+        "ascAppId": "$ASC_APP_ID",
+        "appleTeamId": "$APPLE_TEAM_ID"
       }
     },
     "production": {
@@ -62,9 +62,9 @@
         "track": "production"
       },
       "ios": {
-        "appleId": "ashutosh.ojha@getodin.ai",
-        "ascAppId": "6766839930",
-        "appleTeamId": "X8XU4RM2WY"
+        "appleId": "$APPLE_ID",
+        "ascAppId": "$ASC_APP_ID",
+        "appleTeamId": "$APPLE_TEAM_ID"
       }
     }
   }


### PR DESCRIPTION
## Summary

- Removes hardcoded Apple App Store Connect identifiers from `apps/mobile/eas.json`.
- Replaces them with runtime environment variable references: `$APPLE_ID`, `$ASC_APP_ID`, and `$APPLE_TEAM_ID`.
- Adds the missing `ASC_APP_ID` GitHub repository secret; `APPLE_ID` and `APPLE_TEAM_ID` already existed.

Closes #518

## Detailed Implementation

The EAS iOS submit profiles for both `staging` and `production` previously stored literal Apple values in source control. This PR keeps the existing EAS submit profile structure but changes the values to environment placeholders that EAS resolves at runtime.

This keeps manual `eas submit --platform ios` supported while moving the actual values out of git. Developers running submits locally need the same environment variables exported in their shell. CI continues to use GitHub Secrets for Apple credentials, matching the existing `ios.yml` workflow pattern.

Android submit config remains unchanged. The `serviceAccountKeyPath` value is only a local file path, and the actual Google service account JSON is still decoded from `GOOGLE_SERVICES_JSON_BASE64` during CI.

## Architecture Diagram

```mermaid
flowchart TD
  GH[GitHub Repository Secrets] --> Env[Runtime environment]
  Local[Developer shell env] --> Env
  EASConfig[apps/mobile/eas.json] --> Submit[eas submit]
  Env --> Submit
  Submit --> ASC[App Store Connect]

  EASConfig --> AppleId[$APPLE_ID]
  EASConfig --> AscAppId[$ASC_APP_ID]
  EASConfig --> TeamId[$APPLE_TEAM_ID]

  Old[Hardcoded identifiers in repo] -. removed .-> EASConfig
```

## RCA

The values were likely added when setting up EAS submit profiles because EAS examples often show literal `appleId`, `ascAppId`, and `appleTeamId` values inline. Later CI work moved real Apple credentials into GitHub Secrets, but the older inline submit config stayed in `eas.json`.

While these identifiers are not passwords or tokens, committing them is still the wrong pattern because it exposes PII/account metadata and normalizes putting credential-like values in source control.

## Test Plan

- Verified the branch diff against `origin/main` contains only `apps/mobile/eas.json`.
- Verified GitHub repository secret `ASC_APP_ID` exists after adding it.
- Verified existing repository secrets `APPLE_ID` and `APPLE_TEAM_ID` are present.
- No runtime test needed; this is a config-only change and CI submit paths already consume repo secrets.

Made with [Cursor](https://cursor.com)