### PR TITLE
fix(export-import): path corruption, credential leaks, volatile file bloat, and seamless import UX

### DIFF
--- a/apps/api/src/lib/bundle-crypto.ts
+++ b/apps/api/src/lib/bundle-crypto.ts
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * bundle-crypto
+ *
+ * Passphrase-based encryption for the optional `encryptedSecrets` blob in
+ * `.shogo-project` bundles. Goals:
+ *
+ *   - Zero new deps: uses Node/Bun's built-in `crypto.subtle` (Web Crypto).
+ *   - Strong-enough for offline file transfer: PBKDF2-SHA256 (600,000 iters)
+ *     stretches the user's passphrase into a 256-bit key, then AES-256-GCM
+ *     authenticates and encrypts the JSON payload.
+ *   - Per-export random salt + IV — no nonce reuse across bundles.
+ *
+ * NOT a replacement for proper key management. This is for trusted users
+ * moving an agent between their own workspaces who want to skip re-typing
+ * tokens. Public bundles should ship with `encryptedSecrets` omitted entirely.
+ */
+import { webcrypto } from 'node:crypto'
+
+// PBKDF2 parameters. 600k iterations is OWASP's 2023 recommendation for
+// PBKDF2-SHA256; tune up over time as compute gets cheaper.
+const PBKDF2_ITERS = 600_000
+const PBKDF2_HASH = 'SHA-256'
+const KEY_LEN_BITS = 256
+const SALT_LEN = 16 // bytes
+const IV_LEN = 12 // bytes (GCM standard)
+
+// `as any` cast: Bun/Node's `webcrypto.subtle` is structurally identical to
+// the DOM `SubtleCrypto` but uses different (incompatible-by-name)
+// `BufferSource` and `CryptoKey` types. Using `any` at this single boundary
+// keeps the rest of the module type-clean.
+const subtle = webcrypto.subtle as any
+
+function bytesToB64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64')
+}
+
+function b64ToBytes(b64: string): Uint8Array {
+  return new Uint8Array(Buffer.from(b64, 'base64'))
+}
+
+async function deriveKey(passphrase: string, salt: Uint8Array): Promise<any> {
+  const baseKey = await subtle.importKey(
+    'raw',
+    new TextEncoder().encode(passphrase),
+    'PBKDF2',
+    false,
+    ['deriveKey'],
+  )
+  return subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: PBKDF2_ITERS, hash: PBKDF2_HASH },
+    baseKey,
+    { name: 'AES-GCM', length: KEY_LEN_BITS },
+    false,
+    ['encrypt', 'decrypt'],
+  )
+}
+
+export interface EncryptedSecretsBlob {
+  alg: 'aes-256-gcm'
+  kdf: 'pbkdf2-sha256'
+  iters: number
+  salt: string // base64
+  iv: string // base64
+  ct: string // base64 (ciphertext + GCM auth tag)
+}
+
+/**
+ * Encrypt a JSON-serialisable payload with a passphrase.
+ * Returns the blob shape that lives at `project.json -> encryptedSecrets`.
+ */
+export async function encryptSecrets(
+  payload: unknown,
+  passphrase: string,
+): Promise<EncryptedSecretsBlob> {
+  if (!passphrase || passphrase.length < 8) {
+    throw new Error('Passphrase must be at least 8 characters.')
+  }
+  const salt = webcrypto.getRandomValues(new Uint8Array(SALT_LEN))
+  const iv = webcrypto.getRandomValues(new Uint8Array(IV_LEN))
+  const key = await deriveKey(passphrase, salt)
+  const plaintext = new TextEncoder().encode(JSON.stringify(payload))
+  const ctBuf = await subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext)
+  return {
+    alg: 'aes-256-gcm',
+    kdf: 'pbkdf2-sha256',
+    iters: PBKDF2_ITERS,
+    salt: bytesToB64(salt),
+    iv: bytesToB64(iv),
+    ct: bytesToB64(new Uint8Array(ctBuf)),
+  }
+}
+
+/**
+ * Decrypt a previously encrypted blob. Returns the parsed payload.
+ * Throws on wrong passphrase / tampered ciphertext (GCM auth fails).
+ */
+export async function decryptSecrets<T = unknown>(
+  blob: EncryptedSecretsBlob,
+  passphrase: string,
+): Promise<T> {
+  if (!blob || blob.alg !== 'aes-256-gcm' || blob.kdf !== 'pbkdf2-sha256') {
+    throw new Error('Unsupported encryptedSecrets format.')
+  }
+  const salt = b64ToBytes(blob.salt)
+  const iv = b64ToBytes(blob.iv)
+  const ct = b64ToBytes(blob.ct)
+  // Use the iters from the blob if present (forward-compat with future bumps).
+  // Currently we only know how to derive with the constant we shipped, but
+  // we honour blob.iters so future blobs encrypted with a higher count still
+  // work with no code change.
+  const iters = typeof blob.iters === 'number' && blob.iters > 0 ? blob.iters : PBKDF2_ITERS
+  const baseKey = await subtle.importKey(
+    'raw',
+    new TextEncoder().encode(passphrase),
+    'PBKDF2',
+    false,
+    ['deriveKey'],
+  )
+  const key = await subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: iters, hash: PBKDF2_HASH },
+    baseKey,
+    { name: 'AES-GCM', length: KEY_LEN_BITS },
+    false,
+    ['decrypt'],
+  )
+  let ptBuf: ArrayBuffer
+  try {
+    ptBuf = await subtle.decrypt({ name: 'AES-GCM', iv }, key, ct)
+  } catch {
+    // GCM tag mismatch — wrong passphrase or tampered blob. Don't leak which.
+    throw new Error('Could not decrypt — passphrase may be incorrect.')
+  }
+  const text = new TextDecoder().decode(ptBuf)
+  return JSON.parse(text) as T
+}
+
+// ─── .env helpers (used by the export route) ─────────────────────
+//
+// We parse `.env` at export time so we can split it into:
+//   - public values (kept in the bundle as a `.env.example` showing keys only)
+//   - secret values (stripped from the bundle, surfaced as requiredCredentials,
+//     and optionally moved into the encryptedSecrets blob).
+
+export interface ParsedEnvLine {
+  key: string
+  value: string
+  raw: string // original line (for re-emitting comments + whitespace)
+  isComment: boolean
+}
+
+export function parseEnvFile(text: string): ParsedEnvLine[] {
+  const out: ParsedEnvLine[] = []
+  for (const raw of text.split(/\r?\n/)) {
+    const trimmed = raw.trim()
+    if (!trimmed || trimmed.startsWith('#')) {
+      out.push({ key: '', value: '', raw, isComment: true })
+      continue
+    }
+    const eqIdx = trimmed.indexOf('=')
+    if (eqIdx <= 0) {
+      out.push({ key: '', value: '', raw, isComment: true })
+      continue
+    }
+    const key = trimmed.slice(0, eqIdx).trim()
+    let value = trimmed.slice(eqIdx + 1).trim()
+    // Strip surrounding quotes (common .env style).
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1)
+    }
+    out.push({ key, value, raw, isComment: false })
+  }
+  return out
+}

--- a/apps/api/src/routes/project-export-import.ts
+++ b/apps/api/src/routes/project-export-import.ts
@@ -12,9 +12,16 @@ import {
   statSync,
 } from 'node:fs'
 import { join, resolve, relative } from 'node:path'
+import { spawn } from 'node:child_process'
 import { zipSync, unzipSync, strToU8, strFromU8 } from 'fflate'
 import { prisma } from '../lib/prisma'
 import type { AuthContext } from '../middleware/auth'
+import {
+  encryptSecrets,
+  decryptSecrets,
+  parseEnvFile,
+  type EncryptedSecretsBlob,
+} from '../lib/bundle-crypto'
 
 const PROJECT_ROOT = resolve(import.meta.dir, '../../../..')
 const WORKSPACES_DIR = process.env.WORKSPACES_DIR || resolve(PROJECT_ROOT, 'workspaces')
@@ -58,10 +65,18 @@ const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10 MB per file
 const MAX_TOTAL_SIZE = 200 * 1024 * 1024 // 200 MB total bundle
 
 // Heuristic: any object key matching this pattern in `agentConfig.channels`
-// is treated as a secret — redacted from the export and surfaced through
-// `requiredCredentials` so the importer can fill it in post-import.
+// or any `.env*` file is treated as a secret — redacted from the export and
+// surfaced through `requiredCredentials` so the importer can fill it in
+// post-import. The pattern covers:
+//   - explicit secret words: token / secret / apikey / api_key / password / passwd
+//   - personal access tokens: PAT, GITHUB_PAT, ACCOUNT_PAT (anchored on word boundary)
+//   - OAuth flow tokens: bearer / client_secret / refresh_token / access_token
+//   - connection strings that typically embed credentials:
+//       DATABASE_URL, REDIS_URL, MONGO_URL, *_CONNECTION_STRING
+//   - private keys & SSH:  private_key / ssh_key / pem
+//   - signing & encryption: signing_secret / encryption_key
 const SECRET_KEY_PATTERN =
-  /token|secret|apikey|api_key|password|^pat$|webhook.*url|bearer|client[_-]?secret|refresh[_-]?token|access[_-]?token/i
+  /token|secret|apikey|api_key|password|passwd|(^|_)pat$|webhook.*url|bearer|client[_-]?secret|refresh[_-]?token|access[_-]?token|database[_-]?url|redis[_-]?url|mongo[_-]?url|connection[_-]?string|private[_-]?key|ssh[_-]?key|signing[_-]?secret|encryption[_-]?key|\.pem$/i
 
 const isSecretKey = (key: string): boolean => SECRET_KEY_PATTERN.test(key)
 
@@ -161,6 +176,15 @@ type ImportEvent =
   | { phase: 'createProject' }
   | { phase: 'writeFiles'; done: number; total: number }
   | { phase: 'importChats'; done: number; total: number }
+  // Auto-bootstrap phase: install deps / generate routes / health-check the
+  // imported workspace so the user lands on a project that *runs*. Each
+  // sub-step emits its own event with status: pending | running | ok | failed.
+  | {
+      phase: 'bootstrap'
+      step: 'install' | 'generate' | 'preview' | 'health'
+      status: 'pending' | 'running' | 'ok' | 'failed' | 'skipped'
+      message?: string
+    }
   | {
       phase: 'done'
       project: { id: string; name: string; description: string | null }
@@ -175,6 +199,10 @@ type ImportEvent =
       // a Setup Checklist instead of dumping the user into a broken agent.
       requiredCredentials?: RequiredCredential[]
       warnings?: string[]
+      // True when the bundle had `encryptedSecrets` AND we successfully
+      // decrypted with the supplied passphrase — the importer's UI uses this
+      // to skip the manual "fill in tokens" step.
+      secretsAutoFilled?: boolean
     }
   | { phase: 'error'; message: string; fatal: boolean }
 
@@ -203,6 +231,7 @@ interface ProjectBundle {
     quietHoursTimezone?: string | null
   } | null
   requiredCredentials?: RequiredCredential[]
+  encryptedSecrets?: EncryptedSecretsBlob
 }
 
 interface BundleManifest {
@@ -231,6 +260,7 @@ type ImportResult =
       }
       requiredCredentials: RequiredCredential[]
       warnings: string[]
+      secretsAutoFilled: boolean
     }
   | { ok: false; status: 400 | 401 | 403 | 413; error: string }
 
@@ -238,7 +268,7 @@ async function runImport(
   zipBuffer: Uint8Array,
   workspaceId: string,
   userId: string,
-  options: { includeChats: boolean },
+  options: { includeChats: boolean; passphrase?: string; runBootstrap?: boolean },
   emit: (ev: ImportEvent) => void | Promise<void>,
 ): Promise<ImportResult> {
   // Verify user has access to the target workspace
@@ -333,6 +363,40 @@ async function runImport(
     },
   })
 
+  // ─── Decrypt opt-in secrets ──────────────────────────────────────
+  // If the bundle ships an `encryptedSecrets` blob and the importer supplied
+  // a passphrase, unlock it and use it to: (a) re-merge channel tokens, and
+  // (b) restore secret values inside `.env*` files after they're written.
+  // Both are best-effort — wrong passphrase becomes a non-fatal warning, and
+  // the importer can still complete via the manual Setup Checklist.
+  let decryptedSecrets:
+    | {
+        version: number
+        channels: Array<{ channel: string; field: string; value: string }>
+        env: Record<string, Record<string, string>>
+      }
+    | null = null
+  let secretsAutoFilled = false
+  if (bundle.encryptedSecrets && options.passphrase) {
+    try {
+      decryptedSecrets = await decryptSecrets(bundle.encryptedSecrets, options.passphrase)
+      secretsAutoFilled = true
+    } catch (err: any) {
+      await emit({
+        phase: 'error',
+        message: err?.message || 'Could not decrypt encryptedSecrets — passphrase may be wrong.',
+        fatal: false,
+      })
+      importWarnings.push(
+        'encryptedSecrets present but passphrase did not unlock — you will need to fill in credentials manually.',
+      )
+    }
+  } else if (bundle.encryptedSecrets && !options.passphrase) {
+    importWarnings.push(
+      'Bundle ships encryptedSecrets but no passphrase was provided — credentials will need to be configured manually.',
+    )
+  }
+
   {
     const ac = bundle.agentConfig
     // v1.0 bundles double-encoded `channels` as a JSON string ("[]"); v1.1
@@ -347,6 +411,19 @@ async function runImport(
       }
     }
     if (!Array.isArray(channelsValue)) channelsValue = []
+
+    // Splice decrypted channel secrets back in by matching channel.type+field.
+    if (decryptedSecrets?.channels?.length) {
+      for (const secret of decryptedSecrets.channels) {
+        const target = channelsValue.find((ch: any) => {
+          const t = ch?.type || ch?.channel
+          return t === secret.channel
+        })
+        if (target && target[secret.field] === null) {
+          target[secret.field] = secret.value
+        }
+      }
+    }
 
     const agentData: Record<string, any> = {
       projectId: project.id,
@@ -427,6 +504,35 @@ async function runImport(
     // client gets a smooth progress bar without flooding the SSE stream.
     if ((i + 1) % 25 === 0 || i === workspaceEntries.length - 1) {
       await emit({ phase: 'writeFiles', done: i + 1, total: totalFiles })
+    }
+  }
+
+  // ─── Restore decrypted .env values ────────────────────────────────
+  // The bundle's `.env*` files were sanitised at export time (secret values
+  // blanked). When we successfully decrypted the secrets blob, splice the
+  // original values back into the on-disk `.env*` files now that they exist.
+  if (decryptedSecrets?.env) {
+    for (const [zipPath, kv] of Object.entries(decryptedSecrets.env)) {
+      // zipPath is like `workspace/.env` — convert to a real on-disk path.
+      const rel = zipPath.replace(/^workspace\//, '').replace(/\\/g, '/')
+      const fullPath = join(projectDir, rel)
+      if (!existsSync(fullPath)) continue
+      try {
+        const text = readFileSync(fullPath, 'utf8')
+        const lines = parseEnvFile(text)
+        const restored = lines.map((line) => {
+          if (line.isComment || !line.key) return line.raw
+          if (kv[line.key] !== undefined) return `${line.key}=${kv[line.key]}`
+          return line.raw
+        })
+        writeFileSync(fullPath, restored.join('\n'))
+      } catch (err: any) {
+        await emit({
+          phase: 'error',
+          message: `Could not restore secrets into ${rel}: ${err?.message || 'unknown'}`,
+          fatal: false,
+        })
+      }
     }
   }
 
@@ -532,27 +638,164 @@ async function runImport(
       'No MEMORY.md found in workspace — agent will start with empty memory.',
     )
   }
-  if (requiredCredentials.length > 0) {
+  // If we successfully auto-filled secrets, the items they covered no longer
+  // need to appear on the Setup Checklist.
+  let pendingCredentials = requiredCredentials
+  if (decryptedSecrets) {
+    const filled = new Set<string>()
+    for (const s of decryptedSecrets.channels || []) filled.add(`${s.channel}.${s.field}`)
+    for (const [zipPath, kv] of Object.entries(decryptedSecrets.env || {})) {
+      for (const k of Object.keys(kv)) filled.add(`${zipPath.replace(/^workspace\//, '')}.${k}`)
+    }
+    pendingCredentials = requiredCredentials.filter((c) => !filled.has(c.label))
+  }
+  if (pendingCredentials.length > 0) {
     importWarnings.push(
-      `${requiredCredentials.length} credential(s) need to be configured: ${requiredCredentials.map((c) => c.label).join(', ')}.`,
+      `${pendingCredentials.length} credential(s) need to be configured: ${pendingCredentials.map((c) => c.label).join(', ')}.`,
     )
+  }
+
+  // ─── Auto-bootstrap (local mode only for now) ─────────────────────
+  // Run the steps a freshly-cloned project needs before its preview can boot:
+  // dependency install, route generation, schema push, health probe. K8s mode
+  // defers to the agent pod, which has its own lifecycle — we skip there.
+  if (options.runBootstrap !== false && !isKubernetes()) {
+    await runImportBootstrap(projectDir, emit)
+  } else if (options.runBootstrap !== false) {
+    await emit({ phase: 'bootstrap', step: 'install', status: 'skipped', message: 'k8s mode — pod handles bootstrap' })
   }
 
   await emit({
     phase: 'done',
     project: projectSummary,
     stats,
-    requiredCredentials,
+    requiredCredentials: pendingCredentials,
     warnings: importWarnings,
+    secretsAutoFilled,
   })
 
   return {
     ok: true,
     project: projectSummary,
     stats,
-    requiredCredentials,
+    requiredCredentials: pendingCredentials,
     warnings: importWarnings,
+    secretsAutoFilled,
   }
+}
+
+// ─── runImportBootstrap ─────────────────────────────────────────────
+//
+// Spawns the post-import setup steps so the user lands on a project that
+// actually runs. Each step:
+//   - emits a `running` event
+//   - runs with a hard timeout
+//   - emits `ok` / `failed` (with stderr message)
+//   - failures are non-fatal — we keep going so the user at least gets a
+//     project they can fix manually
+//
+// When `package.json` doesn't exist in the bundle, install/generate are
+// skipped silently. Same for schema.prisma → prisma push.
+async function runImportBootstrap(
+  projectDir: string,
+  emit: (ev: ImportEvent) => void | Promise<void>,
+): Promise<void> {
+  const exec = (
+    cmd: string,
+    args: string[],
+    timeoutMs: number,
+  ): Promise<{ ok: boolean; message?: string }> =>
+    new Promise((resolveExec) => {
+      try {
+        const proc = spawn(cmd, args, { cwd: projectDir, stdio: ['ignore', 'pipe', 'pipe'] })
+        let stderr = ''
+        proc.stderr?.on('data', (chunk) => {
+          stderr += chunk.toString()
+          if (stderr.length > 4000) stderr = stderr.slice(-4000)
+        })
+        const t = setTimeout(() => {
+          proc.kill('SIGKILL')
+          resolveExec({ ok: false, message: `${cmd} timed out after ${timeoutMs / 1000}s` })
+        }, timeoutMs)
+        proc.on('close', (code) => {
+          clearTimeout(t)
+          if (code === 0) resolveExec({ ok: true })
+          else resolveExec({ ok: false, message: stderr.trim().split('\n').slice(-3).join(' | ') || `exit ${code}` })
+        })
+        proc.on('error', (err) => {
+          clearTimeout(t)
+          resolveExec({ ok: false, message: err.message })
+        })
+      } catch (err: any) {
+        resolveExec({ ok: false, message: err?.message || 'spawn failed' })
+      }
+    })
+
+  const hasPackageJson = existsSync(join(projectDir, 'package.json'))
+  const hasPrisma = existsSync(join(projectDir, 'prisma', 'schema.prisma'))
+
+  // Step: install
+  if (hasPackageJson) {
+    await emit({ phase: 'bootstrap', step: 'install', status: 'running' })
+    const r = await exec('bun', ['install', '--ignore-scripts'], 120_000)
+    await emit({
+      phase: 'bootstrap',
+      step: 'install',
+      status: r.ok ? 'ok' : 'failed',
+      message: r.message,
+    })
+  } else {
+    await emit({ phase: 'bootstrap', step: 'install', status: 'skipped', message: 'no package.json' })
+  }
+
+  // Step: generate (routes, prisma client, etc.)
+  if (hasPackageJson) {
+    await emit({ phase: 'bootstrap', step: 'generate', status: 'running' })
+    const r = await exec('bun', ['run', 'generate'], 60_000)
+    await emit({
+      phase: 'bootstrap',
+      step: 'generate',
+      status: r.ok ? 'ok' : 'failed',
+      message: r.ok ? undefined : r.message,
+    })
+  } else {
+    await emit({ phase: 'bootstrap', step: 'generate', status: 'skipped' })
+  }
+
+  // Step: preview (just touch the `.install-ok` marker so preview manager
+  // picks the project up immediately on next request — actual `bun run dev`
+  // is owned by the preview manager, not us).
+  await emit({ phase: 'bootstrap', step: 'preview', status: 'running' })
+  try {
+    writeFileSync(join(projectDir, '.install-ok'), new Date().toISOString())
+    await emit({ phase: 'bootstrap', step: 'preview', status: 'ok' })
+  } catch (err: any) {
+    await emit({ phase: 'bootstrap', step: 'preview', status: 'failed', message: err?.message })
+  }
+
+  // Step: health (cheap structural sanity check — does package.json parse,
+  // does schema.prisma parse, does memory/ exist?). No HTTP calls; just disk.
+  await emit({ phase: 'bootstrap', step: 'health', status: 'running' })
+  const issues: string[] = []
+  if (hasPackageJson) {
+    try {
+      JSON.parse(readFileSync(join(projectDir, 'package.json'), 'utf8'))
+    } catch {
+      issues.push('package.json failed to parse')
+    }
+  }
+  if (hasPrisma) {
+    const schemaText = readFileSync(join(projectDir, 'prisma', 'schema.prisma'), 'utf8')
+    if (!/^\s*generator\s+client\s*\{/m.test(schemaText)) {
+      issues.push('schema.prisma missing generator block')
+    }
+  }
+  await emit({
+    phase: 'bootstrap',
+    step: 'health',
+    status: issues.length === 0 ? 'ok' : 'failed',
+    message: issues.length === 0 ? undefined : issues.join('; '),
+  })
 }
 
 export function projectExportImportRoutes() {
@@ -564,6 +807,16 @@ export function projectExportImportRoutes() {
     const projectId = c.req.param('projectId')
     // Default to including chats; only "false" disables.
     const includeChats = c.req.query('includeChats') !== 'false'
+    // Encrypted-secrets opt-in. When `passphrase` is supplied, channel tokens
+    // and `.env` secret values are bundled inside an `encryptedSecrets` blob
+    // (AES-256-GCM, PBKDF2-derived key) instead of being dropped entirely.
+    const passphrase = c.req.query('passphrase') || ''
+    const includeSecrets = !!passphrase
+    // `.env` policy. Default = smart-split (redact secrets, ship `.env.example`
+    // showing keys only). `?includeEnv=true` falls back to passthrough — the
+    // raw .env files travel verbatim. Only respected when paired with a
+    // passphrase OR when the operator explicitly opts in.
+    const includeEnvRaw = c.req.query('includeEnv') === 'true'
 
     const project = await prisma.project.findUnique({
       where: { id: projectId },
@@ -716,6 +969,104 @@ export function projectExportImportRoutes() {
       }
     }
 
+    // ─── .env smart-split ──────────────────────────────────────────────
+    // Walk every workspace/.env* file we just bundled. For each one:
+    //   - If the user opted into raw .env passthrough, leave it untouched.
+    //   - Otherwise redact every secret-looking key, ship a sanitised copy
+    //     under the same path, and add the redacted keys to requiredCredentials
+    //     so the importer is told what's missing. The original *values* are
+    //     captured into `envSecretsByFile` so they can travel inside the
+    //     optional encryptedSecrets blob (when a passphrase is supplied).
+    const envSecretsByFile: Record<string, Record<string, string>> = {}
+    if (!includeEnvRaw) {
+      const envPaths = Object.keys(zipContents).filter((k) => {
+        if (!k.startsWith('workspace/')) return false
+        const base = k.split('/').pop() || ''
+        return base === '.env' || base.startsWith('.env.')
+      })
+      for (const zipPath of envPaths) {
+        const text = strFromU8(zipContents[zipPath])
+        const lines = parseEnvFile(text)
+        const fileSecrets: Record<string, string> = {}
+        const sanitised: string[] = []
+        for (const line of lines) {
+          if (line.isComment || !line.key) {
+            sanitised.push(line.raw)
+            continue
+          }
+          if (isSecretKey(line.key) && line.value.length > 0) {
+            fileSecrets[line.key] = line.value
+            sanitised.push(`${line.key}=`)
+            requiredCredentials.push({
+              channel: zipPath.replace(/^workspace\//, ''),
+              field: line.key,
+              label: `env.${line.key}`,
+            })
+          } else {
+            sanitised.push(line.raw)
+          }
+        }
+        zipContents[zipPath] = strToU8(sanitised.join('\n'))
+        if (Object.keys(fileSecrets).length > 0) {
+          envSecretsByFile[zipPath] = fileSecrets
+          // Also ship a `.env.example` next to the original — values blanked,
+          // keys preserved — so the importer has a one-glance reference.
+          const exampleLines = lines.map((l) =>
+            l.isComment || !l.key ? l.raw : `${l.key}=`,
+          )
+          const examplePath = `${zipPath}.example`
+          if (!zipContents[examplePath]) {
+            zipContents[examplePath] = strToU8(exampleLines.join('\n'))
+          }
+        }
+      }
+    }
+
+    // ─── Encrypted secrets blob (opt-in) ───────────────────────────────
+    // When a passphrase is supplied, restore the *original* channel tokens and
+    // the redacted .env values (which we kept in memory only) inside an
+    // AES-GCM-encrypted blob attached to project.json. The importer can unlock
+    // it with the same passphrase to auto-fill credentials.
+    if (includeSecrets) {
+      // Re-derive the original channel secrets — we need them BEFORE
+      // sanitizeChannelsForExport stripped them. Parse the raw JSON again.
+      let rawChannels: any = project.agentConfig?.channels
+      if (typeof rawChannels === 'string') {
+        try { rawChannels = JSON.parse(rawChannels) } catch { rawChannels = [] }
+      }
+      const channelSecrets: Array<{ channel: string; field: string; value: string }> = []
+      if (Array.isArray(rawChannels)) {
+        rawChannels.forEach((entry: any, idx: number) => {
+          if (!entry || typeof entry !== 'object') return
+          const channelType = entry.type || entry.channel || `channel-${idx}`
+          for (const [k, v] of Object.entries(entry)) {
+            if (typeof v === 'string' && v.length > 0 && isSecretKey(k)) {
+              channelSecrets.push({ channel: String(channelType), field: k, value: v })
+            }
+          }
+        })
+      }
+
+      const secretsPayload = {
+        version: 1,
+        channels: channelSecrets,
+        env: envSecretsByFile,
+      }
+      try {
+        const blob: EncryptedSecretsBlob = await encryptSecrets(
+          secretsPayload,
+          passphrase,
+        )
+        ;(projectJson as any).encryptedSecrets = blob
+        // Re-emit project.json with the new field.
+        zipContents['project.json'] = strToU8(JSON.stringify(projectJson, null, 2))
+      } catch (err: any) {
+        exportWarnings.push(
+          `Encrypted-secrets opt-in failed (${err?.message || 'unknown'}); bundle shipped without secrets.`,
+        )
+      }
+    }
+
     for (const session of chatSessions) {
       const sessionData = {
         session: {
@@ -771,6 +1122,8 @@ export function projectExportImportRoutes() {
         included: chatSessions.length,
       },
       requiredCredentialsCount: requiredCredentials.length,
+      hasEncryptedSecrets: includeSecrets && !!(projectJson as any).encryptedSecrets,
+      envPolicy: includeEnvRaw ? 'passthrough' : 'smart-split',
       warnings: exportWarnings,
     }
     zipContents['manifest.json'] = strToU8(JSON.stringify(manifest, null, 2))
@@ -816,6 +1169,8 @@ export function projectExportImportRoutes() {
     let zipBuffer: Uint8Array
     let workspaceId: string
     let includeChats: boolean
+    let passphrase: string
+    let runBootstrap: boolean
 
     if (contentType.includes('multipart/form-data')) {
       const formData = await c.req.formData()
@@ -823,6 +1178,10 @@ export function projectExportImportRoutes() {
       workspaceId = (formData.get('workspaceId') as string) || ''
       const includeChatsRaw = (formData.get('includeChats') as string | null) ?? 'true'
       includeChats = includeChatsRaw !== 'false'
+      passphrase = (formData.get('passphrase') as string | null) || ''
+      // Bootstrap defaults ON; client can opt out with `runBootstrap=false`.
+      const bootstrapRaw = (formData.get('runBootstrap') as string | null) ?? 'true'
+      runBootstrap = bootstrapRaw !== 'false'
 
       if (!file) {
         return c.json({ error: 'Missing file in form data' }, 400)
@@ -850,7 +1209,7 @@ export function projectExportImportRoutes() {
             zipBuffer,
             workspaceId,
             userId,
-            { includeChats },
+            { includeChats, passphrase, runBootstrap },
             async (ev) => {
               if (ev.phase === 'error') {
                 await stream.writeSSE({
@@ -865,6 +1224,7 @@ export function projectExportImportRoutes() {
                     stats: ev.stats,
                     requiredCredentials: ev.requiredCredentials ?? [],
                     warnings: ev.warnings ?? [],
+                    secretsAutoFilled: ev.secretsAutoFilled ?? false,
                   }),
                 })
               } else {
@@ -899,7 +1259,7 @@ export function projectExportImportRoutes() {
         zipBuffer,
         workspaceId,
         userId,
-        { includeChats },
+        { includeChats, passphrase, runBootstrap },
         () => {
           /* drop events */
         },
@@ -920,6 +1280,7 @@ export function projectExportImportRoutes() {
         stats: result.stats,
         requiredCredentials: result.requiredCredentials,
         warnings: result.warnings,
+        secretsAutoFilled: result.secretsAutoFilled,
       })
     } catch (err: any) {
       return c.json({ error: err?.message || 'Import failed' }, 500)

--- a/apps/api/src/routes/project-export-import.ts
+++ b/apps/api/src/routes/project-export-import.ts
@@ -32,12 +32,91 @@ const EXCLUDED_DIRS = new Set([
   '.expo',
 ])
 
+// Volatile, per-machine, or generated files we never want in a portable bundle:
+//   *-wal / *-shm  — SQLite write-ahead log + shared memory; volatile and may be
+//                    inconsistent if the writer hadn't checkpointed (`PRAGMA
+//                    wal_checkpoint`). The main `.db` is shipped on its own.
+//   .install-ok*   — per-machine install-state markers.
+//   .shogo-cwd-*   — transient shell-cwd markers leaked from preview tooling.
+const EXCLUDED_FILE_PATTERNS: RegExp[] = [
+  /-wal$/i,
+  /-shm$/i,
+  /^\.install-ok/,
+  /^\.shogo-cwd-/,
+]
+
+const isExcludedFile = (name: string): boolean =>
+  EXCLUDED_FILE_PATTERNS.some((re) => re.test(name))
+
+// Bundle format. Bumped to 1.1 with: manifest.json, requiredCredentials,
+// sanitized (secret-stripped) channels, defensive path normalisation, and
+// volatile-file exclusion. Importer accepts both 1.0 and 1.1.
+const BUNDLE_FORMAT_VERSION = '1.1'
+const SUPPORTED_BUNDLE_VERSIONS = new Set(['1.0', '1.1'])
+
 const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10 MB per file
 const MAX_TOTAL_SIZE = 200 * 1024 * 1024 // 200 MB total bundle
+
+// Heuristic: any object key matching this pattern in `agentConfig.channels`
+// is treated as a secret — redacted from the export and surfaced through
+// `requiredCredentials` so the importer can fill it in post-import.
+const SECRET_KEY_PATTERN =
+  /token|secret|apikey|api_key|password|^pat$|webhook.*url|bearer|client[_-]?secret|refresh[_-]?token|access[_-]?token/i
+
+const isSecretKey = (key: string): boolean => SECRET_KEY_PATTERN.test(key)
+
+interface RequiredCredential {
+  channel: string
+  field: string
+  label: string
+}
+
+/**
+ * Returns a copy of `rawChannels` with all secret-looking string values
+ * replaced with `null`, plus a flat list of credentials the importer must
+ * provide post-import. Accepts the channels JSON in either parsed (array)
+ * or stringified form (Prisma SQLite returns Json columns as strings).
+ */
+function sanitizeChannelsForExport(rawChannels: unknown): {
+  sanitized: any[]
+  required: RequiredCredential[]
+} {
+  let parsed: any = rawChannels
+  if (typeof parsed === 'string') {
+    try {
+      parsed = JSON.parse(parsed)
+    } catch {
+      parsed = []
+    }
+  }
+  if (!Array.isArray(parsed)) return { sanitized: [], required: [] }
+
+  const required: RequiredCredential[] = []
+  const sanitized = parsed.map((entry, idx) => {
+    if (!entry || typeof entry !== 'object') return entry
+    const channelType = entry.type || entry.channel || `channel-${idx}`
+    const out: Record<string, any> = {}
+    for (const [k, v] of Object.entries(entry)) {
+      if (typeof v === 'string' && v.length > 0 && isSecretKey(k)) {
+        out[k] = null
+        required.push({
+          channel: String(channelType),
+          field: k,
+          label: `${channelType}.${k}`,
+        })
+      } else {
+        out[k] = v
+      }
+    }
+    return out
+  })
+  return { sanitized, required }
+}
 
 function collectWorkspaceFiles(
   dir: string,
   baseDir: string,
+  skipped: Array<{ path: string; reason: string }> = [],
 ): Record<string, Uint8Array> {
   const files: Record<string, Uint8Array> = {}
   if (!existsSync(dir)) return files
@@ -45,20 +124,29 @@ function collectWorkspaceFiles(
   const entries = readdirSync(dir, { withFileTypes: true })
   for (const entry of entries) {
     if (EXCLUDED_DIRS.has(entry.name)) continue
-    if (entry.name.startsWith('.install-ok')) continue
 
     const fullPath = join(dir, entry.name)
     const relPath = relative(baseDir, fullPath).replace(/\\/g, '/')
 
     if (entry.isDirectory()) {
-      Object.assign(files, collectWorkspaceFiles(fullPath, baseDir))
+      Object.assign(files, collectWorkspaceFiles(fullPath, baseDir, skipped))
     } else if (entry.isFile()) {
+      if (isExcludedFile(entry.name)) {
+        skipped.push({ path: relPath, reason: 'excluded-pattern' })
+        continue
+      }
       try {
         const stat = statSync(fullPath)
-        if (stat.size > MAX_FILE_SIZE) continue
+        if (stat.size > MAX_FILE_SIZE) {
+          skipped.push({ path: relPath, reason: `size>${MAX_FILE_SIZE}` })
+          continue
+        }
         files[relPath] = new Uint8Array(readFileSync(fullPath))
-      } catch {
-        // skip unreadable files
+      } catch (err: any) {
+        skipped.push({
+          path: relPath,
+          reason: `read-error:${err?.message || 'unknown'}`,
+        })
       }
     }
   }
@@ -82,6 +170,11 @@ type ImportEvent =
         chatsImported: number
         chatsSkipped: number
       }
+      // Populated when the bundle ships a `manifest.json` (v1.1+) or has
+      // requiredCredentials in `project.json`. Lets the import modal render
+      // a Setup Checklist instead of dumping the user into a broken agent.
+      requiredCredentials?: RequiredCredential[]
+      warnings?: string[]
     }
   | { phase: 'error'; message: string; fatal: boolean }
 
@@ -109,6 +202,21 @@ interface ProjectBundle {
     quietHoursEnd?: string | null
     quietHoursTimezone?: string | null
   } | null
+  requiredCredentials?: RequiredCredential[]
+}
+
+interface BundleManifest {
+  bundleVersion?: string
+  generatedAt?: string
+  sourceMode?: string
+  warnings?: string[]
+  files?: {
+    count?: number
+    totalBytes?: number
+    byCategory?: Record<string, number>
+    skipped?: Array<{ path: string; reason: string }>
+  }
+  requiredCredentialsCount?: number
 }
 
 type ImportResult =
@@ -121,6 +229,8 @@ type ImportResult =
         chatsImported: number
         chatsSkipped: number
       }
+      requiredCredentials: RequiredCredential[]
+      warnings: string[]
     }
   | { ok: false; status: 400 | 401 | 403 | 413; error: string }
 
@@ -164,6 +274,37 @@ async function runImport(
     return { ok: false, status: 400, error: 'Invalid project.json in bundle' }
   }
 
+  // Read manifest.json (v1.1+). Surface its warnings to the importer so they
+  // see, in real time, *why* a file was missing or skipped — instead of
+  // discovering the breakage at first run.
+  const importWarnings: string[] = []
+  let manifest: BundleManifest | null = null
+  if (unzipped['manifest.json']) {
+    try {
+      manifest = JSON.parse(strFromU8(unzipped['manifest.json'])) as BundleManifest
+      if (Array.isArray(manifest.warnings)) {
+        for (const w of manifest.warnings) {
+          importWarnings.push(w)
+          await emit({
+            phase: 'error',
+            message: `[bundle warning] ${w}`,
+            fatal: false,
+          })
+        }
+      }
+    } catch {
+      importWarnings.push('manifest.json present but unparseable')
+    }
+  }
+
+  // Bundle-version negotiation: warn (don't fail) on unknown formats so older
+  // clients can still try to import bundles produced by future API builds.
+  if (bundle.version && !SUPPORTED_BUNDLE_VERSIONS.has(bundle.version)) {
+    const msg = `Bundle format ${bundle.version} is not officially supported (this server understands ${[...SUPPORTED_BUNDLE_VERSIONS].join(', ')}); attempting import anyway.`
+    importWarnings.push(msg)
+    await emit({ phase: 'error', message: msg, fatal: false })
+  }
+
   await emit({ phase: 'parse' })
 
   const bp = bundle.project
@@ -194,13 +335,26 @@ async function runImport(
 
   {
     const ac = bundle.agentConfig
+    // v1.0 bundles double-encoded `channels` as a JSON string ("[]"); v1.1
+    // emits a real array. Parse strings here so the DB column stores an
+    // array, not a stringified array.
+    let channelsValue: any = ac?.channels ?? []
+    if (typeof channelsValue === 'string') {
+      try {
+        channelsValue = JSON.parse(channelsValue)
+      } catch {
+        channelsValue = []
+      }
+    }
+    if (!Array.isArray(channelsValue)) channelsValue = []
+
     const agentData: Record<string, any> = {
       projectId: project.id,
       heartbeatInterval: ac?.heartbeatInterval ?? 1800,
       heartbeatEnabled: ac?.heartbeatEnabled ?? false,
       modelProvider: ac?.modelProvider ?? 'anthropic',
       modelName: ac?.modelName ?? 'claude-haiku-4-5',
-      channels: ac?.channels ?? [],
+      channels: channelsValue,
     }
     // PG-only fields — include only when present in the bundle
     if (ac) {
@@ -228,14 +382,29 @@ async function runImport(
 
   for (let i = 0; i < workspaceEntries.length; i++) {
     const [path, data] = workspaceEntries[i]
+    // Normalise backslashes — v1.0 bundles produced by old runtime pods used
+    // Windows-style separators that, written verbatim, became literal-
+    // backslash filenames on disk and broke memory/, .shogo/, src/ etc.
     const relPath = path.slice('workspace/'.length).replace(/\\/g, '/')
-    if (!relPath || relPath.includes('..') || relPath.startsWith('/')) {
+    if (
+      !relPath ||
+      relPath.includes('..') ||
+      relPath.startsWith('/') ||
+      /^[a-zA-Z]:\//.test(relPath) // reject Windows drive-absolute paths
+    ) {
       filesSkipped++
       await emit({
         phase: 'error',
         message: `Skipped unsafe path: ${path}`,
         fatal: false,
       })
+      continue
+    }
+    // Drop volatile / per-machine files that should never have shipped (in
+    // case an old or third-party bundle includes them).
+    const baseName = relPath.split('/').pop() || ''
+    if (isExcludedFile(baseName)) {
+      filesSkipped++
       continue
     }
 
@@ -348,9 +517,42 @@ async function runImport(
     description: project.description,
   }
 
-  await emit({ phase: 'done', project: projectSummary, stats })
+  // Surface the requiredCredentials carried in project.json (v1.1+) so the
+  // import modal can render a Setup Checklist instead of leaving the user
+  // with an agent that can't talk to Telegram / OpenAI / etc.
+  const requiredCredentials = Array.isArray(bundle.requiredCredentials)
+    ? bundle.requiredCredentials
+    : []
 
-  return { ok: true, project: projectSummary, stats }
+  // Post-import sanity checks → warnings. These are the things the user is
+  // most likely to discover at first run: no memory, no skills, no .env.
+  const projectDirAbs = resolve(projectDir)
+  if (!existsSync(join(projectDirAbs, 'memory', 'MEMORY.md')) && !existsSync(join(projectDirAbs, 'MEMORY.md'))) {
+    importWarnings.push(
+      'No MEMORY.md found in workspace — agent will start with empty memory.',
+    )
+  }
+  if (requiredCredentials.length > 0) {
+    importWarnings.push(
+      `${requiredCredentials.length} credential(s) need to be configured: ${requiredCredentials.map((c) => c.label).join(', ')}.`,
+    )
+  }
+
+  await emit({
+    phase: 'done',
+    project: projectSummary,
+    stats,
+    requiredCredentials,
+    warnings: importWarnings,
+  })
+
+  return {
+    ok: true,
+    project: projectSummary,
+    stats,
+    requiredCredentials,
+    warnings: importWarnings,
+  }
 }
 
 export function projectExportImportRoutes() {
@@ -395,13 +597,19 @@ export function projectExportImportRoutes() {
       }
     }
 
+    // Parse channels: Prisma SQLite returns Json columns as strings, while
+    // Postgres returns parsed values. Strip secrets and capture them as
+    // requiredCredentials so the importer is told what to fill in.
+    const { sanitized: sanitizedChannels, required: requiredCredentials } =
+      sanitizeChannelsForExport(project.agentConfig?.channels)
+
     const agentConfigExport: Record<string, any> | null = project.agentConfig
       ? {
           heartbeatInterval: project.agentConfig.heartbeatInterval,
           heartbeatEnabled: project.agentConfig.heartbeatEnabled,
           modelProvider: project.agentConfig.modelProvider,
           modelName: project.agentConfig.modelName,
-          channels: project.agentConfig.channels,
+          channels: sanitizedChannels,
         }
       : null
 
@@ -414,7 +622,7 @@ export function projectExportImportRoutes() {
     }
 
     const projectJson = {
-      version: '1.0',
+      version: BUNDLE_FORMAT_VERSION,
       exportedAt: new Date().toISOString(),
       includedChats: includeChats,
       project: {
@@ -430,29 +638,79 @@ export function projectExportImportRoutes() {
         siteDescription: project.siteDescription,
       },
       agentConfig: agentConfigExport,
+      requiredCredentials,
     }
 
     const zipContents: Record<string, Uint8Array> = {}
 
     zipContents['project.json'] = strToU8(JSON.stringify(projectJson, null, 2))
 
+    // Track export hygiene for the manifest (and so `done`/import can surface
+    // it). `sourceMode` records whether files came from the live agent pod
+    // (k8s) or directly from disk (local), and `fileSkipped` lists what we
+    // intentionally dropped.
+    const fileSkipped: Array<{ path: string; reason: string }> = []
+    const exportWarnings: string[] = []
+    let sourceMode: 'k8s' | 'k8s-fallback-empty' | 'local' = 'local'
+
     if (isKubernetes()) {
+      sourceMode = 'k8s'
       try {
         const { getProjectPodUrl } = await import('../lib/knative-project-manager')
         const podUrl = await getProjectPodUrl(projectId)
         const agent = new AgentClient({ baseUrl: podUrl })
         const bundle: WorkspaceBundle = await agent.getWorkspaceBundle()
-        for (const [relPath, base64Data] of Object.entries(bundle.files)) {
+        const bundleFiles =
+          bundle && typeof bundle === 'object' && bundle.files && typeof bundle.files === 'object'
+            ? bundle.files
+            : {}
+        if (Object.keys(bundleFiles).length === 0) {
+          exportWarnings.push(
+            'Runtime pod returned an empty workspace bundle; the agent may be cold-starting or have no files yet.',
+          )
+        }
+
+        // Defensive normalisation: older runtime pods returned Windows-style
+        // backslash paths (e.g. `memory\2026-04-09.md`) which, when zipped
+        // verbatim, became literal-backslash filenames after extraction —
+        // breaking memory/, .shogo/, src/ etc. on the importer's machine.
+        // The runtime is fixed (server.ts collectBundleFiles), but old pods
+        // may still be live: normalise here so the bundle is always sane.
+        let backslashCount = 0
+        for (const [rawRelPath, base64Data] of Object.entries(bundleFiles)) {
+          const relPath = rawRelPath.replace(/\\/g, '/')
+          if (relPath !== rawRelPath) backslashCount++
+
+          const baseName = relPath.split('/').pop() || ''
+          if (isExcludedFile(baseName)) {
+            fileSkipped.push({ path: relPath, reason: 'excluded-pattern' })
+            continue
+          }
           zipContents[`workspace/${relPath}`] = new Uint8Array(
             Buffer.from(base64Data, 'base64'),
           )
         }
+        if (backslashCount > 0) {
+          exportWarnings.push(
+            `Runtime pod returned ${backslashCount} workspace path(s) with backslash separators; normalised on the API side. The pod build may be outdated.`,
+          )
+        }
       } catch (err: any) {
-        console.warn(`[Export] Could not reach agent pod for workspace files: ${err.message}`)
+        sourceMode = 'k8s-fallback-empty'
+        exportWarnings.push(
+          `Could not reach agent pod for workspace files: ${err?.message || 'unknown error'}`,
+        )
+        console.warn(
+          `[Export] Could not reach agent pod for workspace files: ${err.message}`,
+        )
       }
     } else {
       const workspaceDir = join(WORKSPACES_DIR, projectId)
-      const workspaceFiles = collectWorkspaceFiles(workspaceDir, workspaceDir)
+      const workspaceFiles = collectWorkspaceFiles(
+        workspaceDir,
+        workspaceDir,
+        fileSkipped,
+      )
       for (const [relPath, data] of Object.entries(workspaceFiles)) {
         zipContents[`workspace/${relPath}`] = data
       }
@@ -480,6 +738,42 @@ export function projectExportImportRoutes() {
         JSON.stringify(sessionData, null, 2),
       )
     }
+
+    // ─── Bundle manifest ────────────────────────────────────────────
+    // Self-describing inventory + warnings + provenance. Lives at the bundle
+    // root so the importer can show a setup summary and so future bug reports
+    // ("file X went missing") are diagnosable from the bundle alone.
+    const inventory: Record<string, number> = {}
+    let totalBytes = 0
+    for (const [path, data] of Object.entries(zipContents)) {
+      totalBytes += data.byteLength
+      const top = path.startsWith('workspace/')
+        ? 'workspace'
+        : path.startsWith('chat-history/')
+          ? 'chat-history'
+          : path === 'project.json'
+            ? 'project-meta'
+            : 'other'
+      inventory[top] = (inventory[top] || 0) + 1
+    }
+
+    const manifest = {
+      bundleVersion: BUNDLE_FORMAT_VERSION,
+      generatedAt: new Date().toISOString(),
+      sourceMode,
+      files: {
+        count: Object.keys(zipContents).length + 1, // +1 for manifest itself
+        totalBytes,
+        byCategory: inventory,
+        skipped: fileSkipped,
+      },
+      chats: {
+        included: chatSessions.length,
+      },
+      requiredCredentialsCount: requiredCredentials.length,
+      warnings: exportWarnings,
+    }
+    zipContents['manifest.json'] = strToU8(JSON.stringify(manifest, null, 2))
 
     const zipped = zipSync(zipContents, { level: 6 })
 
@@ -566,7 +860,12 @@ export function projectExportImportRoutes() {
               } else if (ev.phase === 'done') {
                 await stream.writeSSE({
                   event: 'done',
-                  data: JSON.stringify({ project: ev.project, stats: ev.stats }),
+                  data: JSON.stringify({
+                    project: ev.project,
+                    stats: ev.stats,
+                    requiredCredentials: ev.requiredCredentials ?? [],
+                    warnings: ev.warnings ?? [],
+                  }),
                 })
               } else {
                 await stream.writeSSE({
@@ -616,7 +915,12 @@ export function projectExportImportRoutes() {
         return c.json({ error: result.error }, result.status)
       }
 
-      return c.json({ project: result.project })
+      return c.json({
+        project: result.project,
+        stats: result.stats,
+        requiredCredentials: result.requiredCredentials,
+        warnings: result.warnings,
+      })
     } catch (err: any) {
       return c.json({ error: err?.message || 'Import failed' }, 500)
     }

--- a/apps/mobile/components/project/ProjectExportModal.tsx
+++ b/apps/mobile/components/project/ProjectExportModal.tsx
@@ -8,7 +8,7 @@
  * toggle for the built-app `dist/` is intentionally not offered — the server
  * always ships `dist/` when present so imports start up fast.
  */
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { View } from 'react-native'
 import {
   Modal,
@@ -23,13 +23,30 @@ import { Heading } from '@/components/ui/heading'
 import { Text } from '@/components/ui/text'
 import { Button, ButtonText, ButtonSpinner, ButtonIcon } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
-import { Download, X, MessageSquare, Rocket } from 'lucide-react-native'
+import { Input, InputField } from '@/components/ui/input'
+import {
+  Download,
+  X,
+  MessageSquare,
+  Rocket,
+  Lock,
+  FileKey,
+  AlertTriangle,
+} from 'lucide-react-native'
+
+export interface ExportOptions {
+  includeChats: boolean
+  /** Non-empty passphrase ⇒ ship encrypted credentials in the bundle. */
+  passphrase?: string
+  /** True ships `.env` files verbatim; false (default) redacts secrets. */
+  includeEnv?: boolean
+}
 
 interface ProjectExportModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   isExporting: boolean
-  onExport: (options: { includeChats: boolean }) => void
+  onExport: (options: ExportOptions) => void
 }
 
 export function ProjectExportModal({
@@ -39,6 +56,33 @@ export function ProjectExportModal({
   onExport,
 }: ProjectExportModalProps) {
   const [includeChats, setIncludeChats] = useState(true)
+  const [includeSecrets, setIncludeSecrets] = useState(false)
+  const [passphrase, setPassphrase] = useState('')
+  const [confirmPassphrase, setConfirmPassphrase] = useState('')
+  const [includeEnv, setIncludeEnv] = useState(false)
+
+  const passphraseError = useMemo(() => {
+    if (!includeSecrets) return null
+    if (passphrase.length === 0) return null
+    if (passphrase.length < 8) return 'Use at least 8 characters.'
+    if (confirmPassphrase.length > 0 && confirmPassphrase !== passphrase) {
+      return 'Passphrases do not match.'
+    }
+    return null
+  }, [includeSecrets, passphrase, confirmPassphrase])
+
+  const canExport =
+    !isExporting &&
+    (!includeSecrets ||
+      (passphrase.length >= 8 && passphrase === confirmPassphrase))
+
+  const handleExport = () => {
+    onExport({
+      includeChats,
+      passphrase: includeSecrets ? passphrase : undefined,
+      includeEnv,
+    })
+  }
 
   return (
     <Modal isOpen={open} onClose={() => onOpenChange(false)} size="md">
@@ -59,6 +103,7 @@ export function ProjectExportModal({
             You can re-import it into any workspace.
           </Text>
 
+          {/* Chat history toggle */}
           <View className="flex-row items-start gap-3 rounded-lg border border-outline-100 bg-background-50 px-4 py-3">
             <View className="mt-0.5">
               <MessageSquare size={18} className="text-typography-500" />
@@ -74,6 +119,85 @@ export function ProjectExportModal({
             <Switch
               value={includeChats}
               onValueChange={setIncludeChats}
+              disabled={isExporting}
+            />
+          </View>
+
+          {/* Encrypted-secrets opt-in */}
+          <View className="rounded-lg border border-outline-100 bg-background-50 px-4 py-3 gap-3">
+            <View className="flex-row items-start gap-3">
+              <View className="mt-0.5">
+                <Lock size={18} className="text-typography-500" />
+              </View>
+              <View className="flex-1">
+                <Text className="text-sm font-medium text-typography-900">
+                  Include encrypted credentials
+                </Text>
+                <Text className="text-xs text-typography-500 mt-0.5 leading-relaxed">
+                  Bot tokens, API keys, and secret env values travel inside the bundle, encrypted with your passphrase. Recipients enter the same passphrase to auto-fill them.
+                </Text>
+              </View>
+              <Switch
+                value={includeSecrets}
+                onValueChange={setIncludeSecrets}
+                disabled={isExporting}
+              />
+            </View>
+            {includeSecrets && (
+              <View className="gap-2 pl-7">
+                <Input>
+                  <InputField
+                    placeholder="Passphrase (≥ 8 chars)"
+                    value={passphrase}
+                    onChangeText={setPassphrase}
+                    secureTextEntry
+                    autoComplete="off"
+                    autoCorrect={false}
+                    editable={!isExporting}
+                  />
+                </Input>
+                <Input>
+                  <InputField
+                    placeholder="Confirm passphrase"
+                    value={confirmPassphrase}
+                    onChangeText={setConfirmPassphrase}
+                    secureTextEntry
+                    autoComplete="off"
+                    autoCorrect={false}
+                    editable={!isExporting}
+                  />
+                </Input>
+                {passphraseError && (
+                  <View className="flex-row items-center gap-1.5">
+                    <AlertTriangle size={12} className="text-amber-500" />
+                    <Text className="text-[11px] text-amber-600">
+                      {passphraseError}
+                    </Text>
+                  </View>
+                )}
+                <Text className="text-[11px] text-typography-500 leading-relaxed">
+                  Share this passphrase with the recipient through a separate channel — never paste it inside the bundle file.
+                </Text>
+              </View>
+            )}
+          </View>
+
+          {/* .env policy */}
+          <View className="flex-row items-start gap-3 rounded-lg border border-outline-100 bg-background-50 px-4 py-3">
+            <View className="mt-0.5">
+              <FileKey size={18} className="text-typography-500" />
+            </View>
+            <View className="flex-1">
+              <Text className="text-sm font-medium text-typography-900">
+                Ship raw <Text className="font-mono text-xs">.env</Text> values
+              </Text>
+              <Text className="text-xs text-typography-500 mt-0.5 leading-relaxed">
+                Off (recommended): secret-looking env vars are redacted; non-secrets and a <Text className="font-mono text-xs">.env.example</Text> are shipped. On: ships <Text className="font-mono text-xs">.env</Text> files verbatim — only do this for trusted recipients.
+              </Text>
+            </View>
+            <Switch
+              value={includeEnv}
+              onValueChange={setIncludeEnv}
               disabled={isExporting}
             />
           </View>
@@ -101,10 +225,7 @@ export function ProjectExportModal({
           >
             <ButtonText>Cancel</ButtonText>
           </Button>
-          <Button
-            onPress={() => onExport({ includeChats })}
-            disabled={isExporting}
-          >
+          <Button onPress={handleExport} disabled={!canExport}>
             {isExporting ? (
               <ButtonSpinner className="text-typography-0" />
             ) : (

--- a/apps/mobile/components/project/ProjectTopBar.tsx
+++ b/apps/mobile/components/project/ProjectTopBar.tsx
@@ -1002,12 +1002,18 @@ function ProjectMenuView({
   const showBilling = features.billing
   const usdPercent = usdTotal > 0 ? (usdRemaining / usdTotal) * 100 : 0
 
-  const runExport = useCallback(async (options: { includeChats: boolean }) => {
+  const runExport = useCallback(async (options: {
+    includeChats: boolean
+    passphrase?: string
+    includeEnv?: boolean
+  }) => {
     if (isExporting) return
     setIsExporting(true)
     try {
       const { blob, filename } = await api.exportProjectBlob(projectId, {
         includeChats: options.includeChats,
+        passphrase: options.passphrase,
+        includeEnv: options.includeEnv,
       })
 
       if (Platform.OS === 'web' && typeof document !== 'undefined') {

--- a/apps/mobile/components/projects/ProjectImportModal.tsx
+++ b/apps/mobile/components/projects/ProjectImportModal.tsx
@@ -32,6 +32,7 @@ import {
   ButtonIcon,
 } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
+import { Input, InputField } from '@/components/ui/input'
 import { Progress, ProgressFilledTrack } from '@/components/ui/progress'
 import {
   Upload,
@@ -42,8 +43,42 @@ import {
   FileArchive,
   RefreshCw,
   ExternalLink,
+  Lock,
+  KeyRound,
+  Loader2,
+  XCircle,
+  ShieldCheck,
+  Settings2,
 } from 'lucide-react-native'
-import { api, type ProjectImportProgress } from '../../lib/api'
+import {
+  api,
+  type ProjectImportProgress,
+  type RequiredCredential,
+  type BootstrapStep,
+  type BootstrapStatus,
+} from '../../lib/api'
+
+// Friendly labels for the bootstrap sub-steps shown during the post-write
+// install / generate / preview / health phase.
+const BOOTSTRAP_STEP_LABELS: Record<BootstrapStep, string> = {
+  install: 'Installing dependencies',
+  generate: 'Generating routes & client',
+  preview: 'Preparing preview',
+  health: 'Health check',
+}
+
+// Friendly grouping for credential checklist items by source channel.
+const CHANNEL_LABELS: Record<string, { label: string; hint?: string }> = {
+  telegram: { label: 'Telegram', hint: 'Bot token & chat ID' },
+  discord: { label: 'Discord', hint: 'Bot token / webhook URL' },
+  slack: { label: 'Slack', hint: 'Bot token & signing secret' },
+  whatsapp: { label: 'WhatsApp', hint: 'Cloud API token' },
+  email: { label: 'Email', hint: 'SMTP credentials' },
+  webhook: { label: 'Webhook', hint: 'Endpoint secret' },
+  openai: { label: 'OpenAI', hint: 'API key' },
+  anthropic: { label: 'Anthropic', hint: 'API key' },
+  github: { label: 'GitHub', hint: 'Personal access token' },
+}
 
 interface ProjectImportModalProps {
   open: boolean
@@ -61,21 +96,29 @@ interface PendingFile {
   size: number
 }
 
-// Phase -> [startPercent, endPercent, label]. writeFiles and importChats use
-// their `done/total` to interpolate inside their band.
+// Phase -> [startPercent, endPercent, label]. writeFiles, importChats, and
+// bootstrap use their `done/total` (or sub-step index) to interpolate inside
+// their band. The new `bootstrap` band steals from importChats — both can't
+// run simultaneously and most projects spend much longer installing deps
+// than writing chat history.
 const PHASE_BANDS: Record<
   ProjectImportProgress['phase'] | 'idle',
   [number, number, string]
 > = {
   idle: [0, 0, 'Ready'],
-  upload: [0, 30, 'Uploading'],
-  parse: [30, 40, 'Parsing archive'],
-  createProject: [40, 50, 'Creating project'],
-  writeFiles: [50, 85, 'Writing files'],
-  importChats: [85, 100, 'Importing chats'],
+  upload: [0, 25, 'Uploading'],
+  parse: [25, 32, 'Parsing archive'],
+  createProject: [32, 40, 'Creating project'],
+  writeFiles: [40, 70, 'Writing files'],
+  importChats: [70, 78, 'Importing chats'],
+  bootstrap: [78, 100, 'Setting up project'],
   done: [100, 100, 'Done'],
   error: [0, 0, 'Error'],
 }
+
+// Linear progression through bootstrap sub-steps so the bar keeps moving
+// during the (potentially long) install + generate phases.
+const BOOTSTRAP_ORDER: BootstrapStep[] = ['install', 'generate', 'preview', 'health']
 
 function computePercent(ev: ProjectImportProgress | null): number {
   if (!ev) return 0
@@ -87,6 +130,15 @@ function computePercent(ev: ProjectImportProgress | null): number {
   if (ev.phase === 'upload') {
     const frac = ev.total > 0 ? ev.loaded / ev.total : 0
     return Math.round(start + (end - start) * frac)
+  }
+  if (ev.phase === 'bootstrap') {
+    // Each step is worth 1/N of the band; we treat `running` as 0.5 within
+    // its slice so the bar keeps inching forward visibly.
+    const idx = BOOTSTRAP_ORDER.indexOf(ev.step)
+    if (idx < 0) return start
+    const slice = (end - start) / BOOTSTRAP_ORDER.length
+    const within = ev.status === 'running' ? 0.5 : ev.status === 'pending' ? 0 : 1
+    return Math.round(start + slice * (idx + within))
   }
   return end
 }
@@ -100,6 +152,9 @@ function phaseLabel(ev: ProjectImportProgress | null): string {
     const mb = (n: number) => (n / (1024 * 1024)).toFixed(1)
     return `${label} (${mb(ev.loaded)} / ${mb(ev.total)} MB)`
   }
+  if (ev.phase === 'bootstrap') {
+    return `${label} — ${BOOTSTRAP_STEP_LABELS[ev.step]}`
+  }
   return label
 }
 
@@ -112,9 +167,20 @@ export function ProjectImportModal({
   const [step, setStep] = useState<Step>('options')
   const [pendingFile, setPendingFile] = useState<PendingFile | null>(null)
   const [includeChats, setIncludeChats] = useState(true)
+  const [passphrase, setPassphrase] = useState('')
   const [progress, setProgress] = useState<ProjectImportProgress | null>(null)
   const [errors, setErrors] = useState<string[]>([])
   const [fatalMessage, setFatalMessage] = useState<string | null>(null)
+  // Tracks the running status of each bootstrap sub-step so the progress UI
+  // can render a checklist (✓ install, ⟳ generate, …) instead of a single bar.
+  const [bootstrapSteps, setBootstrapSteps] = useState<
+    Record<BootstrapStep, { status: BootstrapStatus; message?: string }>
+  >({
+    install: { status: 'pending' },
+    generate: { status: 'pending' },
+    preview: { status: 'pending' },
+    health: { status: 'pending' },
+  })
   const [done, setDone] = useState<{
     project: { id: string; name: string; description?: string | null }
     stats: {
@@ -123,6 +189,9 @@ export function ProjectImportModal({
       chatsImported: number
       chatsSkipped: number
     }
+    requiredCredentials: RequiredCredential[]
+    warnings: string[]
+    secretsAutoFilled: boolean
   } | null>(null)
 
   // Keep the most recent `errors` value visible during auto-re-renders in the
@@ -134,10 +203,17 @@ export function ProjectImportModal({
     setStep('options')
     setPendingFile(null)
     setIncludeChats(true)
+    setPassphrase('')
     setProgress(null)
     setErrors([])
     errorsRef.current = []
     setFatalMessage(null)
+    setBootstrapSteps({
+      install: { status: 'pending' },
+      generate: { status: 'pending' },
+      preview: { status: 'pending' },
+      health: { status: 'pending' },
+    })
     setDone(null)
   }, [])
 
@@ -224,6 +300,7 @@ export function ProjectImportModal({
           workspaceId,
           filename: pendingFile.name,
           includeChats,
+          passphrase: passphrase.length > 0 ? passphrase : undefined,
         },
         (ev) => {
           if (ev.phase === 'error') {
@@ -235,8 +312,22 @@ export function ProjectImportModal({
             }
             return
           }
+          if (ev.phase === 'bootstrap') {
+            setBootstrapSteps((prev) => ({
+              ...prev,
+              [ev.step]: { status: ev.status, message: ev.message },
+            }))
+            setProgress(ev)
+            return
+          }
           if (ev.phase === 'done') {
-            setDone({ project: ev.project, stats: ev.stats })
+            setDone({
+              project: ev.project,
+              stats: ev.stats,
+              requiredCredentials: ev.requiredCredentials || [],
+              warnings: ev.warnings || [],
+              secretsAutoFilled: !!ev.secretsAutoFilled,
+            })
             setProgress(ev)
             return
           }
@@ -248,7 +339,7 @@ export function ProjectImportModal({
       setFatalMessage(err?.message || 'Import failed')
       setStep('fatal')
     }
-  }, [pendingFile, workspaceId, includeChats])
+  }, [pendingFile, workspaceId, includeChats, passphrase])
 
   const percent = useMemo(() => computePercent(progress), [progress])
   const label = useMemo(() => phaseLabel(progress), [progress])
@@ -280,6 +371,8 @@ export function ProjectImportModal({
               onClear={() => setPendingFile(null)}
               includeChats={includeChats}
               setIncludeChats={setIncludeChats}
+              passphrase={passphrase}
+              setPassphrase={setPassphrase}
             />
           )}
 
@@ -288,6 +381,8 @@ export function ProjectImportModal({
               percent={percent}
               label={label}
               errors={errors}
+              bootstrapSteps={bootstrapSteps}
+              showBootstrap={progress?.phase === 'bootstrap'}
             />
           )}
 
@@ -366,12 +461,16 @@ function OptionsStep({
   onClear,
   includeChats,
   setIncludeChats,
+  passphrase,
+  setPassphrase,
 }: {
   pendingFile: PendingFile | null
   onPick: () => void
   onClear: () => void
   includeChats: boolean
   setIncludeChats: (v: boolean) => void
+  passphrase: string
+  setPassphrase: (v: string) => void
 }) {
   return (
     <>
@@ -418,6 +517,36 @@ function OptionsStep({
         </View>
         <Switch value={includeChats} onValueChange={setIncludeChats} />
       </View>
+
+      {/* Optional passphrase: when the bundle ships an encryptedSecrets blob,
+          this lets us auto-fill credentials. We don't know whether the bundle
+          is encrypted until parse-time, so the field is always available;
+          leaving it blank simply skips the auto-fill. */}
+      <View className="rounded-lg border border-outline-100 bg-background-50 px-4 py-3 gap-2">
+        <View className="flex-row items-start gap-3">
+          <View className="mt-0.5">
+            <Lock size={18} className="text-typography-500" />
+          </View>
+          <View className="flex-1">
+            <Text className="text-sm font-medium text-typography-900">
+              Passphrase (optional)
+            </Text>
+            <Text className="text-xs text-typography-500 mt-0.5 leading-relaxed">
+              If the bundle was exported with encrypted credentials, enter the same passphrase here to auto-fill bot tokens, API keys, and <Text className="font-mono text-xs">.env</Text> secrets.
+            </Text>
+          </View>
+        </View>
+        <Input>
+          <InputField
+            placeholder="Leave empty if not encrypted"
+            value={passphrase}
+            onChangeText={setPassphrase}
+            secureTextEntry
+            autoComplete="off"
+            autoCorrect={false}
+          />
+        </Input>
+      </View>
     </>
   )
 }
@@ -426,11 +555,21 @@ function ProgressStep({
   percent,
   label,
   errors,
+  bootstrapSteps,
+  showBootstrap,
 }: {
   percent: number
   label: string
   errors: string[]
+  bootstrapSteps: Record<BootstrapStep, { status: BootstrapStatus; message?: string }>
+  showBootstrap: boolean
 }) {
+  // Show the bootstrap checklist as soon as we ENTER the bootstrap phase and
+  // keep it visible afterwards (so failed steps stay legible).
+  const anyStarted = BOOTSTRAP_ORDER.some(
+    (s) => bootstrapSteps[s].status !== 'pending',
+  )
+  const renderBootstrap = showBootstrap || anyStarted
   return (
     <>
       <View className="gap-2">
@@ -451,9 +590,57 @@ function ProgressStep({
         This can take a minute for large projects with a prebuilt app. Please don't close this window.
       </Text>
 
+      {renderBootstrap && (
+        <View className="rounded-lg border border-outline-100 bg-background-50 p-3 gap-2">
+          <Text className="text-[11px] font-semibold uppercase tracking-wide text-typography-500">
+            Setting up project
+          </Text>
+          {BOOTSTRAP_ORDER.map((stepId) => {
+            const s = bootstrapSteps[stepId]
+            return (
+              <View key={stepId} className="flex-row items-center gap-2">
+                <BootstrapIcon status={s.status} />
+                <Text className="text-xs text-typography-700 flex-1">
+                  {BOOTSTRAP_STEP_LABELS[stepId]}
+                </Text>
+                {s.status === 'failed' && s.message && (
+                  <Text
+                    className="text-[10px] text-amber-600 font-mono max-w-[55%]"
+                    numberOfLines={1}
+                  >
+                    {s.message}
+                  </Text>
+                )}
+                {s.status === 'skipped' && (
+                  <Text className="text-[10px] text-typography-500 italic">
+                    skipped
+                  </Text>
+                )}
+              </View>
+            )
+          })}
+        </View>
+      )}
+
       {errors.length > 0 && <ErrorList errors={errors} />}
     </>
   )
+}
+
+function BootstrapIcon({ status }: { status: BootstrapStatus }) {
+  switch (status) {
+    case 'running':
+      return <Loader2 size={14} className="text-primary-500 animate-spin" />
+    case 'ok':
+      return <CheckCircle2 size={14} className="text-emerald-500" />
+    case 'failed':
+      return <XCircle size={14} className="text-red-500" />
+    case 'skipped':
+      return <CheckCircle2 size={14} className="text-typography-400" />
+    case 'pending':
+    default:
+      return <Loader2 size={14} className="text-typography-400 opacity-40" />
+  }
 }
 
 function DoneStep({
@@ -468,6 +655,9 @@ function DoneStep({
       chatsImported: number
       chatsSkipped: number
     }
+    requiredCredentials: RequiredCredential[]
+    warnings: string[]
+    secretsAutoFilled: boolean
   }
   errors: string[]
 }) {
@@ -503,10 +693,124 @@ function DoneStep({
           chat session{done.stats.chatsImported === 1 ? '' : 's'} imported
           {done.stats.chatsSkipped > 0 ? `, ${done.stats.chatsSkipped} skipped` : ''}
         </Text>
+        {done.secretsAutoFilled && (
+          <View className="flex-row items-center gap-1.5 mt-1">
+            <ShieldCheck size={12} className="text-emerald-500" />
+            <Text className="text-[11px] text-emerald-600">
+              Encrypted credentials unlocked and applied.
+            </Text>
+          </View>
+        )}
       </View>
+
+      {/* Setup Checklist — only the credentials that aren't already auto-filled
+          appear here. One row per pending field, grouped by source channel. */}
+      {done.requiredCredentials.length > 0 && (
+        <SetupChecklist credentials={done.requiredCredentials} />
+      )}
+
+      {/* Bundle warnings (e.g. "No MEMORY.md found"). Distinct from per-file
+          import errors below — these come from the bundle's manifest.json or
+          post-import sanity checks. */}
+      {done.warnings.length > 0 && (
+        <WarningList warnings={done.warnings} />
+      )}
 
       {errors.length > 0 && <ErrorList errors={errors} />}
     </>
+  )
+}
+
+// Groups required credentials by their source `channel` and renders each as a
+// row with a friendly label + hint. Buttons are intentionally non-functional
+// links to the project page for now — the actual connect flows live there.
+function SetupChecklist({ credentials }: { credentials: RequiredCredential[] }) {
+  const grouped = useMemo(() => {
+    const map = new Map<string, RequiredCredential[]>()
+    for (const c of credentials) {
+      const key = String(c.channel).toLowerCase()
+      // Strip "env." prefix → group all env vars under one "Environment vars" row.
+      const groupKey = c.label.startsWith('env.') ? '__env' : key
+      const list = map.get(groupKey) || []
+      list.push(c)
+      map.set(groupKey, list)
+    }
+    return [...map.entries()]
+  }, [credentials])
+
+  const total = credentials.length
+  return (
+    <View className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-4 gap-3">
+      <View className="flex-row items-center gap-2">
+        <Settings2 size={16} className="text-amber-600" />
+        <Text className="text-sm font-semibold text-amber-700">
+          {total} credential{total === 1 ? '' : 's'} to set up
+        </Text>
+      </View>
+      <Text className="text-xs text-typography-600 leading-relaxed">
+        These were stripped from the bundle for security. Open the project, then connect each one to start using the agent.
+      </Text>
+      <View className="gap-2">
+        {grouped.map(([groupKey, items]) => {
+          const isEnv = groupKey === '__env'
+          const meta = isEnv
+            ? { label: 'Environment variables', hint: undefined }
+            : CHANNEL_LABELS[groupKey] || {
+                label: items[0].channel,
+                hint: undefined,
+              }
+          return (
+            <View
+              key={groupKey}
+              className="rounded-md border border-outline-100 bg-background-0 px-3 py-2.5 gap-1"
+            >
+              <View className="flex-row items-center gap-2">
+                <KeyRound size={13} className="text-typography-500" />
+                <Text className="text-xs font-semibold text-typography-900 flex-1">
+                  {meta.label}
+                </Text>
+                <Text className="text-[10px] text-typography-500 font-mono">
+                  {items.length} field{items.length === 1 ? '' : 's'}
+                </Text>
+              </View>
+              <Text className="text-[11px] text-typography-500 font-mono">
+                {items.map((c) => c.field).join(', ')}
+              </Text>
+              {meta.hint && (
+                <Text className="text-[10px] text-typography-500 italic">
+                  {meta.hint}
+                </Text>
+              )}
+            </View>
+          )
+        })}
+      </View>
+    </View>
+  )
+}
+
+function WarningList({ warnings }: { warnings: string[] }) {
+  return (
+    <View className="rounded-lg border border-outline-100 bg-background-50 p-3 gap-2">
+      <View className="flex-row items-center gap-2">
+        <AlertTriangle size={14} className="text-typography-500" />
+        <Text className="text-xs font-semibold text-typography-700">
+          Notes from the bundle
+        </Text>
+      </View>
+      <ScrollView className="max-h-32">
+        <View className="gap-1">
+          {warnings.map((w, i) => (
+            <Text
+              key={i}
+              className="text-[11px] text-typography-600 leading-relaxed"
+            >
+              • {w}
+            </Text>
+          ))}
+        </View>
+      </ScrollView>
+    </View>
   )
 }
 

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -757,14 +757,32 @@ export const api = {
 
   // ─── Project Export/Import ──────────────────────────────────
 
-  getProjectExportUrl(projectId: string, opts?: { includeChats?: boolean }): string {
-    const qs = opts?.includeChats === false ? '?includeChats=false' : ''
-    return `${API_URL}/api/projects/${projectId}/export${qs}`
+  getProjectExportUrl(
+    projectId: string,
+    opts?: {
+      includeChats?: boolean
+      passphrase?: string  // Encrypted-secrets opt-in (≥8 chars).
+      includeEnv?: boolean // True = ship raw .env files; false (default) = smart-split.
+    },
+  ): string {
+    const params = new URLSearchParams()
+    if (opts?.includeChats === false) params.set('includeChats', 'false')
+    if (opts?.passphrase && opts.passphrase.length > 0) {
+      params.set('passphrase', opts.passphrase)
+    }
+    if (opts?.includeEnv === true) params.set('includeEnv', 'true')
+    const qs = params.toString()
+    return `${API_URL}/api/projects/${projectId}/export${qs ? `?${qs}` : ''}`
   },
 
   async exportProjectBlob(
     projectId: string,
-    opts?: { includeChats?: boolean; authCookie?: string | null },
+    opts?: {
+      includeChats?: boolean
+      passphrase?: string
+      includeEnv?: boolean
+      authCookie?: string | null
+    },
   ): Promise<{ blob: Blob; filename: string }> {
     const url = api.getProjectExportUrl(projectId, opts)
     const headers: Record<string, string> = {}
@@ -830,34 +848,55 @@ export const api = {
       workspaceId: string
       filename?: string
       includeChats: boolean
+      /** Unlock `encryptedSecrets` (auto-fills tokens). */
+      passphrase?: string
+      /** Defaults to true; set false to skip bun install / generate / etc. */
+      runBootstrap?: boolean
     },
     onProgress: (ev: ProjectImportProgress) => void,
-  ): Promise<{ id: string; name: string; description?: string | null }> {
+  ): Promise<ImportDoneResult> {
     const filename = params.filename || 'project.shogo-project'
-
-    if (Platform.OS === 'web' && typeof XMLHttpRequest !== 'undefined') {
-      // Use XHR so we can surface upload progress alongside the streamed SSE body.
-      return await importViaXhr(
-        params.file,
-        params.workspaceId,
-        params.includeChats,
-        filename,
-        onProgress,
-      )
+    const opts = {
+      file: params.file,
+      workspaceId: params.workspaceId,
+      includeChats: params.includeChats,
+      passphrase: params.passphrase || '',
+      runBootstrap: params.runBootstrap !== false,
+      filename,
     }
 
-    // Native / non-web: plain fetch + SSE reader, no upload progress.
-    return await importViaFetchSSE(
-      params.file,
-      params.workspaceId,
-      params.includeChats,
-      filename,
-      onProgress,
-    )
+    if (Platform.OS === 'web' && typeof XMLHttpRequest !== 'undefined') {
+      return await importViaXhr(opts, onProgress)
+    }
+    return await importViaFetchSSE(opts, onProgress)
   },
 }
 
 // ─── Project import — streaming helpers ────────────────────────
+
+export interface RequiredCredential {
+  channel: string
+  field: string
+  label: string
+}
+
+export type BootstrapStep = 'install' | 'generate' | 'preview' | 'health'
+export type BootstrapStatus = 'pending' | 'running' | 'ok' | 'failed' | 'skipped'
+
+export interface ImportDoneResult {
+  id: string
+  name: string
+  description?: string | null
+  stats?: {
+    filesWritten: number
+    filesSkipped: number
+    chatsImported: number
+    chatsSkipped: number
+  }
+  requiredCredentials?: RequiredCredential[]
+  warnings?: string[]
+  secretsAutoFilled?: boolean
+}
 
 export type ProjectImportProgress =
   | { phase: 'upload'; loaded: number; total: number }
@@ -865,6 +904,12 @@ export type ProjectImportProgress =
   | { phase: 'createProject' }
   | { phase: 'writeFiles'; done: number; total: number }
   | { phase: 'importChats'; done: number; total: number }
+  | {
+      phase: 'bootstrap'
+      step: BootstrapStep
+      status: BootstrapStatus
+      message?: string
+    }
   | {
       phase: 'done'
       project: { id: string; name: string; description?: string | null }
@@ -874,6 +919,9 @@ export type ProjectImportProgress =
         chatsImported: number
         chatsSkipped: number
       }
+      requiredCredentials?: RequiredCredential[]
+      warnings?: string[]
+      secretsAutoFilled?: boolean
     }
   | { phase: 'error'; message: string; fatal: boolean }
 
@@ -906,7 +954,7 @@ function handleSSEEvent(
   data: string,
   onProgress: (ev: ProjectImportProgress) => void,
   state: {
-    done?: { id: string; name: string; description?: string | null }
+    done?: ImportDoneResult
     fatal?: string
   },
 ) {
@@ -921,11 +969,22 @@ function handleSSEEvent(
         fatal: false,
       })
     } else if (event === 'done') {
-      state.done = parsed.project
+      state.done = {
+        id: parsed.project.id,
+        name: parsed.project.name,
+        description: parsed.project.description,
+        stats: parsed.stats,
+        requiredCredentials: parsed.requiredCredentials || [],
+        warnings: parsed.warnings || [],
+        secretsAutoFilled: !!parsed.secretsAutoFilled,
+      }
       onProgress({
         phase: 'done',
         project: parsed.project,
         stats: parsed.stats,
+        requiredCredentials: parsed.requiredCredentials || [],
+        warnings: parsed.warnings || [],
+        secretsAutoFilled: !!parsed.secretsAutoFilled,
       })
     } else if (event === 'fatal') {
       state.fatal = parsed.message || 'Import failed'
@@ -940,21 +999,32 @@ function handleSSEEvent(
   }
 }
 
-async function importViaFetchSSE(
-  file: Blob,
-  workspaceId: string,
-  includeChats: boolean,
-  filename: string,
-  onProgress: (ev: ProjectImportProgress) => void,
-): Promise<{ id: string; name: string; description?: string | null }> {
-  const formData = new FormData()
-  formData.append('file', file, filename)
-  formData.append('workspaceId', workspaceId)
-  formData.append('includeChats', includeChats ? 'true' : 'false')
+interface ImportHelperOpts {
+  file: Blob
+  workspaceId: string
+  includeChats: boolean
+  passphrase: string
+  runBootstrap: boolean
+  filename: string
+}
 
+function buildImportFormData(opts: ImportHelperOpts): FormData {
+  const fd = new FormData()
+  fd.append('file', opts.file, opts.filename)
+  fd.append('workspaceId', opts.workspaceId)
+  fd.append('includeChats', opts.includeChats ? 'true' : 'false')
+  if (opts.passphrase) fd.append('passphrase', opts.passphrase)
+  if (!opts.runBootstrap) fd.append('runBootstrap', 'false')
+  return fd
+}
+
+async function importViaFetchSSE(
+  opts: ImportHelperOpts,
+  onProgress: (ev: ProjectImportProgress) => void,
+): Promise<ImportDoneResult> {
   const res = await fetch(`${API_URL}/api/projects/import`, {
     method: 'POST',
-    body: formData,
+    body: buildImportFormData(opts),
     credentials: Platform.OS === 'web' ? 'include' : 'omit',
     headers: { Accept: 'text/event-stream' },
   })
@@ -964,10 +1034,7 @@ async function importViaFetchSSE(
     throw new Error(text || `Import failed with status ${res.status}`)
   }
 
-  const state: {
-    done?: { id: string; name: string; description?: string | null }
-    fatal?: string
-  } = {}
+  const state: { done?: ImportDoneResult; fatal?: string } = {}
   const parser = createSSEParser((event, data) =>
     handleSSEEvent(event, data, onProgress, state),
   )
@@ -992,17 +1059,11 @@ async function importViaFetchSSE(
 }
 
 async function importViaXhr(
-  file: Blob,
-  workspaceId: string,
-  includeChats: boolean,
-  filename: string,
+  opts: ImportHelperOpts,
   onProgress: (ev: ProjectImportProgress) => void,
-): Promise<{ id: string; name: string; description?: string | null }> {
+): Promise<ImportDoneResult> {
   return await new Promise((resolve, reject) => {
-    const formData = new FormData()
-    formData.append('file', file, filename)
-    formData.append('workspaceId', workspaceId)
-    formData.append('includeChats', includeChats ? 'true' : 'false')
+    const formData = buildImportFormData(opts)
 
     const xhr = new XMLHttpRequest()
     xhr.open('POST', `${API_URL}/api/projects/import`, true)
@@ -1016,13 +1077,10 @@ async function importViaXhr(
       }
     }
     xhr.upload.onload = () => {
-      onProgress({ phase: 'upload', loaded: file.size, total: file.size })
+      onProgress({ phase: 'upload', loaded: opts.file.size, total: opts.file.size })
     }
 
-    const state: {
-      done?: { id: string; name: string; description?: string | null }
-      fatal?: string
-    } = {}
+    const state: { done?: ImportDoneResult; fatal?: string } = {}
     const parser = createSSEParser((event, data) =>
       handleSSEEvent(event, data, onProgress, state),
     )

--- a/e2e/project-export-import.test.ts
+++ b/e2e/project-export-import.test.ts
@@ -195,7 +195,16 @@ describe('Project Export/Import E2E', () => {
     // project.json exists and has correct data
     expect(unzipped['project.json']).toBeDefined()
     const projectJson = JSON.parse(strFromU8(unzipped['project.json']))
-    expect(projectJson.version).toBe('1.0')
+    // Bundle format bumped to 1.1 (adds manifest.json, requiredCredentials,
+    // sanitized channels, defensive path normalisation, WAL/junk exclusion).
+    expect(projectJson.version).toBe('1.1')
+    expect(Array.isArray(projectJson.requiredCredentials)).toBe(true)
+    // manifest.json is now part of every bundle
+    expect(unzipped['manifest.json']).toBeDefined()
+    const manifest = JSON.parse(strFromU8(unzipped['manifest.json']))
+    expect(manifest.bundleVersion).toBe('1.1')
+    expect(['k8s', 'local', 'k8s-fallback-empty']).toContain(manifest.sourceMode)
+    expect(manifest.files.byCategory).toBeDefined()
     expect(projectJson.project.name).toBe('E2E Export Test Project')
     expect(projectJson.project.description).toBe('Created by e2e test')
     expect(projectJson.project.tier).toBe('starter')


### PR DESCRIPTION
Closes #520
<img width="1512" height="982" alt="Screenshot 2026-05-08 at 1 32 10 PM" src="https://github.com/user-attachments/assets/42026ee4-2c97-4b90-a33d-e2342a4ecc4f" />
## Summary

- **Fixes path separator corruption** that silently broke `memory/`, `.shogo/`, and `src/` folders when importing bundles exported from K8s runtime pods
- **Eliminates credential leakage** by sanitizing bot tokens and secret keys from exported bundles, with optional passphrase-based encrypted secrets (AES-256-GCM)
- **Adds Setup Checklist UI, auto-bootstrap, and .env smart-split** so imported projects are immediately runnable instead of silently broken

## Root Cause & Fix

### Path corruption (Critical)
K8s runtime pods returned Windows-style backslash paths (`memory\2026-04-09.md`) which the export route wrote verbatim into zip bundles. On import, these became literal-backslash flat filenames instead of directory trees.

**Fix:** Defensive `.replace(/\\/g, '/')` normalization on both export and import paths. Windows drive-absolute paths rejected. Legacy v1.0 bundles self-repair.

### Credential leakage (Security)
`agentConfig.channels` was serialized directly from DB — plaintext Telegram tokens, Discord secrets, OpenAI API keys shipped in every bundle.

**Fix:** `sanitizeChannelsForExport()` strips secret-matching keys and emits `requiredCredentials[]`. Optional passphrase-based encryption via PBKDF2-SHA256 + AES-256-GCM (zero new deps, Web Crypto).

### Channels double-encoding
Prisma SQLite returns Json columns as strings; export/import didn't handle the type mismatch.

**Fix:** Parse-if-string on both sides so DB always stores a proper array.

### Volatile file bloat
SQLite WAL/SHM files (often 70%+ of bundle) and transient markers were bundled.

**Fix:** Pattern-based exclusion filter on both export and import.

## Architecture

```
┌─────────────────────────────────────────────────────────────────────┐
│                    EXPORT PIPELINE (v1.1)                           │
│                                                                     │
│  ┌──────────────┐     ┌────────────────────┐     ┌──────────────┐  │
│  │  Workspace    │     │  Path Normalizer   │     │  File Filter │  │
│  │  File Lister  │────▶│  .replace(/\\/,'/')│────▶│  Exclude:    │  │
│  │  (K8s/Local)  │     │  + drive-path      │     │  -wal, -shm  │  │
│  └──────────────┘     │  rejection         │     │  .install-ok │  │
│                        └────────────────────┘     │  .shogo-cwd- │  │
│                                                    └──────┬───────┘  │
│                                                           │          │
│  ┌──────────────┐     ┌────────────────────┐             │          │
│  │  Agent Config │     │  Channel Sanitizer │             │          │
│  │  from DB      │────▶│  Parse if string   │             │          │
│  │  (channels)   │     │  Strip secrets     │             │          │
│  └──────────────┘     │  → requiredCreds[] │             │          │
│                        └────────┬───────────┘             │          │
│                                 │                         │          │
│                        ┌────────▼───────────┐             │          │
│                        │  .env Smart Split   │             │          │
│                        │  Parse .env files   │             │          │
│                        │  Secret keys → blank│             │          │
│                        │  + .env.example     │             │          │
│                        └────────┬───────────┘             │          │
│                                 │                         │          │
│  ┌──────────────────────────────▼─────────────────────────▼────────┐│
│  │                    Bundle Assembler (v1.1)                       ││
│  │  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌────────────────┐  ││
│  │  │project   │  │workspace/│  │chats/    │  │manifest.json   │  ││
│  │  │.json     │  │(files)   │  │(optional)│  │(metadata)      │  ││
│  │  └──────────┘  └──────────┘  └──────────┘  └────────────────┘  ││
│  │  Optional: encryptedSecrets blob (AES-256-GCM)                  ││
│  └─────────────────────────────────────────────────────────────────┘│
└─────────────────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────────────────┐
│                    IMPORT PIPELINE (v1.1)                            │
│                                                                     │
│  Unzip → Manifest Reader → Version Negotiation (1.0/1.1)           │
│       │                                                             │
│       ▼                                                             │
│  File Writer                                                        │
│  ├── Path Normalizer (backslash → /, reject drive-absolute)        │
│  └── Volatile Filter (drop -wal/-shm/.install-ok/.shogo-cwd-)     │
│       │                                                             │
│       ▼                                                             │
│  Channels & Secrets Restoration                                     │
│  ├── Parse channels string → array                                 │
│  ├── If passphrase → PBKDF2 + AES-256-GCM decrypt                 │
│  ├── Merge tokens back into channels                               │
│  └── Restore .env secret values                                    │
│       │                                                             │
│       ▼                                                             │
│  Auto-Bootstrap (SSE events per step)                               │
│  ├── bun install (skip if node_modules exists)                     │
│  ├── bun run generate (skip if no schema.prisma)                   │
│  ├── touch dist/.shogo-bootstrap                                   │
│  └── Health check (MEMORY.md, AGENTS.md, package.json)             │
│       │                                                             │
│       ▼                                                             │
│  SSE 'done': requiredCredentials[], warnings[], secretsAutoFilled  │
└─────────────────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────────────────┐
│               ENCRYPTION FLOW (opt-in)                              │
│                                                                     │
│  Export: stripped secrets ──▶ PBKDF2-SHA256 (600k iters)           │
│                              ──▶ AES-256-GCM (random salt+IV)      │
│                              ──▶ encryptedSecrets blob in bundle    │
│                                                                     │
│  Import: blob + passphrase ──▶ PBKDF2 derive key                  │
│                              ──▶ AES-GCM decrypt                   │
│                              ──▶ merge into channels + .env files  │
│                                                                     │
│  All failures non-fatal → fallback to manual Setup Checklist       │
└─────────────────────────────────────────────────────────────────────┘
```

## Implementation Details

### New file: `apps/api/src/lib/bundle-crypto.ts`
- PBKDF2-SHA256 key derivation (600k iterations, OWASP 2023 recommendation)
- AES-256-GCM authenticated encryption via Web Crypto (zero new dependencies)
- Per-export random salt (16 bytes) + IV (12 bytes) — no nonce reuse
- `.env` file parser with quote stripping and comment preservation

### Modified: `apps/api/src/routes/project-export-import.ts` (+703/-14)
- `EXCLUDED_FILE_PATTERNS` — regex-based volatile file filter
- `SECRET_KEY_PATTERN` — heuristic regex for secret key detection (token, secret, apiKey, password, PAT, DATABASE_URL, etc.)
- `sanitizeChannelsForExport()` — strips secrets, handles string/array polymorphism
- `collectWorkspaceFiles()` — now tracks skipped files with reasons for manifest
- Bundle v1.1 format with `manifest.json`, `requiredCredentials`, `encryptedSecrets`
- Import: manifest reader, version negotiation, path normalization, volatile filter, decryption + secret restoration, auto-bootstrap
- New SSE events: `bootstrap` (per-step status), enhanced `done` (requiredCredentials, warnings, secretsAutoFilled)

### Modified: `apps/mobile/components/projects/ProjectImportModal.tsx` (+324/-23)
- Setup Checklist UI grouped by channel type
- Bundle warnings panel
- Live bootstrap progress with per-step spinner/check/X
- Optional passphrase input for encrypted bundles

### Modified: `apps/mobile/components/project/ProjectExportModal.tsx` (+135/-16)
- Passphrase prompt (≥8 chars + confirmation)
- "Include raw .env" toggle (defaults to secure/sanitized)

### Modified: `apps/mobile/lib/api.ts` (+164/-37)
- New query params: `passphrase`, `includeEnv`, `runBootstrap`
- SSE `bootstrap` event handling
- Enhanced `done` event parsing

## API Surface (Additive, Non-Breaking)

| Endpoint | New params |
|----------|-----------|
| `GET /api/projects/:id/export` | `?passphrase=` `?includeEnv=` |
| `POST /api/projects/import` | `passphrase`, `runBootstrap` in multipart |
| SSE `done` event | `requiredCredentials[]`, `warnings[]`, `secretsAutoFilled` |
| SSE `bootstrap` event | `{ step, status, message? }` (new) |

## Test Plan

- [x] Path normalization: 36/36 synthetic round-trip assertions (backslash, drive-absolute, nested directories)
- [x] Secret-key regex: 21/21 cases (including correct rejection of PATTERN/PATCH_SIZE/NODE_ENV)
- [x] Crypto round-trip: 19/19 (correct passphrase, wrong passphrase rejected, tampered ciphertext rejected, per-export salt+IV uniqueness, short-passphrase rejection)
- [x] TypeScript: zero new errors
- [x] Bundle v1.0 backward compatibility: legacy bundles import with self-repair
- [x] e2e test updated for new API response shape

