### PR TITLE
fix(admin): fix project search crash on SQLite and improve search bar UX

### DIFF
--- a/apps/desktop/prisma/migrations/20260508001721_add_project_agents_local/migration.sql
+++ b/apps/desktop/prisma/migrations/20260508001721_add_project_agents_local/migration.sql
@@ -1,5 +1,3 @@
-[2mLoaded Prisma config from prisma.config.ts.
-[22m
 -- CreateTable
 CREATE TABLE "project_agents" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -26,4 +24,3 @@ CREATE INDEX "project_agents_workspaceId_idx" ON "project_agents"("workspaceId")
 
 -- CreateIndex
 CREATE UNIQUE INDEX "project_agents_projectId_name_key" ON "project_agents"("projectId", "name");
-

--- a/apps/mobile/app/(admin)/projects/index.tsx
+++ b/apps/mobile/app/(admin)/projects/index.tsx
@@ -7,7 +7,7 @@
  * on mobile shows a compact card list.
  */
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import {
   View,
   Text,
@@ -167,25 +167,36 @@ export default function AdminProjectsPage() {
   const isWide = width >= 900
 
   const [search, setSearch] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
   const [page, setPage] = useState(1)
   const [statusFilter, setStatusFilter] = useState<string>('')
   const [data, setData] = useState<ProjectsResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      setDebouncedSearch(search)
+      setPage(1)
+    }, 350)
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current) }
+  }, [search])
 
   const loadProjects = useCallback(async () => {
     const params: Record<string, string> = {
       page: String(page),
       limit: '20',
     }
-    if (search) params.search = search
+    if (debouncedSearch) params.search = debouncedSearch
     if (statusFilter) params.status = statusFilter
 
     const result = await fetchAdminJson<ProjectsResponse>('/projects', params)
     setData(result)
     setLoading(false)
     setRefreshing(false)
-  }, [page, search, statusFilter])
+  }, [page, debouncedSearch, statusFilter])
 
   useEffect(() => {
     setLoading(true)
@@ -199,7 +210,7 @@ export default function AdminProjectsPage() {
     loadProjects()
   }
 
-  const ListHeader = () => (
+  const listHeader = (
     <View className="gap-3 mb-2">
       <View className={cn(isWide ? 'flex-row items-center gap-3' : 'gap-3')}>
         <View
@@ -213,13 +224,11 @@ export default function AdminProjectsPage() {
             placeholder="Search projects..."
             placeholderTextColor="#9ca3af"
             value={search}
-            onChangeText={(t) => {
-              setSearch(t)
-              setPage(1)
-            }}
+            onChangeText={setSearch}
             autoCapitalize="none"
             autoCorrect={false}
-            className="flex-1 text-foreground text-sm"
+            className="flex-1 text-foreground text-sm web:outline-none"
+            style={{ outline: 'none' } as any}
           />
         </View>
 
@@ -348,7 +357,7 @@ export default function AdminProjectsPage() {
         <FlatList
           data={data?.projects ?? []}
           keyExtractor={(item) => item.id}
-          ListHeaderComponent={<ListHeader />}
+          ListHeaderComponent={listHeader}
           ListFooterComponent={<ListFooter />}
           ListEmptyComponent={loading ? null : <EmptyState />}
           refreshControl={

--- a/packages/sdk/src/generators/admin-routes-generator.ts
+++ b/packages/sdk/src/generators/admin-routes-generator.ts
@@ -52,7 +52,7 @@ function toRoutePath(name: string): string {
  * Get string fields that can be searched
  */
 function getSearchableFields(model: PrismaModel): PrismaField[] {
-  return getScalarFields(model).filter(f => f.type === 'String' && !f.isId)
+  return getScalarFields(model).filter(f => f.type === 'String' && !f.isId && !f.isList)
 }
 
 /**
@@ -121,6 +121,15 @@ export function generateAdminRoutes(
     '  const { prisma, middleware = [] } = config',
     '  const router = new Hono()',
     '',
+    '  // SQLite does not support `mode: "insensitive"` on string filters.',
+    '  // Detect the provider at startup so search clauses can adapt.',
+    '  const isSQLite = (() => {',
+    '    try {',
+    '      const url = process.env.DATABASE_URL || ""',
+    '      return url.startsWith("file:") || url.endsWith(".db") || url.includes("sqlite")',
+    '    } catch { return false }',
+    '  })()',
+    '',
     '  // Apply middleware stack',
     '  for (const mw of middleware) {',
     '    router.use("*", mw)',
@@ -157,10 +166,13 @@ export function generateAdminRoutes(
     if (searchFields.length > 0) {
       lines.push('      let where: any = {}')
       lines.push('      if (search) {')
+      lines.push('        const searchFilter = isSQLite')
+      lines.push('          ? { contains: search }')
+      lines.push('          : { contains: search, mode: "insensitive" as const }')
       lines.push('        where = {')
       lines.push('          OR: [')
       for (const field of searchFields) {
-        lines.push(`            { ${field.name}: { contains: search, mode: "insensitive" } },`)
+        lines.push(`            { ${field.name}: searchFilter },`)
       }
       lines.push('          ]')
       lines.push('        }')


### PR DESCRIPTION
Before
<img width="1851" height="678" alt="image" src="https://github.com/user-attachments/assets/47187fec-9841-403e-80e2-447a875a4c33" />
after
<img width="1918" height="973" alt="image" src="https://github.com/user-attachments/assets/d4dcd135-1a04-4c5c-96a0-41466d1c483e" />
## Summary

- **Fix 500 error on search** — The auto-generated admin routes used Prisma's `mode: "insensitive"` for case-insensitive search, which is PostgreSQL-only. All local/desktop users (SQLite) were hitting a 500 crash on any search query in the Super Admin Panel. The generator now detects the database provider at runtime and omits `mode: "insensitive"` for SQLite.
- **Exclude array fields from search** — `String[]` fields like `schemas` were being included in search queries with `contains`, which Prisma doesn't support on array columns (breaks on both SQLite and PostgreSQL).
- **Fix search bar losing focus** — The search input was firing an API call on every keystroke, and the `ListHeader` was defined as an inline component causing React to unmount/remount it on every re-render. Added 350ms debounce and changed it to a JSX element.
- **Remove focus outline** — Removed the browser's default orange/white focus ring on the search input for a cleaner look.
- **Fix corrupted migration file** — Removed Prisma stdout text with ANSI escape codes that was accidentally baked into a migration SQL file, blocking all local migrations.

## Files changed

| File | Change |
|------|--------|
| `packages/sdk/src/generators/admin-routes-generator.ts` | Exclude `isList` fields from search; add runtime SQLite detection |
| `apps/mobile/app/(admin)/projects/index.tsx` | Debounce search, fix focus loss, remove outline |
| `apps/desktop/prisma/migrations/.../migration.sql` | Remove garbage stdout text from SQL |

## Test plan

- [ ] Search projects in Super Admin Panel on local/desktop (SQLite) — should return results without 500
- [ ] Search projects on staging (PostgreSQL) — should still work with case-insensitive matching
- [ ] Type multiple characters quickly in search bar — cursor should stay in the input
- [ ] Click into search bar — no orange/white outline should appear
- [ ] Run `bun run dev:all` from clean state — migrations should apply without errors