### PR TITLE
Remove unused EAS iOS submit configuration

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -49,22 +49,12 @@
       "android": {
         "serviceAccountKeyPath": "./google-services.json",
         "track": "internal"
-      },
-      "ios": {
-        "appleId": "$APPLE_ID",
-        "ascAppId": "$ASC_APP_ID",
-        "appleTeamId": "$APPLE_TEAM_ID"
       }
     },
     "production": {
       "android": {
         "serviceAccountKeyPath": "./google-services.json",
         "track": "production"
-      },
-      "ios": {
-        "appleId": "$APPLE_ID",
-        "ascAppId": "$ASC_APP_ID",
-        "appleTeamId": "$APPLE_TEAM_ID"
       }
     }
   }


### PR DESCRIPTION
## Summary

- Removes the unused `submit.ios` blocks from `apps/mobile/eas.json`.
- Keeps Android EAS submit configuration unchanged because Android still uses `eas submit`.
- Aligns mobile submit config with the current release architecture: iOS uploads through `xcrun altool`, Android submits through EAS.

Closes #525

## Detailed Implementation

The prior cleanup removed hardcoded Apple identifiers from `eas.json` by replacing them with environment variable placeholders. After reviewing the actual workflows, the iOS submit config is not needed at all.

This PR deletes only:

- `submit.staging.ios`
- `submit.production.ios`

The remaining `submit` config is Android-only:

- `submit.staging.android.serviceAccountKeyPath`
- `submit.staging.android.track`
- `submit.production.android.serviceAccountKeyPath`
- `submit.production.android.track`

No workflow changes are needed. `.github/workflows/ios.yml` uploads the IPA using `xcrun altool` and GitHub Secrets directly. It does not call `eas submit --platform ios`, so it does not need `submit.ios` in `eas.json`.

## Architecture Diagram

```mermaid
flowchart TD
  subgraph IOS[iOS release]
    IOSWF[ios.yml] --> IPA[Build IPA]
    IOSSecrets[GitHub Secrets] --> Upload[xcrun altool]
    IPA --> Upload
    Upload --> ASC[App Store Connect]
  end

  subgraph Android[Android release]
    AndroidWF[android.yml] --> EAS[eas submit --platform android]
    EASJSON[eas.json submit.android] --> EAS
    PlaySecret[GOOGLE_SERVICES_JSON_BASE64] --> EAS
    EAS --> Play[Google Play]
  end

  Removed[submit.ios removed] -. stale config, not used .-> IOSWF
```

## RCA

The `submit.ios` section existed because EAS supports declaring App Store submit metadata in `eas.json`, and it was likely added during earlier/manual EAS submit setup. The repository now uses a custom iOS CI upload path with `xcrun altool`, so that config became stale.

Keeping it, even with environment variable placeholders, incorrectly suggested those fields were required by the iOS workflow. Removing it makes the config match the actual architecture and avoids future confusion around where Apple credentials should live.

## Test Plan

- Verified PR diff against `origin/main` contains only `apps/mobile/eas.json`.
- Verified only the unused iOS submit sections were removed.
- Verified Android submit config remains unchanged.
- Verified no linter errors for `apps/mobile/eas.json`.

Made with [Cursor](https://cursor.com)