### PR TITLE
fix(agent-runtime): quote bundler binary paths on Windows for shell spawns

### DIFF
--- a/packages/agent-runtime/src/canvas-build-manager.ts
+++ b/packages/agent-runtime/src/canvas-build-manager.ts
@@ -301,8 +301,9 @@ export class CanvasBuildManager {
     }
     try {
       await new Promise<void>((resolve, reject) => {
+        const cmd = isWindows ? `"${invocation.cmd}"` : invocation.cmd
         const proc: ChildProcess = spawn(
-          invocation.cmd,
+          cmd,
           [...invocation.argsPrefix, ...this.buildArgsFor(bundler.kind)],
           {
             cwd: this.workspaceDir,

--- a/packages/agent-runtime/src/preview-manager.ts
+++ b/packages/agent-runtime/src/preview-manager.ts
@@ -1606,7 +1606,7 @@ export class PreviewManager {
       let proc: ChildProcess
       try {
         proc = spawn(
-          invocation.cmd,
+          isWindows ? `"${invocation.cmd}"` : invocation.cmd,
           [...invocation.argsPrefix, 'build', '--outDir', DEFAULT_STAGING_DIR, '--emptyOutDir'],
           {
             cwd,
@@ -1690,7 +1690,7 @@ export class PreviewManager {
     let viteProcess: ChildProcess
     try {
       viteProcess = spawn(
-        invocation.cmd,
+        isWindows ? `"${invocation.cmd}"` : invocation.cmd,
         [...invocation.argsPrefix, 'build', '--watch', '--emptyOutDir', 'false'],
         {
           cwd,
@@ -2168,7 +2168,7 @@ export class PreviewManager {
     const exitCode = await new Promise<number | null>((resolveExport) => {
       let proc: ChildProcess
       try {
-        proc = spawn(expoBin, ['export', '--platform', 'web', '--output-dir', DEFAULT_STAGING_DIR], {
+        proc = spawn(isWindows ? `"${expoBin}"` : expoBin, ['export', '--platform', 'web', '--output-dir', DEFAULT_STAGING_DIR], {
           cwd,
           stdio: ['ignore', 'pipe', 'pipe'],
           // `.CMD` shims must go through cmd.exe on Windows.
@@ -2325,7 +2325,7 @@ export class PreviewManager {
     let proc: ChildProcess
     try {
       proc = spawn(
-        expoBin,
+        isWindows ? `"${expoBin}"` : expoBin,
         ['start', '--tunnel', ...portArgs],
         {
           cwd,


### PR DESCRIPTION
### Summary
On Windows, `child_process.spawn(..., { shell: true })` runs through `cmd.exe`, which tokenizes the “executable” part on spaces. When the Vite/Expo shim lives under a path like `C:\Users\First Last\...`, the command is split so only `C:\Users\First` is treated as the program—bundler builds fail with `'...' is not recognized`, even though chat and the rest of the runtime keep working.

### What changed
- **`CanvasBuildManager`**: When spawning the resolved bundler binary with `shell: true` on Windows, wrap the binary path in double quotes so the full path is one token.
- **`PreviewManager`**: Apply the same quoting for all Windows `shell: true` spawns that invoke `vite` / `expo` from `node_modules/.bin` (one-shot build, watch, expo export, expo tunnel).

### Why
Restores canvas/preview builds for developers whose user or workspace paths contain spaces—a regression introduced by using shell mode for `.CMD` shims on Windows.

### How to verify
1. Use a profile/workspace path that includes a space (e.g. `C:\Users\Some User\...`).
2. Run local dev; open a project so the agent workspace builds.
3. Confirm logs no longer show `'C:\Users\Some' is not recognized` and Vite/Expo build steps proceed.

BEFORE - 404 ERROR ON **CANVAS**
**AFTER**
<img width="1591" height="965" alt="image" src="https://github.com/user-attachments/assets/5580957f-04d7-410b-a38b-53898a386131" />

