### PR TITLE
Fix App Review UI and privacy copy

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -57,8 +57,8 @@
       [
         "expo-speech-recognition",
         {
-          "microphonePermission": "Allow Shogo to use the microphone for voice input.",
-          "speechRecognitionPermission": "Allow Shogo to use speech recognition for voice input."
+          "microphonePermission": "Shogo uses your microphone to record your voice when you tap the mic button in chat, so the AI can transcribe what you say into a prompt — for example, asking \"summarize my last meeting notes.\" Audio is processed only to generate the transcript and is not stored.",
+          "speechRecognitionPermission": "Shogo uses Apple's on-device speech recognition to convert your dictated voice into text in the chat input — for example, when you say \"create a new task for tomorrow,\" it appears as text you can edit before sending."
         }
       ],
       [

--- a/apps/mobile/app/(app)/billing.tsx
+++ b/apps/mobile/app/(app)/billing.tsx
@@ -413,9 +413,9 @@ export default observer(function BillingPage() {
       </View>
 
       {/* Plan Cards — md row: equal-height columns; tier slot reserves space so CTAs align */}
-      <View className="gap-6 md:flex-row md:items-stretch" testID="plan-cards-row">
+      <View className="gap-6 md:flex-row md:flex-wrap md:items-stretch xl:flex-nowrap" testID="plan-cards-row">
         {/* Basic Plan */}
-        <View className="md:flex-1 md:w-0 flex flex-col" testID="plan-card-basic">
+        <View className="md:w-[calc(50%-12px)] md:flex-grow-0 xl:w-auto xl:flex-1 xl:basis-0 flex flex-col" testID="plan-card-basic">
           <View className="hidden md:block md:min-h-8" />
           <Card className="md:flex-1 flex flex-col">
             <CardContent className="md:flex-1 flex flex-col p-5 gap-5">
@@ -469,7 +469,7 @@ export default observer(function BillingPage() {
         </View>
 
         {/* Pro Plan */}
-        <View className="md:flex-1 md:w-0 flex flex-col" testID="plan-card-pro">
+        <View className="md:w-[calc(50%-12px)] md:flex-grow-0 xl:w-auto xl:flex-1 xl:basis-0 flex flex-col" testID="plan-card-pro">
           <View className="hidden md:block md:min-h-8" />
           <Card className="md:flex-1 flex flex-col">
             <CardContent className="md:flex-1 flex flex-col p-5 gap-5">
@@ -535,7 +535,7 @@ export default observer(function BillingPage() {
         </View>
 
         {/* Business Plan */}
-        <View className="md:flex-1 md:w-0 flex flex-col" testID="plan-card-business">
+        <View className="md:w-[calc(50%-12px)] md:flex-grow-0 xl:w-auto xl:flex-1 xl:basis-0 flex flex-col" testID="plan-card-business">
           <View className="min-h-8 items-center justify-center px-1">
             <Badge className="bg-primary">
               <Text className="text-xs text-primary-foreground font-medium">Most Popular</Text>
@@ -602,7 +602,7 @@ export default observer(function BillingPage() {
         </View>
 
         {/* Enterprise Plan */}
-        <View className="md:flex-1 md:w-0 flex flex-col" testID="plan-card-enterprise">
+        <View className="md:w-[calc(50%-12px)] md:flex-grow-0 xl:w-auto xl:flex-1 xl:basis-0 flex flex-col" testID="plan-card-enterprise">
           <View className="hidden md:block md:min-h-8" />
           <Card className="md:flex-1 flex flex-col">
             <CardContent className="md:flex-1 flex flex-col p-5 gap-5">


### PR DESCRIPTION
Closes #529

## Summary
- Updates the microphone and speech recognition purpose strings so they clearly explain when Shogo requests access, how the captured input is used, and concrete examples for App Review Guideline 5.1.1(ii).
- Adjusts the billing/pricing card layout on tablet-sized widths so the plan cards wrap into two columns before returning to four columns on extra-wide layouts, preventing the Pro page content from being cropped on iPad Air 11-inch.

## App Review Issues Addressed
- **Guideline 5.1.1(ii) - Privacy purpose strings:** The previous microphone and speech recognition strings were too generic. The revised copy describes tap-to-record voice input, transcription into chat prompts, an example prompt, and that audio is processed only to generate the transcript.
- **Guideline 4 - Design:** The pricing cards previously forced four equal-width columns at medium tablet breakpoints, which could crowd and crop the Pro plan content. The updated layout allows wrapping at medium widths and keeps four columns only at extra-wide widths.

## Files Changed
- `apps/mobile/app.json`
- `apps/mobile/app/(app)/billing.tsx`

## Test Plan
- Not run locally; staged change is limited to configuration copy and responsive layout class updates.
- Recommended verification before resubmission: open the billing page on iPad Air 11-inch dimensions and confirm the Pro card content is readable and not cropped.
- Recommended verification before resubmission: trigger microphone and speech recognition permission prompts on a fresh iOS install and confirm the updated purpose strings appear.

Made with [Cursor](https://cursor.com)