### PR TITLE
fix(mobile): Plans, Tools, and Channels panel error and agent-ready UX

### DIFF
--- a/apps/mobile/components/project/panels/ChannelsPanel.tsx
+++ b/apps/mobile/components/project/panels/ChannelsPanel.tsx
@@ -21,6 +21,7 @@ import {
   Copy,
   Check,
   Phone,
+  AlertTriangle,
 } from 'lucide-react-native'
 import * as Clipboard from 'expo-clipboard'
 import { agentFetch } from '../../../lib/agent-fetch'
@@ -286,6 +287,28 @@ export function ChannelsPanel({ projectId, agentUrl, visible, hasAdvancedModelAc
   }
 
   if (!visible) return null
+
+  if (!agentUrl) {
+    return (
+      <View className="absolute inset-0 flex-col" style={{ display: visible ? 'flex' : 'none' }}>
+        <View className="px-4 py-3 border-b border-border flex-row items-center gap-2">
+          <MessageSquare size={16} className="text-muted-foreground" />
+          <View className="flex-1">
+            <Text className="text-sm font-medium text-foreground">Channels</Text>
+          </View>
+        </View>
+        <View className="flex-1 items-center justify-center px-6">
+          <AlertTriangle className="text-muted-foreground/40 mb-3" size={32} />
+          <Text className="text-sm font-medium text-foreground text-center">
+            Agent not connected
+          </Text>
+          <Text className="text-xs text-muted-foreground text-center mt-1">
+            The agent runtime is starting up. Channels will be available once the agent is ready.
+          </Text>
+        </View>
+      </View>
+    )
+  }
 
   const connectedTypes = new Set(channels.map(ch => ch.type))
 

--- a/apps/mobile/components/project/panels/ChannelsPanel.tsx
+++ b/apps/mobile/components/project/panels/ChannelsPanel.tsx
@@ -21,6 +21,7 @@ import {
   Copy,
   Check,
   Phone,
+  AlertTriangle,
 } from 'lucide-react-native'
 import * as Clipboard from 'expo-clipboard'
 import { agentFetch } from '../../../lib/agent-fetch'
@@ -414,6 +415,28 @@ export function ChannelsPanel({ projectId, workspaceId, agentUrl, visible, hasAd
   }
 
   if (!visible) return null
+
+  if (!agentUrl) {
+    return (
+      <View className="absolute inset-0 flex-col" style={{ display: visible ? 'flex' : 'none' }}>
+        <View className="px-4 py-3 border-b border-border flex-row items-center gap-2">
+          <MessageSquare size={16} className="text-muted-foreground" />
+          <View className="flex-1">
+            <Text className="text-sm font-medium text-foreground">Channels</Text>
+          </View>
+        </View>
+        <View className="flex-1 items-center justify-center px-6">
+          <AlertTriangle className="text-muted-foreground/40 mb-3" size={32} />
+          <Text className="text-sm font-medium text-foreground text-center">
+            Agent not connected
+          </Text>
+          <Text className="text-xs text-muted-foreground text-center mt-1">
+            The agent runtime is starting up. Channels will be available once the agent is ready.
+          </Text>
+        </View>
+      </View>
+    )
+  }
 
   const connectedTypes = new Set(channels.map(ch => ch.type))
 

--- a/apps/mobile/components/project/panels/PlansPanel.tsx
+++ b/apps/mobile/components/project/panels/PlansPanel.tsx
@@ -27,6 +27,7 @@ import {
   Play,
   ChevronDown,
   Check,
+  AlertTriangle,
 } from "lucide-react-native"
 import { MarkdownText } from "../../chat/MarkdownText"
 import { AgentClient, type AgentPlanSummary } from "@shogo-ai/sdk/agent"
@@ -126,6 +127,8 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
   const [buildMode, setBuildMode] = useState<string>(selectedModel || DEFAULT_MODEL_PRO)
   const [showModelPicker, setShowModelPicker] = useState(false)
   const [buildStarted, setBuildStarted] = useState(false)
+  const [fetchError, setFetchError] = useState<string | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
   const prevSelectedPlanRef = useRef<string | null>(null)
 
   // Align Build model with chat when opening a plan or switching plans — not when only
@@ -160,24 +163,28 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
 
   const fetchPlans = useCallback(async () => {
     setLoading(true)
+    setFetchError(null)
     try {
       const list = await agentClient.listPlans()
       setPlans(list)
-    } catch (err) {
-      console.error("[PlansPanel] Failed to fetch plans:", err)
+    } catch (err: any) {
+      setFetchError(err?.message || "Failed to load plans")
     } finally {
       setLoading(false)
     }
   }, [agentClient])
 
+  const [detailError, setDetailError] = useState<string | null>(null)
+
   const fetchPlanDetail = useCallback(
     async (filename: string) => {
       setDetailLoading(true)
+      setDetailError(null)
       try {
         const data = await agentClient.getPlan(filename)
         setPlanContent(data.content)
-      } catch (err) {
-        console.error("[PlansPanel] Failed to fetch plan detail:", err)
+      } catch (err: any) {
+        setDetailError(err?.message || "Failed to load plan")
         setPlanContent(null)
       } finally {
         setDetailLoading(false)
@@ -188,6 +195,7 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
 
   const handleDelete = useCallback(
     async (filename: string) => {
+      setDeleteError(null)
       try {
         await agentClient.deletePlan(filename)
         setPlans((prev) => prev.filter((p) => p.filename !== filename))
@@ -195,8 +203,8 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
           setSelectedPlan(null)
           setPlanContent(null)
         }
-      } catch (err) {
-        console.error("[PlansPanel] Failed to delete plan:", err)
+      } catch (err: any) {
+        setDeleteError(err?.message || "Failed to delete plan")
       }
     },
     [agentClient, selectedPlan]
@@ -402,10 +410,37 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
           )}
         </View>
 
+        {/* Delete error banner */}
+        {deleteError && (
+          <View className="px-4 py-2 bg-destructive/10 flex-row items-center gap-2">
+            <AlertTriangle className="text-destructive" size={14} />
+            <Text className="text-xs text-destructive flex-1">{deleteError}</Text>
+            <Pressable onPress={() => setDeleteError(null)} className="p-1">
+              <Text className="text-xs text-destructive font-medium">Dismiss</Text>
+            </Pressable>
+          </View>
+        )}
+
         {/* Detail body */}
         <ScrollView className="flex-1 px-4 py-3" onScrollBeginDrag={() => setShowModelPicker(false)}>
           {!isStreamingDetail && detailLoading ? (
             <ActivityIndicator className="mt-8" />
+          ) : !isStreamingDetail && detailError ? (
+            <View className="items-center justify-center py-12 px-4">
+              <AlertTriangle className="h-8 w-8 text-destructive/60 mb-3" size={32} />
+              <Text className="text-sm text-foreground text-center font-medium">
+                Couldn't load plan
+              </Text>
+              <Text className="text-xs text-muted-foreground text-center mt-1">
+                {detailError}
+              </Text>
+              <Pressable
+                onPress={() => fetchPlanDetail(selectedPlan!)}
+                className="mt-4 px-4 py-2 bg-primary rounded-lg active:bg-primary/80"
+              >
+                <Text className="text-xs font-medium text-primary-foreground">Retry</Text>
+              </Pressable>
+            </View>
           ) : (
             <>
               <MarkdownText>{body}</MarkdownText>
@@ -520,6 +555,22 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
 
         {loading && !planStream?.isPlanStreaming ? (
           <ActivityIndicator className="mt-8" />
+        ) : fetchError && plans.length === 0 && !planStream?.isPlanStreaming ? (
+          <View className="items-center justify-center py-12 px-4">
+            <AlertTriangle className="h-8 w-8 text-destructive/60 mb-3" size={32} />
+            <Text className="text-sm text-foreground text-center font-medium">
+              Couldn't load plans
+            </Text>
+            <Text className="text-xs text-muted-foreground text-center mt-1">
+              {fetchError}
+            </Text>
+            <Pressable
+              onPress={fetchPlans}
+              className="mt-4 px-4 py-2 bg-primary rounded-lg active:bg-primary/80"
+            >
+              <Text className="text-xs font-medium text-primary-foreground">Retry</Text>
+            </Pressable>
+          </View>
         ) : filteredPlans.length === 0 && !planStream?.isPlanStreaming && !planStream?.streamingPlan ? (
           <View className="items-center justify-center py-12 px-4">
             <ClipboardList className="h-8 w-8 text-muted-foreground/40 mb-3" size={32} />

--- a/apps/mobile/components/project/panels/PlansPanel.tsx
+++ b/apps/mobile/components/project/panels/PlansPanel.tsx
@@ -27,6 +27,7 @@ import {
   ChevronDown,
   Check,
   Languages,
+  AlertTriangle,
 } from "lucide-react-native"
 import { MarkdownText } from "../../chat/MarkdownText"
 import { AgentClient, type AgentPlanSummary } from "@shogo-ai/sdk/agent"
@@ -156,6 +157,7 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
   // filename so navigating between plans doesn't show a stale spinner.
   const [translateLoading, setTranslateLoading] = useState<string | null>(null)
   const [translateError, setTranslateError] = useState<string | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
   const prevSelectedPlanRef = useRef<string | null>(null)
 
   const handleDualPlanToggle = useCallback(() => {
@@ -207,14 +209,17 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
     }
   }, [agentClient])
 
+  const [detailError, setDetailError] = useState<string | null>(null)
+
   const fetchPlanDetail = useCallback(
     async (filename: string) => {
       setDetailLoading(true)
+      setDetailError(null)
       try {
         const data = await agentClient.getPlan(filename)
         setPlanContent(data.content)
-      } catch (err) {
-        console.error("[PlansPanel] Failed to fetch plan detail:", err)
+      } catch (err: any) {
+        setDetailError(err?.message || "Failed to load plan")
         setPlanContent(null)
       } finally {
         setDetailLoading(false)
@@ -225,6 +230,7 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
 
   const handleDelete = useCallback(
     async (filename: string) => {
+      setDeleteError(null)
       try {
         await agentClient.deletePlan(filename)
         setPlans((prev) => prev.filter((p) => p.filename !== filename))
@@ -232,8 +238,8 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
           setSelectedPlan(null)
           setPlanContent(null)
         }
-      } catch (err) {
-        console.error("[PlansPanel] Failed to delete plan:", err)
+      } catch (err: any) {
+        setDeleteError(err?.message || "Failed to delete plan")
       }
     },
     [agentClient, selectedPlan]
@@ -553,10 +559,37 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
           </View>
         )}
 
+        {/* Delete error banner */}
+        {deleteError && (
+          <View className="px-4 py-2 bg-destructive/10 flex-row items-center gap-2">
+            <AlertTriangle className="text-destructive" size={14} />
+            <Text className="text-xs text-destructive flex-1">{deleteError}</Text>
+            <Pressable onPress={() => setDeleteError(null)} className="p-1">
+              <Text className="text-xs text-destructive font-medium">Dismiss</Text>
+            </Pressable>
+          </View>
+        )}
+
         {/* Detail body */}
         <ScrollView className="flex-1 px-4 py-3" onScrollBeginDrag={() => setShowModelPicker(false)}>
           {!isStreamingDetail && detailLoading ? (
             <ActivityIndicator className="mt-8" />
+          ) : !isStreamingDetail && detailError ? (
+            <View className="items-center justify-center py-12 px-4">
+              <AlertTriangle className="h-8 w-8 text-destructive/60 mb-3" size={32} />
+              <Text className="text-sm text-foreground text-center font-medium">
+                Couldn't load plan
+              </Text>
+              <Text className="text-xs text-muted-foreground text-center mt-1">
+                {detailError}
+              </Text>
+              <Pressable
+                onPress={() => fetchPlanDetail(selectedPlan!)}
+                className="mt-4 px-4 py-2 bg-primary rounded-lg active:bg-primary/80"
+              >
+                <Text className="text-xs font-medium text-primary-foreground">Retry</Text>
+              </Pressable>
+            </View>
           ) : isSummaryTab ? (
             summaryText ? (
               <MarkdownText>{summaryText}</MarkdownText>

--- a/apps/mobile/components/project/panels/PlansPanel.tsx
+++ b/apps/mobile/components/project/panels/PlansPanel.tsx
@@ -37,6 +37,10 @@ import { DEFAULT_MODEL_PRO } from "../../chat/ChatInput"
 import type { PlanData } from "../../chat/PlanCard"
 import { useDualPlan } from "../../../lib/dual-plan-preference"
 
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error && err.message ? err.message : fallback
+}
+
 const TIER_LABELS: Record<ModelTier, string> = {
   premium: "Premium",
   standard: "Standard",
@@ -218,8 +222,8 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
       try {
         const data = await agentClient.getPlan(filename)
         setPlanContent(data.content)
-      } catch (err: any) {
-        setDetailError(err?.message || "Failed to load plan")
+      } catch (err) {
+        setDetailError(errorMessage(err, "Failed to load plan"))
         setPlanContent(null)
       } finally {
         setDetailLoading(false)
@@ -238,8 +242,8 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
           setSelectedPlan(null)
           setPlanContent(null)
         }
-      } catch (err: any) {
-        setDeleteError(err?.message || "Failed to delete plan")
+      } catch (err) {
+        setDeleteError(errorMessage(err, "Failed to delete plan"))
       }
     },
     [agentClient, selectedPlan]

--- a/apps/mobile/components/project/panels/ToolsPanel.tsx
+++ b/apps/mobile/components/project/panels/ToolsPanel.tsx
@@ -330,6 +330,26 @@ export function ToolsPanel({ projectId, agentUrl, visible }: ToolsPanelProps) {
 
   if (!visible) return null
 
+  if (!agentUrl) {
+    return (
+      <View className="absolute inset-0 flex-col">
+        <View className="px-4 py-3 border-b border-border flex-row items-center gap-2">
+          <Wrench size={16} className="text-muted-foreground" />
+          <Text className="text-sm font-medium text-foreground">Integrations</Text>
+        </View>
+        <View className="flex-1 items-center justify-center px-6">
+          <AlertTriangle className="text-muted-foreground/40 mb-3" size={32} />
+          <Text className="text-sm font-medium text-foreground text-center">
+            Agent not connected
+          </Text>
+          <Text className="text-xs text-muted-foreground text-center mt-1">
+            The agent runtime is starting up. Integrations will be available once the agent is ready.
+          </Text>
+        </View>
+      </View>
+    )
+  }
+
   return (
     <View className="absolute inset-0 flex-col">
       <View className="px-4 py-3 border-b border-border flex-row items-center gap-2">

--- a/apps/mobile/components/project/panels/ToolsPanel.tsx
+++ b/apps/mobile/components/project/panels/ToolsPanel.tsx
@@ -338,6 +338,26 @@ export function ToolsPanel({ projectId, agentUrl, visible }: ToolsPanelProps) {
 
   if (!visible) return null
 
+  if (!agentUrl) {
+    return (
+      <View className="absolute inset-0 flex-col">
+        <View className="px-4 py-3 border-b border-border flex-row items-center gap-2">
+          <Wrench size={16} className="text-muted-foreground" />
+          <Text className="text-sm font-medium text-foreground">Integrations</Text>
+        </View>
+        <View className="flex-1 items-center justify-center px-6">
+          <AlertTriangle className="text-muted-foreground/40 mb-3" size={32} />
+          <Text className="text-sm font-medium text-foreground text-center">
+            Agent not connected
+          </Text>
+          <Text className="text-xs text-muted-foreground text-center mt-1">
+            The agent runtime is starting up. Integrations will be available once the agent is ready.
+          </Text>
+        </View>
+      </View>
+    )
+  }
+
   return (
     <View className="absolute inset-0 flex-col">
       <View className="px-4 py-3 border-b border-border flex-row items-center gap-2">


### PR DESCRIPTION
## Summary

Improves production-grade UX for three project panels: **Plans**, **Integrations (Tools)**, and **Channels**. Fixes silent failures that looked like empty states and clarifies when the agent runtime is not ready yet.

## Changes

### Plans panel (`PlansPanel.tsx`)

- **List load:** On fetch failure with no cached plans, show an error message and **Retry** instead of “No plans yet”.
- **Plan detail:** On detail fetch failure, show **Couldn’t load plan** with message and **Retry** instead of a blank body.
- **Delete:** On delete failure, show a dismissible **error banner** instead of only logging to the console.

### Tools panel (`ToolsPanel.tsx`)

- When **`agentUrl` is null** (agent not connected / still starting), show a dedicated **“Agent not connected”** placeholder instead of the full search and install UI with dead controls.

### Channels panel (`ChannelsPanel.tsx`)

- Same **`agentUrl` is null** treatment: **“Agent not connected”** placeholder with short explanation instead of a full channel list that cannot load or connect.

## Motivation

- Plans list/detail/delete errors were easy to miss; users could assume there were no plans or that nothing happened.
- Tools and Channels assumed a live agent URL; without it, the UI looked interactive but did nothing.

