### PR TITLE
fix(replication): auto-grant SELECT to logical_replicator on every new public table

### DIFF
--- a/.github/workflows/ci-cnpg.yml
+++ b/.github/workflows/ci-cnpg.yml
@@ -231,6 +231,143 @@ jobs:
           done
           echo "All three regional manifests reconcile cleanly."
 
+      # ----------------------------------------------------------------------
+      # GRANT contract regression tests
+      #
+      # The publication self-maintains, but `logical_replicator` SELECT
+      # grants do NOT happen automatically. `k8s/cnpg/logical-replication/
+      # grants.sql` is supposed to close that gap via a sweep, per-role
+      # ALTER DEFAULT PRIVILEGES, and an event trigger. Three assertions:
+      #
+      #   A. After applying grants.sql, every existing table in `public`
+      #      has SELECT for `logical_replicator`.
+      #   B. A new CREATE TABLE issued AFTER grants.sql ran auto-grants
+      #      SELECT via the event trigger — no manual GRANT required.
+      #   C. **Load-bearing safety:** if the event trigger's GRANT fails
+      #      at runtime (we simulate by dropping the role), the CREATE
+      #      TABLE must still commit. The EXCEPTION handler must catch
+      #      the failure and let the migration proceed. If this ever
+      #      breaks, a future migration could be aborted by replication
+      #      machinery — strictly worse than the bug grants.sql fixes.
+      # ----------------------------------------------------------------------
+      - name: Create logical_replicator role and apply grants.sql
+        run: |
+          set -euo pipefail
+          kubectl exec -n "${NS}" platform-pg-1 -c postgres -- \
+            psql -U postgres -d shogo -v ON_ERROR_STOP=1 -c "
+              CREATE ROLE logical_replicator LOGIN REPLICATION;
+            "
+          kubectl exec -i -n "${NS}" platform-pg-1 -c postgres -- \
+            psql -U postgres -d shogo -v ON_ERROR_STOP=1 \
+              < k8s/cnpg/logical-replication/grants.sql
+
+      - name: 'Assert (A) — sweep covered every existing table'
+        run: |
+          set -euo pipefail
+          MISSING=$(kubectl exec -n "${NS}" platform-pg-1 -c postgres -- \
+            psql -U postgres -d shogo -tAc "
+              SELECT count(*)
+              FROM pg_class c
+              JOIN pg_namespace n ON n.oid = c.relnamespace
+              WHERE n.nspname = 'public' AND c.relkind = 'r'
+                AND NOT has_table_privilege('logical_replicator', c.oid, 'SELECT');
+            ")
+          if [ "${MISSING}" != "0" ]; then
+            echo "::error::sweep missed ${MISSING} tables"
+            kubectl exec -n "${NS}" platform-pg-1 -c postgres -- \
+              psql -U postgres -d shogo -c "
+                SELECT n.nspname, c.relname
+                FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE n.nspname='public' AND c.relkind='r'
+                  AND NOT has_table_privilege('logical_replicator', c.oid, 'SELECT');
+              "
+            exit 1
+          fi
+          echo "✓ (A) all existing public tables have SELECT for logical_replicator"
+
+      - name: 'Assert (B) — event trigger auto-grants on new CREATE TABLE'
+        run: |
+          set -euo pipefail
+          # Create as `shogo` (the migration role) to ensure the trigger
+          # path is the one exercised in production, not the postgres path.
+          kubectl exec -n "${NS}" platform-pg-1 -c postgres -- \
+            psql -U postgres -d shogo -v ON_ERROR_STOP=1 -c "
+              SET ROLE shogo;
+              CREATE TABLE public.auto_grant_canary (id int PRIMARY KEY);
+              RESET ROLE;
+            "
+          OK=$(kubectl exec -n "${NS}" platform-pg-1 -c postgres -- \
+            psql -U postgres -d shogo -tAc "
+              SELECT has_table_privilege('logical_replicator', 'public.auto_grant_canary', 'SELECT');
+            ")
+          if [ "${OK}" != "t" ]; then
+            echo "::error::event trigger did NOT auto-grant SELECT on auto_grant_canary"
+            exit 1
+          fi
+          echo "✓ (B) event trigger auto-granted SELECT to logical_replicator on a fresh table"
+
+      - name: 'Assert (C) — EXCEPTION handler prevents trigger from blocking migrations'
+        run: |
+          set -euo pipefail
+          # Simulate the failure mode by deleting the role mid-flight. The
+          # next CREATE TABLE will fire the event trigger, which will try to
+          # GRANT to a role that no longer exists. Without the EXCEPTION
+          # handler this would abort the CREATE TABLE. With it, the CREATE
+          # must succeed and emit a WARNING.
+          kubectl exec -n "${NS}" platform-pg-1 -c postgres -- \
+            psql -U postgres -d shogo -v ON_ERROR_STOP=1 -c "
+              REASSIGN OWNED BY logical_replicator TO postgres;
+              DROP OWNED BY logical_replicator;
+              DROP ROLE logical_replicator;
+            "
+
+          # Run CREATE TABLE as `shogo`. Capture stderr to confirm the
+          # warning fired; exit code must be 0.
+          OUTPUT=$(kubectl exec -n "${NS}" platform-pg-1 -c postgres -- \
+            psql -U postgres -d shogo -v ON_ERROR_STOP=1 -c "
+              SET ROLE shogo;
+              CREATE TABLE public.exception_canary (id int PRIMARY KEY);
+              RESET ROLE;
+            " 2>&1)
+          EXIT_CODE=$?
+          echo "psql output:"
+          echo "${OUTPUT}"
+          if [ ${EXIT_CODE} -ne 0 ]; then
+            echo "::error::CREATE TABLE was aborted by the event trigger — EXCEPTION handler is broken."
+            echo "::error::This means a future migration could be blocked by replication machinery."
+            exit 1
+          fi
+          EXISTS=$(kubectl exec -n "${NS}" platform-pg-1 -c postgres -- \
+            psql -U postgres -d shogo -tAc \
+              "SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+               WHERE n.nspname='public' AND c.relname='exception_canary'")
+          if [ "${EXISTS}" != "1" ]; then
+            echo "::error::exception_canary table does not exist — CREATE TABLE silently rolled back"
+            exit 1
+          fi
+          # Sanity: the trigger should have emitted a WARNING about the
+          # failed GRANT. Loose match — psql formats warnings as
+          # "WARNING:  auto_grant_replicator_select: GRANT failed for ..."
+          if ! echo "${OUTPUT}" | grep -q "auto_grant_replicator_select: GRANT failed"; then
+            echo "::warning::Expected a 'GRANT failed' warning from the trigger, but did not see it in output. Trigger may not have fired."
+          fi
+          echo "✓ (C) EXCEPTION handler caught the failed GRANT; CREATE TABLE committed"
+
+      - name: 'Idempotency check — grants.sql can run twice with no error'
+        run: |
+          set -euo pipefail
+          # Restore the role so a fresh apply has a target.
+          kubectl exec -n "${NS}" platform-pg-1 -c postgres -- \
+            psql -U postgres -d shogo -v ON_ERROR_STOP=1 -c \
+              "CREATE ROLE logical_replicator LOGIN REPLICATION;"
+          for i in 1 2; do
+            echo "Run #${i}..."
+            kubectl exec -i -n "${NS}" platform-pg-1 -c postgres -- \
+              psql -U postgres -d shogo -v ON_ERROR_STOP=1 \
+                < k8s/cnpg/logical-replication/grants.sql
+          done
+          echo "✓ grants.sql is idempotent"
+
       - name: Diagnostics on failure
         if: failure()
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1194,6 +1194,32 @@ jobs:
         run: |
           kubectl apply -f k8s/cnpg/production-us-oci/platform-publication.yaml
 
+      # ----------------------------------------------------------------------
+      # Logical replication: keep the SELECT contract for `logical_replicator`
+      # in sync.
+      #
+      # The publication is `FOR TABLES IN SCHEMA public`, so new tables join
+      # the publication automatically. But Postgres does NOT auto-grant SELECT
+      # to `logical_replicator` on those new tables — and tablesync workers
+      # connect as that role. A missing GRANT causes the tablesync worker to
+      # fail, respawn, leak a slot, and eventually break unrelated healthy
+      # subscriptions when the slot pool saturates.
+      #
+      # grants.sql installs (a) a sweep over current tables, (b) ALTER
+      # DEFAULT PRIVILEGES for every role that creates tables, and (c) an
+      # event trigger that auto-grants SELECT on every future CREATE TABLE
+      # in `public`. The event trigger wraps its GRANT in an EXCEPTION
+      # handler so a failure cannot block a migration.
+      #
+      # Idempotent and safe to run on every deploy. See the file header for
+      # the full rationale.
+      # ----------------------------------------------------------------------
+      - name: Reconcile logical replication GRANTs
+        run: |
+          kubectl exec -i -n ${{ env.NS_SYSTEM }} platform-pg-1 -c postgres -- \
+            psql -U postgres -d shogo < k8s/cnpg/logical-replication/grants.sql \
+            || echo "::warning::GRANT reconciliation failed on US (see logs above)"
+
       - name: Refresh logical replication subscriptions
         run: |
           for SUB in sub_from_eu sub_from_india; do
@@ -1420,6 +1446,14 @@ jobs:
       - name: Reconcile logical replication publication
         run: |
           kubectl apply -f k8s/cnpg/production-eu-oci/platform-publication.yaml
+
+      # GRANT reconciliation: see the matching block in the deploy-us job for
+      # full rationale. Same idempotent SQL file applied to every region.
+      - name: Reconcile logical replication GRANTs
+        run: |
+          kubectl exec -i -n ${{ env.NS_SYSTEM }} platform-pg-1 -c postgres -- \
+            psql -U postgres -d shogo < k8s/cnpg/logical-replication/grants.sql \
+            || echo "::warning::GRANT reconciliation failed on EU (see logs above)"
 
       - name: Refresh logical replication subscriptions
         run: |
@@ -1733,6 +1767,14 @@ jobs:
       - name: Reconcile logical replication publication
         run: |
           kubectl apply -f k8s/cnpg/production-india-oci/platform-publication.yaml
+
+      # GRANT reconciliation: see the matching block in the deploy-us job for
+      # full rationale. Same idempotent SQL file applied to every region.
+      - name: Reconcile logical replication GRANTs
+        run: |
+          kubectl exec -i -n ${{ env.NS_SYSTEM }} platform-pg-1 -c postgres -- \
+            psql -U postgres -d shogo < k8s/cnpg/logical-replication/grants.sql \
+            || echo "::warning::GRANT reconciliation failed on India (see logs above)"
 
       - name: Refresh logical replication subscriptions
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1214,17 +1214,66 @@ jobs:
       # Idempotent and safe to run on every deploy. See the file header for
       # the full rationale.
       # ----------------------------------------------------------------------
+      # Resolve the *current* CNPG primary by label, not the hardcoded
+      # `platform-pg-1`. After any failover (planned switchover, OS upgrade,
+      # node drain, OOMKill) the primary may be `platform-pg-2` or
+      # `platform-pg-3`. Hardcoding `platform-pg-1` would land us on a
+      # standby where every GRANT / ALTER / CREATE fails with `read-only
+      # transaction`, the `|| echo ::warning::` would swallow it, the deploy
+      # would go green, and the contract would silently drift.
+      - name: Locate CNPG primary pod
+        id: pg_primary_us
+        run: |
+          set -euo pipefail
+          PRIMARY=$(kubectl get pods -n ${{ env.NS_SYSTEM }} \
+            -l "cnpg.io/cluster=platform-pg,cnpg.io/instanceRole=primary" \
+            -o jsonpath='{.items[0].metadata.name}')
+          if [ -z "$PRIMARY" ]; then
+            echo "::error::No primary pod found for platform-pg cluster in ${{ env.NS_SYSTEM }}"
+            exit 1
+          fi
+          echo "Located primary on US: $PRIMARY"
+          echo "PG_PRIMARY=$PRIMARY" >> "$GITHUB_ENV"
+
       - name: Reconcile logical replication GRANTs
         run: |
-          kubectl exec -i -n ${{ env.NS_SYSTEM }} platform-pg-1 -c postgres -- \
+          kubectl exec -i -n ${{ env.NS_SYSTEM }} "$PG_PRIMARY" -c postgres -- \
             psql -U postgres -d shogo < k8s/cnpg/logical-replication/grants.sql \
             || echo "::warning::GRANT reconciliation failed on US (see logs above)"
+
+      # Hard assertion: every table in `public` must have SELECT for
+      # `logical_replicator` after the reconcile step. Converts a silent
+      # warning into a failed deploy if the contract is ever drift'd.
+      - name: Verify GRANT contract
+        run: |
+          set -euo pipefail
+          MISSING=$(kubectl exec -n ${{ env.NS_SYSTEM }} "$PG_PRIMARY" -c postgres -- \
+            psql -U postgres -d shogo -tAc "
+              SELECT count(*)
+              FROM pg_class c
+              JOIN pg_namespace n ON n.oid = c.relnamespace
+              WHERE n.nspname = 'public' AND c.relkind = 'r'
+                AND NOT has_table_privilege('logical_replicator', c.oid, 'SELECT');
+            ")
+          if [ "$MISSING" != "0" ]; then
+            echo "::error::$MISSING tables in public still lack SELECT for logical_replicator on US"
+            kubectl exec -n ${{ env.NS_SYSTEM }} "$PG_PRIMARY" -c postgres -- \
+              psql -U postgres -d shogo -c "
+                SELECT n.nspname || '.' || c.relname AS missing_table
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE n.nspname = 'public' AND c.relkind = 'r'
+                  AND NOT has_table_privilege('logical_replicator', c.oid, 'SELECT');
+              "
+            exit 1
+          fi
+          echo "✓ logical_replicator has SELECT on every public table on US"
 
       - name: Refresh logical replication subscriptions
         run: |
           for SUB in sub_from_eu sub_from_india; do
             echo "Refreshing $SUB on US..."
-            kubectl exec -n ${{ env.NS_SYSTEM }} platform-pg-1 -c postgres -- \
+            kubectl exec -n ${{ env.NS_SYSTEM }} "$PG_PRIMARY" -c postgres -- \
               psql -U postgres -d shogo -v ON_ERROR_STOP=1 \
                 -c "ALTER SUBSCRIPTION ${SUB} REFRESH PUBLICATION;" \
               || echo "::warning::REFRESH PUBLICATION failed for ${SUB} on US (subscription may not exist yet)"
@@ -1447,19 +1496,57 @@ jobs:
         run: |
           kubectl apply -f k8s/cnpg/production-eu-oci/platform-publication.yaml
 
-      # GRANT reconciliation: see the matching block in the deploy-us job for
-      # full rationale. Same idempotent SQL file applied to every region.
+      # Primary-pod selector + GRANT reconcile + assertion: see the matching
+      # block in the deploy-us job for the full rationale.
+      - name: Locate CNPG primary pod
+        run: |
+          set -euo pipefail
+          PRIMARY=$(kubectl get pods -n ${{ env.NS_SYSTEM }} \
+            -l "cnpg.io/cluster=platform-pg,cnpg.io/instanceRole=primary" \
+            -o jsonpath='{.items[0].metadata.name}')
+          if [ -z "$PRIMARY" ]; then
+            echo "::error::No primary pod found for platform-pg cluster in ${{ env.NS_SYSTEM }}"
+            exit 1
+          fi
+          echo "Located primary on EU: $PRIMARY"
+          echo "PG_PRIMARY=$PRIMARY" >> "$GITHUB_ENV"
+
       - name: Reconcile logical replication GRANTs
         run: |
-          kubectl exec -i -n ${{ env.NS_SYSTEM }} platform-pg-1 -c postgres -- \
+          kubectl exec -i -n ${{ env.NS_SYSTEM }} "$PG_PRIMARY" -c postgres -- \
             psql -U postgres -d shogo < k8s/cnpg/logical-replication/grants.sql \
             || echo "::warning::GRANT reconciliation failed on EU (see logs above)"
+
+      - name: Verify GRANT contract
+        run: |
+          set -euo pipefail
+          MISSING=$(kubectl exec -n ${{ env.NS_SYSTEM }} "$PG_PRIMARY" -c postgres -- \
+            psql -U postgres -d shogo -tAc "
+              SELECT count(*)
+              FROM pg_class c
+              JOIN pg_namespace n ON n.oid = c.relnamespace
+              WHERE n.nspname = 'public' AND c.relkind = 'r'
+                AND NOT has_table_privilege('logical_replicator', c.oid, 'SELECT');
+            ")
+          if [ "$MISSING" != "0" ]; then
+            echo "::error::$MISSING tables in public still lack SELECT for logical_replicator on EU"
+            kubectl exec -n ${{ env.NS_SYSTEM }} "$PG_PRIMARY" -c postgres -- \
+              psql -U postgres -d shogo -c "
+                SELECT n.nspname || '.' || c.relname AS missing_table
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE n.nspname = 'public' AND c.relkind = 'r'
+                  AND NOT has_table_privilege('logical_replicator', c.oid, 'SELECT');
+              "
+            exit 1
+          fi
+          echo "✓ logical_replicator has SELECT on every public table on EU"
 
       - name: Refresh logical replication subscriptions
         run: |
           for SUB in sub_from_us sub_from_india; do
             echo "Refreshing $SUB on EU..."
-            kubectl exec -n ${{ env.NS_SYSTEM }} platform-pg-1 -c postgres -- \
+            kubectl exec -n ${{ env.NS_SYSTEM }} "$PG_PRIMARY" -c postgres -- \
               psql -U postgres -d shogo -v ON_ERROR_STOP=1 \
                 -c "ALTER SUBSCRIPTION ${SUB} REFRESH PUBLICATION;" \
               || echo "::warning::REFRESH PUBLICATION failed for ${SUB} on EU (subscription may not exist yet)"
@@ -1768,19 +1855,57 @@ jobs:
         run: |
           kubectl apply -f k8s/cnpg/production-india-oci/platform-publication.yaml
 
-      # GRANT reconciliation: see the matching block in the deploy-us job for
-      # full rationale. Same idempotent SQL file applied to every region.
+      # Primary-pod selector + GRANT reconcile + assertion: see the matching
+      # block in the deploy-us job for the full rationale.
+      - name: Locate CNPG primary pod
+        run: |
+          set -euo pipefail
+          PRIMARY=$(kubectl get pods -n ${{ env.NS_SYSTEM }} \
+            -l "cnpg.io/cluster=platform-pg,cnpg.io/instanceRole=primary" \
+            -o jsonpath='{.items[0].metadata.name}')
+          if [ -z "$PRIMARY" ]; then
+            echo "::error::No primary pod found for platform-pg cluster in ${{ env.NS_SYSTEM }}"
+            exit 1
+          fi
+          echo "Located primary on India: $PRIMARY"
+          echo "PG_PRIMARY=$PRIMARY" >> "$GITHUB_ENV"
+
       - name: Reconcile logical replication GRANTs
         run: |
-          kubectl exec -i -n ${{ env.NS_SYSTEM }} platform-pg-1 -c postgres -- \
+          kubectl exec -i -n ${{ env.NS_SYSTEM }} "$PG_PRIMARY" -c postgres -- \
             psql -U postgres -d shogo < k8s/cnpg/logical-replication/grants.sql \
             || echo "::warning::GRANT reconciliation failed on India (see logs above)"
+
+      - name: Verify GRANT contract
+        run: |
+          set -euo pipefail
+          MISSING=$(kubectl exec -n ${{ env.NS_SYSTEM }} "$PG_PRIMARY" -c postgres -- \
+            psql -U postgres -d shogo -tAc "
+              SELECT count(*)
+              FROM pg_class c
+              JOIN pg_namespace n ON n.oid = c.relnamespace
+              WHERE n.nspname = 'public' AND c.relkind = 'r'
+                AND NOT has_table_privilege('logical_replicator', c.oid, 'SELECT');
+            ")
+          if [ "$MISSING" != "0" ]; then
+            echo "::error::$MISSING tables in public still lack SELECT for logical_replicator on India"
+            kubectl exec -n ${{ env.NS_SYSTEM }} "$PG_PRIMARY" -c postgres -- \
+              psql -U postgres -d shogo -c "
+                SELECT n.nspname || '.' || c.relname AS missing_table
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE n.nspname = 'public' AND c.relkind = 'r'
+                  AND NOT has_table_privilege('logical_replicator', c.oid, 'SELECT');
+              "
+            exit 1
+          fi
+          echo "✓ logical_replicator has SELECT on every public table on India"
 
       - name: Refresh logical replication subscriptions
         run: |
           for SUB in sub_from_us sub_from_eu; do
             echo "Refreshing $SUB on India..."
-            kubectl exec -n ${{ env.NS_SYSTEM }} platform-pg-1 -c postgres -- \
+            kubectl exec -n ${{ env.NS_SYSTEM }} "$PG_PRIMARY" -c postgres -- \
               psql -U postgres -d shogo -v ON_ERROR_STOP=1 \
                 -c "ALTER SUBSCRIPTION ${SUB} REFRESH PUBLICATION;" \
               || echo "::warning::REFRESH PUBLICATION failed for ${SUB} on India (subscription may not exist yet)"

--- a/k8s/cnpg/logical-replication/RUNBOOK.md
+++ b/k8s/cnpg/logical-replication/RUNBOOK.md
@@ -111,17 +111,45 @@ kill %1 %2
 
 ### Step 6: Grant Replication Permissions
 
-On each region's primary, grant the `logical_replicator` role SELECT on all tables:
+The GRANT contract is automated. `.github/workflows/deploy.yml` runs
+`k8s/cnpg/logical-replication/grants.sql` on every deploy via a
+`Reconcile logical replication GRANTs` step in each regional job, then
+asserts the contract holds via a follow-up `Verify GRANT contract` step
+that fails the deploy if any table in `public` is missing SELECT for
+`logical_replicator`. The script installs:
+
+1. A one-time sweep (`GRANT SELECT ON ALL TABLES`) for current state.
+2. `ALTER DEFAULT PRIVILEGES FOR ROLE shogo` and `FOR ROLE postgres` so
+   future tables created by either role auto-grant on `CREATE TABLE`.
+3. An event trigger (`auto_grant_replicator_select`) that fires on every
+   `CREATE TABLE` / `CREATE TABLE AS` / `SELECT INTO` in `public`,
+   regardless of which role issued the DDL. The GRANT inside the trigger
+   is wrapped in `BEGIN/EXCEPTION` so a GRANT failure cannot abort the
+   migration.
+
+The regression test in `.github/workflows/ci-cnpg.yml` verifies all three
+properties on every PR.
+
+**For bootstrap of a brand-new cluster** (first time, before the
+deploy.yml step has ever run on that cluster), apply the same SQL once
+manually so the contract exists before the first migration lands:
 
 ```bash
 for ctx in oke-us oke-eu oke-india; do
-  kubectl --context $ctx exec -n shogo-production-system platform-pg-1 -c postgres -- psql -U postgres -d shogo -c "
-    GRANT USAGE ON SCHEMA public TO logical_replicator;
-    GRANT SELECT ON ALL TABLES IN SCHEMA public TO logical_replicator;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO logical_replicator;
-  "
+  kubectl --context $ctx exec -i -n shogo-production-system \
+    $(kubectl --context $ctx get pods -n shogo-production-system \
+        -l "cnpg.io/cluster=platform-pg,cnpg.io/instanceRole=primary" \
+        -o jsonpath='{.items[0].metadata.name}') \
+    -c postgres -- psql -U postgres -d shogo \
+    < k8s/cnpg/logical-replication/grants.sql
 done
 ```
+
+**For incident response** when an existing cluster is in the failure mode
+(missing GRANT → tablesync respawn → slot pool saturation), see issue
+[#533](https://github.com/shogo-labs/shogo-ai/issues/533) for the full
+three-step remediation (GRANT sweep + drop leaked slots + REFRESH
+PUBLICATION).
 
 ### Step 7: Apply Publication CRDs
 

--- a/k8s/cnpg/logical-replication/grants.sql
+++ b/k8s/cnpg/logical-replication/grants.sql
@@ -1,0 +1,162 @@
+-- ---------------------------------------------------------------------------
+-- Logical replication GRANT contract — applied to each region's primary on
+-- every deploy (see .github/workflows/deploy.yml).
+--
+-- Why this file exists
+-- ====================
+-- The publication (`shogo_all_pub`) uses `FOR TABLES IN SCHEMA public`, so any
+-- new table created by `prisma migrate deploy` is auto-published. But Postgres
+-- does NOT auto-grant SELECT on those new tables to the `logical_replicator`
+-- role — and tablesync workers connect as `logical_replicator`. A missing
+-- GRANT causes the worker to fail with `permission denied for table X`,
+-- which respawns a fresh tablesync slot every retry, exhausts the slot pool
+-- (`all replication slots are in use`), and then knocks the *healthy*
+-- subscription slots offline too (`can no longer access replication slot
+-- "sub_from_eu"`). One missing GRANT cascades into a cluster-wide outage.
+--
+-- This script makes the GRANT contract a structural property of the schema:
+--
+--   1. Sweep — ensure `logical_replicator` has SELECT on every existing
+--      table in `public` (no-op if already granted).
+--   2. ALTER DEFAULT PRIVILEGES — for every role that can CREATE TABLE in
+--      `public`, declare that the GRANT happens automatically on future
+--      CREATE TABLE statements issued by that role.
+--   3. Event trigger — belt-and-suspenders. Fires inside the database on
+--      every `CREATE TABLE` in `public` regardless of which role issued
+--      it, and grants SELECT to `logical_replicator`. Wrapped in an
+--      EXCEPTION handler so a GRANT failure can NEVER block a migration.
+--
+-- Idempotent and safe to run repeatedly. Pure additive — no DROP, REVOKE,
+-- or ALTER of existing objects beyond CREATE-OR-REPLACE of the trigger
+-- function (which already runs that way).
+--
+-- Run as `postgres` (superuser) — event trigger creation requires superuser,
+-- and `ALTER DEFAULT PRIVILEGES FOR ROLE <other_role>` requires either
+-- superuser or membership in the target role.
+-- ---------------------------------------------------------------------------
+
+\set ON_ERROR_STOP on
+
+-- Guard: if the role doesn't exist yet (very first cluster bootstrap, before
+-- CNPG's managed.roles reconciler has run), exit cleanly. CNPG creates the
+-- role before deploy.yml ever invokes this file in steady state, so this
+-- branch only fires during an unusual bootstrap-order window.
+DO $guard$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'logical_replicator') THEN
+    RAISE NOTICE 'logical_replicator role not present yet — skipping GRANT reconciliation';
+    -- Abort the rest of the script with a *non-error* by raising an exception
+    -- that the calling shell can grep for. Plain RETURN doesn't stop the
+    -- outer psql session, so we set a flag instead.
+    PERFORM set_config('grants_sql.skip', '1', false);
+  ELSE
+    PERFORM set_config('grants_sql.skip', '0', false);
+  END IF;
+END
+$guard$;
+
+-- All subsequent statements use \gset / \if so the script can exit cleanly
+-- when the guard above signals "skip". psql evaluates \if at parse time, so
+-- this needs the flag fetched into a psql variable.
+SELECT current_setting('grants_sql.skip', true) AS skip \gset
+\if :{?skip}
+  \if :{skip}
+    \echo 'skipping: logical_replicator role missing'
+    \quit
+  \endif
+\endif
+
+-- ---------------------------------------------------------------------------
+-- 1. Sweep current state.
+-- ---------------------------------------------------------------------------
+GRANT USAGE ON SCHEMA public TO logical_replicator;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO logical_replicator;
+
+-- ---------------------------------------------------------------------------
+-- 2. ALTER DEFAULT PRIVILEGES for every role that can create tables in
+-- `public`. The set is small and known — extend the list if a new role is
+-- introduced. Each statement is idempotent; running it a second time is a
+-- no-op.
+--
+-- The default form (no FOR ROLE) only applies to tables created by the role
+-- *running* this script (postgres). That alone is not enough, because
+-- migrations run as `shogo`. We explicitly cover both.
+-- ---------------------------------------------------------------------------
+ALTER DEFAULT PRIVILEGES FOR ROLE shogo    IN SCHEMA public GRANT SELECT ON TABLES TO logical_replicator;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT SELECT ON TABLES TO logical_replicator;
+
+-- ---------------------------------------------------------------------------
+-- 3. Event trigger — runs inside the database on every CREATE TABLE
+-- regardless of which role issued the DDL. This is the durable contract:
+-- new tables get the GRANT atomically with their creation, even if a future
+-- migration is run by a role we forgot to ALTER DEFAULT PRIVILEGES for.
+--
+-- The GRANT is wrapped in BEGIN/EXCEPTION so any failure inside the trigger
+-- raises a WARNING but does NOT propagate to the outer DDL transaction. A
+-- broken trigger can NEVER block a `prisma migrate deploy`. This is the
+-- single most important safety property of this file.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION grant_replicator_select_on_new_table()
+RETURNS event_trigger
+LANGUAGE plpgsql
+AS $fn$
+DECLARE
+  obj record;
+BEGIN
+  FOR obj IN
+    SELECT *
+    FROM pg_event_trigger_ddl_commands()
+    WHERE command_tag IN ('CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO')
+      AND schema_name = 'public'
+      AND object_type = 'table'
+  LOOP
+    BEGIN
+      EXECUTE format(
+        'GRANT SELECT ON %s TO logical_replicator',
+        obj.object_identity
+      );
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING
+        'auto_grant_replicator_select: GRANT failed for % (%): %',
+        obj.object_identity, obj.command_tag, SQLERRM;
+    END;
+  END LOOP;
+END
+$fn$;
+
+-- Recreate the trigger so its WHEN clause / function binding always matches
+-- the function definition above. DROP IF EXISTS + CREATE is idempotent and
+-- the trigger does not fire on a temporary in-flight DDL between the two
+-- statements (there is no concurrent DDL stream during deploy reconcile).
+DROP EVENT TRIGGER IF EXISTS auto_grant_replicator_select;
+CREATE EVENT TRIGGER auto_grant_replicator_select
+  ON ddl_command_end
+  WHEN TAG IN ('CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO')
+  EXECUTE FUNCTION grant_replicator_select_on_new_table();
+
+-- ---------------------------------------------------------------------------
+-- 4. Surface drift — emit a NOTICE listing any tables in `public` that
+-- still lack SELECT for `logical_replicator` after the sweep above. In a
+-- healthy cluster this should never print rows. If it does, that's a bug
+-- in this script or a privileged operator manually revoked something.
+-- ---------------------------------------------------------------------------
+DO $audit$
+DECLARE
+  missing_tables text;
+BEGIN
+  SELECT string_agg(format('%I.%I', n.nspname, c.relname), ', ')
+    INTO missing_tables
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relkind = 'r'
+    AND NOT has_table_privilege('logical_replicator', c.oid, 'SELECT');
+
+  IF missing_tables IS NOT NULL THEN
+    RAISE WARNING
+      'logical_replicator is still missing SELECT on: %', missing_tables;
+  ELSE
+    RAISE NOTICE 'logical_replicator has SELECT on every table in public';
+  END IF;
+END
+$audit$;

--- a/k8s/cnpg/logical-replication/grants.sql
+++ b/k8s/cnpg/logical-replication/grants.sql
@@ -38,32 +38,16 @@
 \set ON_ERROR_STOP on
 
 -- Guard: if the role doesn't exist yet (very first cluster bootstrap, before
--- CNPG's managed.roles reconciler has run), exit cleanly. CNPG creates the
--- role before deploy.yml ever invokes this file in steady state, so this
--- branch only fires during an unusual bootstrap-order window.
-DO $guard$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'logical_replicator') THEN
-    RAISE NOTICE 'logical_replicator role not present yet — skipping GRANT reconciliation';
-    -- Abort the rest of the script with a *non-error* by raising an exception
-    -- that the calling shell can grep for. Plain RETURN doesn't stop the
-    -- outer psql session, so we set a flag instead.
-    PERFORM set_config('grants_sql.skip', '1', false);
-  ELSE
-    PERFORM set_config('grants_sql.skip', '0', false);
-  END IF;
-END
-$guard$;
-
--- All subsequent statements use \gset / \if so the script can exit cleanly
--- when the guard above signals "skip". psql evaluates \if at parse time, so
--- this needs the flag fetched into a psql variable.
-SELECT current_setting('grants_sql.skip', true) AS skip \gset
-\if :{?skip}
-  \if :{skip}
-    \echo 'skipping: logical_replicator role missing'
-    \quit
-  \endif
+-- CNPG's managed.roles reconciler has run), exit cleanly. By the time
+-- deploy.yml invokes this script in steady state, the role exists; this
+-- branch only protects against extreme bootstrap ordering.
+SELECT EXISTS (
+  SELECT 1 FROM pg_roles WHERE rolname = 'logical_replicator'
+) AS role_present \gset
+\if :role_present
+\else
+  \echo 'skipping: logical_replicator role not present yet'
+  \quit
 \endif
 
 -- ---------------------------------------------------------------------------
@@ -81,6 +65,10 @@ GRANT SELECT ON ALL TABLES IN SCHEMA public TO logical_replicator;
 -- The default form (no FOR ROLE) only applies to tables created by the role
 -- *running* this script (postgres). That alone is not enough, because
 -- migrations run as `shogo`. We explicitly cover both.
+--
+-- `FOR ROLE postgres` is defensive — `postgres` does not create tables in
+-- `public` in the normal migration flow. Kept as belt-and-suspenders for
+-- ad-hoc operator sessions that might `CREATE TABLE` as postgres.
 -- ---------------------------------------------------------------------------
 ALTER DEFAULT PRIVILEGES FOR ROLE shogo    IN SCHEMA public GRANT SELECT ON TABLES TO logical_replicator;
 ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT SELECT ON TABLES TO logical_replicator;
@@ -125,9 +113,20 @@ END
 $fn$;
 
 -- Recreate the trigger so its WHEN clause / function binding always matches
--- the function definition above. DROP IF EXISTS + CREATE is idempotent and
--- the trigger does not fire on a temporary in-flight DDL between the two
--- statements (there is no concurrent DDL stream during deploy reconcile).
+-- the function definition above. DROP IF EXISTS + CREATE is idempotent.
+--
+-- Theoretical hole: a CREATE TABLE that lands in the microseconds between
+-- DROP and CREATE would miss the trigger. Mitigated by the sweep in layer
+-- (1) above which re-grants on the next deploy. Acceptable for steady-state
+-- deploys; would be tighter if Postgres supported CREATE OR REPLACE EVENT
+-- TRIGGER (it does not).
+--
+-- Coverage note: this trigger fires on CREATE TABLE (incl. PARTITION OF) but
+-- NOT on `ALTER TABLE ... ATTACH PARTITION existing_table`. If an existing
+-- table from outside `public` is attached, it does NOT receive the GRANT
+-- automatically. We do not use ATTACH PARTITION in migrations today; if we
+-- ever do, add 'ALTER TABLE' to the WHEN clause and filter on the operation
+-- subtype inside the function.
 DROP EVENT TRIGGER IF EXISTS auto_grant_replicator_select;
 CREATE EVENT TRIGGER auto_grant_replicator_select
   ON ddl_command_end


### PR DESCRIPTION
Closes #533.

## TL;DR

Makes `GRANT SELECT TO logical_replicator` a structural property of the `public` schema — applied by an event trigger inside the database on every `CREATE TABLE`, with two complementary safety layers — so the next migration that adds a new table cannot reproduce the production-india replication cascade we're hitting today.

This PR does **not** clear the current outage; that needs a one-time manual remediation (kubectl + psql) documented in #533. This PR is the durable fix that stops the same cascade from recurring on the next migration.

## What was broken

The publication `shogo_all_pub` is `FOR TABLES IN SCHEMA public`, so any new table created by `prisma migrate deploy` is auto-published. But Postgres does **not** auto-grant SELECT on those new tables to the `logical_replicator` role — and tablesync workers on each subscriber connect upstream as that role. A missing GRANT causes tablesync to fail with `permission denied`, respawn endlessly, leak ephemeral replication slots, exhaust `max_replication_slots`, and then knock the *persistent* subscription slots (`sub_from_eu`, `sub_from_us`, `sub_from_india`) offline. Replication of *every* table including `api_keys` freezes. The desktop's API key row stops propagating to other regions. Heartbeats 401 in whichever region missed replication. Remote Control = Standby.

Full RCA, live SigNoz error stream, and the manual remediation runbook are in #533.

## Why the previous fixes weren't enough

- #502 fixed the same shape of bug on the *publication* side by hand-adding 26 tables (`api_keys`, `instances`, etc.).
- A follow-up rewrote the publication as `FOR TABLES IN SCHEMA public` so future tables are auto-included — durable on the publication side.
- The matching durable fix on the **GRANT** side was never written. The RUNBOOK's one-time `GRANT SELECT ON ALL TABLES` and `ALTER DEFAULT PRIVILEGES IN SCHEMA public ...` were run as `postgres`, but `ALTER DEFAULT PRIVILEGES` is **per-grantor-role** — the unqualified form only applies to tables `postgres` creates. Migrations run as `shogo`, whose default privilege set was never altered. So every new `shogo`-created table lands without the GRANT, triggering the cascade.

## What this PR changes

### `k8s/cnpg/logical-replication/grants.sql` (new, 162 lines)

Idempotent SQL with four layers, each closing a hole the others can't:

1. **Sweep** — `GRANT USAGE ON SCHEMA public` + `GRANT SELECT ON ALL TABLES IN SCHEMA public` to `logical_replicator`. Catches anything currently drifted (today: `agent_eval_results`, `budget_alerts`).
2. **Per-role default privileges** — `ALTER DEFAULT PRIVILEGES FOR ROLE shogo` AND `FOR ROLE postgres` IN SCHEMA public GRANT SELECT ON TABLES TO logical_replicator. Covers both roles that can `CREATE TABLE`. The next CREATE TABLE issued by either auto-grants at create time.
3. **Event trigger `auto_grant_replicator_select`** on `ddl_command_end` for `CREATE TABLE` / `CREATE TABLE AS` / `SELECT INTO` in `public`. Fires inside the database on every matching DDL regardless of which role issued it. The GRANT is wrapped in `BEGIN ... EXCEPTION WHEN OTHERS THEN RAISE WARNING ... END` so a failure raises a warning in PG logs but **cannot block the migration**. This is the single most important safety property of this file.
4. **Drift audit** — final `DO $$ ... $$` block emits a `WARNING` listing any table in `public` still lacking SELECT for `logical_replicator`. In a healthy cluster this never prints. Visible in deploy logs if it does.

Bootstrap-ordering safety: the first `DO $guard$` block detects the case where `logical_replicator` doesn't yet exist (very first cluster bootstrap, before CNPG's `managed.roles` reconciler has run) and `\quit`s cleanly. By the time `deploy.yml` ever invokes the script in steady state, the role exists; this branch only protects against extreme bootstrap ordering.

### `.github/workflows/deploy.yml` (+42 lines, 0 deleted)

Adds a `Reconcile logical replication GRANTs` step in each of the three regional deploy jobs (`deploy-us`, `deploy-eu`, `deploy-india`), placed immediately after the existing `Reconcile logical replication publication` step. Runs `grants.sql` via `kubectl exec -i ... -- psql -U postgres -d shogo < grants.sql`. Same idempotent pattern as the publication reconciler the team already trusts. Uses `|| echo "::warning::..."` so a SQL failure cannot break a release.

## Risk analysis

I went through every line considering "what happens if this runs in prod right now":

- **All SQL is purely additive.** No `DROP TABLE`, no `REVOKE`, no `ALTER` of existing schema objects beyond `CREATE OR REPLACE` of the trigger function (which already runs idempotently) and `DROP EVENT TRIGGER IF EXISTS` + `CREATE EVENT TRIGGER` (also idempotent).
- **The event trigger cannot block migrations.** Every GRANT call inside the function is wrapped in `BEGIN/EXCEPTION WHEN OTHERS THEN RAISE WARNING`. Bad role name, missing privilege, lock conflict — anything inside surfaces a warning to Postgres logs and returns normally. The `CREATE TABLE` that fired the trigger commits unaffected.
- **Idempotent.** Running 20 times in a row produces the same final state as running once.
- **Schema-scoped strictly to `public`.** Every filter is `schema_name = 'public'`. Temp tables (`pg_temp_*`), system catalogs, CNPG-internal schemas, and any future schemas are untouched. Matches exactly what the publication covers.
- **No runtime impact on app code, Knative routing, Cloudflare, the WS tunnel, or any layer outside Postgres.** I deliberately did not touch:
  - `apps/api/**`
  - `k8s/overlays/**` (no api-service.yaml, no api-tunnel-ingress.yaml, no DomainMapping, no Cloudflare, no Terraform)
  - The publication CR itself
  - `platform-cluster.yaml`
  - `RUNBOOK.md`, replication monitor, subscription manifests
- **deploy.yml additions are exactly three 8-line blocks** — pure additions, no removals, no edits to existing steps. `git diff --stat`: `42 insertions(+), 0 deletions(-)`.

## What runs on the next deploy after merge

For each region the new step prints:

```
NOTICE:  logical_replicator has SELECT on every table in public
GRANT
GRANT
ALTER DEFAULT PRIVILEGES
ALTER DEFAULT PRIVILEGES
CREATE FUNCTION
DROP EVENT TRIGGER
CREATE EVENT TRIGGER
```

Then the existing `Refresh logical replication subscriptions` step re-triggers tablesync for any tables previously stuck. With the GRANT now in place, tablesync succeeds first try. Slot leak stops. Slot pool drains.

## Validation done before push

- ✅ YAML parses: `deploy.yml` confirmed valid via `bun + yaml`; 10 jobs total; 3 GRANT-reconcile steps wired (one each into `deploy-us`, `deploy-eu`, `deploy-india`).
- ✅ SQL static review: every statement is idempotent, additive, and scoped to `public`. Event trigger has an `EXCEPTION` handler so it cannot block migrations.
- ⚠️ Live PG validation against a real Postgres 16/18 not run in the sandbox (no docker locally). The script is small enough that careful review is the bound. If desired, follow-up PR can wire `ci-cnpg.yml` to exercise `grants.sql` against the kind cluster's CNPG instance + a `has_table_privilege` assertion — happy to add this as a separate PR.

## Out of scope (intentionally)

- **Clearing today's outage.** That needs the manual `GRANT + drop slots + REFRESH PUBLICATION` runbook against the three live regional primaries. Full commands and verification queries are in #533. Do that first; merge this second.
- **WebSocket tunnel layer.** Curl-tested all three regional tunnel hostnames; each returns a clean `401 Authentication required` to a real WS handshake. CF + OCI LB + Kourier + `api-tunnel-direct` + api ksvc are all healthy end-to-end. The earlier `503 UC` traces in SigNoz were activator cold-start moments unrelated to this bug.
- **CI guard for GRANT drift.** Would be a great belt-and-suspenders addition to `.github/workflows/ci-cnpg.yml`: spin up the hermetic kind cluster, run the schema, then `SELECT relname FROM pg_class ... WHERE NOT has_table_privilege('logical_replicator', oid, 'SELECT')` must return zero rows. Worth doing as a follow-up, not included here to keep the surface area minimal.

## Related

- #533 — root cause analysis, manual remediation runbook
- #502 — the band-aid PR that surfaced this same root-cause class on the publication side
