### PR TITLE
fix(runtime): auto-rotate AI_PROXY_TOKEN before 7-day expiry

### DIFF
--- a/packages/shared-runtime/src/__tests__/token-refresh.test.ts
+++ b/packages/shared-runtime/src/__tests__/token-refresh.test.ts
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Tests for the AI_PROXY_TOKEN auto-rotation loop.
+ *
+ * What we cover here:
+ *   - readJwtExpMs() round-trips for valid JWTs, returns null for garbage.
+ *   - The loop fetches /api/internal/pod-config/<projectId> at the
+ *     configured interval and applies the returned env to process.env.
+ *   - onTokenRotate hook fires after env is applied (and its throw does
+ *     NOT abort the loop).
+ *   - Network failures (5xx, throw) do not crash the loop — next tick
+ *     still fires.
+ *   - PROJECT_ID=__POOL__ (or missing) skips the fetch entirely.
+ *   - stop() cancels future ticks deterministically.
+ *
+ * We don't exercise the JWT-exp-driven early-refresh path here because
+ * that would require advancing time — bun:test doesn't ship a clock-fake.
+ * The interval-driven path covers the same code path with deterministic
+ * timing.
+ */
+
+import {
+  describe, test, expect, beforeEach, afterEach, mock,
+} from 'bun:test'
+import { startTokenRefreshLoop, readJwtExpMs } from '../token-refresh'
+
+const ORIGINAL_FETCH = globalThis.fetch
+const ORIGINAL_ENV = { ...process.env }
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const enc = (obj: unknown) =>
+    Buffer.from(JSON.stringify(obj))
+      .toString('base64')
+      .replace(/=+$/, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+  return `${enc({ alg: 'HS256', typ: 'JWT' })}.${enc(payload)}.signature-not-verified`
+}
+
+beforeEach(() => {
+  // Point the loop at a deterministic API URL — we'll mock fetch anyway.
+  process.env.SHOGO_API_URL = 'http://api.test.svc.cluster.local'
+  delete process.env.AI_PROXY_URL
+  delete process.env.AI_PROXY_TOKEN
+})
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH
+  // Restore env to whatever the suite started with.
+  for (const k of Object.keys(process.env)) delete process.env[k]
+  Object.assign(process.env, ORIGINAL_ENV)
+})
+
+describe('readJwtExpMs', () => {
+  test('decodes exp from a well-formed JWT', () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600
+    expect(readJwtExpMs(makeJwt({ exp }))).toBe(exp * 1000)
+  })
+
+  test('returns null when exp is missing', () => {
+    expect(readJwtExpMs(makeJwt({ projectId: 'p1' }))).toBeNull()
+  })
+
+  test('returns null when exp is not a number', () => {
+    expect(readJwtExpMs(makeJwt({ exp: 'soon' }))).toBeNull()
+  })
+
+  test('returns null for garbage input', () => {
+    expect(readJwtExpMs('not-a-jwt')).toBeNull()
+    expect(readJwtExpMs('')).toBeNull()
+    expect(readJwtExpMs('only.one')).toBeNull()
+  })
+})
+
+describe('startTokenRefreshLoop', () => {
+  test('fetches pod-config and applies env on each tick', async () => {
+    const fetchCalls: Array<{ url: string; headers: Record<string, string> }> = []
+    const newToken = makeJwt({ exp: Math.floor(Date.now() / 1000) + 7 * 86400, projectId: 'p1' })
+    globalThis.fetch = mock(async (url: string, init: any) => {
+      fetchCalls.push({ url, headers: init?.headers ?? {} })
+      return new Response(
+        JSON.stringify({
+          projectId: 'p1',
+          env: { AI_PROXY_TOKEN: newToken, RUNTIME_AUTH_SECRET: 'fresh-secret' },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )
+    }) as any
+
+    const handle = startTokenRefreshLoop({
+      getProjectId: () => 'p1',
+      intervalMs: 10_000,        // not actually awaited — we call refreshNow
+      jitterMs: 0,
+      logPrefix: 'test',
+    })
+    try {
+      const env = await handle.refreshNow()
+      expect(env).not.toBeNull()
+      expect(env?.AI_PROXY_TOKEN).toBe(newToken)
+      expect(process.env.AI_PROXY_TOKEN).toBe(newToken)
+      expect(process.env.RUNTIME_AUTH_SECRET).toBe('fresh-secret')
+      expect(fetchCalls).toHaveLength(1)
+      expect(fetchCalls[0].url).toBe('http://api.test.svc.cluster.local/api/internal/pod-config/p1')
+    } finally {
+      handle.stop()
+    }
+  })
+
+  test('invokes onTokenRotate after env is applied; hook throw does not abort loop', async () => {
+    globalThis.fetch = mock(async () =>
+      new Response(JSON.stringify({ projectId: 'p1', env: { AI_PROXY_TOKEN: 'tok-1' } }), { status: 200 }),
+    ) as any
+
+    let observedTokenAtHook: string | undefined
+    const handle = startTokenRefreshLoop({
+      getProjectId: () => 'p1',
+      intervalMs: 10_000,
+      jitterMs: 0,
+      onTokenRotate: (env) => {
+        observedTokenAtHook = process.env.AI_PROXY_TOKEN
+        expect(env.AI_PROXY_TOKEN).toBe('tok-1')
+        throw new Error('hook threw on purpose')
+      },
+    })
+    try {
+      const env = await handle.refreshNow()
+      // hook ran AFTER env was applied
+      expect(observedTokenAtHook).toBe('tok-1')
+      // and despite the throw, refresh still completed successfully
+      expect(env?.AI_PROXY_TOKEN).toBe('tok-1')
+    } finally {
+      handle.stop()
+    }
+  })
+
+  test('non-2xx response logs and returns null without throwing', async () => {
+    globalThis.fetch = mock(async () =>
+      new Response('forbidden', { status: 403 }),
+    ) as any
+    const handle = startTokenRefreshLoop({
+      getProjectId: () => 'p1',
+      intervalMs: 10_000,
+      jitterMs: 0,
+    })
+    try {
+      const env = await handle.refreshNow()
+      expect(env).toBeNull()
+      // token was NOT clobbered with anything
+      expect(process.env.AI_PROXY_TOKEN).toBeUndefined()
+    } finally {
+      handle.stop()
+    }
+  })
+
+  test('fetch rejection is caught — loop survives transient network errors', async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error('ECONNREFUSED')
+    }) as any
+    const handle = startTokenRefreshLoop({
+      getProjectId: () => 'p1',
+      intervalMs: 10_000,
+      jitterMs: 0,
+    })
+    try {
+      const env = await handle.refreshNow()
+      expect(env).toBeNull()
+    } finally {
+      handle.stop()
+    }
+  })
+
+  test('skips fetch entirely while project is in pool / unassigned', async () => {
+    const fetchSpy = mock(async () => new Response('{}', { status: 200 }))
+    globalThis.fetch = fetchSpy as any
+
+    const handle = startTokenRefreshLoop({
+      getProjectId: () => '__POOL__',
+      intervalMs: 10_000,
+      jitterMs: 0,
+    })
+    try {
+      const env = await handle.refreshNow()
+      expect(env).toBeNull()
+      expect(fetchSpy).not.toHaveBeenCalled()
+    } finally {
+      handle.stop()
+    }
+
+    const handle2 = startTokenRefreshLoop({
+      getProjectId: () => null,
+      intervalMs: 10_000,
+      jitterMs: 0,
+    })
+    try {
+      const env = await handle2.refreshNow()
+      expect(env).toBeNull()
+      expect(fetchSpy).not.toHaveBeenCalled()
+    } finally {
+      handle2.stop()
+    }
+  })
+
+  test('stop() cancels the scheduled tick', async () => {
+    let calls = 0
+    globalThis.fetch = mock(async () => {
+      calls++
+      return new Response(JSON.stringify({ projectId: 'p1', env: {} }), { status: 200 })
+    }) as any
+
+    const handle = startTokenRefreshLoop({
+      getProjectId: () => 'p1',
+      intervalMs: 25,           // tiny interval so we'd see ticks if we waited
+      jitterMs: 0,
+    })
+    handle.stop()
+    // Wait through what would have been multiple ticks if the timer survived
+    await new Promise((r) => setTimeout(r, 100))
+    expect(calls).toBe(0)
+  })
+
+  test('uses ServiceAccount token in Authorization header when present', async () => {
+    // Point at a tmp file we control so readSAToken returns our value.
+    // The module hardcodes the K8s SA path; we can't override it without
+    // disk access, so this test verifies the header is omitted in the
+    // "no SA token on disk" common-case (running outside a pod).
+    let observedHeaders: Record<string, string> = {}
+    globalThis.fetch = mock(async (_url: string, init: any) => {
+      observedHeaders = init?.headers ?? {}
+      return new Response(JSON.stringify({ projectId: 'p1', env: {} }), { status: 200 })
+    }) as any
+    const handle = startTokenRefreshLoop({
+      getProjectId: () => 'p1',
+      intervalMs: 10_000,
+      jitterMs: 0,
+    })
+    try {
+      await handle.refreshNow()
+      expect(observedHeaders['Content-Type']).toBe('application/json')
+      // outside a pod, no SA token mounted → no Authorization header
+      expect(observedHeaders['Authorization']).toBeUndefined()
+    } finally {
+      handle.stop()
+    }
+  })
+})

--- a/packages/shared-runtime/src/__tests__/token-refresh.test.ts
+++ b/packages/shared-runtime/src/__tests__/token-refresh.test.ts
@@ -219,11 +219,13 @@ describe('startTokenRefreshLoop', () => {
     expect(calls).toBe(0)
   })
 
-  test('uses ServiceAccount token in Authorization header when present', async () => {
-    // Point at a tmp file we control so readSAToken returns our value.
-    // The module hardcodes the K8s SA path; we can't override it without
-    // disk access, so this test verifies the header is omitted in the
-    // "no SA token on disk" common-case (running outside a pod).
+  test('omits Authorization header when no ServiceAccount token is mounted (outside-pod case)', async () => {
+    // The module reads the K8s SA token from a hardcoded path inside
+    // `readSAToken()`. Without restructuring `readSAToken` to be injectable,
+    // we can only exercise the negative path here: outside a pod, the file
+    // doesn't exist, so readSAToken returns null and no Authorization
+    // header is attached. Positive-case coverage (header IS set when token
+    // IS present) is tracked as a follow-up — see issue #535.
     let observedHeaders: Record<string, string> = {}
     globalThis.fetch = mock(async (_url: string, init: any) => {
       observedHeaders = init?.headers ?? {}
@@ -239,6 +241,49 @@ describe('startTokenRefreshLoop', () => {
       expect(observedHeaders['Content-Type']).toBe('application/json')
       // outside a pod, no SA token mounted → no Authorization header
       expect(observedHeaders['Authorization']).toBeUndefined()
+    } finally {
+      handle.stop()
+    }
+  })
+
+  test('concurrent refreshNow() calls coalesce into a single fetch (single-flight)', async () => {
+    // Regression guard for the timer-multiplication bug: without
+    // single-flight coalescing, two overlapping refresh() invocations
+    // would each schedule a new setTimeout in their finally, leaking
+    // timers that compound on every subsequent tick. The fix is to
+    // share the in-flight promise between concurrent callers; this
+    // test verifies both that the fetch is issued once and that the
+    // two callers receive the same resolved env.
+    let fetchCount = 0
+    let resolveFetch: ((res: Response) => void) | null = null
+    globalThis.fetch = mock(
+      () =>
+        new Promise<Response>((resolve) => {
+          fetchCount++
+          resolveFetch = resolve
+        }),
+    ) as any
+    const handle = startTokenRefreshLoop({
+      getProjectId: () => 'p1',
+      intervalMs: 60_000,
+      jitterMs: 0,
+    })
+    try {
+      // Two overlapping refreshNow() calls while the fetch is pending.
+      const p1 = handle.refreshNow()
+      const p2 = handle.refreshNow()
+      // Let microtasks drain so both calls reach the fetch path.
+      await new Promise((r) => setTimeout(r, 10))
+      expect(fetchCount).toBe(1)
+      resolveFetch!(
+        new Response(JSON.stringify({ projectId: 'p1', env: { AI_PROXY_TOKEN: 'rotated' } }), {
+          status: 200,
+        }),
+      )
+      const [r1, r2] = await Promise.all([p1, p2])
+      expect(r1).toEqual({ AI_PROXY_TOKEN: 'rotated' })
+      expect(r2).toEqual({ AI_PROXY_TOKEN: 'rotated' })
+      expect(fetchCount).toBe(1)
     } finally {
       handle.stop()
     }

--- a/packages/shared-runtime/src/self-assign.ts
+++ b/packages/shared-runtime/src/self-assign.ts
@@ -88,7 +88,13 @@ export async function checkSelfAssign(apiUrl?: string, workDir?: string): Promis
   }
 }
 
-function readSAToken(): string | null {
+/**
+ * Read the Kubernetes ServiceAccount token mounted at the standard path.
+ * Returns null when not running inside a pod. Exported so the token-refresh
+ * loop can reuse the exact same auth used by self-assign on boot, instead of
+ * duplicating the path and read logic.
+ */
+export function readSAToken(): string | null {
   try {
     if (existsSync(SA_TOKEN_PATH)) {
       return readFileSync(SA_TOKEN_PATH, 'utf-8').trim()
@@ -99,7 +105,16 @@ function readSAToken(): string | null {
   return null
 }
 
-function deriveApiUrl(): string | null {
+/**
+ * Resolve the Shogo API base URL the runtime should talk to. Looks at
+ * SHOGO_API_URL / API_URL explicit overrides, falls back to deriving from
+ * AI_PROXY_URL (stripping the `/api/ai/v1` suffix), and finally constructs
+ * an in-cluster ClusterIP-style URL from SYSTEM_NAMESPACE.
+ *
+ * Exported so the token-refresh loop hits the same endpoint self-assign
+ * uses on boot.
+ */
+export function deriveApiUrl(): string | null {
   if (process.env.SHOGO_API_URL) return process.env.SHOGO_API_URL
   if (process.env.API_URL) return process.env.API_URL
 

--- a/packages/shared-runtime/src/server-framework.ts
+++ b/packages/shared-runtime/src/server-framework.ts
@@ -27,6 +27,7 @@ import { initInstrumentation, traceOperation } from './instrumentation'
 import { createLogger } from './logger'
 import { configureAIProxy } from './ai-proxy'
 import { checkSelfAssign, POOL_ASSIGNMENT_MARKER } from './self-assign'
+import { startTokenRefreshLoop, type TokenRefreshHandle } from './token-refresh'
 
 export interface RuntimeAppConfig {
   /** Display name used in logs (e.g. 'agent-runtime', 'runtime') */
@@ -55,6 +56,16 @@ export interface RuntimeAppConfig {
    * Extra data to include in the /health response.
    */
   getHealthExtra?: () => Record<string, unknown>
+  /**
+   * Optional hook invoked after the token-refresh loop has rotated
+   * `AI_PROXY_TOKEN` (and any other short-lived credential the API returns).
+   * Use this to rebuild model clients that captured the old token at
+   * construction time. Errors thrown here are caught and logged — they
+   * never abort the refresh loop. Most LLM SDKs read `ANTHROPIC_API_KEY` /
+   * `OPENAI_API_KEY` from `process.env` at request time when constructed
+   * without an explicit key, so this hook is optional belt-and-suspenders.
+   */
+  onTokenRotate?: (env: Record<string, string>) => void | Promise<void>
 }
 
 export interface RuntimeState {
@@ -70,6 +81,13 @@ export interface RuntimeState {
   lastRequestAt: number
   /** AI proxy configuration (reconfigured on assign) */
   aiProxy: ReturnType<typeof configureAIProxy>
+  /**
+   * Handle to the token-refresh loop, when one is running. Null before a
+   * project assignment has happened, set once self-assign or /pool/assign
+   * promotes the pod. Exposed on state so tests and graceful-shutdown
+   * paths can stop the loop deterministically.
+   */
+  tokenRefresh: TokenRefreshHandle | null
   /** Server start time */
   serverStartTime: number
   /** Entrypoint start time (from STARTUP_TIME env) */
@@ -186,8 +204,39 @@ export async function createRuntimeApp(config: RuntimeAppConfig): Promise<Runtim
     poolAssignedAt,
     lastRequestAt,
     aiProxy,
+    tokenRefresh: null,
     serverStartTime: SERVER_START_TIME,
     entrypointStartTime: ENTRYPOINT_START_TIME,
+  }
+
+  // ---------------------------------------------------------------------------
+  // Token refresh loop bootstrap
+  //
+  // Starts the AI_PROXY_TOKEN auto-rotation loop once the pod is bound to a
+  // real project. Idempotent — calling this more than once is a no-op after
+  // the first successful start. Reads `state.currentProjectId` at refresh
+  // time, so a /pool/assign that changes the bound project after start is
+  // picked up automatically without restarting the loop.
+  //
+  // See packages/shared-runtime/src/token-refresh.ts for full rationale.
+  // ---------------------------------------------------------------------------
+  const ensureTokenRefreshLoop = () => {
+    if (state.tokenRefresh) return
+    state.tokenRefresh = startTokenRefreshLoop({
+      logPrefix: `${config.name}/token-refresh`,
+      getProjectId: () => state.currentProjectId ?? null,
+      onTokenRotate: config.onTokenRotate,
+    })
+    logTiming('token refresh loop started')
+  }
+
+  // If the pod already has a project at startup — either by booting in
+  // non-pool mode with PROJECT_ID set, or by completing self-assign on
+  // boot — start the refresh loop immediately. Pure warm-pool pods
+  // (still PROJECT_ID=__POOL__) defer this until /pool/assign promotes
+  // them; see the /pool/assign handler below.
+  if (state.currentProjectId && state.currentProjectId !== '__POOL__') {
+    ensureTokenRefreshLoop()
   }
 
   // ---------------------------------------------------------------------------
@@ -200,6 +249,10 @@ export async function createRuntimeApp(config: RuntimeAppConfig): Promise<Runtim
       if (shuttingDown) return
       shuttingDown = true
       console.log(`[${config.name}] ${signal} received — draining for 5s before exit`)
+      // Stop the token-refresh timer so it can't fire a stray fetch during
+      // shutdown. The timer is .unref()'d so it shouldn't keep the loop
+      // alive either way, but stopping is the explicit contract.
+      state.tokenRefresh?.stop()
       setTimeout(() => process.exit(0), 5_000)
     })
   }
@@ -487,6 +540,12 @@ export async function createRuntimeApp(config: RuntimeAppConfig): Promise<Runtim
       } catch (writeErr: any) {
         console.warn(`[${config.name}] Could not persist pool assignment marker: ${writeErr.message}`)
       }
+
+      // 6. Start the token-refresh loop. The injected AI_PROXY_TOKEN is a
+      //    short-TTL JWT (currently 7 days from build-project-env.ts) and
+      //    the pod can outlive it. The loop refreshes well before exp; see
+      //    packages/shared-runtime/src/token-refresh.ts for rationale.
+      ensureTokenRefreshLoop()
 
       const duration = Date.now() - startTime
       logTiming(`Pool assignment complete for ${projectId} (${duration}ms)`)

--- a/packages/shared-runtime/src/token-refresh.ts
+++ b/packages/shared-runtime/src/token-refresh.ts
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * AI_PROXY_TOKEN auto-rotation for long-lived runtime pods.
+ *
+ * Why this exists
+ * ===============
+ * `apps/api/src/lib/runtime/build-project-env.ts` generates `AI_PROXY_TOKEN`
+ * as a 7-day HMAC-signed JWT. The token is injected into the runtime pod
+ * once — at `/pool/assign` (warm-pool promotion) or at boot via
+ * `checkSelfAssign()`. After injection it lives in `process.env` for the
+ * lifetime of the process and is never refreshed.
+ *
+ * Knative warm-pool pods routinely outlive the token. A pod that was
+ * promoted to a real project on day 0 and has not been evicted by day 8
+ * will still hold the day-0 token, which expired on day 7. Every chat
+ * request from then on fails with:
+ *
+ *   Provider error: 401 Invalid or missing proxy token.
+ *
+ * Restarting the pod clears the symptom — `checkSelfAssign()` on boot
+ * fetches a fresh token — but it returns on day 15 unless the pod has
+ * been restarted in the meantime. The token's TTL becomes a hidden
+ * load-bearing operational constant.
+ *
+ * What this module does
+ * =====================
+ * After a pod has been assigned to a project (either via boot self-assign
+ * or via `/pool/assign`), `startTokenRefreshLoop()` is invoked with a
+ * `getProjectId()` closure. The loop:
+ *
+ *   1. Wakes up every REFRESH_INTERVAL_MS (12h) ± REFRESH_JITTER_MS (±1h),
+ *      so a fleet of promoted pods doesn't stampede the API.
+ *   2. Re-hits the same endpoint `checkSelfAssign` uses on boot —
+ *      `${apiUrl}/api/internal/pod-config/<projectId>` — using the same
+ *      ServiceAccount-token auth.
+ *   3. Applies the response's env to `process.env`. Any short-lived
+ *      credential the API mints (AI_PROXY_TOKEN, RUNTIME_AUTH_SECRET,
+ *      WEBHOOK_TOKEN, COMPOSIO_API_KEY) rotates transparently.
+ *   4. Calls back into the runtime's `onTokenRotate` hook (if provided),
+ *      so the runtime can rebuild model clients that captured the old
+ *      token at construction time. Most LLM SDKs read env at request
+ *      time IF constructed without an explicit apiKey, so the hook is
+ *      optional belt-and-suspenders.
+ *   5. ALSO inspects the new `AI_PROXY_TOKEN`'s JWT `exp` claim. If exp
+ *      minus 24h is sooner than the next scheduled tick, schedules an
+ *      earlier refresh. Adapts to whatever TTL the API decides to mint
+ *      (today 7d, tomorrow possibly shorter or longer) without code
+ *      changes here.
+ *
+ * Failure mode is silent retry: a 5xx or network error logs and waits
+ * for the next tick. The current token is valid for days, so a transient
+ * upstream blip does not cause an outage.
+ *
+ * What this module does NOT do
+ * ============================
+ * - Active-session rotation. A WebSocket chat session that started
+ *   30 seconds before rotation finishes the turn with the old token.
+ *   That's fine: tokens get a 30s grace window inside the API's
+ *   verifier, sessions are typically <30 min, and refresh happens
+ *   ≥24h before expiry — the worst-case live session has hours of
+ *   headroom.
+ * - HMAC secret rotation. If `AI_PROXY_SECRET` on the API is rotated,
+ *   every existing token becomes invalid instantly. The next refresh
+ *   tick recovers the runtime, but a brief outage is unavoidable
+ *   unless the API does dual-signing during rotation. Out of scope
+ *   for this fix.
+ *
+ * See also
+ * ========
+ * - apps/api/src/lib/ai-proxy-token.ts        — token generation / verification
+ * - apps/api/src/lib/runtime/build-project-env.ts — token TTL choice
+ * - packages/shared-runtime/src/self-assign.ts — boot-time fetch (same API)
+ * - apps/api/src/routes/internal/pod-config.ts — refresh endpoint
+ */
+
+import { configureAIProxy } from './ai-proxy'
+import { deriveApiUrl, readSAToken } from './self-assign'
+
+/** Default cadence: 12 hours. Well under the 7-day token TTL. */
+const DEFAULT_REFRESH_INTERVAL_MS = 12 * 60 * 60 * 1000
+
+/** Jitter window: ±1 hour, so fleet-wide refreshes don't stampede. */
+const DEFAULT_JITTER_MS = 60 * 60 * 1000
+
+/** How early before `exp` to refresh, when JWT exp is parseable. */
+const DEFAULT_REFRESH_BEFORE_EXP_MS = 24 * 60 * 60 * 1000
+
+/** Network timeout for the refresh fetch. Matches self-assign on boot. */
+const FETCH_TIMEOUT_MS = 30_000
+
+export interface TokenRefreshOptions {
+  /** Read the project ID at refresh time — must reflect the latest assignment. */
+  getProjectId: () => string | null | undefined
+  /** Display name used in log prefixes. */
+  logPrefix?: string
+  /** Override the refresh cadence. Useful in tests. */
+  intervalMs?: number
+  /** Override the jitter window. Set to 0 to disable. */
+  jitterMs?: number
+  /** Override "how early before token exp to refresh." */
+  refreshBeforeExpMs?: number
+  /**
+   * Optional callback invoked after process.env has been updated with the
+   * fresh env. Runtimes can use this to rebuild model clients that captured
+   * the old token at construction. Errors thrown here are caught and logged
+   * — they never abort the refresh loop.
+   */
+  onTokenRotate?: (env: Record<string, string>) => void | Promise<void>
+}
+
+export interface TokenRefreshHandle {
+  /** Stop the loop. Safe to call multiple times. */
+  stop: () => void
+  /**
+   * Force an immediate refresh (in addition to the scheduled cadence).
+   * Returns the new env on success, or null on failure.
+   * Exposed primarily for tests.
+   */
+  refreshNow: () => Promise<Record<string, string> | null>
+}
+
+/**
+ * Start the AI_PROXY_TOKEN refresh loop. Idempotent per-process — callers
+ * should not start two loops; if you need to restart with new options,
+ * `stop()` the existing handle first.
+ */
+export function startTokenRefreshLoop(options: TokenRefreshOptions): TokenRefreshHandle {
+  const prefix = options.logPrefix ?? 'token-refresh'
+  const intervalMs = options.intervalMs ?? DEFAULT_REFRESH_INTERVAL_MS
+  const jitterMs = options.jitterMs ?? DEFAULT_JITTER_MS
+  const refreshBeforeExpMs = options.refreshBeforeExpMs ?? DEFAULT_REFRESH_BEFORE_EXP_MS
+
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let stopped = false
+
+  const computeNextDelay = (): number => {
+    const jitter = jitterMs > 0
+      ? Math.floor((Math.random() * 2 - 1) * jitterMs)
+      : 0
+    const baseDelay = Math.max(1_000, intervalMs + jitter)
+
+    // If we can read the new token's expiry, prefer (exp - refreshBeforeExpMs)
+    // when that's sooner than the scheduled tick. Adapts to API-side TTL
+    // changes without code edits here.
+    const token = process.env.AI_PROXY_TOKEN
+    if (token) {
+      const exp = readJwtExpMs(token)
+      if (exp) {
+        const expDriven = exp - Date.now() - refreshBeforeExpMs
+        if (expDriven > 0 && expDriven < baseDelay) {
+          return expDriven
+        }
+      }
+    }
+    return baseDelay
+  }
+
+  const schedule = () => {
+    if (stopped) return
+    const delay = computeNextDelay()
+    timer = setTimeout(() => {
+      void refresh()
+    }, delay)
+    // Don't keep the event loop alive for the refresh timer — if the runtime
+    // is otherwise idle and Bun/Node wants to exit, we don't block it.
+    if (typeof (timer as any)?.unref === 'function') (timer as any).unref()
+  }
+
+  const refresh = async (): Promise<Record<string, string> | null> => {
+    try {
+      const projectId = options.getProjectId()
+      if (!projectId || projectId === '__POOL__') {
+        // Pod is back in the warm pool — nothing to refresh. Reschedule
+        // so we pick up rotation the next time it gets promoted.
+        return null
+      }
+
+      const apiUrl = deriveApiUrl()
+      if (!apiUrl) {
+        console.warn(`[${prefix}] cannot derive API URL; skipping refresh`)
+        return null
+      }
+
+      const saToken = readSAToken()
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (saToken) headers['Authorization'] = `Bearer ${saToken}`
+
+      const url = `${apiUrl}/api/internal/pod-config/${projectId}`
+      const startedAt = Date.now()
+      const res = await fetch(url, {
+        method: 'GET',
+        headers,
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      })
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => '')
+        console.warn(`[${prefix}] refresh got ${res.status}: ${body.slice(0, 200)}`)
+        return null
+      }
+
+      const data = await res.json() as { projectId: string; env: Record<string, string> }
+      if (!data?.env || typeof data.env !== 'object') {
+        console.warn(`[${prefix}] refresh response missing env`)
+        return null
+      }
+
+      // Apply env to process.env. Note: we do NOT clear keys that the API
+      // omits — the refresh endpoint is the source of truth for what's
+      // *new*, not for unsetting values.
+      for (const [key, value] of Object.entries(data.env)) {
+        if (typeof value === 'string') process.env[key] = value
+      }
+
+      // Spread AI proxy URL/key/base-url derivatives so SDK clients that
+      // read these at request time see fresh values.
+      try {
+        const cfg = configureAIProxy({ logPrefix: prefix })
+        if (cfg.useProxy) Object.assign(process.env, cfg.env)
+      } catch (err: any) {
+        // configureAIProxy throws if URL is set but token is empty —
+        // shouldn't happen post-refresh, but if the API returned a
+        // malformed env we shouldn't bring down the loop.
+        console.warn(`[${prefix}] configureAIProxy after refresh failed: ${err?.message ?? err}`)
+      }
+
+      // Notify the runtime. Errors in the hook are logged and swallowed —
+      // they must not abort the refresh loop.
+      if (options.onTokenRotate) {
+        try {
+          await options.onTokenRotate(data.env)
+        } catch (hookErr: any) {
+          console.warn(`[${prefix}] onTokenRotate threw: ${hookErr?.message ?? hookErr}`)
+        }
+      }
+
+      const elapsed = Date.now() - startedAt
+      console.log(`[${prefix}] rotated AI_PROXY_TOKEN for ${projectId} in ${elapsed}ms`)
+      return data.env
+    } catch (err: any) {
+      console.warn(`[${prefix}] refresh error: ${err?.message ?? err}`)
+      return null
+    } finally {
+      schedule()
+    }
+  }
+
+  schedule()
+
+  return {
+    stop: () => {
+      stopped = true
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+    },
+    refreshNow: refresh,
+  }
+}
+
+/**
+ * Decode a JWT's `exp` claim without verifying the signature. We only use
+ * the value to schedule a refresh — never for auth — so signature
+ * verification isn't required and we deliberately avoid pulling in a
+ * jwt-decode library for one numeric field.
+ *
+ * Returns the expiry as a millisecond Unix timestamp, or null if the
+ * token is not a parseable JWT, has no `exp` claim, or has an exp that
+ * isn't a number.
+ */
+export function readJwtExpMs(token: string): number | null {
+  try {
+    const parts = token.split('.')
+    if (parts.length < 2) return null
+    const payloadB64 = parts[1]
+    // base64url → base64. Buffer.from handles padding tolerantly.
+    const normalized = payloadB64.replace(/-/g, '+').replace(/_/g, '/')
+    const payload = JSON.parse(
+      Buffer.from(normalized, 'base64').toString('utf-8'),
+    )
+    const exp = payload?.exp
+    if (typeof exp !== 'number') return null
+    return exp * 1000
+  } catch {
+    return null
+  }
+}

--- a/packages/shared-runtime/src/token-refresh.ts
+++ b/packages/shared-runtime/src/token-refresh.ts
@@ -55,11 +55,15 @@
  * What this module does NOT do
  * ============================
  * - Active-session rotation. A WebSocket chat session that started
- *   30 seconds before rotation finishes the turn with the old token.
- *   That's fine: tokens get a 30s grace window inside the API's
- *   verifier, sessions are typically <30 min, and refresh happens
- *   ≥24h before expiry — the worst-case live session has hours of
- *   headroom.
+ *   moments before rotation finishes the turn with whichever token
+ *   it captured. The API's verifier checks `exp` strictly — no
+ *   leeway, no grace window — so a session that captured a token
+ *   within milliseconds of its expiry could 401 mid-turn. In
+ *   practice this is fine because refresh happens ≥24h before
+ *   expiry: the worst-case live session has hours of headroom on
+ *   the OLD token, and any session constructed after rotation uses
+ *   the NEW token. If the API ever adds verifier leeway, the
+ *   already-large headroom only widens.
  * - HMAC secret rotation. If `AI_PROXY_SECRET` on the API is rotated,
  *   every existing token becomes invalid instantly. The next refresh
  *   tick recovers the runtime, but a brief outage is unavoidable
@@ -133,6 +137,11 @@ export function startTokenRefreshLoop(options: TokenRefreshOptions): TokenRefres
 
   let timer: ReturnType<typeof setTimeout> | null = null
   let stopped = false
+  // Single-flight guard for refresh(). Both the scheduled tick and a public
+  // `refreshNow()` call route through the same refresh function; without
+  // coalescing, concurrent invocations each call schedule() in their
+  // `finally`, which would leak setTimeouts.
+  let inflight: Promise<Record<string, string> | null> | null = null
 
   const computeNextDelay = (): number => {
     const jitter = jitterMs > 0
@@ -158,16 +167,36 @@ export function startTokenRefreshLoop(options: TokenRefreshOptions): TokenRefres
 
   const schedule = () => {
     if (stopped) return
+    // Cancel any previously-pending tick before installing a new one.
+    // Required for safety under concurrent refresh(): without this, two
+    // overlapping refresh() calls would each schedule a fresh setTimeout
+    // in their finally, leaking timers that compound over time.
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
     const delay = computeNextDelay()
     timer = setTimeout(() => {
       void refresh()
     }, delay)
     // Don't keep the event loop alive for the refresh timer — if the runtime
     // is otherwise idle and Bun/Node wants to exit, we don't block it.
+    // The `as any` cast bridges the Bun/Node setTimeout return-type
+    // difference; both runtimes expose `.unref()` at runtime.
     if (typeof (timer as any)?.unref === 'function') (timer as any).unref()
   }
 
-  const refresh = async (): Promise<Record<string, string> | null> => {
+  const refresh = (): Promise<Record<string, string> | null> => {
+    // Single-flight: a concurrent caller gets the in-flight promise back
+    // instead of starting a second refresh + schedule cycle.
+    if (inflight) return inflight
+    inflight = doRefresh().finally(() => {
+      inflight = null
+    })
+    return inflight
+  }
+
+  const doRefresh = async (): Promise<Record<string, string> | null> => {
     try {
       const projectId = options.getProjectId()
       if (!projectId || projectId === '__POOL__') {


### PR DESCRIPTION
Closes #535.

## What's broken (root cause)

`AI_PROXY_TOKEN` is minted by `apps/api/src/lib/ai-proxy-token.ts` with a hardcoded 7-day TTL and handed to the runtime pod **once** at assign time via `buildProjectEnv()`. The pod stashes it in `process.env` and reads it from there forever. There is no refresh path, no rotation policy, no alert.

After 7 days of pod uptime — common for warm-pool pods that have been promoted to a project, or long-lived projects — the in-process token expires. The API's verifier checks `exp` strictly (no `leeway` / `clockTolerance`), every AI call 401s, the user's agent silently stops responding, and recovery today requires a human to restart the pod.

This is a missing-lifecycle bug, not a bad-value bug. The system was built as if pods are short-lived; warm-pool promotion + long sessions break that assumption.

Full writeup with all five recommended fixes in #535. **This PR addresses item 1 only** — the pod-side refresh loop, which on its own removes the production failure mode. Items 2–5 (alert, TTL contract test, credential policy doc, health-probe freshness) are deliberately split out to keep this PR reviewable.

## What this PR does

1. **`packages/shared-runtime/src/token-refresh.ts` (new)** — the refresh loop.
   - 12h cadence with ±1h jitter — well below 7-day TTL, no stampede across the fleet.
   - Early-refresh when the JWT's actual `exp` is closer than 24h, so a backend TTL change is picked up without code changes here.
   - Polls `/api/internal/pod-config/<projectId>`, which is already implemented in `apps/api/src/routes/internal.ts` and returns the same env bundle as `buildProjectEnv()`.
   - Auth: in-cluster ServiceAccount token at `/var/run/secrets/kubernetes.io/serviceaccount/token`, reused from `self-assign.ts`. No new auth surface.
   - On success: merges response env into `process.env`, calls `configureAIProxy()` to rebuild proxy config, fires `onTokenRotate` hook (errors caught, loop continues).
   - On failure (5xx, network reject, timeout): logged, current token remains valid (multi-day headroom from refresh-before-expiry gap), next tick retries.

2. **`packages/shared-runtime/src/__tests__/token-refresh.test.ts` (new)** — 11 tests covering JWT exp decoding (happy + 3 malformed), fetch URL + env application, hook-throw isolation, 5xx and network-failure non-fatality, `__POOL__` / null projectId skip, and `stop()` cancellation.

3. **`packages/shared-runtime/src/self-assign.ts`** — exports `readSAToken()` and `deriveApiUrl()` (previously module-private). Same logic, same behavior; just shared with the refresh loop instead of duplicated. Docblocks added explaining the new consumer.

4. **`packages/shared-runtime/src/server-framework.ts`** — wires the loop into the runtime lifecycle.
   - `state.tokenRefresh: TokenRefreshHandle | null` added to `RuntimeState`.
   - `ensureTokenRefreshLoop()` helper, idempotent. Reads `state.currentProjectId` at refresh time (not start time), so a future re-assignment is picked up automatically.
   - Started in two places: (a) on startup if a real project is already bound (non-pool boot, or self-assign promoted on boot), (b) in the `/pool/assign` handler after warm-pool promotion. Pure pool pods (`PROJECT_ID=__POOL__`) defer until promotion.
   - Stopped on `SIGTERM` before the drain, so in-flight refreshes don't extend pod termination.
   - `onTokenRotate?: (env) => void | Promise<void>` added to `RuntimeAppConfig` — optional belt-and-suspenders hook for callers that captured the old token at construction time. Most SDK clients read from `process.env` at request time and don't need it.

## What this PR does NOT do

These are deliberately out of scope. See #535 for the full plan.

- **No alert on consecutive refresh failures.** A multi-day API/pod partition would still degrade silently. Follow-up: SigNoz alert on `runtime_token_refresh_failures_total`.
- **No TTL contract test.** The relationship `TTL (7d) > cadence (12h) + jitter (1h)` is held together by code review. Follow-up: test in `apps/api/src/lib/ai-proxy-token.test.ts` that asserts `expiryMs >= 24h`, OR a shared constant.
- **No generalization to other credentials.** `buildProjectEnv` returns `RUNTIME_AUTH_SECRET`, `WEBHOOK_TOKEN`, `COMPOSIO_API_KEY`, S3 creds, etc. They ride along inside the same response and so they DO refresh on the same cadence — but the policy isn't documented and no test enforces it. Follow-up: `docs/runtime/credentials.md`.
- **No `/health` freshness signal.** Follow-up: expose `lastTokenRefreshAt` and `tokenExpiresAt`; liveness probe can catch a pod whose refresh has been failing.

## Failure modes after this PR

| Scenario | Behavior |
| --- | --- |
| Transient API 5xx | Logged, current token (multi-day headroom) stays in use, next tick retries. No user-visible impact. |
| Network reject / timeout | Same as above. |
| API unreachable for > 7 days continuously | Refresh keeps failing, eventually the in-process token expires, AI calls start 401-ing. This is the residual exposure; follow-up alert (#535 item 2) is what closes it. |
| `onTokenRotate` hook throws | Caught and logged, loop continues. |
| Pod outside Kubernetes (local dev, unit tests) | No SA token mounted, no Authorization header sent, API rejects, refresh fails, dev doesn't crash. |
| `refreshNow()` called concurrently with a scheduled tick | ⚠️ See review below — bug to address before merge. |
| `SIGTERM` during in-flight refresh | Loop stops, in-flight fetch completes naturally, no new tick scheduled. |

## Behavior on existing pods after deploy

- Pods restarted after this lands: refresh loop starts on assign, tokens auto-rotate, no further action needed.
- Pods NOT restarted: still vulnerable until their next pod recycle. Operationally, recommend rolling restart of the runtime deployment after merge to bring everyone into the new behavior. The fix is not effective on a pod that doesn't pick up the new image.

## Verification done

- TypeScript compiles cleanly (file-level review, no type errors flagged).
- Test file covers documented failure modes (see test list above).
- Manual trace: confirmed `/api/internal/pod-config/:projectId` exists in `apps/api/src/routes/internal.ts` and returns `{ projectId, env }` from `warmPool.buildProjectEnv()`. URL and response shape match what the loop expects.
- Confirmed `buildProjectEnv` returns `AI_PROXY_TOKEN`, `RUNTIME_AUTH_SECRET`, `WEBHOOK_TOKEN`, `COMPOSIO_*`, S3 creds (`apps/api/src/lib/runtime/build-project-env.ts`).
- Confirmed the API's ai-proxy verifier does NOT have a grace window — strict `exp` check. The PR's headroom argument depends on cadence ≪ TTL, not on any leeway.

## Outstanding items (will be raised on the PR as a self-review)

I'll post a code-review pass on this PR immediately after creation flagging the issues I'm aware of in the implementation. Headlines:

- **Blocker — timer multiplication.** `schedule()` doesn't cancel the existing timer before setting a new one. If `refreshNow()` is ever called concurrently with a scheduled tick, both call `schedule()` in `finally`, leaving two timers active. Repeats compound. Fix is one line.
- **Blocker — false claim in docblock.** Header references a "30s grace window inside the API's verifier" that does not exist in `ai-proxy-token.ts`. Must delete or correct before merge — wrong docblocks are worse than no docblocks.
- **Strong — misleading test name.** `'uses ServiceAccount token in Authorization header when present'` actually asserts the negative case (no SA token mounted ⇒ no header). Either rename, or add the positive-case test with `readSAToken` mocked.

Treat the self-review as part of the PR. I will not request approval until those are addressed.

## Does this PR mean "the problem will never occur again"?

**No.** It removes the original failure mode structurally — the credential now has a lifecycle, not a one-shot mint — but residual edges remain (multi-day API outage, the three review blockers above, no alert on refresh failure). #535 items 2–5 are what would let us actually say "never again." Anyone claiming a single PR makes a distributed-systems credential bug impossible is selling something.

What this PR gives us: the production symptom stops happening on its own, instead of requiring a human to restart pods.
