### PR TITLE
fix(studio): scope All Projects to active workspace + group Shared with me by workspace

### DIFF
--- a/apps/mobile/app/(app)/projects/index.tsx
+++ b/apps/mobile/app/(app)/projects/index.tsx
@@ -79,6 +79,7 @@ import { ProjectCard } from '../../../components/home/ProjectCard'
 import { api } from '../../../lib/api'
 import { useToast, Toast, ToastTitle, ToastDescription } from '@/components/ui/toast'
 import { ProjectImportModal } from '../../../components/projects/ProjectImportModal'
+import { useActiveWorkspace } from '../../../hooks/useActiveWorkspace'
 
 // Types
 type SortBy = 'lastEdited' | 'dateCreated' | 'alphabetical'
@@ -256,9 +257,12 @@ export default observer(function AllProjectsPage() {
   // Native phones: 2 columns for readable titles and touch targets; web keeps 3-up grid.
   const numColumns = viewMode === 'grid' ? (isNativeMobile ? 2 : 3) : 1
 
-  // Find current workspace
+  // Use the workspace the user explicitly selected in the sidebar.
+  // Falling back to workspaces[0] previously caused invited-workspace
+  // projects to leak into "All projects" when the user belonged to
+  // multiple workspaces.
+  const currentWorkspace = useActiveWorkspace()
   const workspaces = store?.workspaceCollection?.all ?? []
-  const currentWorkspace = workspaces[0] ?? null
 
   // Load data
   useEffect(() => {

--- a/apps/mobile/app/(app)/shared.tsx
+++ b/apps/mobile/app/(app)/shared.tsx
@@ -22,6 +22,7 @@ import {
   LayoutGrid,
   List,
   ChevronDown,
+  ChevronRight,
   FolderOpen,
   Users,
   Settings,
@@ -46,6 +47,41 @@ const SORT_OPTIONS: { value: SortBy; label: string }[] = [
 
 function getTimeAgo(timestamp: number): string {
   return formatDistanceToNow(new Date(timestamp), { addSuffix: true })
+}
+
+type SharedGroup = {
+  workspace: any
+  role: string
+  projects: any[]
+  latestUpdatedAt: number
+}
+
+const COLLAPSE_STORAGE_KEY = 'shogo:shared:collapsed'
+
+function readCollapsedFromStorage(): Record<string, boolean> {
+  if (typeof window === 'undefined' || !window.localStorage) return {}
+  try {
+    const raw = window.localStorage.getItem(COLLAPSE_STORAGE_KEY)
+    return raw ? JSON.parse(raw) : {}
+  } catch {
+    return {}
+  }
+}
+
+function writeCollapsedToStorage(state: Record<string, boolean>) {
+  if (typeof window === 'undefined' || !window.localStorage) return
+  try {
+    const compact: Record<string, true> = {}
+    for (const [id, v] of Object.entries(state)) if (v) compact[id] = true
+    window.localStorage.setItem(COLLAPSE_STORAGE_KEY, JSON.stringify(compact))
+  } catch {
+    // ignore quota / privacy-mode errors
+  }
+}
+
+function roleLabel(role: string | undefined): string {
+  if (!role) return 'Member'
+  return role.charAt(0).toUpperCase() + role.slice(1)
 }
 
 const GRADIENT_COLORS = [
@@ -154,13 +190,73 @@ export default observer(function SharedWithMePage() {
     return result
   }, [sharedProjects, searchQuery, sortBy])
 
-  const getWorkspaceName = useCallback(
-    (project: any) => {
-      const ws = sharedWorkspaces.find((w: any) => w.id === project.workspaceId)
-      return ws?.name || 'Unknown workspace'
-    },
-    [sharedWorkspaces]
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>(() =>
+    readCollapsedFromStorage()
   )
+
+  const toggleCollapsed = useCallback((workspaceId: string) => {
+    setCollapsed((prev) => ({ ...prev, [workspaceId]: !prev[workspaceId] }))
+  }, [])
+
+  const roleByWorkspaceId = useMemo(() => {
+    const out: Record<string, string> = {}
+    if (!user?.id) return out
+    for (const m of membersColl.all as any[]) {
+      if (m.userId === user.id) out[m.workspaceId] = m.role
+    }
+    return out
+  }, [user?.id, membersColl.all])
+
+  const groups: SharedGroup[] = useMemo(() => {
+    const byWs = new Map<string, SharedGroup>()
+    for (const p of filteredProjects as any[]) {
+      const ws = sharedWorkspaces.find((w: any) => w.id === p.workspaceId)
+      if (!ws) continue
+      let g = byWs.get(ws.id)
+      if (!g) {
+        g = {
+          workspace: ws,
+          role: roleByWorkspaceId[ws.id] || 'member',
+          projects: [],
+          latestUpdatedAt: 0,
+        }
+        byWs.set(ws.id, g)
+      }
+      g.projects.push(p)
+      const t = p.updatedAt || p.createdAt || 0
+      if (t > g.latestUpdatedAt) g.latestUpdatedAt = t
+    }
+    const arr = Array.from(byWs.values())
+    if (sortBy === 'lastEdited') {
+      arr.sort((a, b) => b.latestUpdatedAt - a.latestUpdatedAt)
+    } else if (sortBy === 'dateCreated') {
+      arr.sort((a, b) => {
+        const ac = a.workspace.createdAt || 0
+        const bc = b.workspace.createdAt || 0
+        return bc - ac
+      })
+    } else {
+      arr.sort((a, b) =>
+        (a.workspace.name || '').localeCompare(b.workspace.name || '')
+      )
+    }
+    return arr
+  }, [filteredProjects, sharedWorkspaces, roleByWorkspaceId, sortBy])
+
+  const totalFiltered = filteredProjects.length
+  const visibleGroupCount = groups.length
+
+  // Persist collapse state to storage as a side effect (keeps the
+  // setState updater pure). Also prune ids for workspaces that no
+  // longer appear in `groups` so the payload doesn't grow forever.
+  useEffect(() => {
+    const validIds = new Set(groups.map((g) => g.workspace.id))
+    const pruned: Record<string, boolean> = {}
+    for (const [id, v] of Object.entries(collapsed)) {
+      if (v && validIds.has(id)) pruned[id] = true
+    }
+    writeCollapsedToStorage(pruned)
+  }, [collapsed, groups])
 
   const handleProjectPress = useCallback(
     (project: any) => {
@@ -207,11 +303,6 @@ export default observer(function SharedWithMePage() {
           className={cn('items-center justify-center', getPlaceholderColor(project.name || ''))}
         >
           <FolderOpen size={28} className="text-white/30" />
-          {/* Shared badge */}
-          <View className="absolute top-2 left-2 flex-row items-center bg-black/30 rounded-md px-2 py-0.5">
-            <Users size={12} className="text-white mr-1" />
-            <Text className="text-white text-xs">Shared</Text>
-          </View>
           {/* Star button */}
           <Pressable
             onPress={() => handleToggleStar(project)}
@@ -241,14 +332,14 @@ export default observer(function SharedWithMePage() {
                 {project.name}
               </Text>
               <Text className="text-muted-foreground text-xs" numberOfLines={1}>
-                {getWorkspaceName(project)}
+                {getTimeAgo(project.updatedAt || project.createdAt)}
               </Text>
             </View>
           </View>
         </View>
       </Pressable>
     ),
-    [handleProjectPress, handleToggleStar, getWorkspaceName, starredProjectIds, user?.name]
+    [handleProjectPress, handleToggleStar, starredProjectIds, user?.name]
   )
 
   const renderListItem = useCallback(
@@ -266,16 +357,11 @@ export default observer(function SharedWithMePage() {
           <FolderOpen size={16} className="text-white/50" />
         </View>
         <View className="flex-1 mr-3">
-          <View className="flex-row items-center gap-1.5">
-            <Text className="text-foreground text-sm font-medium" numberOfLines={1}>
-              {project.name}
-            </Text>
-            <View className="bg-muted rounded px-1.5 py-0.5">
-              <Text className="text-muted-foreground text-[10px]">Shared</Text>
-            </View>
-          </View>
+          <Text className="text-foreground text-sm font-medium" numberOfLines={1}>
+            {project.name}
+          </Text>
           <Text className="text-muted-foreground text-xs" numberOfLines={1}>
-            {getWorkspaceName(project)} · {getTimeAgo(project.updatedAt || project.createdAt)}
+            {getTimeAgo(project.updatedAt || project.createdAt)}
           </Text>
         </View>
         <Pressable onPress={() => handleToggleStar(project)} className="p-2">
@@ -287,7 +373,54 @@ export default observer(function SharedWithMePage() {
         </Pressable>
       </Pressable>
     ),
-    [handleProjectPress, handleToggleStar, getWorkspaceName, starredProjectIds]
+    [handleProjectPress, handleToggleStar, starredProjectIds]
+  )
+
+  const renderSectionHeader = useCallback(
+    (group: SharedGroup) => {
+      const isCollapsed = !!collapsed[group.workspace.id]
+      const Chevron = isCollapsed ? ChevronRight : ChevronDown
+      return (
+        <Pressable
+          onPress={() => toggleCollapsed(group.workspace.id)}
+          accessibilityRole="button"
+          accessibilityState={{ expanded: !isCollapsed }}
+          className="flex-row items-center pl-3 pr-4 py-3 bg-muted/60 dark:bg-muted/40 border-y border-border border-l-2 border-l-primary/50 hover:bg-muted/80 dark:hover:bg-muted/60"
+        >
+          <View
+            className={cn(
+              'w-8 h-8 rounded-md items-center justify-center mr-3 ml-1',
+              getPlaceholderColor(group.workspace.name || '')
+            )}
+          >
+            <Text className="text-white text-sm font-semibold">
+              {(group.workspace.name || '?').charAt(0).toUpperCase()}
+            </Text>
+          </View>
+          <View className="flex-1 mr-3">
+            <View className="flex-row items-center gap-2">
+              <Text className="text-foreground text-[15px] font-semibold" numberOfLines={1}>
+                {group.workspace.name || 'Untitled workspace'}
+              </Text>
+              <View className="bg-background border border-border rounded px-1.5 py-0.5">
+                <Text className="text-muted-foreground text-[10px]">
+                  {roleLabel(group.role)}
+                </Text>
+              </View>
+            </View>
+            <Text className="text-muted-foreground text-xs mt-0.5" numberOfLines={1}>
+              {group.projects.length}{' '}
+              {group.projects.length === 1 ? 'project' : 'projects'}
+              {group.latestUpdatedAt
+                ? ` · updated ${getTimeAgo(group.latestUpdatedAt)}`
+                : ''}
+            </Text>
+          </View>
+          <Chevron size={16} className="text-muted-foreground" />
+        </Pressable>
+      )
+    },
+    [collapsed, toggleCollapsed]
   )
 
   return (
@@ -301,6 +434,12 @@ export default observer(function SharedWithMePage() {
         <Text className="text-muted-foreground text-sm mt-1">
           Projects from workspaces you've been invited to
         </Text>
+        {!isLoading && totalFiltered > 0 && (
+          <Text className="text-muted-foreground text-xs mt-1">
+            {totalFiltered} {totalFiltered === 1 ? 'project' : 'projects'} across{' '}
+            {visibleGroupCount} {visibleGroupCount === 1 ? 'workspace' : 'workspaces'}
+          </Text>
+        )}
       </View>
 
       {/* Filters Bar */}
@@ -357,21 +496,36 @@ export default observer(function SharedWithMePage() {
               : 'Projects you are invited to will appear here. When someone adds you to their workspace, you\'ll see their projects here.'}
           </Text>
         </View>
-      ) : viewMode === 'grid' ? (
-        <FlatList
-          key="grid-2"
-          data={filteredProjects}
-          keyExtractor={(item: any) => item.id}
-          numColumns={2}
-          contentContainerClassName="p-2.5 pt-4"
-          renderItem={renderGridItem}
-        />
       ) : (
         <FlatList
-          key="list-1"
-          data={filteredProjects}
-          keyExtractor={(item: any) => item.id}
-          renderItem={renderListItem}
+          key={`groups-${viewMode}`}
+          data={groups}
+          keyExtractor={(g) => g.workspace.id}
+          contentContainerClassName="pb-8"
+          renderItem={({ item: group }) => {
+            const isCollapsed = !!collapsed[group.workspace.id]
+            return (
+              <View className="mb-2">
+                {renderSectionHeader(group)}
+                {!isCollapsed &&
+                  (viewMode === 'grid' ? (
+                    <View className="flex-row flex-wrap p-2.5">
+                      {group.projects.map((p: any) => (
+                        <View key={p.id} className="w-1/2">
+                          {renderGridItem({ item: p })}
+                        </View>
+                      ))}
+                    </View>
+                  ) : (
+                    <View>
+                      {group.projects.map((p: any) => (
+                        <View key={p.id}>{renderListItem({ item: p })}</View>
+                      ))}
+                    </View>
+                  ))}
+              </View>
+            )
+          }}
         />
       )}
 


### PR DESCRIPTION
Closes #537.

## What

Fixes two related multi-workspace UX problems in the studio Projects experience:

1. The **All projects** page no longer leaks projects from invited workspaces — it scopes strictly to the workspace the user has selected in the sidebar.
2. The **Shared with me** page now bundles projects under the workspace they belong to, with a polished, theme-aware section header per workspace.

Both changes are frontend-only (`apps/mobile`). No backend, schema, auth, or generated SDK files were touched.

## Commits in this PR

1. `fix(projects): scope All Projects to active workspace`
2. `feat(shared): group Shared with me by workspace + visual polish`

They’re kept as separate commits so reviewers can read the bug fix and the UX enhancement independently.

---

## 1) `fix(projects): scope All Projects to active workspace`

### Problem

`apps/mobile/app/(app)/projects/index.tsx` derived the “current workspace” for the page from `store.workspaceCollection.all[0]`:

```ts
const workspaces = store?.workspaceCollection?.all ?? []
const currentWorkspace = workspaces[0] ?? null
```

When the user belongs to more than one workspace, `workspaces[0]` is not guaranteed to be the workspace selected in the sidebar (collection order depends on the Map insertion order returned by the API). Every downstream consumer of `currentWorkspace.id` therefore keyed off the wrong workspace:

- the `projects.loadAll({ workspaceId })` call (L290–292),
- the starred-projects effect (L307–323),
- the client-side filter `p.workspaceId === currentWorkspace.id` (L358–360).

### Fix

Use the existing `useActiveWorkspace()` hook (the same hook the Home screen already uses) so the page reads the workspace the user actually selected. The sidebar workspace switcher already persists that selection via `setActiveWorkspaceId` in `apps/mobile/lib/workspace-store.ts`.

```ts
import { useActiveWorkspace } from '../../../hooks/useActiveWorkspace'
...
const currentWorkspace = useActiveWorkspace()
const workspaces = store?.workspaceCollection?.all ?? []
```

The strict client-side `workspaceId` filter is kept as defense-in-depth against MST cache bleed from `shared.tsx`, which calls `projects.loadAll()` without a workspace filter.

No backend change is needed — `apps/api/src/generated/project.hooks.ts → beforeList` already enforces workspace membership and honors `?workspaceId=`.

### Diff

`apps/mobile/app/(app)/projects/index.tsx`: +6 / -2.

---

## 2) `feat(shared): group Shared with me by workspace + visual polish`

### Problem

`apps/mobile/app/(app)/shared.tsx` was correct at the data layer (it loads all accessible projects and filters to workspaces where the current user is a non-owner member), but visually it offered no grouping. With multiple invited workspaces and duplicate project names across them (e.g. two `YC Founder Operating System` projects from `test Personal` and `test90 Personal`), the page was hard to scan.

### Design

Projects are now bundled under a **collapsible workspace section** with a clear visual treatment:

- workspace avatar + initial (existing `getPlaceholderColor` helper)
- workspace name (`text-[15px] font-semibold`)
- role pill (`Admin` / `Member` / `Guest`) derived from the current user’s membership row
- `{N} projects · updated {time ago}` meta line, where `latestUpdatedAt` is the newest project `updatedAt` in the group
- chevron with `accessibilityState.expanded` for a11y (renders as `aria-expanded` on react-native-web)

The header bar is intentionally theme-aware so it reads distinctly in both light and dark themes:

- `bg-muted/60` (light), `dark:bg-muted/40`
- `hover:bg-muted/80`, `dark:hover:bg-muted/60`
- `border-y border-border` plus a 2px `border-l-2 border-l-primary/50` accent that visually brackets the group
- the role pill switches to `bg-background border border-border` so it remains legible on the tinted bar

### State, persistence, sort

- New `SharedGroup` type and a memoized `groups` computation. Workspaces are derived strictly from `filteredProjects`, so empty headers can never appear.
- **Per-workspace collapse state** persisted to `localStorage` under `shogo:shared:collapsed`. Writes happen in a `useEffect([collapsed, groups])` (the `setState` updater itself is pure, which is StrictMode-safe). Each write also **prunes** ids for workspaces that no longer appear in `groups`, so the payload cannot grow unbounded.
- **Sort-aware workspace ordering** — workspaces themselves follow the project sort dropdown:
  - `sortBy === 'lastEdited'`  → groups by `latestUpdatedAt` desc
  - `sortBy === 'dateCreated'` → groups by `workspace.createdAt` desc
  - default                   → alphabetical via `localeCompare`
- The `FlatList` is keyed on `groups-{viewMode}` so the view-mode toggle forces a clean remount instead of leaving stale memoized rows around.

### Bundled visual cleanups (intentional, in the same commit)

The section header now carries the workspace identity, so the redundant per-card hints are removed on this page only:

- the `Shared` overlay badge inside grid cards
- the `Shared` pill inside list rows
- the workspace subtitle inside both grid and list cards (replaced with a relative timestamp)

A small meta chip is added under the page title: `{N} projects across {M} workspaces` (only shown when there are results).

Grid mode uses `flex-row flex-wrap` with `w-1/2` cells (rather than nesting `FlatList numColumns={2}` inside another `FlatList`) so we don’t hit react-native-web’s nested-VirtualizedList warning.

### Diff

`apps/mobile/app/(app)/shared.tsx`: +190 / -36.

---

## Test plan

1. Build is clean (`tsc --noEmit` reports zero new errors in either file).
2. **Multi-workspace user (the screenshotted scenario):**
   - With personal workspace selected in the sidebar, open `/projects` → only the personal workspace’s projects appear.
   - Open `/shared` → projects grouped under each invited workspace, with role pill and project count visible.
   - Two `YC Founder Operating System` projects from two different workspaces are now visually disambiguated by their owning workspace header.
   - Collapse a workspace, hard-refresh → it remains collapsed (localStorage).
   - Switch the sort dropdown to *Last edited* → workspace order updates accordingly; *Alphabetical* restores name ordering.
   - Toggle grid ↔ list view → both modes render correctly under section headers; no nested-VirtualizedList warnings in the console.
3. **Single-workspace user:** unchanged behavior on `/projects`; a single section header appears on `/shared` and looks intentional rather than redundant.
4. **Empty state on `/shared`:** existing copy unchanged; never renders an empty workspace header.
5. **Search:** typing in the shared-page search filters within groups; groups with zero matches are hidden; the meta chip updates live.
6. **Theme switch:** the workspace header bar remains clearly distinguishable in both light and dark themes.

## Out of scope (deferred follow-ups)

- `useActiveWorkspace` is not reactive — sidebar workspace switches only propagate on the next route mount. Worth promoting the active id to a MobX observable or React context, but separately.
- Projects shared via direct project-level membership (no workspace membership) do not surface on `/shared`. Pre-existing limitation; needs a product decision before changing.
- Sticky workspace headers while scrolling (`stickyHeaderIndices`) would be a nice readability win for very long groups.

## Risk

Low. Both changes are frontend-only and scoped to two files in `apps/mobile`. No schema, generated SDK, auth, or backend touched. The strict workspace filter on `/projects` is additive defense-in-depth. The Shared-with-me grouping reuses existing memoized data (`filteredProjects`, `sharedWorkspaces`, `membersColl.all`) and reuses the existing `renderGridItem` / `renderListItem` for the card layouts.
