### PR TITLE
Fix TodoWidget task state drift

### DIFF
--- a/apps/mobile/components/chat/turns/AssistantContent.tsx
+++ b/apps/mobile/components/chat/turns/AssistantContent.tsx
@@ -628,12 +628,22 @@ export const AssistantContent = memo(
     [orderedParts],
   )
 
-  const firstTodoWriteId = useMemo(() => {
-    const first = groupedParts.find(
-      (p): p is Extract<GroupedMessagePart, { type: "tool" }> =>
-        p.type === "tool" && (p.tool.toolName === "TodoWrite" || p.tool.toolName === "todo_write"),
-    )
-    return first?.id
+  // Find the first and last todo_write tool parts. We render a single
+  // consolidated TodoWidget at the first position, but always feed it the
+  // *latest* tool call's data so the user sees up-to-date task statuses.
+  const { firstTodoWriteId, lastTodoTool } = useMemo(() => {
+    let firstId: string | undefined
+    let lastTool: ToolCallData | undefined
+    for (const p of groupedParts) {
+      if (
+        p.type === "tool" &&
+        (p.tool.toolName === "TodoWrite" || p.tool.toolName === "todo_write")
+      ) {
+        if (!firstId) firstId = p.id
+        lastTool = p.tool
+      }
+    }
+    return { firstTodoWriteId: firstId, lastTodoTool: lastTool }
   }, [groupedParts])
 
   if (groupedParts.length === 0) {
@@ -739,17 +749,20 @@ export const AssistantContent = memo(
           }
 
           if (part.tool.toolName === "TodoWrite" || part.tool.toolName === "todo_write") {
-            const isFirst = part.id === firstTodoWriteId
-            const isExpanded = isFirst
-              ? !expandedTools.has(part.id)
-              : expandedTools.has(part.id)
+            // Only render ONE consolidated widget at the first position;
+            // always use the latest todo_write's tool data so the user
+            // sees the most up-to-date task statuses.
+            if (part.id !== firstTodoWriteId) return null
+            const displayTool = lastTodoTool ?? part.tool
+            const isExpanded = !expandedTools.has(part.id)
 
             return (
               <TodoWidget
                 key={part.id}
-                tool={part.tool}
+                tool={displayTool}
                 isExpanded={isExpanded}
                 onToggle={getToggle(part.id)}
+                isMessageStreaming={isStreaming}
               />
             )
           }

--- a/apps/mobile/components/chat/turns/TodoWidget.tsx
+++ b/apps/mobile/components/chat/turns/TodoWidget.tsx
@@ -34,6 +34,8 @@ export interface TodoWidgetProps {
   isExpanded?: boolean
   onToggle?: () => void
   className?: string
+  /** When false (message done streaming), in_progress tasks are shown as completed. */
+  isMessageStreaming?: boolean
 }
 
 function parseTodos(args?: Record<string, unknown>): TodoItem[] {
@@ -242,7 +244,8 @@ function todoToolPropsEqual(
   if (
     prev.isExpanded !== next.isExpanded ||
     prev.onToggle !== next.onToggle ||
-    prev.className !== next.className
+    prev.className !== next.className ||
+    prev.isMessageStreaming !== next.isMessageStreaming
   ) {
     return false
   }
@@ -265,8 +268,24 @@ function TodoWidgetImpl({
   isExpanded: controlledExpanded,
   onToggle,
   className,
+  isMessageStreaming,
 }: TodoWidgetProps) {
-  const todos = useMemo(() => parseTodos(tool.args), [tool.args])
+  const rawTodos = useMemo(() => parseTodos(tool.args), [tool.args])
+
+  // When the message is done streaming, auto-reconcile any remaining
+  // in_progress tasks to "completed" so the widget doesn't
+  // show stale spinners after the agent has finished.
+  const todos = useMemo(() => {
+    if (isMessageStreaming !== false) return rawTodos
+    const hasInProgress = rawTodos.some((t) => t.status === "in_progress")
+    if (!hasInProgress) return rawTodos
+    return rawTodos.map((t) =>
+      t.status === "in_progress"
+        ? { ...t, status: "completed" as const }
+        : t,
+    )
+  }, [rawTodos, isMessageStreaming])
+
   const isExpanded = controlledExpanded ?? true
 
   const handleToggle = () => {


### PR DESCRIPTION
## Summary
- Render one consolidated Tasks widget for multiple `todo_write` calls in a chat turn.
- Feed the visible widget the latest `todo_write` payload so progress, counts, and rows reflect the current checklist.
- Resolve stale `in_progress` task display once the assistant message has finished streaming.

## Detailed Implementation
`AssistantContent` now scans grouped message parts to find the first `todo_write` tool ID and the latest `todo_write` tool payload. It keeps the Tasks panel at the first tool position in the transcript, but renders only that one panel and passes the latest tool data into `TodoWidget`.

`TodoWidget` now accepts `isMessageStreaming`. While the message streams, it renders tool statuses normally. Once streaming ends, any remaining `in_progress` tasks are visually treated as completed, which suppresses stale spinners and active counts after the agent turn is complete.

## Architecture Diagram

```mermaid
flowchart TD
  Agent[Agent emits todo_write calls] --> Parts[AI SDK message parts]
  Parts --> Extract[extractOrderedParts]
  Extract --> Grouped[groupConsecutiveParts]
  Grouped --> FirstLast[Find firstTodoWriteId and lastTodoTool]
  FirstLast --> SingleWidget[Render one TodoWidget at first position]
  SingleWidget --> LatestState[Use latest todo_write args]
  LatestState --> TaskUI[Tasks panel rows and progress]
  StreamState[Message isStreaming] --> Reconcile[Resolve stale in_progress on completion]
  Reconcile --> TaskUI
```

## Test Plan
- `ReadLints` on `AssistantContent.tsx` and `TodoWidget.tsx`
- `bun --no-env-file test components/chat/turns/__tests__/groupMessagesIntoTurns.test.ts components/chat/turns/__tests__/askUserQuestionDraftStore.test.ts` from `apps/mobile`

Closes #540

Made with [Cursor](https://cursor.com)