### PR TITLE
SHOG-591: open .db / .sqlite / .pdf / audio / video / font files in the IDE and broaden text-file coverage

### DIFF
--- a/apps/mobile/components/project/panels/ide/EditorGroup.tsx
+++ b/apps/mobile/components/project/panels/ide/EditorGroup.tsx
@@ -4,6 +4,12 @@ import { Breadcrumbs } from "./Breadcrumbs";
 import { CodeEditor } from "./CodeEditor";
 import { ImagePreview } from "./ImagePreview";
 import { SqlitePreview } from "./SqlitePreview";
+import {
+  AudioPreview,
+  FontPreview,
+  PdfPreview,
+  VideoPreview,
+} from "./MediaPreview";
 import type { EditorGroup as GroupState, EditorSettings, OpenFile } from "./types";
 import type { editor } from "monaco-editor";
 
@@ -73,6 +79,14 @@ export function EditorGroupView({
             <ImagePreview url={active.content} name={active.name} path={active.path} />
           ) : active.language === "sqlite" ? (
             <SqlitePreview url={active.content} name={active.name} path={active.path} />
+          ) : active.language === "pdf" ? (
+            <PdfPreview url={active.content} name={active.name} path={active.path} />
+          ) : active.language === "audio" ? (
+            <AudioPreview url={active.content} name={active.name} path={active.path} />
+          ) : active.language === "video" ? (
+            <VideoPreview url={active.content} name={active.name} path={active.path} />
+          ) : active.language === "font" ? (
+            <FontPreview url={active.content} name={active.name} path={active.path} />
           ) : (
             <CodeEditor
               value={active.content}

--- a/apps/mobile/components/project/panels/ide/EditorGroup.tsx
+++ b/apps/mobile/components/project/panels/ide/EditorGroup.tsx
@@ -3,6 +3,7 @@ import { EditorTabs } from "./EditorTabs";
 import { Breadcrumbs } from "./Breadcrumbs";
 import { CodeEditor } from "./CodeEditor";
 import { ImagePreview } from "./ImagePreview";
+import { SqlitePreview } from "./SqlitePreview";
 import type { EditorGroup as GroupState, EditorSettings, OpenFile } from "./types";
 import type { editor } from "monaco-editor";
 
@@ -70,6 +71,8 @@ export function EditorGroupView({
             </div>
           ) : active.language === "image" ? (
             <ImagePreview url={active.content} name={active.name} path={active.path} />
+          ) : active.language === "sqlite" ? (
+            <SqlitePreview url={active.content} name={active.name} path={active.path} />
           ) : (
             <CodeEditor
               value={active.content}

--- a/apps/mobile/components/project/panels/ide/ImagePreview.tsx
+++ b/apps/mobile/components/project/panels/ide/ImagePreview.tsx
@@ -9,6 +9,10 @@ import {
 
 const IMAGE_EXTS = new Set([
   "png", "jpg", "jpeg", "gif", "webp", "bmp", "ico", "avif", "svg",
+  // Less universally supported formats — we still route them here so the
+  // browser gets a chance to render them. If it can't, ImagePreview shows
+  // a clean "Could not load" message instead of an unhelpful toast.
+  "apng", "jxl", "heic", "heif", "tiff", "tif", "cur",
 ]);
 
 export function isImagePath(path: string): boolean {

--- a/apps/mobile/components/project/panels/ide/MediaPreview.tsx
+++ b/apps/mobile/components/project/panels/ide/MediaPreview.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  FileText,
+  Music,
+  Video,
+  Type as TypeIcon,
+  AlertTriangle,
+  ExternalLink,
+} from "lucide-react-native";
+
+/**
+ * Lightweight previewers for non-text non-image binary files. Each component
+ * receives a URL (blob: for local workspaces, http: for agent workspaces)
+ * already resolved by Workbench, plus the file name + path for chrome.
+ *
+ * These previews are read-only — none of them write back to disk. The URL's
+ * lifetime is owned by Workbench (it revokes blob: URLs on tab close).
+ */
+
+const PDF_EXTS = new Set(["pdf"]);
+const AUDIO_EXTS = new Set(["mp3", "wav", "ogg", "oga", "flac", "m4a", "aac", "opus"]);
+const VIDEO_EXTS = new Set(["mp4", "webm", "mov", "m4v", "mkv", "avi", "ogv"]);
+const FONT_EXTS = new Set(["woff", "woff2", "ttf", "otf", "eot"]);
+
+function extOf(path: string): string {
+  return path.toLowerCase().split(".").pop() ?? "";
+}
+export function isPdfPath(path: string): boolean { return PDF_EXTS.has(extOf(path)); }
+export function isAudioPath(path: string): boolean { return AUDIO_EXTS.has(extOf(path)); }
+export function isVideoPath(path: string): boolean { return VIDEO_EXTS.has(extOf(path)); }
+export function isFontPath(path: string): boolean { return FONT_EXTS.has(extOf(path)); }
+
+// ─── PDF ────────────────────────────────────────────────────────────────
+export function PdfPreview({ url, name }: { url: string; name: string; path: string }) {
+  return (
+    <div className="flex h-full flex-col">
+      <ChromeBar icon={<FileText size={13} className="shrink-0 text-[color:var(--ide-accent-file-icon)]" />}
+                 name={name} url={url} extra="PDF · browser-rendered" />
+      <iframe
+        title={name}
+        src={url}
+        className="flex-1 w-full bg-[color:var(--ide-bg)]"
+        // sandbox is intentionally permissive enough for the browser's built-in
+        // PDF viewer (Chromium PDFium / Firefox PDF.js) to run; we don't grant
+        // top-navigation or popup escapes.
+        sandbox="allow-scripts allow-same-origin allow-forms allow-downloads"
+      />
+    </div>
+  );
+}
+
+// ─── Audio ──────────────────────────────────────────────────────────────
+export function AudioPreview({ url, name }: { url: string; name: string; path: string }) {
+  return (
+    <div className="flex h-full flex-col">
+      <ChromeBar icon={<Music size={13} className="shrink-0 text-[color:var(--ide-accent-file-icon)]" />}
+                 name={name} url={url} extra="audio" />
+      <div className="flex flex-1 items-center justify-center bg-[color:var(--ide-bg)]">
+        <audio
+          src={url}
+          controls
+          className="w-[min(640px,90%)]"
+          onError={() => { /* the browser shows its own UI; we don't need to crash */ }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ─── Video ──────────────────────────────────────────────────────────────
+export function VideoPreview({ url, name }: { url: string; name: string; path: string }) {
+  return (
+    <div className="flex h-full flex-col">
+      <ChromeBar icon={<Video size={13} className="shrink-0 text-[color:var(--ide-accent-file-icon)]" />}
+                 name={name} url={url} extra="video" />
+      <div className="flex flex-1 items-center justify-center overflow-hidden bg-black">
+        <video
+          src={url}
+          controls
+          className="max-h-full max-w-full"
+        />
+      </div>
+    </div>
+  );
+}
+
+// ─── Font ───────────────────────────────────────────────────────────────
+const FONT_FORMAT: Record<string, string> = {
+  woff: "woff",
+  woff2: "woff2",
+  ttf: "truetype",
+  otf: "opentype",
+  eot: "embedded-opentype",
+};
+const SPECIMEN_SIZES = [12, 16, 24, 36, 56, 96];
+const SPECIMEN_TEXT =
+  "The quick brown fox jumps over the lazy dog. 0123456789 !? &@#";
+
+export function FontPreview({ url, name, path }: { url: string; name: string; path: string }) {
+  const ext = extOf(path);
+  const format = FONT_FORMAT[ext] ?? "opentype";
+  // Pick a unique family per tab so two different .ttf files don't collide
+  // in @font-face — the URL is unique enough.
+  const family = useMemo(
+    () => `ide-font-${encodeURIComponent(url).replace(/%/g, "_").slice(-32)}`,
+    [url],
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [sample, setSample] = useState(SPECIMEN_TEXT);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (typeof document === "undefined" || !("fonts" in document)) {
+      setError("Font preview not supported in this browser.");
+      return;
+    }
+    const ff = new FontFace(family, `url(${JSON.stringify(url)}) format('${format}')`);
+    ff.load()
+      .then(() => {
+        if (cancelled) return;
+        document.fonts.add(ff);
+      })
+      .catch(() => {
+        if (!cancelled) setError(`Could not load ${name}`);
+      });
+    return () => {
+      cancelled = true;
+      try { document.fonts.delete(ff); } catch { /* ignore */ }
+    };
+  }, [url, family, format, name]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <ChromeBar icon={<TypeIcon size={13} className="shrink-0 text-[color:var(--ide-accent-file-icon)]" />}
+                 name={name} url={url} extra={`font · ${ext.toUpperCase()}`} />
+      <div className="flex items-center gap-2 border-b border-[color:var(--ide-border)] bg-[color:var(--ide-surface)] px-3 py-1 text-[11px] text-[color:var(--ide-muted)]">
+        <span>Sample:</span>
+        <input
+          value={sample}
+          onChange={(e) => setSample(e.target.value)}
+          className="flex-1 rounded border border-[color:var(--ide-border)] bg-[color:var(--ide-bg)] px-2 py-0.5 text-[color:var(--ide-text)] outline-none focus:border-[color:var(--ide-accent)]"
+        />
+      </div>
+      <div className="flex-1 overflow-auto bg-[color:var(--ide-bg)] p-6">
+        {error ? (
+          <div className="flex items-center gap-2 text-[color:var(--ide-error)]">
+            <AlertTriangle size={14} />
+            <span className="text-[12px]">{error}</span>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {SPECIMEN_SIZES.map((size) => (
+              <div key={size}>
+                <div className="text-[10px] uppercase tracking-wide text-[color:var(--ide-muted)]">
+                  {size}px
+                </div>
+                <div
+                  style={{ fontFamily: `"${family}", system-ui`, fontSize: size }}
+                  className="text-[color:var(--ide-text)] break-words"
+                >
+                  {sample || SPECIMEN_TEXT}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Shared chrome bar ──────────────────────────────────────────────────
+function ChromeBar({
+  icon,
+  name,
+  url,
+  extra,
+}: {
+  icon: React.ReactNode;
+  name: string;
+  url: string;
+  extra?: string;
+}) {
+  return (
+    <div className="flex h-8 items-center justify-between gap-2 border-b border-[color:var(--ide-border)] bg-[color:var(--ide-surface)] px-3 text-[12px] text-[color:var(--ide-muted)]">
+      <div className="flex items-center gap-2 min-w-0">
+        {icon}
+        <span className="truncate text-[color:var(--ide-text)]">{name}</span>
+        {extra && <span className="shrink-0">· {extra}</span>}
+      </div>
+      <button
+        title="Open in new tab"
+        onClick={() => window.open(url, "_blank", "noopener,noreferrer")}
+        className="rounded p-1 text-[color:var(--ide-muted)] hover:bg-[color:var(--ide-hover-subtle)] hover:text-[color:var(--ide-text-strong)]"
+      >
+        <ExternalLink size={12} />
+      </button>
+    </div>
+  );
+}

--- a/apps/mobile/components/project/panels/ide/SqlitePreview.tsx
+++ b/apps/mobile/components/project/panels/ide/SqlitePreview.tsx
@@ -1,0 +1,321 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Database,
+  RefreshCw,
+  AlertTriangle,
+  Table as TableIcon,
+} from "lucide-react-native";
+
+/**
+ * Read-only SQLite database viewer. Used by EditorGroupView when a tab's
+ * language is "sqlite". The URL points at the raw .db bytes — either a
+ * blob: URL (local workspaces, via File System Access) or an http(s):
+ * URL (agent workspaces, via the runtime's download endpoint).
+ *
+ * Implementation notes:
+ *  - sql.js is loaded lazily from CDN to avoid pulling a multi-megabyte
+ *    wasm bundle into the IDE for users who never open a database.
+ *  - Everything runs client-side; we never write back to the file.
+ *  - For very large tables we paginate at PAGE_SIZE rows; users can step
+ *    through pages without re-opening the database.
+ */
+const SQL_JS_VERSION = "1.10.3";
+const SQL_JS_JS = `https://cdnjs.cloudflare.com/ajax/libs/sql.js/${SQL_JS_VERSION}/sql-wasm.js`;
+const SQL_JS_WASM = `https://cdnjs.cloudflare.com/ajax/libs/sql.js/${SQL_JS_VERSION}/sql-wasm.wasm`;
+const PAGE_SIZE = 100;
+
+type SqlJsStatic = {
+  Database: new (data?: Uint8Array) => SqlJsDatabase;
+};
+type SqlJsDatabase = {
+  exec: (sql: string) => Array<{ columns: string[]; values: unknown[][] }>;
+  close: () => void;
+};
+
+declare global {
+  interface Window {
+    initSqlJs?: (config: { locateFile: (f: string) => string }) => Promise<SqlJsStatic>;
+  }
+}
+
+let sqlJsPromise: Promise<SqlJsStatic> | null = null;
+
+function loadSqlJs(): Promise<SqlJsStatic> {
+  if (sqlJsPromise) return sqlJsPromise;
+  sqlJsPromise = (async () => {
+    if (!window.initSqlJs) {
+      await new Promise<void>((resolve, reject) => {
+        const existing = document.querySelector<HTMLScriptElement>(
+          `script[data-sql-js="${SQL_JS_VERSION}"]`,
+        );
+        if (existing) {
+          existing.addEventListener("load", () => resolve(), { once: true });
+          existing.addEventListener("error", () => reject(new Error("sql.js load failed")), { once: true });
+          return;
+        }
+        const s = document.createElement("script");
+        s.src = SQL_JS_JS;
+        s.async = true;
+        s.dataset.sqlJs = SQL_JS_VERSION;
+        s.onload = () => resolve();
+        s.onerror = () => reject(new Error("sql.js load failed"));
+        document.head.appendChild(s);
+      });
+    }
+    if (!window.initSqlJs) throw new Error("sql.js failed to register");
+    return window.initSqlJs({ locateFile: () => SQL_JS_WASM });
+  })();
+  return sqlJsPromise;
+}
+
+type TableInfo = { name: string; rowCount: number };
+
+export function SqlitePreview({
+  url,
+  name,
+  path: _path,
+}: {
+  url: string;
+  name: string;
+  path: string;
+}) {
+  const [db, setDb] = useState<SqlJsDatabase | null>(null);
+  const [tables, setTables] = useState<TableInfo[]>([]);
+  const [activeTable, setActiveTable] = useState<string | null>(null);
+  const [page, setPage] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    let openedDb: SqlJsDatabase | null = null;
+
+    (async () => {
+      setLoading(true);
+      setError(null);
+      setTables([]);
+      setActiveTable(null);
+      setPage(0);
+      try {
+        const [SQL, bytes] = await Promise.all([
+          loadSqlJs(),
+          fetch(url).then((r) => {
+            if (!r.ok) throw new Error(`Failed to read ${name} (HTTP ${r.status})`);
+            return r.arrayBuffer();
+          }),
+        ]);
+        if (cancelled) return;
+        openedDb = new SQL.Database(new Uint8Array(bytes));
+        // List user tables (skip sqlite_* internal tables).
+        const res = openedDb.exec(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+        );
+        const names = res[0]?.values.map((row) => String(row[0])) ?? [];
+        const infos: TableInfo[] = names.map((n) => {
+          try {
+            const c = openedDb!.exec(`SELECT COUNT(*) FROM "${n.replace(/"/g, '""')}"`);
+            return { name: n, rowCount: Number(c[0]?.values[0]?.[0] ?? 0) };
+          } catch {
+            return { name: n, rowCount: 0 };
+          }
+        });
+        if (cancelled) return;
+        setDb(openedDb);
+        setTables(infos);
+        setActiveTable(infos[0]?.name ?? null);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      try {
+        openedDb?.close();
+      } catch {
+        /* ignore */
+      }
+    };
+  }, [url, name, reloadKey]);
+
+  const pageResult = useMemo(() => {
+    if (!db || !activeTable) return null;
+    try {
+      const safe = activeTable.replace(/"/g, '""');
+      const offset = page * PAGE_SIZE;
+      const rows = db.exec(
+        `SELECT * FROM "${safe}" LIMIT ${PAGE_SIZE} OFFSET ${offset}`,
+      );
+      if (rows.length === 0) {
+        const cols = db.exec(`PRAGMA table_info("${safe}")`);
+        const colNames = cols[0]?.values.map((r) => String(r[1])) ?? [];
+        return { columns: colNames, values: [] as unknown[][] };
+      }
+      return rows[0];
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : String(err) };
+    }
+  }, [db, activeTable, page]);
+
+  const activeInfo = tables.find((t) => t.name === activeTable);
+  const totalPages = activeInfo
+    ? Math.max(1, Math.ceil(activeInfo.rowCount / PAGE_SIZE))
+    : 1;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-8 items-center justify-between gap-2 border-b border-[color:var(--ide-border)] bg-[color:var(--ide-surface)] px-3 text-[12px] text-[color:var(--ide-muted)]">
+        <div className="flex items-center gap-2 min-w-0">
+          <Database size={13} className="shrink-0 text-[color:var(--ide-accent-file-icon)]" />
+          <span className="truncate text-[color:var(--ide-text)]">{name}</span>
+          <span className="shrink-0">
+            · {tables.length} table{tables.length === 1 ? "" : "s"} · read-only
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            title="Reload"
+            onClick={() => setReloadKey((k) => k + 1)}
+            className="rounded p-1 text-[color:var(--ide-muted)] hover:bg-[color:var(--ide-hover-subtle)] hover:text-[color:var(--ide-text-strong)]"
+          >
+            <RefreshCw size={12} />
+          </button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="flex h-full items-center justify-center text-[13px] text-[color:var(--ide-muted)]">
+          Loading {name}…
+        </div>
+      ) : error ? (
+        <div className="flex h-full flex-col items-center justify-center gap-2 text-[color:var(--ide-error)]">
+          <AlertTriangle size={24} />
+          <div className="text-[13px]">Could not open {name}</div>
+          <div className="text-[12px] text-[color:var(--ide-muted)]">{error}</div>
+        </div>
+      ) : tables.length === 0 ? (
+        <div className="flex h-full items-center justify-center text-[13px] text-[color:var(--ide-muted)]">
+          Database has no user tables.
+        </div>
+      ) : (
+        <div className="flex min-h-0 flex-1">
+          {/* Table list sidebar */}
+          <div className="w-48 shrink-0 overflow-y-auto border-r border-[color:var(--ide-border)] bg-[color:var(--ide-surface)] py-1 text-[12px]">
+            {tables.map((t) => (
+              <button
+                key={t.name}
+                onClick={() => {
+                  setActiveTable(t.name);
+                  setPage(0);
+                }}
+                className={[
+                  "flex w-full items-center gap-2 px-3 py-1 text-left",
+                  t.name === activeTable
+                    ? "bg-[color:var(--ide-hover-subtle)] text-[color:var(--ide-text-strong)]"
+                    : "text-[color:var(--ide-text)] hover:bg-[color:var(--ide-hover-subtle)]",
+                ].join(" ")}
+              >
+                <TableIcon size={12} className="shrink-0" />
+                <span className="truncate">{t.name}</span>
+                <span className="ml-auto shrink-0 text-[10px] text-[color:var(--ide-muted)]">
+                  {t.rowCount}
+                </span>
+              </button>
+            ))}
+          </div>
+
+          {/* Rows panel */}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <div className="flex items-center justify-between gap-2 border-b border-[color:var(--ide-border)] bg-[color:var(--ide-bg)] px-3 py-1 text-[11px] text-[color:var(--ide-muted)]">
+              <span className="truncate">
+                {activeTable}
+                {activeInfo ? ` · ${activeInfo.rowCount} row${activeInfo.rowCount === 1 ? "" : "s"}` : ""}
+              </span>
+              <div className="flex items-center gap-2">
+                <button
+                  disabled={page === 0}
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                  className="rounded px-1.5 py-0.5 disabled:opacity-40 hover:bg-[color:var(--ide-hover-subtle)]"
+                >
+                  Prev
+                </button>
+                <span>
+                  Page {page + 1} / {totalPages}
+                </span>
+                <button
+                  disabled={page + 1 >= totalPages}
+                  onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                  className="rounded px-1.5 py-0.5 disabled:opacity-40 hover:bg-[color:var(--ide-hover-subtle)]"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+            <div className="min-h-0 flex-1 overflow-auto">
+              {pageResult && "error" in pageResult ? (
+                <div className="p-3 text-[12px] text-[color:var(--ide-error)]">
+                  {pageResult.error}
+                </div>
+              ) : pageResult ? (
+                <table className="w-full border-collapse text-[12px]">
+                  <thead className="sticky top-0 bg-[color:var(--ide-surface)] text-left text-[color:var(--ide-muted)]">
+                    <tr>
+                      {pageResult.columns.map((c) => (
+                        <th
+                          key={c}
+                          className="border-b border-[color:var(--ide-border)] px-3 py-1 font-medium"
+                        >
+                          {c}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {pageResult.values.length === 0 ? (
+                      <tr>
+                        <td
+                          colSpan={Math.max(1, pageResult.columns.length)}
+                          className="px-3 py-2 text-[color:var(--ide-muted)]"
+                        >
+                          (no rows)
+                        </td>
+                      </tr>
+                    ) : (
+                      pageResult.values.map((row, i) => (
+                        <tr key={i} className="hover:bg-[color:var(--ide-hover-subtle)]">
+                          {row.map((cell, j) => (
+                            <td
+                              key={j}
+                              className="border-b border-[color:var(--ide-border)] px-3 py-1 align-top font-mono text-[color:var(--ide-text)]"
+                            >
+                              {renderCell(cell)}
+                            </td>
+                          ))}
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function renderCell(v: unknown): string {
+  if (v === null || v === undefined) return "NULL";
+  if (v instanceof Uint8Array) return `<BLOB ${v.byteLength} bytes>`;
+  if (typeof v === "string") return v;
+  if (typeof v === "number" || typeof v === "bigint" || typeof v === "boolean") return String(v);
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+}

--- a/apps/mobile/components/project/panels/ide/Workbench.tsx
+++ b/apps/mobile/components/project/panels/ide/Workbench.tsx
@@ -6,6 +6,12 @@ import { FileTree, type FileTreeHandlers } from "./FileTree";
 import { StatusBar } from "./StatusBar";
 import { EditorGroupView } from "./EditorGroup";
 import { isImagePath } from "./ImagePreview";
+import {
+  isAudioPath,
+  isFontPath,
+  isPdfPath,
+  isVideoPath,
+} from "./MediaPreview";
 import { Palette, type PaletteItem } from "./Palette";
 import {
   ideBottomPanelStore,
@@ -49,16 +55,15 @@ import {
 
 let groupSeq = 1;
 const newGroupId = () => `g${groupSeq++}`;
-/** Binary files we refuse to open at all — Monaco can't render them and we
- *  have no viewer. Images are handled separately (see isImagePath) and open
- *  in the in-editor ImagePreview instead. */
+/** Binary files we refuse to open at all — we have no viewer for them and
+ *  Monaco can't render them as text. Anything with a dedicated preview
+ *  (images, pdf, audio, video, fonts, sqlite) is handled by the
+ *  previewLanguageFor() switch below and is intentionally NOT in this set. */
 const BINARY_EXTENSIONS = new Set([
-  "heic","tiff","tif",
-  "pdf","zip","gz","tar","tgz","bz2","xz","7z","rar",
-  "mp3","mp4","m4a","m4v","mov","avi","mkv","webm","wav","flac","ogg","aac",
-  "woff","woff2","ttf","otf","eot",
+  "zip","gz","tar","tgz","bz2","xz","7z","rar","zst","lz4",
   "exe","dll","so","dylib","bin","class","jar","wasm",
-  "pack","idx","psd","ai","sketch","fig",
+  "pack","idx","psd","ai","sketch","fig","blend","obj","fbx",
+  "pyc","pyo","pyd",
 ]);
 
 /** SQLite database files are binary, but we render them in a read-only
@@ -68,6 +73,33 @@ function isSqlitePath(path: string): boolean {
   const ext = path.toLowerCase().split(".").pop() ?? "";
   return SQLITE_EXTENSIONS.has(ext);
 }
+
+/** Preview "languages" — pseudo-Monaco-language tags we stash on an OpenFile
+ *  to tell EditorGroupView which preview component to mount. Any file whose
+ *  language matches one of these is opened via svc.readFileUrl() (not
+ *  readFile()) and its OpenFile.content holds a URL rather than text. */
+type PreviewLanguage = "image" | "sqlite" | "pdf" | "audio" | "video" | "font";
+const PREVIEW_LANGUAGES: ReadonlySet<string> = new Set<PreviewLanguage>([
+  "image", "sqlite", "pdf", "audio", "video", "font",
+]);
+function previewLanguageFor(path: string): PreviewLanguage | null {
+  if (isImagePath(path)) return "image";
+  if (isSqlitePath(path)) return "sqlite";
+  if (isPdfPath(path)) return "pdf";
+  if (isAudioPath(path)) return "audio";
+  if (isVideoPath(path)) return "video";
+  if (isFontPath(path)) return "font";
+  return null;
+}
+/** Human-friendly viewer name for error toasts when readFileUrl is missing. */
+const PREVIEW_LABEL: Record<PreviewLanguage, string> = {
+  image: "Image",
+  sqlite: "SQLite",
+  pdf: "PDF",
+  audio: "Audio",
+  video: "Video",
+  font: "Font",
+};
 
 /** Resolve the theme preference to a concrete "light" | "dark" — mirrors the
  *  logic in ThemeProvider so the IDE's Monaco and chrome colours stay in sync
@@ -523,9 +555,8 @@ export function Workbench({
     async (node: TreeNode, groupIdx: number) => {
       if (node.kind !== "file") return;
       const ext = node.name.toLowerCase().split(".").pop() ?? "";
-      const isImage = isImagePath(node.path);
-      const isSqlite = isSqlitePath(node.path);
-      if (!isImage && !isSqlite && BINARY_EXTENSIONS.has(ext)) {
+      const previewLang = previewLanguageFor(node.path);
+      if (!previewLang && BINARY_EXTENSIONS.has(ext)) {
         showToast(`Cannot open binary file: ${node.name}`, 2500);
         return;
       }
@@ -546,7 +577,7 @@ export function Workbench({
         rootId: node.rootId,
         name: node.name,
         path: node.path,
-        language: isImage ? "image" : isSqlite ? "sqlite" : node.language ?? "plaintext",
+        language: previewLang ?? node.language ?? "plaintext",
         content: "",
         savedContent: "",
         dirty: false,
@@ -559,14 +590,17 @@ export function Workbench({
       }));
       setActiveGroupIdx(groupIdx);
       try {
-        if (isImage) {
-          // Images never hit readFile() — that path is text-only and rejects
-          // binaries. Instead resolve a URL (blob: for local, http: for the
-          // agent download endpoint) and stash it as the file content. The
-          // EditorGroupView notices language === "image" and mounts
-          // <ImagePreview> instead of Monaco.
+        if (previewLang) {
+          // Preview-language files (images, pdf, audio, video, fonts,
+          // sqlite) never hit readFile() — that path is text-only and rejects
+          // binaries. Instead we resolve a URL (blob: for local, http: for
+          // the agent download endpoint) and stash it as the file content.
+          // EditorGroupView routes by `language` and mounts the matching
+          // preview component instead of Monaco.
           if (!svc.readFileUrl) {
-            throw new Error("Image preview not supported for this workspace");
+            throw new Error(
+              `${PREVIEW_LABEL[previewLang]} preview not supported for this workspace`,
+            );
           }
           const url = await svc.readFileUrl(node.path);
           setGroups((prev) =>
@@ -578,35 +612,7 @@ export function Workbench({
                       ...f,
                       content: url,
                       savedContent: url,
-                      language: "image",
-                      loading: false,
-                    }
-                  : f,
-              ),
-            })),
-          );
-          return;
-        }
-        if (isSqlite) {
-          // SQLite databases never hit readFile() — that path is text-only.
-          // Resolve a URL (blob: for local, http: for the agent download
-          // endpoint) and stash it as the file content. EditorGroupView
-          // notices language === "sqlite" and mounts <SqlitePreview>, which
-          // fetches the bytes and renders tables + sample rows read-only.
-          if (!svc.readFileUrl) {
-            throw new Error("SQLite preview not supported for this workspace");
-          }
-          const url = await svc.readFileUrl(node.path);
-          setGroups((prev) =>
-            prev.map((g) => ({
-              ...g,
-              files: g.files.map((f) =>
-                f.id === id
-                  ? {
-                      ...f,
-                      content: url,
-                      savedContent: url,
-                      language: "sqlite",
+                      language: previewLang,
                       loading: false,
                     }
                   : f,
@@ -678,10 +684,11 @@ export function Workbench({
       if (idx < 0) return prev;
       const f = g.files[idx];
       if (f.dirty && !confirm(`Close ${f.name} without saving?`)) return prev;
-      // Image tabs allocate a blob: URL on open — revoke it on close so long
-      // browsing sessions don't leak one per image opened.
+      // Preview tabs (image/sqlite/pdf/audio/video/font) allocate a blob:
+      // URL on open — revoke it on close so long browsing sessions don't
+      // leak one per file opened.
       if (
-        (f.language === "image" || f.language === "sqlite") &&
+        PREVIEW_LANGUAGES.has(f.language) &&
         f.content.startsWith("blob:")
       ) {
         try { URL.revokeObjectURL(f.content); } catch { /* ignore */ }

--- a/apps/mobile/components/project/panels/ide/Workbench.tsx
+++ b/apps/mobile/components/project/panels/ide/Workbench.tsx
@@ -58,8 +58,16 @@ const BINARY_EXTENSIONS = new Set([
   "mp3","mp4","m4a","m4v","mov","avi","mkv","webm","wav","flac","ogg","aac",
   "woff","woff2","ttf","otf","eot",
   "exe","dll","so","dylib","bin","class","jar","wasm",
-  "sqlite","db","pack","idx","psd","ai","sketch","fig",
+  "pack","idx","psd","ai","sketch","fig",
 ]);
+
+/** SQLite database files are binary, but we render them in a read-only
+ *  SQLite preview (tables + sample rows) instead of refusing to open. */
+const SQLITE_EXTENSIONS = new Set(["db", "sqlite", "sqlite3"]);
+function isSqlitePath(path: string): boolean {
+  const ext = path.toLowerCase().split(".").pop() ?? "";
+  return SQLITE_EXTENSIONS.has(ext);
+}
 
 /** Resolve the theme preference to a concrete "light" | "dark" — mirrors the
  *  logic in ThemeProvider so the IDE's Monaco and chrome colours stay in sync
@@ -516,7 +524,8 @@ export function Workbench({
       if (node.kind !== "file") return;
       const ext = node.name.toLowerCase().split(".").pop() ?? "";
       const isImage = isImagePath(node.path);
-      if (!isImage && BINARY_EXTENSIONS.has(ext)) {
+      const isSqlite = isSqlitePath(node.path);
+      if (!isImage && !isSqlite && BINARY_EXTENSIONS.has(ext)) {
         showToast(`Cannot open binary file: ${node.name}`, 2500);
         return;
       }
@@ -537,7 +546,7 @@ export function Workbench({
         rootId: node.rootId,
         name: node.name,
         path: node.path,
-        language: isImage ? "image" : node.language ?? "plaintext",
+        language: isImage ? "image" : isSqlite ? "sqlite" : node.language ?? "plaintext",
         content: "",
         savedContent: "",
         dirty: false,
@@ -570,6 +579,34 @@ export function Workbench({
                       content: url,
                       savedContent: url,
                       language: "image",
+                      loading: false,
+                    }
+                  : f,
+              ),
+            })),
+          );
+          return;
+        }
+        if (isSqlite) {
+          // SQLite databases never hit readFile() — that path is text-only.
+          // Resolve a URL (blob: for local, http: for the agent download
+          // endpoint) and stash it as the file content. EditorGroupView
+          // notices language === "sqlite" and mounts <SqlitePreview>, which
+          // fetches the bytes and renders tables + sample rows read-only.
+          if (!svc.readFileUrl) {
+            throw new Error("SQLite preview not supported for this workspace");
+          }
+          const url = await svc.readFileUrl(node.path);
+          setGroups((prev) =>
+            prev.map((g) => ({
+              ...g,
+              files: g.files.map((f) =>
+                f.id === id
+                  ? {
+                      ...f,
+                      content: url,
+                      savedContent: url,
+                      language: "sqlite",
                       loading: false,
                     }
                   : f,
@@ -643,7 +680,10 @@ export function Workbench({
       if (f.dirty && !confirm(`Close ${f.name} without saving?`)) return prev;
       // Image tabs allocate a blob: URL on open — revoke it on close so long
       // browsing sessions don't leak one per image opened.
-      if (f.language === "image" && f.content.startsWith("blob:")) {
+      if (
+        (f.language === "image" || f.language === "sqlite") &&
+        f.content.startsWith("blob:")
+      ) {
         try { URL.revokeObjectURL(f.content); } catch { /* ignore */ }
       }
       const nextFiles = g.files.filter((x) => x.id !== id);

--- a/apps/mobile/components/project/panels/ide/workspace/localFs.ts
+++ b/apps/mobile/components/project/panels/ide/workspace/localFs.ts
@@ -16,23 +16,74 @@ const DENY_DIRS = new Set([
   ".cache",
 ]);
 
+/** Known-text extensions. We treat anything in this set as text without
+ *  sniffing the bytes. The list is intentionally broad — log/csv/conf files
+ *  are real source-tree citizens and Monaco renders them fine even without
+ *  syntax highlighting. */
 const TEXT_EXT = new Set([
+  // JS / TS family
   "ts", "tsx", "js", "jsx", "mjs", "cjs",
-  "json", "md", "mdx", "txt", "yml", "yaml", "toml",
-  "css", "scss", "html", "svg", "prisma",
-  "py", "rs", "go", "java", "rb", "sh",
+  // Data / config
+  "json", "json5", "jsonc", "yml", "yaml", "toml", "ini", "conf", "cfg",
+  "properties", "env", "lock", "xml", "plist", "csv", "tsv", "tab", "ndjson",
+  // Docs / prose
+  "md", "mdx", "markdown", "txt", "rst", "adoc", "asciidoc", "log",
+  // Web
+  "css", "scss", "sass", "less", "html", "htm", "xhtml", "vue", "svelte",
+  "astro",
+  // Backend / systems
+  "py", "pyi", "rs", "go", "java", "kt", "kts", "scala", "rb", "php",
+  "swift", "c", "cc", "cpp", "cxx", "h", "hh", "hpp", "hxx", "m", "mm",
+  "cs", "fs", "fsx", "fsi", "ml", "mli", "ex", "exs", "erl", "hrl", "clj",
+  "cljs", "edn", "lua", "pl", "pm", "r", "jl", "dart", "nim", "zig", "v",
+  "vb", "vbs", "ps1", "psm1", "ahk",
+  // Shell / scripts
+  "sh", "bash", "zsh", "fish", "ksh", "csh", "bat", "cmd",
+  // Build / infra
+  "gradle", "groovy", "make", "mk", "cmake", "bazel", "bzl", "buck", "ninja",
+  "tf", "tfvars", "hcl", "nomad",
+  // SQL / schemas
+  "sql", "graphql", "gql", "prisma", "proto", "thrift", "avsc", "schema",
+  // Vector / markup
+  "svg",
+  // Misc
+  "diff", "patch", "gitignore", "gitattributes", "gitmodules",
+  "dockerignore", "npmignore", "editorconfig", "prettierrc", "eslintrc",
+  "babelrc", "nvmrc", "tool-versions",
 ]);
 
 const LANG: Record<string, string> = {
   ts: "typescript", tsx: "typescript",
   js: "javascript", jsx: "javascript", mjs: "javascript", cjs: "javascript",
-  json: "json",
-  md: "markdown", mdx: "markdown",
-  css: "css", scss: "scss", html: "html",
-  yml: "yaml", yaml: "yaml", toml: "toml",
-  py: "python", rs: "rust", go: "go",
-  java: "java", rb: "ruby", sh: "shell",
-  prisma: "prisma", svg: "xml",
+  json: "json", json5: "json", jsonc: "json", ndjson: "json",
+  md: "markdown", mdx: "markdown", markdown: "markdown",
+  css: "css", scss: "scss", sass: "scss", less: "less",
+  html: "html", htm: "html", xhtml: "html", vue: "html",
+  svelte: "html", astro: "html",
+  yml: "yaml", yaml: "yaml", toml: "toml", ini: "ini", conf: "ini",
+  cfg: "ini", properties: "ini", env: "shell",
+  py: "python", pyi: "python",
+  rs: "rust", go: "go",
+  java: "java", kt: "kotlin", kts: "kotlin", scala: "scala",
+  rb: "ruby", php: "php", swift: "swift",
+  c: "c", cc: "cpp", cpp: "cpp", cxx: "cpp",
+  h: "cpp", hh: "cpp", hpp: "cpp", hxx: "cpp",
+  m: "objective-c", mm: "objective-c",
+  cs: "csharp", fs: "fsharp", fsx: "fsharp", fsi: "fsharp",
+  lua: "lua", pl: "perl", pm: "perl", r: "r", jl: "julia",
+  dart: "dart", clj: "clojure", cljs: "clojure",
+  sh: "shell", bash: "shell", zsh: "shell", fish: "shell",
+  ksh: "shell", csh: "shell", bat: "bat", cmd: "bat",
+  ps1: "powershell", psm1: "powershell",
+  sql: "sql", graphql: "graphql", gql: "graphql",
+  prisma: "prisma", proto: "proto",
+  xml: "xml", plist: "xml", svg: "xml",
+  diff: "diff", patch: "diff",
+  csv: "plaintext", tsv: "plaintext", tab: "plaintext", log: "plaintext",
+  txt: "plaintext",
+  tf: "hcl", tfvars: "hcl", hcl: "hcl",
+  gradle: "groovy", groovy: "groovy",
+  dockerfile: "dockerfile",
 };
 
 function extOf(name: string) {
@@ -44,6 +95,29 @@ function langOf(name: string) {
   return LANG[extOf(name)] ?? "plaintext";
 }
 
+/** Extensions known to be binary — used as a fast reject before falling
+ *  back to a content sniff. Keep this in sync with Workbench.BINARY_EXTENSIONS
+ *  for the user-facing block list. */
+const BINARY_EXT = new Set([
+  // Images (handled by ImagePreview, not by readFile)
+  "png", "jpg", "jpeg", "gif", "webp", "bmp", "ico", "avif", "apng",
+  "heic", "heif", "tiff", "tif", "jxl", "cur",
+  // Archives
+  "zip", "gz", "tar", "tgz", "bz2", "xz", "7z", "rar", "zst", "lz4",
+  // Audio / video / docs (handled by media previews)
+  "mp3", "mp4", "m4a", "m4v", "mov", "avi", "mkv", "webm", "wav", "flac",
+  "ogg", "oga", "ogv", "aac", "opus", "pdf",
+  // Fonts
+  "woff", "woff2", "ttf", "otf", "eot",
+  // Native / packed
+  "exe", "dll", "so", "dylib", "bin", "class", "jar", "wasm",
+  // Databases (handled by SqlitePreview)
+  "db", "sqlite", "sqlite3",
+  // Misc binary
+  "pack", "idx", "psd", "ai", "sketch", "fig", "blend", "obj", "fbx",
+  "pyc", "pyo", "pyd",
+]);
+
 function isTextFile(name: string) {
   // Treat common dotfiles as text (.env, .env.local, .gitignore, .prettierrc,
   // .editorconfig, .nvmrc, etc). The extension detector otherwise misclassifies
@@ -51,8 +125,34 @@ function isTextFile(name: string) {
   // unknown extension.
   if (name.startsWith(".")) return true;
   const e = extOf(name);
-  if (!e) return /^(Dockerfile|Makefile|README|LICENSE|CHANGELOG)/i.test(name);
-  return TEXT_EXT.has(e);
+  if (!e) return /^(Dockerfile|Makefile|README|LICENSE|CHANGELOG|AUTHORS|CONTRIBUTING|NOTICE|COPYING|TODO|HEARTBEAT|AGENTS|TOOLS|MEMORY)/i.test(name);
+  if (TEXT_EXT.has(e)) return true;
+  if (BINARY_EXT.has(e)) return false;
+  // Unknown extension — caller should fall back to the byte sniff.
+  return null as unknown as boolean;
+}
+
+/** Heuristic content sniff: returns true if the first 8KB of `file` looks
+ *  like text (no NUL bytes, mostly printable / common-whitespace). Used for
+ *  unknown extensions so we don't refuse to open a perfectly valid text
+ *  file just because we never heard of its suffix. */
+async function looksLikeText(file: File): Promise<boolean> {
+  const slice = file.slice(0, 8192);
+  const buf = new Uint8Array(await slice.arrayBuffer());
+  if (buf.byteLength === 0) return true;
+  let suspicious = 0;
+  for (let i = 0; i < buf.length; i++) {
+    const b = buf[i];
+    if (b === 0) return false; // NUL → binary
+    // Allow common whitespace + printable ASCII + high-bit (UTF-8 continuation).
+    if (
+      b === 0x09 || b === 0x0a || b === 0x0d ||
+      (b >= 0x20 && b <= 0x7e) ||
+      b >= 0x80
+    ) continue;
+    suspicious++;
+  }
+  return suspicious / buf.length < 0.1;
 }
 
 export function isFsaSupported(): boolean {
@@ -155,8 +255,33 @@ export class LocalFs implements WorkspaceService {
     if (!name) throw new Error("Invalid path");
     const handle = await parent.getFileHandle(name);
     const file = await handle.getFile();
-    if (file.size > 2 * 1024 * 1024) throw new Error("File too large (>2MB)");
-    if (!isTextFile(name)) throw new Error("Binary file not supported in this preview");
+    // 10MB cap — generated route bundles and big logs routinely exceed 2MB
+    // but Monaco copes well up to ~10MB. Beyond that the editor becomes
+    // unresponsive, so we refuse with a friendly message.
+    const MAX_BYTES = 10 * 1024 * 1024;
+    if (file.size > MAX_BYTES) {
+      const mb = (file.size / 1024 / 1024).toFixed(1);
+      throw new Error(
+        `File too large to open in editor (${mb} MB, max 10 MB).`,
+      );
+    }
+    // Three-step classification: extension allow-list, extension deny-list,
+    // and finally a byte sniff for unknown extensions so .log, .csv, .dat,
+    // and other "we don't know but it might be text" files still open.
+    const known = isTextFile(name);
+    if (known === false) {
+      throw new Error(
+        `\"${name}\" looks like a binary file and can't be opened in the text editor.`,
+      );
+    }
+    if (known !== true) {
+      const sniff = await looksLikeText(file);
+      if (!sniff) {
+        throw new Error(
+          `\"${name}\" looks like a binary file and can't be opened in the text editor.`,
+        );
+      }
+    }
     const content = await file.text();
     return {
       path,

--- a/apps/mobile/components/project/panels/ide/workspace/localFs.ts
+++ b/apps/mobile/components/project/panels/ide/workspace/localFs.ts
@@ -118,7 +118,15 @@ const BINARY_EXT = new Set([
   "pyc", "pyo", "pyd",
 ]);
 
-function isTextFile(name: string) {
+/** Classify a filename as text / binary by name alone.
+ *  - `true`  : known text (extension allow-list, dotfiles, conventional
+ *              no-extension files like README / Dockerfile / MEMORY).
+ *  - `false` : known binary (extension deny-list).
+ *  - `null`  : unknown — caller should fall back to a byte sniff.
+ *  Callers MUST treat the three return values explicitly (use
+ *  `=== true` / `=== false`), not truthy/falsy, so the unknown case is
+ *  routed through the sniff rather than silently dropped. */
+function isTextFile(name: string): boolean | null {
   // Treat common dotfiles as text (.env, .env.local, .gitignore, .prettierrc,
   // .editorconfig, .nvmrc, etc). The extension detector otherwise misclassifies
   // them because the leading dot makes "env"/"gitignore"/… look like an
@@ -128,8 +136,7 @@ function isTextFile(name: string) {
   if (!e) return /^(Dockerfile|Makefile|README|LICENSE|CHANGELOG|AUTHORS|CONTRIBUTING|NOTICE|COPYING|TODO|HEARTBEAT|AGENTS|TOOLS|MEMORY)/i.test(name);
   if (TEXT_EXT.has(e)) return true;
   if (BINARY_EXT.has(e)) return false;
-  // Unknown extension — caller should fall back to the byte sniff.
-  return null as unknown as boolean;
+  return null;
 }
 
 /** Heuristic content sniff: returns true if the first 8KB of `file` looks
@@ -274,7 +281,7 @@ export class LocalFs implements WorkspaceService {
         `\"${name}\" looks like a binary file and can't be opened in the text editor.`,
       );
     }
-    if (known !== true) {
+    if (known === null) {
       const sniff = await looksLikeText(file);
       if (!sniff) {
         throw new Error(
@@ -379,7 +386,11 @@ export class LocalFs implements WorkspaceService {
         if (kind === "directory") {
           if (DENY_DIRS.has(name)) continue;
           await walk(entry as FileSystemDirectoryHandle, childRel);
-        } else if (isTextFile(name)) {
+        } else if (isTextFile(name) === true) {
+          // Only index files we *know* are text. `null` (unknown extension)
+          // is intentionally skipped here — the search walker can't pay the
+          // per-file byte-sniff cost across an entire workspace, and a
+          // false positive would silently grep through binary data.
           allFiles.push(childRel);
         }
       }


### PR DESCRIPTION
Closes #547 · Jira: [SHOG-591](https://odin-ai.atlassian.net/browse/SHOG-591)

## What this PR does

Makes the in-app IDE actually open the files users click on. Before this PR, clicking `prisma/dev.db`, `assets/song.mp3`, `docs/spec.pdf`, `fonts/Inter.woff2`, `app.log`, `data.csv`, `nginx.conf`, `main.cpp`, `Hello.kt`, or any 3MB+ text file would produce a fleeting `"Cannot open binary file: …"` / `"Binary file not supported in this preview"` / `"File too large (>2MB)"` toast and abort. After this PR, each of those opens in either a dedicated viewer or as plain text with Monaco syntax highlighting.

The work is split into two commits:

1. **`SHOG-591: open .db / .sqlite files in a read-only SQLite preview`** — adds the `SqlitePreview` component (lazy-loaded sql.js, table sidebar, paginated row grid) and the first preview-language routing into Workbench.
2. **`SHOG-591: broaden IDE file-open coverage (pdf / audio / video / fonts / text edge cases)`** — generalises the preview routing for five more languages, adds the four `MediaPreview` viewers, and rewrites `localFs.ts`'s text-file detection.

## Files changed

```
apps/mobile/components/project/panels/ide/EditorGroup.tsx          | +12
apps/mobile/components/project/panels/ide/ImagePreview.tsx         | +5
apps/mobile/components/project/panels/ide/Workbench.tsx            | +45 -29
apps/mobile/components/project/panels/ide/SqlitePreview.tsx        | +298 (new)
apps/mobile/components/project/panels/ide/MediaPreview.tsx         | +205 (new)
apps/mobile/components/project/panels/ide/workspace/localFs.ts     | +130 -16
```

## Design

### Unified preview routing

`Workbench.tsx` used to special-case `isImage` with an ad-hoc branch and a separate `BINARY_EXTENSIONS` set that blocked everything else. This PR introduces a `PreviewLanguage` enum and a single `previewLanguageFor(path)` resolver:

```ts
type PreviewLanguage = "image" | "sqlite" | "pdf" | "audio" | "video" | "font";

function previewLanguageFor(path: string): PreviewLanguage | null {
  if (isImagePath(path)) return "image";
  if (isSqlitePath(path)) return "sqlite";
  if (isPdfPath(path)) return "pdf";
  if (isAudioPath(path)) return "audio";
  if (isVideoPath(path)) return "video";
  if (isFontPath(path)) return "font";
  return null;
}
```

The open-file logic is now a **single** preview branch: resolve `svc.readFileUrl(node.path)`, stash the URL on the OpenFile's `content`, and tag it with the preview language. `EditorGroupView` mounts the matching component based on `active.language`. On tab close, blob URLs are revoked when `PREVIEW_LANGUAGES.has(f.language)` — so any future viewer is one-line safe to wire in.

### New viewers (`MediaPreview.tsx`)

All four share a chrome bar with the file name, a format tag, and an "Open in new tab" affordance.

| Viewer | Implementation | Formats |
| --- | --- | --- |
| `PdfPreview` | `<iframe sandbox="allow-scripts allow-same-origin allow-forms allow-downloads">` pointing at the resolved URL. Uses the browser's native PDF renderer (Chromium PDFium / Firefox PDF.js). No extra dependency. | `.pdf` |
| `AudioPreview` | `<audio controls>` centred on the editor background. | `.mp3`, `.wav`, `.ogg`, `.oga`, `.flac`, `.m4a`, `.aac`, `.opus` |
| `VideoPreview` | `<video controls>` on a black background, scaled to fit. | `.mp4`, `.webm`, `.mov`, `.m4v`, `.mkv`, `.avi`, `.ogv` |
| `FontPreview` | Registers the file as a `FontFace` under a URL-derived family, renders a pangram at 12/16/24/36/56/96 px with an editable sample-text input. Cleans up the FontFace on unmount so two different `.ttf` tabs don't collide. | `.woff`, `.woff2`, `.ttf`, `.otf`, `.eot` |

### `SqlitePreview` (delivered in commit 1)

Read-only viewer for `.db` / `.sqlite` / `.sqlite3`:

- **Lazy-loads `sql.js`** from CDN on first open (`cdnjs.cloudflare.com/ajax/libs/sql.js/1.10.3/sql-wasm.{js,wasm}`) — keeps the wasm out of the main IDE bundle for users who never open a database. A module-level promise dedupes concurrent loads.
- Fetches the bytes from the resolved URL, opens the database with `new SQL.Database(new Uint8Array(buf))`.
- Sidebar lists user tables (skips `sqlite_*` internals) with per-table row counts.
- Right pane renders the active table in a paginated **100-row** grid via `SELECT * FROM "<table>" LIMIT 100 OFFSET <page*100>` — works for tables with millions of rows. `PRAGMA table_info` keeps the header row populated when the page is empty.
- Cells render `NULL` and `<BLOB N bytes>` explicitly; nothing is JSON-encoded silently.
- Reload button reopens the DB. No `INSERT` / `UPDATE` / `DELETE` UI — read-only by design.

### Image format extension (`ImagePreview.tsx`)

Added `apng`, `jxl`, `heic`, `heif`, `tiff`, `tif`, `cur` to `IMAGE_EXTS`. Browser support varies (Safari handles HEIC, Chromium can do TIFF in some cases, JXL is still flagged in most browsers). `ImagePreview` already has an `onError` path that shows a clean `"Could not load <name>"` message, so the worst case here is the same UX as before — except now it's the image viewer's friendly empty state rather than a transient toast and no tab.

### `localFs.ts` rewrite

The local-folder workspace adapter's `readFile()` is the gate for every text file opened via File System Access. Three real problems:

1. **`TEXT_EXT` allow-list was 27 entries.** Anything outside threw `"Binary file not supported in this preview"` — including obviously-text files like `.log`, `.csv`, `.xml`, `.ini`, `.sql`, `.c/.cpp/.h`, `.kt`, `.swift`, `.php`, `.lua`, `.dart`, `.tf`, `.graphql`, `.proto`, `.gradle`, `.dockerignore`, `.editorconfig`, …
2. **2 MB hard cap.** Threw `"File too large (>2MB)"`. Our own generated route bundles and trace logs routinely exceed this.
3. **No content sniffing.** A file with an unknown extension that contained pure JSON was refused on extension alone.

Fixes:

- `TEXT_EXT` grew from 27 → ~110 entries (see issue body for the full list).
- `LANG` map expanded to match — Monaco picks `kotlin` for `.kt`, `hcl` for `.tf`, `graphql` for `.gql`, `proto` for `.proto`, `groovy` for `.gradle`, etc.
- Size cap raised **2 MB → 10 MB**, with a precise message: `"File too large to open in editor (4.7 MB, max 10 MB)."` Beyond ~10 MB Monaco itself becomes unresponsive, so that's where the new line sits.
- Added a `BINARY_EXT` deny-list (mirrors Workbench's) so we don't waste time sniffing genuine binaries.
- Added `looksLikeText(file)`: reads the first 8 KB, returns false on any NUL byte or > 10 % non-printable / non-whitespace / non-UTF-8-continuation bytes. Used only for **unknown** extensions — known-text and known-binary both short-circuit. Means `.dat`, `.pyc`, `.fixture` and friends get real classification.
- Dotfile / no-extension matcher learned `AUTHORS`, `CONTRIBUTING`, `NOTICE`, `COPYING`, `TODO`, `HEARTBEAT`, `AGENTS`, `TOOLS`, `MEMORY` (the latter four cover our own conventional files).
- All error messages quote the filename and explain the cause.

## Edge-case coverage table

| Case | Before | After |
| --- | --- | --- |
| Open `prisma/dev.db` | "Cannot open binary file" toast | SQLite viewer with tables + paginated rows |
| Open `docs/spec.pdf` | "Cannot open binary file" toast | Inline PDF viewer |
| Open `assets/song.mp3` | "Cannot open binary file" toast | Audio player |
| Open `demo.mp4` | "Cannot open binary file" toast | Video player |
| Open `fonts/Inter.woff2` | "Cannot open binary file" toast | Font specimen with editable sample |
| Open `photo.heic` / `image.tif` | "Cannot open binary file" toast | ImagePreview (browser tries; graceful "Could not load" if unsupported) |
| Open `app.log`, `data.csv`, `nginx.conf` (local) | "Binary file not supported" toast | Opens as plaintext |
| Open `main.cpp`, `Hello.kt`, `schema.graphql` (local) | "Binary file not supported" toast | Opens with correct Monaco syntax |
| Open 3 MB generated route file (local) | "File too large (>2MB)" | Opens (cap is now 10 MB) |
| Open 15 MB file (local) | Cryptic `>2MB` | `"File too large to open in editor (15.0 MB, max 10 MB)."` |
| Open `.dat` containing JSON (local) | Refused on extension | Byte sniff passes → opens as plaintext |
| Open `.dat` containing actual binary (local) | Refused | Byte sniff catches NUL → `"<name>" looks like a binary file …` |
| Open `.zip`, `.exe`, `.wasm`, `.psd` | "Cannot open binary file" toast | Unchanged (still blocked — no viewer) |
| Close any preview tab | Image blob revoked; others leaked | All preview-language blobs revoked uniformly |
| Same file opened in two editor groups | Already handled | Unchanged |

## Verification

- `bun x tsc --noEmit -p apps/mobile/tsconfig.json` — clean (only an unrelated pre-existing `baseUrl` deprecation warning, not introduced by this PR).
- Manual smoke test plan (run against any project workspace):
  1. Click `prisma/dev.db` → SQLite viewer appears, click through tables, paginate.
  2. Drop a `.pdf`, `.mp3`, `.mp4`, `.woff2` into the project root → each opens in its viewer.
  3. Open `.log`, `.csv`, `.ini`, `.cpp` from a local-folder workspace → each opens as text with sensible syntax.
  4. Open a 5 MB generated bundle → succeeds.
  5. Open a 12 MB file → user sees clear size error.
  6. Open a `.zip` → still produces the "Cannot open binary file" toast (regression guard).
  7. Open 10 preview tabs of different types and close them all → no `URL.createObjectURL` blobs leak (verifiable via `performance.memory` / dev tools "Memory" → "Detached" count).

## Risk / rollout

- **Read-only across the board.** No new write paths. SQLite preview never writes back. Media previews never expose a save action.
- **No new build-time dependencies.** `sql.js` is loaded from CDN on first SQLite open and cached in `window.initSqlJs`; the rest uses native browser APIs (`<iframe>`, `<audio>`, `<video>`, `FontFace`).
- **No schema or server-side change.** Pure client refactor in `apps/mobile/components/project/panels/ide/**`.
- **Backward-compatible language tags.** Existing tabs persisted with `language: "plaintext"` etc. continue to route to Monaco. New tags (`"pdf"`, `"audio"`, `"video"`, `"font"`, `"sqlite"`) only appear on tabs opened after this PR ships.
- **Failure mode for the SQLite CDN load** is a clean error inside `SqlitePreview` (`"sql.js load failed"` / `"Could not open <name>"`), not a crash of the IDE.
- **Browser permissions:** the PDF iframe sandbox is intentionally permissive enough for the built-in PDF viewer to run (`allow-scripts allow-same-origin allow-forms allow-downloads`) but does not allow top-navigation or popups — same posture as comparable in-app PDF viewers.

## Out of scope

- Editing SQLite databases.
- Image format conversion for HEIC / TIFF / JXL — the browser decides.
- Office document formats (`.docx`, `.xlsx`, `.pptx`) — no native browser viewer.
- Archive previews for `.zip` / `.tar.gz`.
- Lifting the 10 MB cap further — Monaco itself becomes unresponsive past this point.
