### PR TITLE
sidebar notification icon position & templates search focus outline

### DIFF
--- a/apps/mobile/app/(app)/templates.tsx
+++ b/apps/mobile/app/(app)/templates.tsx
@@ -277,7 +277,7 @@ export default observer(function TemplatesPage() {
           >
             <Search size={16} className="text-muted-foreground" />
             <TextInput
-              className="flex-1 ml-2 py-0 text-sm text-foreground web:outline-none"
+              className="flex-1 ml-2 py-0 text-sm text-foreground web:outline-none no-focus-ring"
               placeholder="Search templates by name, category, or tag..."
               placeholderTextColor="#71717a"
               value={searchQuery}

--- a/apps/mobile/components/layout/AppSidebar.tsx
+++ b/apps/mobile/components/layout/AppSidebar.tsx
@@ -506,7 +506,7 @@ function UserMenu({ user, onSignOut, onNavigate, isSuperAdmin, isWide = true, bo
             accessibilityLabel={`${user?.name || 'User'} — open user menu`}
             accessibilityHint="Opens menu with profile, appearance, and sign out options"
             accessibilityState={{ expanded: isOpen }}
-            className="flex-row items-center gap-2 active:opacity-80"
+            className="flex-row items-center gap-2 active:opacity-80 min-w-0 flex-1"
           >
             <Avatar
               fallback={getInitials(user?.name)}
@@ -514,7 +514,7 @@ function UserMenu({ user, onSignOut, onNavigate, isSuperAdmin, isWide = true, bo
               size="sm"
             />
             {!collapsed && (
-              <Text className="text-sm text-foreground flex-1" numberOfLines={1}>
+              <Text className="text-sm text-foreground flex-1 min-w-0" numberOfLines={1}>
                 {user?.name || 'User'}
               </Text>
             )}
@@ -545,7 +545,7 @@ function UserMenu({ user, onSignOut, onNavigate, isSuperAdmin, isWide = true, bo
         accessibilityLabel={`${user?.name || 'User'} — open user menu`}
         accessibilityHint="Opens menu with profile, appearance, and sign out options"
         accessibilityState={{ expanded: isOpen }}
-        className="flex-row items-center gap-2 active:opacity-80"
+        className="flex-row items-center gap-2 active:opacity-80 min-w-0 flex-1"
       >
         <Avatar
           fallback={getInitials(user?.name)}
@@ -553,7 +553,7 @@ function UserMenu({ user, onSignOut, onNavigate, isSuperAdmin, isWide = true, bo
           size="sm"
         />
         {!collapsed && (
-          <Text className="text-sm text-foreground flex-1" numberOfLines={1}>
+          <Text className="text-sm text-foreground flex-1 min-w-0" numberOfLines={1}>
             {user?.name || 'User'}
           </Text>
         )}
@@ -1456,20 +1456,22 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
             collapsed ? 'justify-center' : 'px-3'
           )}
         >
-          <UserMenu
-            user={user}
-            onSignOut={handleSignOut}
-            onNavigate={(href) => { router.push(href as any); onNavPress() }}
-            isSuperAdmin={isSuperAdmin}
-            isWide={isWide}
-            bottomInset={insets.bottom}
-            collapsed={collapsed}
-          />
+          <View className={cn(!collapsed && 'flex-1 min-w-0')}>
+            <UserMenu
+              user={user}
+              onSignOut={handleSignOut}
+              onNavigate={(href) => { router.push(href as any); onNavPress() }}
+              isSuperAdmin={isSuperAdmin}
+              isWide={isWide}
+              bottomInset={insets.bottom}
+              collapsed={collapsed}
+            />
+          </View>
 
           {!collapsed && (
             <Pressable
               onPress={() => setInboxOpen(true)}
-              className="relative p-1.5 rounded-md active:bg-muted"
+              className="relative p-1.5 rounded-md active:bg-muted shrink-0"
             >
               <Inbox size={18} className="text-muted-foreground" />
               {pendingInvites.length > 0 && (


### PR DESCRIPTION
Summary
Sidebar notification icon: Fixed the inbox icon in the sidebar bottom bar being positioned relative to the user name length. It now stays pinned to the right edge regardless of how long the name is. Long names truncate with ellipsis instead of pushing the icon off-screen.
Templates search outline: Removed the orange focus outline that appeared inside the search bar on the Agent Templates page when typing.
Changes
apps/mobile/components/layout/AppSidebar.tsx — Wrapped UserMenu in a flex-1 min-w-0 container; added shrink-0 to the inbox icon; added min-w-0 to the user menu trigger for proper text truncation.
apps/mobile/app/(app)/templates.tsx — Added no-focus-ring class to the search TextInput to suppress the global input:focus outline.
before 
<img width="409" height="117" alt="image" src="https://github.com/user-attachments/assets/95234e38-b881-42c2-9abb-5bae0d190a2b" />
