### PR TITLE
fix(import): handle sync progress phase

### DIFF
--- a/apps/mobile/components/projects/ProjectImportModal.tsx
+++ b/apps/mobile/components/projects/ProjectImportModal.tsx
@@ -92,14 +92,19 @@ const PHASE_BANDS: Record<
   parse: [25, 35, 'Parsing archive'],
   createProject: [35, 45, 'Creating project'],
   writeFiles: [45, 80, 'Writing files'],
-  importChats: [80, 100, 'Importing chats'],
+  importChats: [80, 95, 'Importing chats'],
+  syncToS3: [95, 99, 'Syncing workspace'],
   done: [100, 100, 'Done'],
   error: [0, 0, 'Error'],
 }
 
+function phaseBand(phase: ProjectImportProgress['phase']): [number, number, string] {
+  return PHASE_BANDS[phase] ?? [0, 0, 'Working']
+}
+
 function computePercent(ev: ProjectImportProgress | null): number {
   if (!ev) return 0
-  const [start, end] = PHASE_BANDS[ev.phase]
+  const [start, end] = phaseBand(ev.phase)
   if (ev.phase === 'writeFiles' || ev.phase === 'importChats') {
     const frac = ev.total > 0 ? ev.done / ev.total : 0
     return Math.round(start + (end - start) * frac)
@@ -108,17 +113,26 @@ function computePercent(ev: ProjectImportProgress | null): number {
     const frac = ev.total > 0 ? ev.loaded / ev.total : 0
     return Math.round(start + (end - start) * frac)
   }
+  if (ev.phase === 'syncToS3') {
+    return ev.status === 'ok' || ev.status === 'skipped' ? end : start
+  }
   return end
 }
 
 function phaseLabel(ev: ProjectImportProgress | null): string {
   if (!ev) return ''
-  const [, , label] = PHASE_BANDS[ev.phase]
+  const [, , label] = phaseBand(ev.phase)
   if (ev.phase === 'writeFiles') return `${label} (${ev.done} / ${ev.total})`
   if (ev.phase === 'importChats') return `${label} (${ev.done} / ${ev.total})`
   if (ev.phase === 'upload') {
     const mb = (n: number) => (n / (1024 * 1024)).toFixed(1)
     return `${label} (${mb(ev.loaded)} / ${mb(ev.total)} MB)`
+  }
+  if (ev.phase === 'syncToS3') {
+    if (ev.status === 'ok') return 'Workspace synced'
+    if (ev.status === 'skipped') return 'Workspace sync skipped'
+    if (ev.status === 'failed') return 'Workspace sync failed'
+    return label
   }
   return label
 }

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -1069,6 +1069,13 @@ export type ProjectImportProgress =
   | { phase: 'writeFiles'; done: number; total: number }
   | { phase: 'importChats'; done: number; total: number }
   | {
+      phase: 'syncToS3'
+      status: 'running' | 'ok' | 'failed' | 'skipped'
+      bytes?: number
+      durationMs?: number
+      message?: string
+    }
+  | {
       phase: 'done'
       project: { id: string; name: string; description?: string | null }
       stats: {


### PR DESCRIPTION
## Summary

Closes #552.

Fixes the project import modal crash that happens when the backend emits the Kubernetes-only `syncToS3` progress phase during import. The mobile client now models and renders that phase instead of trying to destructure missing progress metadata.

## RCA

The backend import SSE contract includes `phase: 'syncToS3'` while uploading the imported workspace from the API pod's local disk to S3. That phase was added on the backend so warm-pool runtime pods can later download the imported workspace instead of booting with an empty/default project.

The mobile import modal had a local `PHASE_BANDS` map for progress rendering, but it only covered upload, parse, createProject, writeFiles, importChats, done, and error. When a `syncToS3` event arrived, `PHASE_BANDS[ev.phase]` evaluated to `undefined`. The modal then destructured that value in `computePercent` / `phaseLabel`, causing the app-level runtime crash: `undefined is not iterable`.

Root cause: frontend import progress handling drifted from the backend SSE event contract after the backend added the `syncToS3` progress phase.

## Detailed Implementation

- Add `syncToS3` to `ProjectImportProgress` in `apps/mobile/lib/api.ts`, matching the backend event shape: `status`, optional `bytes`, optional `durationMs`, and optional `message`.
- Add a `syncToS3` progress band in `ProjectImportModal` between chat import and done, so import progress now moves through workspace sync before reaching 100%.
- Add labels for sync states:
  - running: `Syncing workspace`
  - ok: `Workspace synced`
  - skipped: `Workspace sync skipped`
  - failed: `Workspace sync failed`
- Add a defensive `phaseBand` helper so future unknown progress phases fall back to a non-crashing `Working` label instead of taking down the full page.

## Scope

This PR is intentionally limited to the import progress crash. It does not change import bootstrap behavior, runtime preview startup, backend S3 sync semantics, Redis/Postgres local infra, or unrelated mobile UI areas.

## Test Plan

- Verified branch diff contains only:
  - `apps/mobile/lib/api.ts`
  - `apps/mobile/components/projects/ProjectImportModal.tsx`
- Confirmed the backend import event contract includes `syncToS3` and the mobile type/progress map now includes the same phase.
- Attempted local diagnostics/typecheck, but local Expo/TypeScript diagnostics are currently blocked/noisy due existing environment configuration issues (`expo/tsconfig.base` resolution / JSX config / missing local dependency context). No additional import files were changed to work around those environment issues.


Made with [Cursor](https://cursor.com)