### PR TITLE
ci: ARM-native runners + Bun cache mounts (Phase A)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -276,7 +276,7 @@ jobs:
   # ===========================================================================
   build-base-image:
     name: Build Runtime Base Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: [resolve-config, detect-changes]
     if: needs.detect-changes.outputs.runtime_base_changed == 'true'
     environment: ${{ needs.resolve-config.outputs.environment == 'production' && 'production-us' || needs.resolve-config.outputs.environment }}
@@ -314,9 +314,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Set up QEMU for multi-arch builds
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-
       - name: Build and push base image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
@@ -337,7 +334,7 @@ jobs:
   # ===========================================================================
   build-and-push:
     name: Build ${{ matrix.image }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: [resolve-config, detect-changes, build-base-image]
     if: |
       always() &&
@@ -393,9 +390,6 @@ jobs:
           else
             echo "prefix=${{ needs.resolve-config.outputs.environment }}" >> $GITHUB_OUTPUT
           fi
-
-      - name: Set up QEMU for multi-arch builds
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Build and push ${{ matrix.image }} image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -51,7 +51,8 @@ COPY prisma.config.local.ts ./prisma.config.local.ts
 COPY shogo.config.json ./shogo.config.json
 
 # Install all dependencies (postinstall generates Prisma client)
-RUN bun install
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+    bun install
 
 # Source for everything we build. The SDK's `dts: true` tsup pass
 # needs every cross-package type import resolvable (e.g.
@@ -93,7 +94,8 @@ RUN bun run generate:routes
 # afterwards — the API doesn't need it at runtime, only the
 # (now-populated) `templates/<id>/dist/` directories.
 WORKDIR /app/templates/runtime-template
-RUN bun install
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+    bun install
 WORKDIR /app
 RUN bun run --cwd packages/agent-runtime build-template-dists && \
     rm -rf templates/runtime-template/node_modules
@@ -141,7 +143,8 @@ COPY prisma.config.local.ts ./prisma.config.local.ts
 
 RUN chown -R appuser:appgroup /app
 USER appuser
-RUN bun install
+RUN --mount=type=cache,target=/home/appuser/.bun/install/cache,uid=1001,gid=1001 \
+    bun install
 
 # =============================================================================
 # Production image
@@ -223,7 +226,8 @@ USER appuser
 
 # Rebuild per-package module resolution links from .bun/ cache (no downloads).
 # Running as appuser so output is correctly owned — no chown -R needed.
-RUN bun install --ignore-scripts
+RUN --mount=type=cache,target=/home/appuser/.bun/install/cache,uid=1001,gid=1001 \
+    bun install --ignore-scripts
 
 # Build hash for version detection (set at build time by CI)
 ARG BUILD_HASH=dev

--- a/apps/mobile/Dockerfile
+++ b/apps/mobile/Dockerfile
@@ -64,7 +64,8 @@ COPY prisma.config.ts ./prisma.config.ts
 COPY prisma.config.local.ts ./prisma.config.local.ts
 
 # Install all dependencies (postinstall generates Prisma client)
-RUN bun install
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+    bun install
 
 # Source for everything the mobile build touches. Metro resolves
 # `@shogo-ai/sdk → dist/index.js` and the SDK's `dts: true` tsup pass

--- a/packages/agent-runtime/Dockerfile
+++ b/packages/agent-runtime/Dockerfile
@@ -81,7 +81,8 @@ RUN bun run build:packages
 # This is the **single** template the runtime now seeds — the legacy
 # `templates/skill-server/` install was retired alongside the unified
 # server architecture (see migrations/skill-server-to-root.ts).
-RUN cd templates/runtime-template && bun install
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+    cd templates/runtime-template && bun install
 
 # Pre-build per-template canvas dist/ bundles. Each agent template
 # (packages/agent-runtime/templates/<id>/) ships a `src/App.tsx` rendering
@@ -148,7 +149,8 @@ COPY prisma.config.local.ts ./prisma.config.local.ts
 # so all of node_modules is created with uid 1001 ownership from the start.
 RUN chown -R appuser:appgroup /app
 USER appuser
-RUN bun install
+RUN --mount=type=cache,target=/home/appuser/.bun/install/cache,uid=1001,gid=1001 \
+    bun install
 
 # =============================================================================
 # Stage 2: production image — layer source code onto base image
@@ -204,6 +206,8 @@ USER appuser
 
 # Rebuild bun's module resolution links from .bun/ cache (no downloads).
 # Running as appuser so output is correctly owned — no chown -R needed.
-RUN bun install --ignore-scripts
+# Cache target matches BUN_INSTALL_CACHE_DIR set in Dockerfile.base.
+RUN --mount=type=cache,target=/app/.bun/cache,uid=1001,gid=1001 \
+    bun install --ignore-scripts
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary

Phase A of two-phase CI speedup. Targets the QEMU bottleneck.

- Switch \`build-base-image\` and \`build-and-push\` matrix jobs to \`ubuntu-24.04-arm\`
- Drop \`docker/setup-qemu-action\` from both jobs (runner is now natively arm64)
- Add Bun BuildKit cache mounts to every \`bun install\` in \`apps/api/Dockerfile\`, \`apps/mobile/Dockerfile\`, and \`packages/agent-runtime/Dockerfile\`. Stages running as appuser get \`uid=1001,gid=1001\`; runtime production stage targets \`/app/.bun/cache\` to match \`BUN_INSTALL_CACHE_DIR\` from \`Dockerfile.base\`.

Baseline (job 75969013191):
- Build runtime: 53 min (build step 49m26s under QEMU)
- Build api: 36 min
- Build Runtime Base Image: 28 min
- Build web: 8 min

Expected after this PR: runtime ~12-15 min, api ~5-8 min, base ~5 min, web unchanged.

Phase B (workspace-deps base image to dedupe \`bun install\` + \`build:packages\` across the matrix) is a separate PR.

## Test plan

- [ ] CI run on this PR succeeds for all four image builds
- [ ] Runtime wall time under 20 min
- [ ] After merge to main, real deploy run completes and \`/api/health\` is 200 on staging

Made with [Cursor](https://cursor.com)