### PR TITLE
feat(mobile): warn when skill requires disabled capabilities

### DIFF
--- a/apps/mobile/components/project/panels/CapabilitiesPanel.tsx
+++ b/apps/mobile/components/project/panels/CapabilitiesPanel.tsx
@@ -871,7 +871,7 @@ export function CapabilitiesPanel({
       {/* Skills tab */}
       {subTab === 'skills' && (
         <View className="flex-1 relative">
-          <SkillsPanel projectId={projectId} agentUrl={agentUrl} visible />
+          <SkillsPanel projectId={projectId} agentUrl={agentUrl} visible capabilities={capabilities} />
         </View>
       )}
 

--- a/apps/mobile/components/project/panels/SkillsPanel.tsx
+++ b/apps/mobile/components/project/panels/SkillsPanel.tsx
@@ -2,9 +2,11 @@
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { View, Text, Pressable, ScrollView, ActivityIndicator, TextInput } from 'react-native'
-import { Zap, RefreshCw, BookOpen, Download, Check, Trash2, Plus, ChevronDown, ChevronRight, Search, Globe, FileCode } from 'lucide-react-native'
+import { Zap, RefreshCw, BookOpen, Download, Check, Trash2, Plus, ChevronDown, ChevronRight, Search, Globe, FileCode, AlertTriangle } from 'lucide-react-native'
 import { cn } from '@shogo/shared-ui/primitives'
 import { agentFetch } from '../../../lib/agent-fetch'
+import type { CapabilitySettings } from './CapabilitiesPanel'
+import { findDisabledCapabilities } from './tool-categories'
 
 interface Skill {
   name: string
@@ -38,9 +40,10 @@ interface SkillsPanelProps {
   projectId: string
   agentUrl: string | null
   visible: boolean
+  capabilities?: CapabilitySettings
 }
 
-export function SkillsPanel({ projectId, agentUrl, visible }: SkillsPanelProps) {
+export function SkillsPanel({ projectId, agentUrl, visible, capabilities }: SkillsPanelProps) {
   const [skills, setSkills] = useState<Skill[]>([])
   const [bundledSkills, setBundledSkills] = useState<BundledSkill[]>([])
   const [registrySkills, setRegistrySkills] = useState<RegistrySkill[]>([])
@@ -494,6 +497,19 @@ export function SkillsPanel({ projectId, agentUrl, visible }: SkillsPanelProps) 
                               ))}
                             </View>
                           ) : null}
+
+                          {capabilities && skill.tools?.length > 0 && (() => {
+                            const disabled = findDisabledCapabilities(skill.tools, capabilities)
+                            if (disabled.length === 0) return null
+                            return (
+                              <View className="flex-row items-center gap-1.5 mt-2 ml-5 px-2 py-1.5 rounded-md bg-amber-500/10">
+                                <AlertTriangle size={12} className="text-amber-500" />
+                                <Text className="text-[10px] text-amber-600 dark:text-amber-400 flex-1">
+                                  Requires disabled: {disabled.join(' · ')}
+                                </Text>
+                              </View>
+                            )
+                          })()}
                         </Pressable>
 
                         {isExpanded && skill.content ? (
@@ -559,6 +575,8 @@ export function SkillsPanel({ projectId, agentUrl, visible }: SkillsPanelProps) 
               const isExpanded = expandedSkill === skill.name
               const content = skillContent[skill.name]
               const isLoadingThis = loadingContent === skill.name
+              const bundledMatch = bundledSkills.find((b) => b.name === skill.name)
+              const installedTools = bundledMatch?.tools ?? []
 
               return (
                 <View key={skill.name} className="border border-border rounded-lg">
@@ -610,6 +628,19 @@ export function SkillsPanel({ projectId, agentUrl, visible }: SkillsPanelProps) 
                         ))}
                       </View>
                     ) : null}
+
+                    {capabilities && installedTools.length > 0 && (() => {
+                      const disabled = findDisabledCapabilities(installedTools, capabilities)
+                      if (disabled.length === 0) return null
+                      return (
+                        <View className="flex-row items-center gap-1.5 mt-2 ml-5 px-2 py-1.5 rounded-md bg-amber-500/10">
+                          <AlertTriangle size={12} className="text-amber-500" />
+                          <Text className="text-[10px] text-amber-600 dark:text-amber-400 flex-1">
+                            Requires disabled: {disabled.join(' · ')}
+                          </Text>
+                        </View>
+                      )
+                    })()}
                   </Pressable>
 
                   {isExpanded && (

--- a/apps/mobile/components/project/panels/tool-categories.ts
+++ b/apps/mobile/components/project/panels/tool-categories.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import type { CapabilitySettings } from './CapabilitiesPanel'
+
+/**
+ * Maps resolved tool names back to the CapabilitySettings toggle that gates
+ * them. Derived from the CAPABILITIES array in CapabilitiesPanel and the
+ * TOOL_GROUP_MAP in agent-runtime gateway-tools.ts.
+ *
+ * Only tools that have a corresponding capability toggle are listed.
+ * Tools like `write_file`, `read_file`, `search`, `canvas_*` are always
+ * available and don't have a user-facing capability gate.
+ */
+const TOOL_TO_CAPABILITY: Record<string, { key: keyof CapabilitySettings; label: string }> = {
+  web:                   { key: 'webEnabled',       label: 'Web Search' },
+  browser:               { key: 'browserEnabled',   label: 'Browser Control' },
+  exec:                  { key: 'shellEnabled',     label: 'Shell' },
+  exec_wait:             { key: 'shellEnabled',     label: 'Shell' },
+  heartbeat_configure:   { key: 'heartbeatEnabled', label: 'Heartbeat' },
+  heartbeat_status:      { key: 'heartbeatEnabled', label: 'Heartbeat' },
+  generate_image:        { key: 'imageGenEnabled',  label: 'Image Generation' },
+  memory_read:           { key: 'memoryEnabled',    label: 'Memory' },
+  memory_write:          { key: 'memoryEnabled',    label: 'Memory' },
+  memory_search:         { key: 'memoryEnabled',    label: 'Memory' },
+  quick_action:          { key: 'quickActionsEnabled', label: 'Quick Actions' },
+}
+
+/**
+ * Given a skill's list of required tool names and the current capability
+ * settings, returns an array of human-readable labels for capabilities
+ * that the skill needs but the user has disabled.
+ *
+ * Returns an empty array when all required capabilities are enabled (or
+ * when the skill only uses always-on tools like write_file / canvas_*).
+ */
+export function findDisabledCapabilities(
+  tools: string[],
+  capabilities: CapabilitySettings,
+): string[] {
+  const seen = new Set<string>()
+  const disabled: string[] = []
+
+  for (const tool of tools) {
+    const mapping = TOOL_TO_CAPABILITY[tool]
+    if (!mapping) continue
+    if (seen.has(mapping.key)) continue
+    seen.add(mapping.key)
+
+    if (!capabilities[mapping.key]) {
+      disabled.push(mapping.label)
+    }
+  }
+
+  return disabled
+}


### PR DESCRIPTION
## Summary

- Skill cards now show an **amber warning banner** when a skill depends on tools from capabilities the user has toggled off (e.g. Web Search, Memory, Shell)
- Warnings appear on both **bundled library cards** (pre-install) and **installed skill cards** (post-install)
- Install remains functional — warnings are advisory, not blocking
- 
<img width="1487" height="588" alt="image" src="https://github.com/user-attachments/assets/8d176160-5678-40ee-9304-ba92006f4475" />


## Changes

| File | What |
|---|---|
| \pps/mobile/components/project/panels/tool-categories.ts\ | **New** — maps tool names to CapabilitySettings keys with human-readable labels |
| \pps/mobile/components/project/panels/SkillsPanel.tsx\ | Accepts optional \capabilities\ prop; renders warning banner via \indDisabledCapabilities()\ |
| \pps/mobile/components/project/panels/CapabilitiesPanel.tsx\ | Passes \capabilities\ prop through to embedded \<SkillsPanel>\ |

## How it works

1. \	ool-categories.ts\ defines a static \TOOL_TO_CAPABILITY\ map (e.g. \web\ -> \webEnabled\/\Web Search\, \memory_read\ -> \memoryEnabled\/\Memory\)
2. \indDisabledCapabilities(tools, capabilities)\ returns human-readable labels for any disabled capabilities the skill needs
3. SkillsPanel renders an amber \AlertTriangle\ banner below tool tags when the list is non-empty

## Test plan

- [ ] Open a project -> Capabilities -> Skills tab
- [ ] Disable **Web Search** and **Memory** in the Configuration tab
- [ ] Switch to Skills tab -> Library -> Built-in: confirm skills needing web/memory show amber warning
- [ ] Install one of those skills: confirm the installed card also shows the warning
- [ ] Re-enable the capabilities: confirm warnings disappear
- [ ] Verify install/remove/expand flows still work normally

Made with [Cursor](https://cursor.com)