### PR TITLE
ci: workspace-deps base image to dedupe matrix work (Phase B)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -345,6 +345,10 @@ jobs:
     name: Build Workspace Deps Image
     runs-on: ubuntu-24.04-arm
     needs: [resolve-config, detect-changes]
+    # Runs whenever any matrix image is set to build. Docs doesn't consume
+    # workspace-deps, but on a cache hit this rebuild is ~30s and we'd need
+    # the matrix `if:` to special-case docs (matrix context isn't available
+    # at job level), which gets ugly. Pay the small cost.
     if: needs.detect-changes.outputs.has_changes == 'true'
     environment: ${{ needs.resolve-config.outputs.environment == 'production' && 'production-us' || needs.resolve-config.outputs.environment }}
     timeout-minutes: 30
@@ -391,13 +395,14 @@ jobs:
   build-and-push:
     name: Build ${{ matrix.image }}
     runs-on: ubuntu-24.04-arm
-    needs: [resolve-config, detect-changes, build-base-image]
+    needs: [resolve-config, detect-changes, build-base-image, build-workspace-deps]
     if: |
       always() &&
       needs.resolve-config.result == 'success' &&
       needs.detect-changes.result == 'success' &&
       needs.detect-changes.outputs.has_changes == 'true' &&
-      (needs.build-base-image.result == 'success' || needs.build-base-image.result == 'skipped')
+      (needs.build-base-image.result == 'success' || needs.build-base-image.result == 'skipped') &&
+      needs.build-workspace-deps.result == 'success'
     environment: ${{ needs.resolve-config.outputs.environment == 'production' && 'production-us' || needs.resolve-config.outputs.environment }}
     timeout-minutes: 60
 
@@ -459,6 +464,7 @@ jobs:
             ${{ needs.resolve-config.outputs.ocir_registry }}/shogo/${{ matrix.image_name }}:${{ steps.tag-prefix.outputs.prefix }}-latest
             ${{ needs.resolve-config.outputs.ocir_registry }}/shogo/${{ matrix.image_name }}:${{ steps.tag-prefix.outputs.prefix }}-${{ github.sha }}
           build-args: |
+            ${{ matrix.build_args != '' && format('WORKSPACE_DEPS={0}/shogo/shogo-workspace-deps:{1}', needs.resolve-config.outputs.ocir_registry, github.sha) || '' }}
             ${{ matrix.build_args == 'api' && format('ALLOWED_ORIGINS={0}', vars.ALLOWED_ORIGINS) || '' }}
             ${{ matrix.build_args == 'api' && format('BUILD_HASH={0}', github.sha) || '' }}
             ${{ matrix.build_args == 'web' && format('EXPO_PUBLIC_API_URL={0}', vars.EXPO_PUBLIC_API_URL) || '' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -329,6 +329,62 @@ jobs:
           cache-to: type=gha,mode=max,scope=runtime-base-oci
 
   # ===========================================================================
+  # Stage 1.7: Build Workspace Deps Image
+  # ===========================================================================
+  # Bakes the JS workspace once per CI run: full `bun install` (uid 1001),
+  # `bun run build:packages`, `generate:routes`, runtime-template install,
+  # `build-template-dists`, and external Claude skills. Downstream matrix
+  # images (api, web, runtime) `FROM` this image instead of doing all of
+  # the above three times in parallel.
+  #
+  # Gated on has_changes so we only rebuild when at least one matrix image
+  # also rebuilds — saves cycles on docs-only PRs. GHA layer cache makes
+  # no-op rebuilds fast even when triggered.
+  # ===========================================================================
+  build-workspace-deps:
+    name: Build Workspace Deps Image
+    runs-on: ubuntu-24.04-arm
+    needs: [resolve-config, detect-changes]
+    if: needs.detect-changes.outputs.has_changes == 'true'
+    environment: ${{ needs.resolve-config.outputs.environment == 'production' && 'production-us' || needs.resolve-config.outputs.environment }}
+    timeout-minutes: 30
+
+    env:
+      OCI_CLI_USER: ${{ secrets.OCI_USER_OCID }}
+      OCI_CLI_TENANCY: ${{ secrets.OCI_TENANCY_OCID }}
+      OCI_CLI_FINGERPRINT: ${{ secrets.OCI_FINGERPRINT }}
+      OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_PRIVATE_KEY }}
+      OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Login to OCIR
+        run: |
+          echo "${{ secrets.OCI_AUTH_TOKEN }}" | docker login \
+            ${{ vars.OCI_REGION }}.ocir.io \
+            -u "${{ vars.OCI_TENANCY_NAMESPACE }}/${{ secrets.OCI_USERNAME }}" \
+            --password-stdin
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build and push workspace-deps image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: docker/workspace-deps/Dockerfile
+          platforms: linux/arm64
+          push: true
+          provenance: false
+          tags: |
+            ${{ needs.resolve-config.outputs.ocir_registry }}/shogo/shogo-workspace-deps:latest
+            ${{ needs.resolve-config.outputs.ocir_registry }}/shogo/shogo-workspace-deps:${{ github.sha }}
+          cache-from: type=gha,scope=workspace-deps-oci
+          cache-to: type=gha,mode=max,scope=workspace-deps-oci
+
+  # ===========================================================================
   # Stage 2: Build and Push Docker Images to OCIR (in parallel)
   # Images are pushed to the primary (US) OCIR registry.
   # ===========================================================================

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -2,181 +2,86 @@
 # =============================================================================
 # Shogo API Server Dockerfile
 # =============================================================================
-# Multi-stage build for production-optimized API server
-# Runs Hono server on port 8002 (configurable via API_PORT)
-# Includes BetterAuth for authentication
+# Multi-stage build for production-optimized API server.
+# Runs Hono server on port 8002 (configurable via API_PORT).
+# Includes BetterAuth for authentication.
 #
-# Workspace package.jsons are glob-copied via BuildKit `COPY --parents`
-# (requires `# syntax=docker/dockerfile:1.7-labs` directive above).
-# Adding a new `packages/<X>/` is now a no-op for this Dockerfile —
-# the glob picks it up automatically. The `--parents` flag preserves
-# the directory structure (without it, all package.jsons would land
-# in the same dest dir and clobber each other).
+# Phase B refactor: builder/deps stages collapsed into a single FROM of the
+# pre-baked shogo-workspace-deps image (see docker/workspace-deps/Dockerfile),
+# which contains the JS workspace already installed (uid 1001), with
+# build:packages, generate:routes, build-template-dists, and external skills
+# all pre-applied. The production stage now just COPY --from=workspace and
+# rebuilds module resolution links.
+#
+# The production base is node:25-slim (debian) rather than node:25-alpine to
+# match workspace-deps' libc (glibc), so prisma engines and other native
+# binaries copy across cleanly without rebuilding.
 # =============================================================================
 
-FROM oven/bun:1.3-alpine AS builder
+ARG WORKSPACE_DEPS
+
+FROM ${WORKSPACE_DEPS} AS workspace
+# No-op: workspace-deps already has node_modules + source + built artifacts.
+# Aliased here so the COPY --from=workspace lines below read naturally.
+
+# =============================================================================
+# Production image (debian-slim, glibc — matches workspace-deps libc)
+# =============================================================================
+FROM node:25-slim
 
 WORKDIR /app
 
-# Native-module build toolchain (better-sqlite3 → node-gyp → python3).
-# Required under QEMU where no prebuilt binary matches the emulated arch
-# and better-sqlite3 has to compile from source. The Bun image ships
-# neither Node.js nor node-gyp, so we install both explicitly.
-RUN apk add --no-cache python3 make g++ nodejs npm && \
-    npm install -g node-gyp
-
-# Copy workspace root files
-COPY package.json bun.lock ./
-COPY tsconfig.base.json ./
-
-# All workspace members must be present for bun install to resolve the
-# `packages/*` and `apps/*` workspaces glob in the root package.json.
-# Single glob copy preserves directory structure thanks to --parents.
-COPY --parents packages/*/package.json ./
-COPY --parents apps/*/package.json ./
-
-# Copy scripts needed for postinstall
-COPY scripts ./scripts
-
-# Copy patches required by `patchedDependencies` in package.json — bun install
-# fails fast if a referenced .patch file isn't present in the build context.
-COPY patches ./patches
-
-# Copy prisma schema and config before install (postinstall runs db:generate:all)
-COPY prisma ./prisma
-COPY prisma.config.ts ./prisma.config.ts
-COPY prisma.config.local.ts ./prisma.config.local.ts
-
-# Copy shogo SDK config (drives `bun run generate:routes` later in this stage)
-COPY shogo.config.json ./shogo.config.json
-
-# Install all dependencies (postinstall generates Prisma client)
-RUN --mount=type=cache,target=/root/.bun/install/cache \
-    bun install
-
-# Source for everything we build. The SDK's `dts: true` tsup pass
-# needs every cross-package type import resolvable (e.g.
-# `import { ... } from '@shogo-ai/core/chat-message'`), so we copy
-# the lot rather than try to enumerate which ones each upstream
-# build touches. Build context size is dominated by node_modules
-# anyway, and BuildKit caches this layer across rebuilds when the
-# packages/ tree hasn't changed.
-COPY packages ./packages
-COPY apps/api ./apps/api
-COPY templates/runtime-template ./templates/runtime-template
-
-# Build the SDK and its split-out workspace deps in dependency
-# order (core → agent → db → email → voice → cli → sdk). The root
-# `build:packages` script encodes this graph and is the canonical
-# entry point — building only `packages/sdk` is no longer enough
-# because its tsup dts pass needs each dep's `dist/*.d.ts` first.
-WORKDIR /app
-RUN bun run build:packages
-
-# Regenerate Hono routes/hooks/admin-routes from prisma/schema.prisma so that
-# adding a model (e.g. WorkspaceGrant) only requires committing the schema
-# change — the per-model `*.routes.ts` and `*.hooks.ts` files under
-# `apps/api/src/generated/` are reproduced from the schema here. Without this
-# step, anything ignored by `**/src/generated/` in .gitignore (i.e. any file
-# generated after that rule was added) silently never reaches the image and
-# crash-loops the API on first import. Outputs are governed by
-# shogo.config.json.
-WORKDIR /app
-RUN bun run generate:routes
-
-# Pre-build per-template canvas dist/ bundles so the API's
-# `RuntimeManager.ensureProjectDirectory` ships them into every project
-# workspace and the canvas iframe paints the correct surface on the
-# first request (no "Project Ready" flash). Requires the runtime-template
-# to have its deps installed because the build script symlinks
-# templates/runtime-template/node_modules into each per-template staging
-# dir to share vite/react/postcss/tailwind. The deps tree is dropped
-# afterwards — the API doesn't need it at runtime, only the
-# (now-populated) `templates/<id>/dist/` directories.
-WORKDIR /app/templates/runtime-template
-RUN --mount=type=cache,target=/root/.bun/install/cache \
-    bun install
-WORKDIR /app
-RUN bun run --cwd packages/agent-runtime build-template-dists && \
-    rm -rf templates/runtime-template/node_modules
-
-# Clean per-package node_modules (bun symlinks that resolve via .bun/ cache).
-# These are rebuilt in the production stage via `bun install --ignore-scripts`.
-RUN rm -rf packages/*/node_modules
-
-# =============================================================================
-# Parallel deps stage — node_modules pre-owned by uid 1001
-# =============================================================================
-# Runs IN PARALLEL with builder (BuildKit). Installs as appuser so all files
-# in node_modules are created with uid 1001 ownership. COPY --from=deps
-# preserves this ownership natively — no --chown flag or chown -R needed.
-# =============================================================================
-FROM oven/bun:1.3-alpine AS deps
-
-WORKDIR /app
-
-# Native-module build toolchain (better-sqlite3 → node-gyp → python3).
-# Required under QEMU where no prebuilt binary matches the emulated arch
-# and better-sqlite3 has to compile from source. The Bun image ships
-# neither Node.js nor node-gyp, so we install both explicitly.
-RUN apk add --no-cache python3 make g++ nodejs npm && \
-    npm install -g node-gyp
-
-RUN addgroup -g 1001 -S appgroup && adduser -u 1001 -S appuser -G appgroup
-
-COPY package.json bun.lock ./
-COPY tsconfig.base.json ./
-
-# Single glob copy for all workspace package.jsons — same pattern as
-# the builder stage above. See the file header for why.
-COPY --parents packages/*/package.json ./
-COPY --parents apps/*/package.json ./
-
-COPY scripts ./scripts
-
-# Same patches directory as the builder stage — bun install fails without it.
-COPY patches ./patches
-
-COPY prisma ./prisma
-COPY prisma.config.ts ./prisma.config.ts
-COPY prisma.config.local.ts ./prisma.config.local.ts
-
-RUN chown -R appuser:appgroup /app
-USER appuser
-RUN --mount=type=cache,target=/home/appuser/.bun/install/cache,uid=1001,gid=1001 \
-    bun install
-
-# =============================================================================
-# Production image
-# =============================================================================
-FROM node:25-alpine
-
-WORKDIR /app
-
-# Install curl for healthchecks, bash for shell, and Bun
-RUN apk add --no-cache curl bash unzip && \
+# Runtime deps for the entrypoint and healthcheck:
+#   curl  -> healthcheck
+#   bash  -> shell scripts
+#   netcat-openbsd -> entrypoint.sh nc port-wait
+#   ca-certificates -> outbound HTTPS
+# Plus Bun (entry point uses `bun run`).
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl bash unzip ca-certificates netcat-openbsd && \
     curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash -s "bun-v1.3.9" && \
-    rm -rf /root/.bun
+    rm -rf /root/.bun /var/lib/apt/lists/*
 
-# Create non-root user for security
-RUN addgroup -g 1001 -S appgroup && \
-    adduser -u 1001 -S appuser -G appgroup
+RUN groupadd -g 1001 appgroup && useradd -u 1001 -g appgroup -m -s /bin/bash appuser
 
-# Copy node_modules from deps stage. Files are already owned by uid 1001
-# (installed as appuser in deps), so COPY preserves ownership natively —
-# no --chown flag needed, eliminating the ~480s ownership traversal.
-COPY --from=deps /app/node_modules ./node_modules
+# Pull node_modules and the full prebuilt workspace from the workspace-deps
+# image. Files are already owned by uid 1001 (workspace-deps installs as
+# appuser), so COPY preserves ownership without a --chown traversal.
+COPY --from=workspace /app/node_modules ./node_modules
+COPY --from=workspace /app/packages/agent-runtime ./packages/agent-runtime
+COPY --from=workspace /app/packages/shared-runtime ./packages/shared-runtime
+COPY --from=workspace /app/packages/sdk ./packages/sdk
+COPY --from=workspace /app/packages/model-catalog ./packages/model-catalog
+COPY --from=workspace /app/apps/api ./apps/api
+COPY --from=workspace /app/package.json /app/bun.lock /app/tsconfig.base.json ./
 
-# Copy built source from builder (small files, --chown is fast here)
-COPY --chown=appuser:appgroup --from=builder /app/packages/agent-runtime ./packages/agent-runtime
-COPY --chown=appuser:appgroup --from=builder /app/packages/shared-runtime ./packages/shared-runtime
-COPY --chown=appuser:appgroup --from=builder /app/packages/sdk ./packages/sdk
-COPY --chown=appuser:appgroup --from=builder /app/apps/api ./apps/api
-COPY --chown=appuser:appgroup --from=builder /app/package.json ./
-COPY --chown=appuser:appgroup --from=builder /app/bun.lock ./
-COPY --chown=appuser:appgroup --from=builder /app/tsconfig.base.json ./
+# Stub package.jsons for every workspace member not shipped in the image
+# (the `bun install --ignore-scripts` below still walks the workspace
+# graph; missing package.jsons fail with `error: Workspace dependency not
+# found`). The `/app/./` pivot tells BuildKit to preserve everything after
+# `/app/`. Already-shipped source dirs get their package.json overwritten
+# here, which is fine because the content is identical.
+COPY --from=workspace --parents /app/./packages/*/package.json ./
+COPY --from=workspace --parents /app/./apps/*/package.json ./
 
-# Re-create workspace symlinks (Docker COPY doesn't preserve cross-tree symlinks)
+# Same patches as workspace-deps used during install — `bun install
+# --ignore-scripts` below resolves patchedDependencies and fails without them.
+COPY --from=workspace /app/patches ./patches
+
+# Prisma schema + config for runtime migrations.
+COPY --from=workspace /app/prisma ./prisma
+COPY --from=workspace /app/prisma.config.ts ./prisma.config.ts
+
+# Runtime template for RuntimeManager project initialization (workspace-deps
+# stripped its node_modules after building template dists; the dists travel
+# with packages/agent-runtime/templates above).
+COPY --from=workspace /app/templates/runtime-template ./templates/runtime-template
+
+COPY --chown=appuser:appgroup apps/api/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+# Re-create workspace symlinks (Docker COPY doesn't preserve cross-tree symlinks).
 RUN mkdir -p node_modules/@shogo && \
     ln -sf ../../../packages/shared-runtime node_modules/@shogo/shared-runtime && \
     ln -sf ../../../packages/sdk node_modules/@shogo/sdk && \
@@ -184,69 +89,29 @@ RUN mkdir -p node_modules/@shogo && \
     ln -sf ../../../packages/model-catalog node_modules/@shogo/model-catalog && \
     chown -h appuser:appgroup node_modules/@shogo node_modules/@shogo/*
 
-# Stub package.jsons for every workspace member not shipped in the image
-# (the `bun install --ignore-scripts` further down still walks the workspace
-# graph; missing package.jsons fail with `error: Workspace dependency not
-# found`). Single glob copy preserves directory structure thanks to
-# --parents; adding new packages is automatic. The `/app/./` pivot tells
-# BuildKit to preserve everything after `/app/` (i.e., `packages/X/...`).
-# Already-shipped source (agent-runtime, shared-runtime, sdk) gets its
-# package.json overwritten by this same line, which is fine because the
-# file content is identical.
-COPY --chown=appuser:appgroup --from=builder --parents /app/./packages/*/package.json ./
-COPY --chown=appuser:appgroup --from=builder --parents /app/./apps/*/package.json ./
-# model-catalog ships its source (canvas-runtime peer needs it at runtime)
-COPY --chown=appuser:appgroup --from=builder /app/packages/model-catalog ./packages/model-catalog/
-
-# Same patches as builder/deps stages — bun install --ignore-scripts at line ~189
-# also resolves `patchedDependencies` and fails without these files.
-COPY --chown=appuser:appgroup --from=builder /app/patches ./patches
-
-# Copy prisma schema, config, and migrations for runtime migrations
-COPY --chown=appuser:appgroup --from=builder /app/prisma ./prisma
-COPY --chown=appuser:appgroup --from=builder /app/prisma.config.ts ./prisma.config.ts
-
-# Copy SDK examples folder for templates API
-COPY --chown=appuser:appgroup packages/sdk/examples ./packages/sdk/examples
-
-# Copy runtime template for RuntimeManager project initialization
-COPY --chown=appuser:appgroup templates/runtime-template ./templates/runtime-template
-
-# Copy entrypoint script
-COPY --chown=appuser:appgroup apps/api/entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
-
-# Create directories and set permissions (must be done as root)
 RUN mkdir -p /app/workspaces /app/.claude && \
     chmod 777 /app /app/.claude && \
     chown appuser:appgroup /app/workspaces /app/.claude
 
-# Switch to non-root user before rebuilding workspace links
 USER appuser
 
-# Rebuild per-package module resolution links from .bun/ cache (no downloads).
-# Running as appuser so output is correctly owned — no chown -R needed.
+# Rebuild per-package module resolution links from .bun/ cache (no downloads
+# under normal operation). Running as appuser so output is correctly owned.
 RUN --mount=type=cache,target=/home/appuser/.bun/install/cache,uid=1001,gid=1001 \
     bun install --ignore-scripts
 
-# Build hash for version detection (set at build time by CI)
 ARG BUILD_HASH=dev
 ENV BUILD_HASH=$BUILD_HASH
 
-# Environment defaults
 ENV NODE_ENV=production
 ENV API_PORT=8002
 
-# Expose API port and Vite runtime ports
 EXPOSE 8002
 EXPOSE 5200-5209
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
   CMD curl -sf http://localhost:${API_PORT}/api/health || exit 1
 
-# Run API server
 WORKDIR /app/apps/api
 ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["bun", "run", "src/entry.ts"]
-

--- a/apps/mobile/Dockerfile
+++ b/apps/mobile/Dockerfile
@@ -2,19 +2,21 @@
 # =============================================================================
 # Shogo Web Frontend Dockerfile (Expo Web Export)
 # =============================================================================
-# Multi-stage build:
-# 1. Install workspace deps with Bun, build with Expo/Metro (requires Node)
-# 2. Serve static files with Nginx (reverse proxy for /api)
+# Phase B refactor: builder is now FROM the pre-baked shogo-workspace-deps
+# image (debian, bun, full install + build:packages applied). We just COPY
+# in apps/mobile and run expo export.
 #
-# Workspace package.jsons are glob-copied via BuildKit `COPY --parents`
-# (requires the `# syntax=docker/dockerfile:1.7-labs` directive above).
+# Production stage is unchanged: nginx-alpine serving the exported static
+# files. The builder stage's libc doesn't matter for production because the
+# only thing that crosses the boundary is the JS/CSS/HTML bundle.
 # =============================================================================
 
-FROM --platform=$BUILDPLATFORM node:22-alpine AS builder
+ARG WORKSPACE_DEPS
+
+FROM ${WORKSPACE_DEPS} AS builder
 
 WORKDIR /app
 
-# Build arguments — empty defaults produce relative URLs (proxied by nginx)
 ARG EXPO_PUBLIC_API_URL=
 ARG EXPO_PUBLIC_BUILD_HASH=dev
 ARG EXPO_PUBLIC_APP_ENV=development
@@ -34,63 +36,27 @@ ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
 ENV SENTRY_ORG=$SENTRY_ORG
 ENV SENTRY_PROJECT=$SENTRY_PROJECT
 
-# Install Bun (used for fast dependency installation)
-RUN apk add --no-cache bash curl && \
-    curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash -s "bun-v1.3.9" && \
-    rm -rf /root/.bun
-
-# Install Sentry CLI standalone binary (statically linked, works on Alpine/musl)
+# Sentry CLI standalone binary (statically linked, works on glibc/musl).
+# Installed as root so it lands in /usr/local/bin (workspace's USER is appuser).
+USER root
 RUN curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION="3.3.4" sh
+USER appuser
 
-# Copy workspace root files
-COPY package.json bun.lock ./
-COPY tsconfig.base.json ./
+# apps/mobile source — workspace-deps does not bake this in (workspace-deps
+# only bakes apps/api source because that's the only one needing
+# generate:routes). Mobile source is shallow enough to copy directly.
+COPY --chown=appuser:appgroup apps/mobile ./apps/mobile
 
-# All workspace members must be present for bun install to resolve the
-# `packages/*` and `apps/*` workspaces glob in the root package.json.
-COPY --parents packages/*/package.json ./
-COPY --parents apps/*/package.json ./
-
-# Copy scripts needed for postinstall
-COPY scripts ./scripts
-
-# Copy patches required by `patchedDependencies` in package.json — bun install
-# fails fast if a referenced .patch file isn't present in the build context.
-COPY patches ./patches
-
-# Copy prisma schema and config before install (postinstall runs db:generate:all)
-COPY prisma ./prisma
-COPY prisma.config.ts ./prisma.config.ts
-COPY prisma.config.local.ts ./prisma.config.local.ts
-
-# Install all dependencies (postinstall generates Prisma client)
-RUN --mount=type=cache,target=/root/.bun/install/cache \
-    bun install
-
-# Source for everything the mobile build touches. Metro resolves
-# `@shogo-ai/sdk → dist/index.js` and the SDK's `dts: true` tsup pass
-# needs every cross-package type import resolvable. Single COPY removes
-# per-package bleed and is cache-friendly when packages/ is unchanged.
-COPY packages ./packages
-
-COPY apps/mobile ./apps/mobile
-
-# Build the SDK and its split-out workspace deps in dependency
-# order (core → agent → db → email → voice → cli → sdk). Metro
-# resolves `@shogo-ai/sdk → dist/index.js` for the Expo web export,
-# and the SDK's tsup dts pass needs each dep's `dist/*.d.ts` first.
-WORKDIR /app
-RUN bun run build:packages
-
-# Build Expo web export (Metro bundler outputs to apps/mobile/dist/)
+# Build Expo web export (Metro bundler outputs to apps/mobile/dist/).
+# packages/*/dist are already pre-built in workspace-deps.
 WORKDIR /app/apps/mobile
 RUN npx expo export --platform web
 
 # Inject analytics scripts into the exported HTML (Expo "single" mode strips
-# <script> tags from +html.tsx, so we inject them post-export)
+# <script> tags from +html.tsx, so we inject them post-export).
 RUN node scripts/inject-analytics.js
 
-# Upload source maps to Sentry (inject debug IDs, upload, then strip maps)
+# Upload source maps to Sentry (inject debug IDs, upload, then strip maps).
 # Upload is non-fatal: a Sentry misconfiguration should not block a deploy.
 RUN if [ -n "$SENTRY_AUTH_TOKEN" ]; then \
       sentry-cli sourcemaps inject --release "$EXPO_PUBLIC_BUILD_HASH" ./dist && \
@@ -108,10 +74,8 @@ ENV API_UPSTREAM=http://shogo-api.shogo-system.svc.cluster.local:8002
 ENV API_HOST=shogo-api.shogo-system.svc.cluster.local
 ENV DNS_RESOLVER=kube-dns.kube-system.svc.cluster.local
 
-# Copy built static files
 COPY --from=builder /app/apps/mobile/dist /usr/share/nginx/html
 
-# Copy nginx configuration template
 COPY apps/mobile/nginx.conf /etc/nginx/nginx.conf.template
 
 EXPOSE 80

--- a/apps/mobile/Dockerfile
+++ b/apps/mobile/Dockerfile
@@ -36,10 +36,14 @@ ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
 ENV SENTRY_ORG=$SENTRY_ORG
 ENV SENTRY_PROJECT=$SENTRY_PROJECT
 
-# Sentry CLI standalone binary (statically linked, works on glibc/musl).
-# Installed as root so it lands in /usr/local/bin (workspace's USER is appuser).
+# Sentry CLI standalone binary. The get-cli/ install script doesn't reliably
+# land sentry-cli in PATH on this debian base, so download the prebuilt
+# arm64 binary directly. Installed as root so it lands in /usr/local/bin
+# (workspace's USER is appuser).
 USER root
-RUN curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION="3.3.4" sh
+RUN curl -fsSL "https://github.com/getsentry/sentry-cli/releases/download/3.3.4/sentry-cli-Linux-aarch64" \
+        -o /usr/local/bin/sentry-cli && \
+    chmod +x /usr/local/bin/sentry-cli
 USER appuser
 
 # apps/mobile source — workspace-deps does not bake this in (workspace-deps

--- a/docker/workspace-deps/Dockerfile
+++ b/docker/workspace-deps/Dockerfile
@@ -1,0 +1,93 @@
+# syntax=docker/dockerfile:1.7-labs
+# =============================================================================
+# Workspace Deps Image (Debian)
+# =============================================================================
+# Single-stage image baked once per CI run, then consumed by every matrix
+# image (api, web, runtime) so each one stops re-running `bun install` and
+# `bun run build:packages`. Contents:
+#
+#   /app/node_modules                            (full install, uid 1001)
+#   /app/packages/*/package.json                 (workspace stubs)
+#   /app/packages/*/dist                         (output of build:packages)
+#   /app/packages/agent-runtime/templates/*/dist (per-template canvas dists)
+#   /app/packages/agent-runtime/src/bundled-claude-skills/*
+#                                                (fetched external skills)
+#   /app/apps/api/src/generated/*                (generate:routes output)
+#   /app/templates/runtime-template              (deps stripped after build)
+#   /app/patches /app/prisma /app/scripts        (config/source needed
+#                                                downstream)
+#
+# Downstream matrix Dockerfiles use `FROM ${WORKSPACE_DEPS}` to inherit
+# everything above. We bake debian (matches Dockerfile.base) so binary
+# native modules layer-copy cleanly into both python:3.12-slim
+# (runtime base) and node:25-alpine (api production) — same arm64 ABI.
+# =============================================================================
+
+FROM oven/bun:1.3-debian
+
+WORKDIR /app
+
+# Native-module build toolchain (better-sqlite3 → node-gyp → python3) and
+# git for fetch-external-skills.ts. Even on ARM-native runners, some
+# packages (e.g. better-sqlite3 for non-aligned bun versions) still build
+# from source.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        python3 make g++ nodejs npm git ca-certificates && \
+    npm install -g node-gyp && \
+    rm -rf /var/lib/apt/lists/*
+
+# Match downstream uid 1001 ownership so COPY --from=workspace-deps preserves
+# permissions cleanly into api/runtime production stages.
+RUN groupadd -g 1001 appgroup && useradd -u 1001 -g appgroup -m -s /bin/bash appuser
+
+# Workspace root files
+COPY package.json bun.lock tsconfig.base.json ./
+
+# Workspace member package.jsons (BuildKit `COPY --parents` preserves dirs)
+COPY --parents packages/*/package.json ./
+COPY --parents apps/*/package.json ./
+
+COPY scripts ./scripts
+COPY patches ./patches
+COPY prisma ./prisma
+COPY prisma.config.ts prisma.config.local.ts shogo.config.json ./
+
+RUN chown -R appuser:appgroup /app
+USER appuser
+
+# Full install as appuser → node_modules owned by uid 1001 from the start,
+# so downstream COPY --from=workspace-deps doesn't need --chown.
+RUN --mount=type=cache,target=/home/appuser/.bun/install/cache,uid=1001,gid=1001 \
+    bun install
+
+# Source for everything build:packages and generate:routes touch. The SDK's
+# `dts: true` tsup pass needs every cross-package type import resolvable.
+COPY --chown=appuser:appgroup packages ./packages
+COPY --chown=appuser:appgroup apps/api ./apps/api
+COPY --chown=appuser:appgroup templates/runtime-template ./templates/runtime-template
+
+# Build the SDK and its split-out workspace deps in dependency order
+# (core → agent → db → email → voice → cli → sdk). The root build:packages
+# script encodes this graph.
+RUN bun run build:packages
+
+# Regenerate Hono routes/hooks/admin-routes from prisma/schema.prisma. The
+# postinstall hook also runs this, but rerun explicitly here so the output
+# is part of an immutable layer (postinstall is best-effort).
+RUN bun run generate:routes
+
+# Pre-build per-template canvas dist/ bundles. Reuses the runtime-template
+# node_modules (symlinked into per-template staging dirs) and drops them
+# afterwards — the API/runtime images ship the populated templates/<id>/dist/
+# directories only.
+RUN --mount=type=cache,target=/home/appuser/.bun/install/cache,uid=1001,gid=1001 \
+    cd templates/runtime-template && \
+    bun install --frozen-lockfile && \
+    cd /app && \
+    bun run --cwd packages/agent-runtime build-template-dists && \
+    rm -rf templates/runtime-template/node_modules
+
+# Fetch external Claude Code skills declared in skill-registry.json. Writes
+# to packages/agent-runtime/src/bundled-claude-skills/<source>/<skill>/SKILL.md.
+RUN bun run scripts/fetch-external-skills.ts

--- a/docker/workspace-deps/Dockerfile
+++ b/docker/workspace-deps/Dockerfile
@@ -33,7 +33,7 @@ WORKDIR /app
 # from source.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        python3 make g++ nodejs npm git ca-certificates && \
+        python3 make g++ nodejs npm git curl ca-certificates && \
     npm install -g node-gyp && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/workspace-deps/Dockerfile
+++ b/docker/workspace-deps/Dockerfile
@@ -81,9 +81,12 @@ RUN bun run generate:routes
 # node_modules (symlinked into per-template staging dirs) and drops them
 # afterwards — the API/runtime images ship the populated templates/<id>/dist/
 # directories only.
+# Plain `bun install` (no --frozen-lockfile): the runtime-template's
+# bun.lock has drift relative to its package.json on this branch and the
+# original apps/api/runtime Dockerfiles also use plain bun install here.
 RUN --mount=type=cache,target=/home/appuser/.bun/install/cache,uid=1001,gid=1001 \
     cd templates/runtime-template && \
-    bun install --frozen-lockfile && \
+    bun install && \
     cd /app && \
     bun run --cwd packages/agent-runtime build-template-dists && \
     rm -rf templates/runtime-template/node_modules

--- a/packages/agent-runtime/Dockerfile
+++ b/packages/agent-runtime/Dockerfile
@@ -2,188 +2,56 @@
 # =============================================================================
 # Unified Runtime Dockerfile
 # =============================================================================
-# Builds on the pre-built base image (Dockerfile.base) which contains system
-# packages, template archives, and MCP servers.
-# This layer only adds application source code and bun dependencies.
+# Phase B refactor: the previous builder + deps stages are gone. The runtime
+# image now layers source from the pre-baked shogo-workspace-deps image
+# (`docker/workspace-deps/Dockerfile`) onto the system-package base image
+# (`packages/agent-runtime/Dockerfile.base`). All of bun install,
+# build:packages, runtime-template install, build-template-dists, and
+# fetch-external-skills happen exactly once per CI run inside workspace-deps.
 #
-# Build: DOCKER_BUILDKIT=1 docker build \
-#          --build-arg BASE_IMAGE=<ecr>/shogo/shogo-runtime-base:latest \
-#          -t runtime -f packages/agent-runtime/Dockerfile .
-# Run:   docker run -e PROJECT_ID=test -e AI_PROXY_TOKEN=... runtime
-#
-# Workspace package.jsons are glob-copied via BuildKit `COPY --parents`
-# (requires `# syntax=docker/dockerfile:1.7-labs` directive above).
-# Adding a new `packages/<X>/` is now a no-op for this Dockerfile —
-# the glob picks it up automatically. Cross-stage `--from` copies need
-# an explicit `/./` pivot (e.g. `/app/./packages/*/...`) to preserve
-# directory structure relative to /app rather than relative to the
-# first wildcard.
+# Build:
+#   DOCKER_BUILDKIT=1 docker build \
+#     --build-arg BASE_IMAGE=<reg>/shogo/shogo-runtime-base:latest \
+#     --build-arg WORKSPACE_DEPS=<reg>/shogo/shogo-workspace-deps:latest \
+#     -t runtime -f packages/agent-runtime/Dockerfile .
 # =============================================================================
 
 ARG BASE_IMAGE=shogo-runtime-base:latest
+ARG WORKSPACE_DEPS
+
+FROM ${WORKSPACE_DEPS} AS workspace
+# No-op: workspace-deps already has node_modules + source + built artifacts.
 
 # =============================================================================
-# Stage 0: builder — install all deps, copy source
-# =============================================================================
-FROM oven/bun:1.3-debian AS builder
-
-WORKDIR /app
-
-# Native-module build toolchain (better-sqlite3 → node-gyp → python3).
-# Required under QEMU where no prebuilt binary matches the emulated arch
-# and better-sqlite3 has to compile from source. The Bun image ships
-# neither Node.js nor node-gyp, so we install both explicitly.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3 make g++ nodejs npm && \
-    npm install -g node-gyp && \
-    rm -rf /var/lib/apt/lists/*
-
-COPY package.json bun.lock ./
-COPY tsconfig.base.json ./
-
-# All workspace members must be present for bun install to resolve the
-# `packages/*` and `apps/*` workspaces glob in the root package.json.
-# Single glob copy preserves directory structure thanks to --parents.
-COPY --parents packages/*/package.json ./
-COPY --parents apps/*/package.json ./
-
-COPY scripts ./scripts
-
-# Copy patches required by `patchedDependencies` in package.json — bun install
-# fails with "Couldn't find patch file" when this directory is missing from
-# the build context.
-COPY patches ./patches
-
-# Copy prisma schema and config before install (postinstall runs db:generate:all)
-COPY prisma ./prisma
-COPY prisma.config.ts ./prisma.config.ts
-COPY prisma.config.local.ts ./prisma.config.local.ts
-
-RUN --mount=type=cache,target=/root/.bun/install/cache \
-    bun install
-
-# Source for everything we build. The SDK's `dts: true` tsup pass
-# needs every cross-package type import resolvable, and the Dockerfile
-# previously enumerated 10+ packages anyway. Single COPY removes the
-# per-package bleed and is cache-friendly when packages/ is unchanged.
-COPY packages ./packages
-COPY templates/runtime-template ./templates/runtime-template
-
-# Build @shogo-ai/sdk and its split-out workspace deps in
-# dependency order (core → agent → db → email → voice → cli →
-# sdk). The SDK's package.json "exports" resolve to ./dist/*, so
-# `import '@shogo-ai/sdk/memory'` fails at agent-runtime startup
-# without this; and the SDK's tsup dts pass needs each dep's
-# `dist/*.d.ts` to be present first.
-RUN bun run build:packages
-
-# Pre-install runtime-template dependencies so workspaces get node_modules instantly.
-# This is the **single** template the runtime now seeds — the legacy
-# `templates/skill-server/` install was retired alongside the unified
-# server architecture (see migrations/skill-server-to-root.ts).
-RUN --mount=type=cache,target=/root/.bun/install/cache \
-    cd templates/runtime-template && bun install
-
-# Pre-build per-template canvas dist/ bundles. Each agent template
-# (packages/agent-runtime/templates/<id>/) ships a `src/App.tsx` rendering
-# its curated surface; the build script stages it on top of the
-# runtime-template, runs `vite build`, and writes the result to
-# `templates/<id>/dist/`. `seedWorkspaceFromTemplate` and
-# `overlayAgentTemplateCodeDirs` cp this dist over the workspace's dist
-# (`force:true`), so the canvas iframe paints the correct template
-# surface on the very first request — no flash of "Project Ready" while
-# Vite does its cold rebuild.
-#
-# Rebuilding here (rather than relying on whatever `dist/` was committed)
-# means staging/production images can never drift from the template's
-# committed `src/`. ~30s for ~20 templates thanks to the symlinked
-# node_modules.
-RUN bun run --cwd packages/agent-runtime build-template-dists
-
-# Fetch external Claude Code skills from skill-registry.json
-RUN apt-get update && apt-get install -y --no-install-recommends git && \
-    bun run scripts/fetch-external-skills.ts && \
-    apt-get purge -y git && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
-
-RUN rm -rf packages/*/node_modules apps/*/node_modules
-
-# =============================================================================
-# Stage 1: deps — full node_modules with workspace links
-# =============================================================================
-FROM oven/bun:1.3-debian AS deps
-
-WORKDIR /app
-
-# Native-module build toolchain (better-sqlite3 → node-gyp → python3).
-# Required under QEMU where no prebuilt binary matches the emulated arch
-# and better-sqlite3 has to compile from source. The Bun image ships
-# neither Node.js nor node-gyp, so we install both explicitly.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3 make g++ nodejs npm && \
-    npm install -g node-gyp && \
-    rm -rf /var/lib/apt/lists/*
-
-# Create user matching production uid so node_modules is pre-owned by uid 1001.
-# COPY --from=deps preserves ownership, so no --chown or chown -R needed later.
-RUN groupadd -g 1001 appgroup && useradd -u 1001 -g appgroup appuser
-
-COPY package.json bun.lock ./
-COPY tsconfig.base.json ./
-
-# Single glob copy for all workspace package.jsons — same pattern as
-# the builder stage above. See the file header for why.
-COPY --parents packages/*/package.json ./
-COPY --parents apps/*/package.json ./
-
-COPY scripts ./scripts
-
-# Same patches directory as the builder stage — bun install fails without it.
-COPY patches ./patches
-
-# Copy prisma schema and config before install (postinstall runs db:generate:all)
-COPY prisma ./prisma
-COPY prisma.config.ts ./prisma.config.ts
-COPY prisma.config.local.ts ./prisma.config.local.ts
-
-# chown the small set of config files (~30 files, instant), then install as appuser
-# so all of node_modules is created with uid 1001 ownership from the start.
-RUN chown -R appuser:appgroup /app
-USER appuser
-RUN --mount=type=cache,target=/home/appuser/.bun/install/cache,uid=1001,gid=1001 \
-    bun install
-
-# =============================================================================
-# Stage 2: production image — layer source code onto base image
+# Production image — layer source code onto base image
 # =============================================================================
 FROM ${BASE_IMAGE}
 
 WORKDIR /app
 
-COPY --from=deps /app/node_modules ./node_modules
-COPY --chown=appuser:appgroup --from=builder /app/packages/shared-runtime ./packages/shared-runtime
-COPY --chown=appuser:appgroup --from=builder /app/packages/agent-runtime ./packages/agent-runtime
-COPY --chown=appuser:appgroup --from=builder /app/packages/model-catalog ./packages/model-catalog
-COPY --chown=appuser:appgroup --from=builder /app/packages/sdk ./packages/sdk
-COPY --chown=appuser:appgroup --from=builder /app/templates/runtime-template ./templates/runtime-template
-COPY --chown=appuser:appgroup --from=builder /app/package.json ./
-COPY --chown=appuser:appgroup --from=builder /app/bun.lock ./
-COPY --chown=appuser:appgroup --from=builder /app/tsconfig.base.json ./
+# node_modules and built source from workspace-deps. Files are already owned
+# by uid 1001 (workspace-deps installs as appuser), so COPY preserves
+# ownership without --chown traversal.
+COPY --from=workspace /app/node_modules ./node_modules
+COPY --from=workspace /app/packages/shared-runtime ./packages/shared-runtime
+COPY --from=workspace /app/packages/agent-runtime ./packages/agent-runtime
+COPY --from=workspace /app/packages/model-catalog ./packages/model-catalog
+COPY --from=workspace /app/packages/sdk ./packages/sdk
+COPY --from=workspace /app/templates/runtime-template ./templates/runtime-template
+COPY --from=workspace /app/package.json /app/bun.lock /app/tsconfig.base.json ./
 
 # Stub package.jsons for every workspace member not shipped in the image
 # (the `bun install --ignore-scripts` further down still walks the workspace
 # graph; missing package.jsons fail with `error: Workspace dependency not
-# found`). Single glob copy preserves directory structure thanks to
-# --parents. The `/app/./` pivot tells BuildKit to preserve everything
-# after `/app/` (i.e., `packages/X/...`). Already-shipped source
-# (shared-runtime, agent-runtime, sdk, model-catalog) gets its
-# package.json overwritten by this same line, which is fine because the
-# file content is identical.
-COPY --chown=appuser:appgroup --from=builder --parents /app/./packages/*/package.json ./
-COPY --chown=appuser:appgroup --from=builder --parents /app/./apps/*/package.json ./
+# found`). The `/app/./` pivot tells BuildKit to preserve everything after
+# `/app/`. Already-shipped source dirs get their package.json overwritten
+# here, which is fine because the content is identical.
+COPY --from=workspace --parents /app/./packages/*/package.json ./
+COPY --from=workspace --parents /app/./apps/*/package.json ./
 
-# Same patches as builder/deps stages — `bun install --ignore-scripts` below
-# still re-resolves the patched dependency and fails without these files.
-COPY --chown=appuser:appgroup --from=builder /app/patches ./patches
+# Same patches workspace-deps used during install — `bun install
+# --ignore-scripts` below resolves patchedDependencies and fails without them.
+COPY --from=workspace /app/patches ./patches
 
 COPY --chown=appuser:appgroup packages/agent-runtime/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
## Summary

Phase B of the CI speedup. Builds on Phase A (PR #555).

Adds a pre-matrix \`shogo-workspace-deps\` image that bakes the JS workspace once per CI run (\`bun install\`, \`build:packages\`, \`generate:routes\`, runtime-template install, \`build-template-dists\`, \`fetch-external-skills\`). Each matrix Dockerfile then \`FROM\`s it instead of re-doing all of that work three times in parallel.

### Files
- \`docker/workspace-deps/Dockerfile\` — new (debian, bun, full pre-bake)
- \`.github/workflows/deploy.yml\` — new \`build-workspace-deps\` job; matrix gains \`WORKSPACE_DEPS\` build-arg
- \`apps/api/Dockerfile\` — builder/deps stages collapsed; production switched from node:25-alpine to node:25-slim (debian, libc-matched). ~150 lines removed.
- \`apps/mobile/Dockerfile\` — builder is now \`FROM \${WORKSPACE_DEPS}\`; production stays nginx-alpine.
- \`packages/agent-runtime/Dockerfile\` — builder/deps stages gone; layers workspace-deps onto BASE_IMAGE. Duplicate runtime-template install (item #6 from the plan) eliminated.

### Validated on branch (workflow_dispatch run 25862309319)

| Job | Cold | Warm |
|-----|------|------|
| Build Workspace Deps Image | 7.08 min | ~0.5 min |
| Build api | 3.16 min | ~0.6 min |
| Build runtime | 5.46 min | ~2 min |
| Build web | 4.26 min | — |
| Build docs | 0.4 min | — |

Wall time gated on workspace-deps + slowest matrix:
- Cold: ~12-13 min (vs Phase A ~17 min, Phase 0 baseline ~53 min)
- Warm: ~3-4 min

### Issues fixed during validation

- \`bun install --frozen-lockfile\` failed in templates/runtime-template (lockfile drift) — reverted to plain \`bun install\`, matching what the original Dockerfiles did.
- Sentry CLI \`get-cli/\` install script didn't put \`sentry-cli\` in PATH on debian — switched to direct prebuilt-binary download.
- \`curl\` was not in workspace-deps base — added to apt list.

## Test plan

- [x] \`build-workspace-deps\` builds and pushes cleanly
- [x] \`Build api\`, \`Build web\`, \`Build runtime\` all succeed FROM workspace-deps
- [ ] After merge to main, real deploy run completes and \`/api/health\` is 200 on staging

Made with [Cursor](https://cursor.com)