### PR TITLE
test(shared-app): add unit tests for dynamic-app module

### DIFF
--- a/packages/shared-app/src/dynamic-app/__tests__/component-schema.test.ts
+++ b/packages/shared-app/src/dynamic-app/__tests__/component-schema.test.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, it, expect } from 'vitest'
+import {
+  COMPONENT_SCHEMA,
+  COMPONENT_CATEGORIES,
+  getComponentSchema,
+  getComponentsByCategory,
+} from '../component-schema'
+
+describe('COMPONENT_SCHEMA', () => {
+  it('is a non-empty array', () => {
+    expect(COMPONENT_SCHEMA.length).toBeGreaterThan(0)
+  })
+
+  it('every schema has required fields', () => {
+    for (const s of COMPONENT_SCHEMA) {
+      expect(typeof s.type).toBe('string')
+      expect(s.type.length).toBeGreaterThan(0)
+      expect(COMPONENT_CATEGORIES).toContain(s.category)
+      expect(typeof s.description).toBe('string')
+      expect(typeof s.hasChildren).toBe('boolean')
+      expect(typeof s.props).toBe('object')
+    }
+  })
+
+  it('has unique type names', () => {
+    const types = COMPONENT_SCHEMA.map((s) => s.type)
+    expect(new Set(types).size).toBe(types.length)
+  })
+
+  it('includes core component types', () => {
+    const types = COMPONENT_SCHEMA.map((s) => s.type)
+    expect(types).toContain('Row')
+    expect(types).toContain('Column')
+    expect(types).toContain('Text')
+    expect(types).toContain('Button')
+    expect(types).toContain('Table')
+    expect(types).toContain('Card')
+  })
+})
+
+describe('COMPONENT_CATEGORIES', () => {
+  it('contains all expected categories', () => {
+    expect(COMPONENT_CATEGORIES).toContain('layout')
+    expect(COMPONENT_CATEGORIES).toContain('extended')
+    expect(COMPONENT_CATEGORIES).toContain('display')
+    expect(COMPONENT_CATEGORIES).toContain('data')
+    expect(COMPONENT_CATEGORIES).toContain('interactive')
+  })
+
+  it('has exactly 5 categories', () => {
+    expect(COMPONENT_CATEGORIES).toHaveLength(5)
+  })
+})
+
+describe('getComponentSchema', () => {
+  it('returns schema for a known type', () => {
+    const schema = getComponentSchema('Button')
+    expect(schema).toBeDefined()
+    expect(schema!.type).toBe('Button')
+    expect(schema!.category).toBe('interactive')
+  })
+
+  it('returns undefined for unknown type', () => {
+    expect(getComponentSchema('NonExistent')).toBeUndefined()
+  })
+
+  it('returns schema with correct props for Text', () => {
+    const schema = getComponentSchema('Text')
+    expect(schema).toBeDefined()
+    expect(schema!.props).toHaveProperty('text')
+    expect(schema!.props.text.required).toBe(true)
+  })
+
+  it('returns schema with hasChildren=true for layout components', () => {
+    const row = getComponentSchema('Row')
+    expect(row!.hasChildren).toBe(true)
+  })
+
+  it('returns schema with hasChildren=false for leaf components', () => {
+    const badge = getComponentSchema('Badge')
+    expect(badge!.hasChildren).toBe(false)
+  })
+})
+
+describe('getComponentsByCategory', () => {
+  it('returns layout components', () => {
+    const layouts = getComponentsByCategory('layout')
+    expect(layouts.length).toBeGreaterThan(0)
+    expect(layouts.every((s) => s.category === 'layout')).toBe(true)
+  })
+
+  it('returns interactive components', () => {
+    const interactive = getComponentsByCategory('interactive')
+    expect(interactive.length).toBeGreaterThan(0)
+    expect(interactive.every((s) => s.category === 'interactive')).toBe(true)
+    const types = interactive.map((s) => s.type)
+    expect(types).toContain('Button')
+    expect(types).toContain('TextField')
+  })
+
+  it('returns empty array for unknown category', () => {
+    expect(getComponentsByCategory('unknown')).toEqual([])
+  })
+
+  it('all categories together equal the full schema', () => {
+    let total = 0
+    for (const cat of COMPONENT_CATEGORIES) {
+      total += getComponentsByCategory(cat).length
+    }
+    expect(total).toBe(COMPONENT_SCHEMA.length)
+  })
+})

--- a/packages/shared-app/src/dynamic-app/__tests__/pointer.test.ts
+++ b/packages/shared-app/src/dynamic-app/__tests__/pointer.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, it, expect } from 'vitest'
+import { getByPointer, setByPointer } from '../pointer'
+
+describe('getByPointer', () => {
+  it('returns undefined for empty pointer', () => {
+    expect(getByPointer({ a: 1 }, '')).toEqual({ a: 1 })
+  })
+
+  it('returns the root object for "/" pointer', () => {
+    expect(getByPointer({ a: 1 }, '/')).toEqual({ a: 1 })
+  })
+
+  it('resolves a simple top-level key', () => {
+    expect(getByPointer({ name: 'hello' }, '/name')).toBe('hello')
+  })
+
+  it('resolves nested keys', () => {
+    const obj = { user: { profile: { age: 30 } } }
+    expect(getByPointer(obj, '/user/profile/age')).toBe(30)
+  })
+
+  it('resolves array indices', () => {
+    const obj = { items: ['a', 'b', 'c'] }
+    expect(getByPointer(obj, '/items/1')).toBe('b')
+  })
+
+  it('returns undefined for missing paths', () => {
+    expect(getByPointer({ a: 1 }, '/b')).toBeUndefined()
+  })
+
+  it('returns undefined for deeply missing paths', () => {
+    expect(getByPointer({ a: { b: 1 } }, '/a/c/d')).toBeUndefined()
+  })
+
+  it('handles RFC 6901 escaped characters (~0 for ~ and ~1 for /)', () => {
+    const obj = { 'a/b': { '~c': 'found' } }
+    expect(getByPointer(obj, '/a~1b/~0c')).toBe('found')
+  })
+
+  it('returns undefined when traversing through null', () => {
+    const obj = { a: null } as any
+    expect(getByPointer(obj, '/a/b')).toBeUndefined()
+  })
+
+  it('resolves to a nested object', () => {
+    const obj = { data: { list: [1, 2, 3] } }
+    expect(getByPointer(obj, '/data/list')).toEqual([1, 2, 3])
+  })
+})
+
+describe('setByPointer', () => {
+  it('sets a top-level key', () => {
+    const obj: Record<string, unknown> = {}
+    setByPointer(obj, '/name', 'hello')
+    expect(obj.name).toBe('hello')
+  })
+
+  it('sets a nested key, creating intermediate objects', () => {
+    const obj: Record<string, unknown> = {}
+    setByPointer(obj, '/a/b/c', 42)
+    expect((obj as any).a.b.c).toBe(42)
+  })
+
+  it('creates arrays when next segment is numeric', () => {
+    const obj: Record<string, unknown> = {}
+    setByPointer(obj, '/items/0', 'first')
+    expect(Array.isArray((obj as any).items)).toBe(true)
+    expect((obj as any).items[0]).toBe('first')
+  })
+
+  it('overwrites existing values', () => {
+    const obj: Record<string, unknown> = { x: 'old' }
+    setByPointer(obj, '/x', 'new')
+    expect(obj.x).toBe('new')
+  })
+
+  it('does nothing for empty pointer', () => {
+    const obj: Record<string, unknown> = { a: 1 }
+    setByPointer(obj, '', 'ignored')
+    expect(obj).toEqual({ a: 1 })
+  })
+
+  it('does nothing for "/" pointer', () => {
+    const obj: Record<string, unknown> = { a: 1 }
+    setByPointer(obj, '/', 'ignored')
+    expect(obj).toEqual({ a: 1 })
+  })
+
+  it('handles escaped characters', () => {
+    const obj: Record<string, unknown> = {}
+    setByPointer(obj, '/a~1b', 'value')
+    expect(obj['a/b']).toBe('value')
+  })
+
+  it('handles setting into existing nested objects', () => {
+    const obj: Record<string, unknown> = { user: { name: 'Alice' } }
+    setByPointer(obj, '/user/age', 25)
+    expect((obj as any).user.name).toBe('Alice')
+    expect((obj as any).user.age).toBe(25)
+  })
+})

--- a/packages/shared-app/src/dynamic-app/__tests__/resolve-children.test.ts
+++ b/packages/shared-app/src/dynamic-app/__tests__/resolve-children.test.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, it, expect } from 'vitest'
+import { resolveChildDescriptors } from '../resolve-children'
+import type { ComponentDefinition } from '../types'
+
+function makeComponents(defs: ComponentDefinition[]): Map<string, ComponentDefinition> {
+  const map = new Map<string, ComponentDefinition>()
+  for (const d of defs) {
+    map.set(d.id, d)
+  }
+  return map
+}
+
+describe('resolveChildDescriptors', () => {
+  it('returns empty array when no child or children defined', () => {
+    const def: ComponentDefinition = { id: 'root', component: 'Column' }
+    const result = resolveChildDescriptors(def, new Map(), {})
+    expect(result).toEqual([])
+  })
+
+  it('resolves a single child reference', () => {
+    const parent: ComponentDefinition = { id: 'parent', component: 'Card', child: 'text-1' }
+    const child: ComponentDefinition = { id: 'text-1', component: 'Text', text: 'Hello' }
+    const components = makeComponents([parent, child])
+    const result = resolveChildDescriptors(parent, components, {})
+    expect(result).toHaveLength(1)
+    expect(result[0].kind).toBe('single')
+    expect((result[0] as any).childId).toBe('text-1')
+    expect((result[0] as any).definition).toBe(child)
+  })
+
+  it('returns empty when single child reference is missing from map', () => {
+    const parent: ComponentDefinition = { id: 'parent', component: 'Card', child: 'missing' }
+    const result = resolveChildDescriptors(parent, new Map(), {})
+    expect(result).toEqual([])
+  })
+
+  it('resolves static children array', () => {
+    const parent: ComponentDefinition = {
+      id: 'col',
+      component: 'Column',
+      children: ['text-1', 'badge-1'],
+    }
+    const text: ComponentDefinition = { id: 'text-1', component: 'Text', text: 'Hi' }
+    const badge: ComponentDefinition = { id: 'badge-1', component: 'Badge', text: 'New' }
+    const components = makeComponents([parent, text, badge])
+
+    const result = resolveChildDescriptors(parent, components, {})
+    expect(result).toHaveLength(2)
+    expect(result[0].kind).toBe('static')
+    expect((result[0] as any).childId).toBe('text-1')
+    expect(result[1].kind).toBe('static')
+    expect((result[1] as any).childId).toBe('badge-1')
+  })
+
+  it('skips missing children in static array', () => {
+    const parent: ComponentDefinition = {
+      id: 'col',
+      component: 'Column',
+      children: ['exists', 'missing'],
+    }
+    const child: ComponentDefinition = { id: 'exists', component: 'Text', text: 'Hi' }
+    const components = makeComponents([parent, child])
+
+    const result = resolveChildDescriptors(parent, components, {})
+    expect(result).toHaveLength(1)
+    expect((result[0] as any).childId).toBe('exists')
+  })
+
+  it('resolves template children from data model', () => {
+    const parent: ComponentDefinition = {
+      id: 'list',
+      component: 'DataList',
+      children: { path: '/todos', templateId: 'todo-tmpl' },
+    }
+    const template: ComponentDefinition = { id: 'todo-tmpl', component: 'Card', title: 'Template' }
+    const components = makeComponents([parent, template])
+    const dataModel = {
+      todos: [
+        { title: 'Task 1', done: false },
+        { title: 'Task 2', done: true },
+      ],
+    }
+
+    const result = resolveChildDescriptors(parent, components, dataModel)
+    expect(result).toHaveLength(2)
+    expect(result[0].kind).toBe('template')
+    expect((result[0] as any).index).toBe(0)
+    expect((result[0] as any).scopeData).toEqual({ title: 'Task 1', done: false })
+    expect((result[0] as any).scopePath).toBe('/todos/0')
+    expect(result[1].kind).toBe('template')
+    expect((result[1] as any).index).toBe(1)
+    expect((result[1] as any).scopeData).toEqual({ title: 'Task 2', done: true })
+    expect((result[1] as any).scopePath).toBe('/todos/1')
+  })
+
+  it('returns empty when template data is not an array', () => {
+    const parent: ComponentDefinition = {
+      id: 'list',
+      component: 'DataList',
+      children: { path: '/notArray', templateId: 'tmpl' },
+    }
+    const template: ComponentDefinition = { id: 'tmpl', component: 'Text', text: 'x' }
+    const components = makeComponents([parent, template])
+    const dataModel = { notArray: 'string-value' }
+
+    const result = resolveChildDescriptors(parent, components, dataModel)
+    expect(result).toEqual([])
+  })
+
+  it('returns empty when template id is not found', () => {
+    const parent: ComponentDefinition = {
+      id: 'list',
+      component: 'DataList',
+      children: { path: '/items', templateId: 'missing-tmpl' },
+    }
+    const components = makeComponents([parent])
+    const dataModel = { items: [1, 2, 3] }
+
+    const result = resolveChildDescriptors(parent, components, dataModel)
+    expect(result).toEqual([])
+  })
+
+  it('wraps primitive items in { value: item } for template scope', () => {
+    const parent: ComponentDefinition = {
+      id: 'list',
+      component: 'DataList',
+      children: { path: '/tags', templateId: 'tag-tmpl' },
+    }
+    const template: ComponentDefinition = { id: 'tag-tmpl', component: 'Badge', text: 'x' }
+    const components = makeComponents([parent, template])
+    const dataModel = { tags: ['alpha', 'beta'] }
+
+    const result = resolveChildDescriptors(parent, components, dataModel)
+    expect(result).toHaveLength(2)
+    expect((result[0] as any).scopeData).toEqual({ value: 'alpha' })
+    expect((result[1] as any).scopeData).toEqual({ value: 'beta' })
+  })
+})

--- a/packages/shared-app/src/dynamic-app/__tests__/resolve-props.test.ts
+++ b/packages/shared-app/src/dynamic-app/__tests__/resolve-props.test.ts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, it, expect } from 'vitest'
+import { resolveValue, resolveComponentProps, sanitizeForRender, RESERVED_KEYS } from '../resolve-props'
+import type { ApiDataSourceLike } from '../resolve-props'
+import type { ComponentDefinition } from '../types'
+
+describe('RESERVED_KEYS', () => {
+  it('contains id, component, child, children', () => {
+    expect(RESERVED_KEYS.has('id')).toBe(true)
+    expect(RESERVED_KEYS.has('component')).toBe(true)
+    expect(RESERVED_KEYS.has('child')).toBe(true)
+    expect(RESERVED_KEYS.has('children')).toBe(true)
+  })
+})
+
+describe('resolveValue', () => {
+  const dataModel = {
+    user: { name: 'Alice', age: 30 },
+    items: ['a', 'b', 'c'],
+  }
+
+  it('returns primitive values unchanged', () => {
+    expect(resolveValue('hello', dataModel)).toBe('hello')
+    expect(resolveValue(42, dataModel)).toBe(42)
+    expect(resolveValue(true, dataModel)).toBe(true)
+    expect(resolveValue(null, dataModel)).toBeNull()
+    expect(resolveValue(undefined, dataModel)).toBeUndefined()
+  })
+
+  it('resolves dynamic path bindings from data model', () => {
+    expect(resolveValue({ path: '/user/name' }, dataModel)).toBe('Alice')
+    expect(resolveValue({ path: '/items/0' }, dataModel)).toBe('a')
+  })
+
+  it('resolves path against scope data for relative paths', () => {
+    const scopeData = { title: 'Task 1' }
+    expect(resolveValue({ path: 'title' }, dataModel, null, scopeData)).toBe('Task 1')
+  })
+
+  it('resolves api bindings using apiDataSource', () => {
+    const apiSource: ApiDataSourceLike = {
+      getData: (api: string) => `data-from-${api}`,
+    }
+    expect(resolveValue({ api: 'users' }, dataModel, apiSource)).toBe('data-from-users')
+  })
+
+  it('resolves arrays recursively', () => {
+    const val = [{ path: '/user/name' }, 'static', { path: '/user/age' }]
+    expect(resolveValue(val, dataModel)).toEqual(['Alice', 'static', 30])
+  })
+
+  it('resolves plain objects recursively', () => {
+    const val = { label: { path: '/user/name' }, count: 5 }
+    expect(resolveValue(val, dataModel)).toEqual({ label: 'Alice', count: 5 })
+  })
+
+  it('resolves action objects with context', () => {
+    const action = {
+      name: 'submit',
+      context: { userName: { path: '/user/name' } },
+    }
+    const result = resolveValue(action, dataModel) as any
+    expect(result.name).toBe('submit')
+    expect(result.context.userName).toBe('Alice')
+  })
+
+  it('resolves action with sendToAgent flag', () => {
+    const action = {
+      name: 'ask',
+      sendToAgent: true,
+      context: { q: 'hello' },
+    }
+    const result = resolveValue(action, dataModel) as any
+    expect(result.context._sendToAgent).toBe(true)
+  })
+
+  it('resolves action with mutation', () => {
+    const action = {
+      name: 'delete',
+      mutation: { endpoint: '/api/items/:id', method: 'DELETE', params: { id: { path: '/user/name' } } },
+      context: {},
+    }
+    const result = resolveValue(action, dataModel) as any
+    expect(result.context._mutation.endpoint).toBe('/api/items/Alice')
+    expect(result.context._mutation.method).toBe('DELETE')
+  })
+})
+
+describe('sanitizeForRender', () => {
+  it('converts objects in text-render props to JSON strings', () => {
+    const resolved = { text: { nested: true }, label: 'ok', value: { x: 1 } }
+    const result = sanitizeForRender({ ...resolved })
+    expect(result.text).toBe('{"nested":true}')
+    expect(result.label).toBe('ok')
+    expect(result.value).toBe('{"x":1}')
+  })
+
+  it('leaves strings untouched', () => {
+    const resolved = { text: 'hello', title: 'world' }
+    const result = sanitizeForRender({ ...resolved })
+    expect(result.text).toBe('hello')
+    expect(result.title).toBe('world')
+  })
+
+  it('leaves arrays untouched in text props', () => {
+    const resolved = { text: [1, 2, 3] }
+    const result = sanitizeForRender({ ...resolved })
+    expect(result.text).toEqual([1, 2, 3])
+  })
+
+  it('leaves null and undefined untouched', () => {
+    const resolved = { text: null, title: undefined }
+    const result = sanitizeForRender({ ...resolved })
+    expect(result.text).toBeNull()
+    expect(result.title).toBeUndefined()
+  })
+
+  it('does not touch non-text-render props', () => {
+    const resolved = { onClick: { name: 'click' }, rows: [{ a: 1 }] }
+    const result = sanitizeForRender({ ...resolved })
+    expect(result.onClick).toEqual({ name: 'click' })
+    expect(result.rows).toEqual([{ a: 1 }])
+  })
+})
+
+describe('resolveComponentProps', () => {
+  const dataModel = { title: 'Hello', count: 5 }
+
+  it('resolves props from a component definition', () => {
+    const def: ComponentDefinition = {
+      id: 'text-1',
+      component: 'Text',
+      text: { path: '/title' },
+    }
+    const result = resolveComponentProps(def, dataModel)
+    expect(result.text).toBe('Hello')
+  })
+
+  it('skips reserved keys (id, component, child, children)', () => {
+    const def: ComponentDefinition = {
+      id: 'card-1',
+      component: 'Card',
+      child: 'text-1',
+      title: 'My Card',
+    }
+    const result = resolveComponentProps(def, dataModel)
+    expect(result).not.toHaveProperty('id')
+    expect(result).not.toHaveProperty('component')
+    expect(result).not.toHaveProperty('child')
+    expect(result.title).toBe('My Card')
+  })
+
+  it('sanitizes object values in text-render props', () => {
+    const def: ComponentDefinition = {
+      id: 'badge-1',
+      component: 'Badge',
+      text: { path: '/count' },
+      label: { nested: true } as any,
+    }
+    const result = resolveComponentProps(def, dataModel)
+    expect(result.text).toBe(5)
+    expect(result.label).toBe('{"nested":true}')
+  })
+
+  it('uses apiDataSource when provided', () => {
+    const apiSource: ApiDataSourceLike = {
+      getData: () => [{ id: 1 }, { id: 2 }],
+    }
+    const def: ComponentDefinition = {
+      id: 'table-1',
+      component: 'Table',
+      rows: { api: 'items' },
+    }
+    const result = resolveComponentProps(def, dataModel, apiSource)
+    expect(result.rows).toEqual([{ id: 1 }, { id: 2 }])
+  })
+})

--- a/packages/shared-app/src/dynamic-app/__tests__/types.test.ts
+++ b/packages/shared-app/src/dynamic-app/__tests__/types.test.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, it, expect } from 'vitest'
+import { isDynamicPath, isApiBinding } from '../types'
+
+describe('isDynamicPath', () => {
+  it('returns true for objects with a string path property', () => {
+    expect(isDynamicPath({ path: '/data/name' })).toBe(true)
+  })
+
+  it('returns true even when extra properties exist', () => {
+    expect(isDynamicPath({ path: '/x', other: 123 })).toBe(true)
+  })
+
+  it('returns false for null', () => {
+    expect(isDynamicPath(null)).toBe(false)
+  })
+
+  it('returns false for undefined', () => {
+    expect(isDynamicPath(undefined)).toBe(false)
+  })
+
+  it('returns false for strings', () => {
+    expect(isDynamicPath('/data/name')).toBe(false)
+  })
+
+  it('returns false for numbers', () => {
+    expect(isDynamicPath(42)).toBe(false)
+  })
+
+  it('returns false for objects without path', () => {
+    expect(isDynamicPath({ api: 'users' })).toBe(false)
+  })
+
+  it('returns false when path is not a string', () => {
+    expect(isDynamicPath({ path: 123 })).toBe(false)
+  })
+
+  it('returns false for arrays', () => {
+    expect(isDynamicPath([{ path: '/x' }])).toBe(false)
+  })
+})
+
+describe('isApiBinding', () => {
+  it('returns true for objects with a string api property', () => {
+    expect(isApiBinding({ api: 'users' })).toBe(true)
+  })
+
+  it('returns true with optional params and refreshInterval', () => {
+    expect(isApiBinding({ api: 'orders', params: { limit: 10 }, refreshInterval: 5000 })).toBe(true)
+  })
+
+  it('returns false for null', () => {
+    expect(isApiBinding(null)).toBe(false)
+  })
+
+  it('returns false for undefined', () => {
+    expect(isApiBinding(undefined)).toBe(false)
+  })
+
+  it('returns false for strings', () => {
+    expect(isApiBinding('users')).toBe(false)
+  })
+
+  it('returns false for objects without api', () => {
+    expect(isApiBinding({ path: '/data' })).toBe(false)
+  })
+
+  it('returns false when api is not a string', () => {
+    expect(isApiBinding({ api: 123 })).toBe(false)
+  })
+
+  it('returns false for arrays', () => {
+    expect(isApiBinding([{ api: 'users' }])).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests for **all 5 pure modules** in `packages/shared-app/src/dynamic-app/` — a module that previously had **zero test coverage**
- Improves `packages/shared-app` coverage dramatically without touching any production code
- All 78 new tests pass; zero regressions to existing tests

## Coverage Impact

### Overall `packages/shared-app` Coverage

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| **% Functions** | 80.21% | **92.56%** | **+12.35%** |
| **% Lines** | 64.99% | **89.74%** | **+24.75%** |
| Test files | 2 | **7** | +5 |
| Total tests | 34 | **112** | +78 |
| Passing tests | 34 | **112** | +78 |

### Per-File Coverage (all new)

| File | % Funcs | % Lines | Notes |
|------|---------|---------|-------|
| `pointer.ts` | **100%** | **100%** | RFC 6901 JSON Pointer get/set |
| `resolve-children.ts` | **100%** | **100%** | Single, static, template child resolution |
| `resolve-props.ts` | **100%** | **100%** | Data binding, API binding, mutation resolution |
| `types.ts` | **100%** | **100%** | `isDynamicPath`, `isApiBinding` type guards |
| `component-schema.ts` | **87.5%** | **98.18%** | Schema registry, category lookups |

## New Test Files (5 files, 616 lines, 78 tests)

| File | Tests | What's covered |
|------|:-----:|----------------|
| `pointer.test.ts` | 18 | `getByPointer` (nested keys, arrays, RFC 6901 escapes, null traversal) + `setByPointer` (create intermediate objects/arrays, overwrite, escapes) |
| `types.test.ts` | 17 | `isDynamicPath` (9 cases: valid paths, null/undefined/string/number/no-path/non-string-path/arrays) + `isApiBinding` (8 cases: valid bindings, edge cases) |
| `component-schema.test.ts` | 15 | `COMPONENT_SCHEMA` structure + uniqueness, `COMPONENT_CATEGORIES` completeness, `getComponentSchema` known/unknown/props/children, `getComponentsByCategory` filtering + completeness |
| `resolve-props.test.ts` | 19 | `RESERVED_KEYS`, `resolveValue` (primitives, path bindings, scope data, API bindings, arrays, objects, actions with context/sendToAgent/mutation), `sanitizeForRender` (objects→JSON, strings/arrays/null preserved), `resolveComponentProps` (full integration: skip reserved, resolve, sanitize, API source) |
| `resolve-children.test.ts` | 9 | `resolveChildDescriptors` (no children, single child, missing child, static array, missing in array, template from data model, non-array data, missing template, primitive scope wrapping) |

## Pre-existing Test Results (unchanged)

The 2 existing test files (`auto-resuming-fetch.test.ts`, `remote-http-interceptor.test.ts`) continue passing with no changes.

## Test Plan

- [x] `bun run --cwd packages/shared-app test` — all 112 tests pass, 0 failures
- [x] `bun run --cwd packages/shared-app test:coverage` — coverage improved from 80.21%/64.99% to 92.56%/89.74%
- [x] Only new test files added; zero production code changes
- [ ] CI passes
