### PR TITLE
feat(mobile): grouped tool tags in Skills panel

### DIFF
--- a/apps/mobile/components/project/panels/GroupedToolTags.tsx
+++ b/apps/mobile/components/project/panels/GroupedToolTags.tsx
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import { useMemo, useState } from 'react'
+import { View, Text, Pressable } from 'react-native'
+import { ChevronDown, ChevronUp } from 'lucide-react-native'
+import { cn } from '@shogo/shared-ui/primitives'
+import {
+  groupToolsByCategory,
+  categoryTextClass,
+  categoryBgClass,
+} from './tool-categories'
+
+interface GroupedToolTagsProps {
+  tools: string[]
+  className?: string
+}
+
+export function GroupedToolTags({ tools, className }: GroupedToolTagsProps) {
+  const [expanded, setExpanded] = useState(false)
+  const groups = useMemo(() => groupToolsByCategory(tools), [tools])
+
+  if (groups.length === 0) return null
+
+  if (!expanded) {
+    return (
+      <Pressable
+        onPress={() => setExpanded(true)}
+        accessibilityRole="button"
+        accessibilityLabel="Show tool details by category"
+        accessibilityHint="Expands grouped tool list"
+        className={cn('flex-row flex-wrap gap-1 mt-1.5', className)}
+      >
+        {groups.map(({ category, tools: categoryTools }) => (
+          <View
+            key={category.id}
+            className={cn(
+              'flex-row items-center gap-1 rounded px-1.5 py-0.5',
+              categoryBgClass(category.color),
+            )}
+          >
+            <Text
+              className={cn('text-[10px] font-semibold', categoryTextClass(category.color))}
+            >
+              {category.label}
+            </Text>
+            {categoryTools.length > 1 ? (
+              <Text className={cn('text-[10px]', categoryTextClass(category.color))}>
+                {categoryTools.length}
+              </Text>
+            ) : null}
+          </View>
+        ))}
+        <ChevronDown size={12} className="text-muted-foreground self-center" />
+      </Pressable>
+    )
+  }
+
+  return (
+    <View className={cn('mt-1.5 gap-1.5', className)}>
+      {groups.map(({ category, tools: categoryTools }) => (
+        <View key={category.id} className="flex-row flex-wrap items-center gap-1">
+          <View
+            className={cn(
+              'rounded px-1.5 py-0.5 mr-0.5',
+              categoryBgClass(category.color),
+            )}
+          >
+            <Text
+              className={cn('text-[10px] font-semibold', categoryTextClass(category.color))}
+            >
+              {category.label}
+            </Text>
+          </View>
+          {categoryTools.map((tool) => (
+            <View key={tool} className="px-1.5 py-0.5 bg-muted/80 rounded">
+              <Text className="text-muted-foreground text-[10px]">{tool}</Text>
+            </View>
+          ))}
+        </View>
+      ))}
+      <Pressable
+        onPress={() => setExpanded(false)}
+        accessibilityRole="button"
+        accessibilityLabel="Collapse tool list"
+        className="flex-row items-center gap-0.5 self-start mt-0.5"
+      >
+        <ChevronUp size={12} className="text-muted-foreground" />
+        <Text className="text-[10px] text-muted-foreground">Show less</Text>
+      </Pressable>
+    </View>
+  )
+}

--- a/apps/mobile/components/project/panels/SkillsPanel.tsx
+++ b/apps/mobile/components/project/panels/SkillsPanel.tsx
@@ -5,11 +5,13 @@ import { View, Text, Pressable, ScrollView, ActivityIndicator, TextInput } from 
 import { Zap, RefreshCw, BookOpen, Download, Check, Trash2, Plus, ChevronDown, ChevronRight, Search, Globe, FileCode } from 'lucide-react-native'
 import { cn } from '@shogo/shared-ui/primitives'
 import { agentFetch } from '../../../lib/agent-fetch'
+import { GroupedToolTags } from './GroupedToolTags'
 
 interface Skill {
   name: string
   description: string
   trigger: string
+  tools?: string[]
 }
 
 interface SkillScript {
@@ -106,6 +108,7 @@ export function SkillsPanel({ projectId, agentUrl, visible }: SkillsPanelProps) 
           name: s.name,
           description: s.description || '',
           trigger: s.trigger || '',
+          tools: Array.isArray(s.tools) ? s.tools : undefined,
         })),
       )
       if (bundledRes.ok) {
@@ -220,6 +223,22 @@ export function SkillsPanel({ projectId, agentUrl, visible }: SkillsPanelProps) 
     }
     return counts
   }, [registrySkills])
+
+  const bundledToolsByName = useMemo(() => {
+    const map = new Map<string, string[]>()
+    for (const s of bundledSkills) {
+      if (s.tools?.length) map.set(s.name, s.tools)
+    }
+    return map
+  }, [bundledSkills])
+
+  const resolveSkillTools = useCallback(
+    (name: string, tools?: string[]) => {
+      if (tools?.length) return tools
+      return bundledToolsByName.get(name) ?? []
+    },
+    [bundledToolsByName],
+  )
 
   return (
     <View className="absolute inset-0 flex-col" style={{ display: visible ? 'flex' : 'none' }}>
@@ -486,13 +505,7 @@ export function SkillsPanel({ projectId, agentUrl, visible }: SkillsPanelProps) 
                           ) : null}
 
                           {skill.tools?.length > 0 ? (
-                            <View className="flex-row flex-wrap gap-1 mt-1.5 ml-5">
-                              {skill.tools.map((tool) => (
-                                <View key={tool} className="px-1.5 py-0.5 bg-muted rounded">
-                                  <Text className="text-muted-foreground text-[10px]">{tool}</Text>
-                                </View>
-                              ))}
-                            </View>
+                            <GroupedToolTags tools={skill.tools} className="ml-5" />
                           ) : null}
                         </Pressable>
 
@@ -559,6 +572,7 @@ export function SkillsPanel({ projectId, agentUrl, visible }: SkillsPanelProps) 
               const isExpanded = expandedSkill === skill.name
               const content = skillContent[skill.name]
               const isLoadingThis = loadingContent === skill.name
+              const installedTools = resolveSkillTools(skill.name, skill.tools)
 
               return (
                 <View key={skill.name} className="border border-border rounded-lg">
@@ -609,6 +623,10 @@ export function SkillsPanel({ projectId, agentUrl, visible }: SkillsPanelProps) 
                           </View>
                         ))}
                       </View>
+                    ) : null}
+
+                    {installedTools.length > 0 ? (
+                      <GroupedToolTags tools={installedTools} className="ml-5" />
                     ) : null}
                   </Pressable>
 

--- a/apps/mobile/components/project/panels/tool-categories.ts
+++ b/apps/mobile/components/project/panels/tool-categories.ts
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+export interface ToolCategory {
+  id: string
+  label: string
+  /** Tailwind color name, e.g. "purple" → text-purple-400, bg-purple-500/15 */
+  color: string
+  tools: readonly string[]
+}
+
+export const TOOL_CATEGORIES: readonly ToolCategory[] = [
+  {
+    id: 'canvas',
+    label: 'Canvas',
+    color: 'purple',
+    tools: [
+      'canvas_create',
+      'canvas_update',
+      'canvas_api_schema',
+      'canvas_api_seed',
+      'canvas_api_bind',
+    ],
+  },
+  {
+    id: 'web',
+    label: 'Web',
+    color: 'blue',
+    tools: ['web'],
+  },
+  {
+    id: 'browser',
+    label: 'Browser',
+    color: 'cyan',
+    tools: ['browser'],
+  },
+  {
+    id: 'shell',
+    label: 'Shell',
+    color: 'orange',
+    tools: ['exec', 'exec_wait'],
+  },
+  {
+    id: 'memory',
+    label: 'Memory',
+    color: 'emerald',
+    tools: ['memory_read', 'memory_write', 'memory_search'],
+  },
+  {
+    id: 'messaging',
+    label: 'Messaging',
+    color: 'sky',
+    tools: ['send_message', 'channel_connect', 'channel_disconnect', 'channel_list'],
+  },
+  {
+    id: 'discovery',
+    label: 'Discovery',
+    color: 'amber',
+    tools: [
+      'tool_search',
+      'tool_install',
+      'tool_uninstall',
+      'mcp_search',
+      'mcp_install',
+      'mcp_uninstall',
+    ],
+  },
+  {
+    id: 'files',
+    label: 'Files',
+    color: 'zinc',
+    tools: [
+      'read_file',
+      'write_file',
+      'edit_file',
+      'delete_file',
+      'search',
+      'read_lints',
+      'impact_radius',
+      'detect_changes',
+      'review_context',
+    ],
+  },
+  {
+    id: 'heartbeat',
+    label: 'Heartbeat',
+    color: 'rose',
+    tools: ['heartbeat_configure', 'heartbeat_status'],
+  },
+  {
+    id: 'planning',
+    label: 'Planning',
+    color: 'indigo',
+    tools: ['todo_write'],
+  },
+  {
+    id: 'other',
+    label: 'Other',
+    color: 'zinc',
+    tools: [],
+  },
+] as const
+
+const TOOL_TO_CATEGORY = new Map<string, ToolCategory>()
+for (const category of TOOL_CATEGORIES) {
+  if (category.id === 'other') continue
+  for (const tool of category.tools) {
+    TOOL_TO_CATEGORY.set(tool, category)
+  }
+}
+
+const OTHER_CATEGORY = TOOL_CATEGORIES.find((c) => c.id === 'other')!
+
+export interface GroupedTools {
+  category: ToolCategory
+  tools: string[]
+}
+
+/** Group tool names by category; unknown tools land in Other. */
+export function groupToolsByCategory(tools: string[]): GroupedTools[] {
+  if (!tools.length) return []
+
+  const buckets = new Map<string, string[]>()
+  const order: string[] = []
+
+  for (const tool of tools) {
+    const category = TOOL_TO_CATEGORY.get(tool) ?? OTHER_CATEGORY
+    if (!buckets.has(category.id)) {
+      buckets.set(category.id, [])
+      order.push(category.id)
+    }
+    buckets.get(category.id)!.push(tool)
+  }
+
+  return order.map((id) => {
+    const category = TOOL_CATEGORIES.find((c) => c.id === id) ?? OTHER_CATEGORY
+    return { category, tools: buckets.get(id)! }
+  })
+}
+
+export function categoryTextClass(color: string): string {
+  switch (color) {
+    case 'purple':
+      return 'text-purple-400'
+    case 'blue':
+      return 'text-blue-400'
+    case 'cyan':
+      return 'text-cyan-400'
+    case 'orange':
+      return 'text-orange-400'
+    case 'emerald':
+      return 'text-emerald-400'
+    case 'sky':
+      return 'text-sky-400'
+    case 'amber':
+      return 'text-amber-400'
+    case 'rose':
+      return 'text-rose-400'
+    case 'indigo':
+      return 'text-indigo-400'
+    default:
+      return 'text-muted-foreground'
+  }
+}
+
+export function categoryBgClass(color: string): string {
+  switch (color) {
+    case 'purple':
+      return 'bg-purple-500/15'
+    case 'blue':
+      return 'bg-blue-500/15'
+    case 'cyan':
+      return 'bg-cyan-500/15'
+    case 'orange':
+      return 'bg-orange-500/15'
+    case 'emerald':
+      return 'bg-emerald-500/15'
+    case 'sky':
+      return 'bg-sky-500/15'
+    case 'amber':
+      return 'bg-amber-500/15'
+    case 'rose':
+      return 'bg-rose-500/15'
+    case 'indigo':
+      return 'bg-indigo-500/15'
+    default:
+      return 'bg-muted'
+  }
+}


### PR DESCRIPTION
## Summary

Improves the Skills panel by replacing flat gray tool chips with **category-grouped** tags (Canvas, Web, Memory, Files, Messaging, Discovery, etc.) and an **expand/collapse** row to reveal individual tool names. No backend or install behavior changes.
<img width="1377" height="563" alt="image" src="https://github.com/user-attachments/assets/511c58e1-b5b4-4882-849f-6b6d0f92543c" />


## Changes

- Add `tool-categories.ts`: tool name → category mapping and `groupToolsByCategory()`.
- Add `GroupedToolTags.tsx`: collapsed category chips + expanded per-tool pills.
- Update `SkillsPanel.tsx`: use grouped UI for bundled library cards; for installed skills, parse `tools` from agent status when present and fall back to bundled skill metadata by name.

## Test plan

- [ ] Capabilities → Skills → Library (bundled): open a skill with tools; verify collapsed chips show categories; tap to expand and see tool names; collapse again.
- [ ] Installed skills list: skills with tools from status show grouped tags; if status omits tools, verify fallback from bundled list when the skill exists there.
- [ ] Skills with only unknown tool names show under **Other**.
- [ ] Light/dark: category chips remain readable.
