### PR TITLE
test(shared-app): add tests for chat helpers, marketplace categories and integrations

### DIFF
--- a/packages/shared-app/src/chat/__tests__/message-helpers.test.ts
+++ b/packages/shared-app/src/chat/__tests__/message-helpers.test.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, it, expect } from 'vitest'
+import {
+  extractTextContent,
+  formatErrorMessage,
+  isTunnelDisconnectError,
+  formatToolName,
+  getToolCategory,
+  ERROR_CODE_MESSAGES,
+} from '../message-helpers'
+
+describe('extractTextContent', () => {
+  it('returns content string when present', () => {
+    expect(extractTextContent({ content: 'Hello world' })).toBe('Hello world')
+  })
+
+  it('extracts text from parts array', () => {
+    const message = {
+      parts: [
+        { type: 'text', text: 'Hello ' },
+        { type: 'tool-call' },
+        { type: 'text', text: 'world' },
+      ],
+    }
+    expect(extractTextContent(message)).toBe('Hello world')
+  })
+
+  it('prefers content string over parts', () => {
+    const message = {
+      content: 'from content',
+      parts: [{ type: 'text', text: 'from parts' }],
+    }
+    expect(extractTextContent(message)).toBe('from content')
+  })
+
+  it('returns empty string when no content or parts', () => {
+    expect(extractTextContent({})).toBe('')
+  })
+
+  it('returns empty string when content is empty string', () => {
+    expect(extractTextContent({ content: '' })).toBe('')
+  })
+
+  it('handles parts with missing text', () => {
+    const message = { parts: [{ type: 'text' }, { type: 'text', text: 'ok' }] }
+    expect(extractTextContent(message)).toBe('ok')
+  })
+})
+
+describe('ERROR_CODE_MESSAGES', () => {
+  it('has messages for all known error codes', () => {
+    const codes = ['pod_unavailable', 'rate_limit_exceeded', 'usage_limit_reached',
+      'insufficient_credits', 'session_expired', 'internal_error', 'shutting_down', 'offline']
+    for (const code of codes) {
+      expect(ERROR_CODE_MESSAGES[code]).toBeDefined()
+      expect(typeof ERROR_CODE_MESSAGES[code]).toBe('string')
+    }
+  })
+})
+
+describe('isTunnelDisconnectError', () => {
+  it('detects tunnel disconnect patterns', () => {
+    expect(isTunnelDisconnectError('tunnel disconnected')).toBe(true)
+    expect(isTunnelDisconnectError('instance is offline')).toBe(true)
+    expect(isTunnelDisconnectError('stream error occurred')).toBe(true)
+    expect(isTunnelDisconnectError('stream timed out')).toBe(true)
+  })
+
+  it('detects connection error patterns', () => {
+    expect(isTunnelDisconnectError('network error')).toBe(true)
+    expect(isTunnelDisconnectError('fetch failed')).toBe(true)
+    expect(isTunnelDisconnectError('ECONNRESET')).toBe(true)
+    expect(isTunnelDisconnectError('socket hang up')).toBe(true)
+  })
+
+  it('detects JSON-wrapped offline error', () => {
+    const json = JSON.stringify({ error: { code: 'offline' } })
+    expect(isTunnelDisconnectError(json)).toBe(true)
+  })
+
+  it('detects JSON-wrapped tunnel message', () => {
+    const json = JSON.stringify({ error: { message: 'tunnel disconnected' } })
+    expect(isTunnelDisconnectError(json)).toBe(true)
+  })
+
+  it('returns false for normal errors', () => {
+    expect(isTunnelDisconnectError('something else went wrong')).toBe(false)
+    expect(isTunnelDisconnectError('invalid input')).toBe(false)
+  })
+})
+
+describe('formatErrorMessage', () => {
+  it('returns friendly message for known error codes in JSON', () => {
+    const json = JSON.stringify({ error: { code: 'rate_limit_exceeded' } })
+    expect(formatErrorMessage(json)).toBe(ERROR_CODE_MESSAGES.rate_limit_exceeded)
+  })
+
+  it('returns error.message from JSON', () => {
+    const json = JSON.stringify({ error: { message: 'Custom error text' } })
+    expect(formatErrorMessage(json)).toBe('Custom error text')
+  })
+
+  it('returns top-level message from JSON', () => {
+    const json = JSON.stringify({ message: 'Top level' })
+    expect(formatErrorMessage(json)).toBe('Top level')
+  })
+
+  it('returns connection interrupted for network errors', () => {
+    expect(formatErrorMessage('fetch failed')).toBe('Connection interrupted. Please tap Retry to continue.')
+    expect(formatErrorMessage('ECONNREFUSED')).toBe('Connection interrupted. Please tap Retry to continue.')
+  })
+
+  it('returns raw message when not JSON and no pattern match', () => {
+    expect(formatErrorMessage('Some random error')).toBe('Some random error')
+  })
+})
+
+describe('formatToolName', () => {
+  it('formats MCP tool names with dots', () => {
+    expect(formatToolName('mcp__shogo__store_query')).toBe('shogo.store_query')
+  })
+
+  it('handles MCP tools with single part', () => {
+    expect(formatToolName('mcp__toolname')).toBe('toolname')
+  })
+
+  it('returns non-MCP names unchanged', () => {
+    expect(formatToolName('Read')).toBe('Read')
+    expect(formatToolName('Write')).toBe('Write')
+    expect(formatToolName('custom_tool')).toBe('custom_tool')
+  })
+})
+
+describe('getToolCategory', () => {
+  it('categorizes MCP tools', () => {
+    expect(getToolCategory('mcp__shogo__query')).toBe('mcp')
+    expect(getToolCategory('mcp__github__pr')).toBe('mcp')
+  })
+
+  it('categorizes file tools', () => {
+    expect(getToolCategory('Read')).toBe('file')
+    expect(getToolCategory('Write')).toBe('file')
+    expect(getToolCategory('Edit')).toBe('file')
+    expect(getToolCategory('Glob')).toBe('file')
+    expect(getToolCategory('Grep')).toBe('file')
+  })
+
+  it('categorizes skill tools', () => {
+    expect(getToolCategory('Skill')).toBe('skill')
+    expect(getToolCategory('Task')).toBe('skill')
+  })
+
+  it('returns other for unknown tools', () => {
+    expect(getToolCategory('CustomTool')).toBe('other')
+    expect(getToolCategory('something')).toBe('other')
+  })
+})

--- a/packages/shared-app/src/chat/__tests__/useChatTransport.test.ts
+++ b/packages/shared-app/src/chat/__tests__/useChatTransport.test.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, it, expect } from 'vitest'
+import { buildChatApiUrl, buildChatTurnUrl } from '../useChatTransport'
+
+describe('buildChatApiUrl', () => {
+  it('returns local agent URL when provided', () => {
+    expect(buildChatApiUrl('http://localhost:8002', 'proj_1', 'http://localhost:3000'))
+      .toBe('http://localhost:3000/agent/chat')
+  })
+
+  it('builds project-scoped URL when projectId is provided', () => {
+    expect(buildChatApiUrl('http://localhost:8002', 'proj_123'))
+      .toBe('http://localhost:8002/api/projects/proj_123/chat')
+  })
+
+  it('builds generic chat URL when no projectId or localAgentUrl', () => {
+    expect(buildChatApiUrl('http://localhost:8002', undefined))
+      .toBe('http://localhost:8002/api/chat')
+  })
+
+  it('works with empty string base URL (same-origin)', () => {
+    expect(buildChatApiUrl('', 'proj_1'))
+      .toBe('/api/projects/proj_1/chat')
+  })
+
+  it('prefers localAgentUrl over projectId', () => {
+    expect(buildChatApiUrl('http://api.example.com', 'proj_1', 'http://local:3000'))
+      .toBe('http://local:3000/agent/chat')
+  })
+
+  it('handles null localAgentUrl same as undefined', () => {
+    expect(buildChatApiUrl('http://localhost:8002', 'proj_1', null))
+      .toBe('http://localhost:8002/api/projects/proj_1/chat')
+  })
+})
+
+describe('buildChatTurnUrl', () => {
+  it('builds turn URL for a project', () => {
+    expect(buildChatTurnUrl('http://localhost:8002', 'proj_1', null, 'session_abc'))
+      .toBe('http://localhost:8002/api/projects/proj_1/chat/session_abc/turn')
+  })
+
+  it('builds turn URL with local agent', () => {
+    expect(buildChatTurnUrl('', undefined, 'http://local:3000', 'sess_1'))
+      .toBe('http://local:3000/agent/chat/sess_1/turn')
+  })
+
+  it('encodes special characters in session ID', () => {
+    expect(buildChatTurnUrl('http://api.test', 'proj_1', null, 'sess/special&id'))
+      .toBe('http://api.test/api/projects/proj_1/chat/sess%2Fspecial%26id/turn')
+  })
+
+  it('strips trailing slashes from the computed chat base', () => {
+    expect(buildChatTurnUrl('http://api.test', 'proj_1', null, 'sess_1'))
+      .toBe('http://api.test/api/projects/proj_1/chat/sess_1/turn')
+  })
+
+  it('works without projectId or localAgentUrl', () => {
+    expect(buildChatTurnUrl('http://api.test', undefined, null, 'sess_1'))
+      .toBe('http://api.test/api/chat/sess_1/turn')
+  })
+})

--- a/packages/shared-app/src/marketplace/__tests__/categories.test.ts
+++ b/packages/shared-app/src/marketplace/__tests__/categories.test.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, it, expect } from 'vitest'
+import {
+  MARKETPLACE_CATEGORIES,
+  findCategory,
+  categoryLabel,
+  categoryAccent,
+} from '../categories'
+
+describe('MARKETPLACE_CATEGORIES', () => {
+  it('is a non-empty array', () => {
+    expect(MARKETPLACE_CATEGORIES.length).toBeGreaterThan(0)
+  })
+
+  it('every category has required fields', () => {
+    for (const cat of MARKETPLACE_CATEGORIES) {
+      expect(typeof cat.slug).toBe('string')
+      expect(cat.slug.length).toBeGreaterThan(0)
+      expect(typeof cat.label).toBe('string')
+      expect(cat.label.length).toBeGreaterThan(0)
+      expect(typeof cat.icon).toBe('string')
+      expect(typeof cat.tagline).toBe('string')
+      expect(cat.accent).toMatch(/^#[0-9a-f]{6}$/i)
+    }
+  })
+
+  it('has unique slugs', () => {
+    const slugs = MARKETPLACE_CATEGORIES.map((c) => c.slug)
+    expect(new Set(slugs).size).toBe(slugs.length)
+  })
+
+  it('includes known categories', () => {
+    const slugs = MARKETPLACE_CATEGORIES.map((c) => c.slug)
+    expect(slugs).toContain('personal')
+    expect(slugs).toContain('development')
+    expect(slugs).toContain('business')
+    expect(slugs).toContain('research')
+  })
+})
+
+describe('findCategory', () => {
+  it('returns category for known slug', () => {
+    const result = findCategory('development')
+    expect(result).not.toBeNull()
+    expect(result!.label).toBe('Development')
+    expect(result!.icon).toBe('Code')
+  })
+
+  it('is case-insensitive', () => {
+    expect(findCategory('DEVELOPMENT')).not.toBeNull()
+    expect(findCategory('Business')).not.toBeNull()
+  })
+
+  it('returns null for unknown slug', () => {
+    expect(findCategory('nonexistent')).toBeNull()
+  })
+
+  it('returns null for null/undefined', () => {
+    expect(findCategory(null)).toBeNull()
+    expect(findCategory(undefined)).toBeNull()
+  })
+
+  it('returns null for empty string', () => {
+    expect(findCategory('')).toBeNull()
+  })
+})
+
+describe('categoryLabel', () => {
+  it('returns label for known category', () => {
+    expect(categoryLabel('personal')).toBe('Personal')
+    expect(categoryLabel('sales')).toBe('Sales')
+  })
+
+  it('returns slug as fallback for unknown category', () => {
+    expect(categoryLabel('custom')).toBe('custom')
+  })
+
+  it('returns "Uncategorized" for null/undefined', () => {
+    expect(categoryLabel(null)).toBe('Uncategorized')
+    expect(categoryLabel(undefined)).toBe('Uncategorized')
+  })
+})
+
+describe('categoryAccent', () => {
+  it('returns accent color for known category', () => {
+    const accent = categoryAccent('development')
+    expect(accent).toMatch(/^#[0-9a-f]{6}$/i)
+    expect(accent).toBe('#06b6d4')
+  })
+
+  it('returns default gray for unknown category', () => {
+    expect(categoryAccent('unknown')).toBe('#71717a')
+  })
+
+  it('returns default gray for null/undefined', () => {
+    expect(categoryAccent(null)).toBe('#71717a')
+    expect(categoryAccent(undefined)).toBe('#71717a')
+  })
+})

--- a/packages/shared-app/src/marketplace/__tests__/integrations.test.ts
+++ b/packages/shared-app/src/marketplace/__tests__/integrations.test.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, it, expect } from 'vitest'
+import {
+  KNOWN_INTEGRATIONS,
+  TAG_PERMISSION_COPY,
+  resolveIntegration,
+  resolvePermissionCopy,
+} from '../integrations'
+
+describe('KNOWN_INTEGRATIONS', () => {
+  it('is a non-empty record', () => {
+    expect(Object.keys(KNOWN_INTEGRATIONS).length).toBeGreaterThan(0)
+  })
+
+  it('every entry has label and icon', () => {
+    for (const [key, integration] of Object.entries(KNOWN_INTEGRATIONS)) {
+      expect(typeof integration.label).toBe('string')
+      expect(integration.label.length).toBeGreaterThan(0)
+      expect(typeof integration.icon).toBe('string')
+      expect(integration.icon.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('includes common integrations', () => {
+    expect(KNOWN_INTEGRATIONS.github).toBeDefined()
+    expect(KNOWN_INTEGRATIONS.slack).toBeDefined()
+    expect(KNOWN_INTEGRATIONS.gmail).toBeDefined()
+    expect(KNOWN_INTEGRATIONS.stripe).toBeDefined()
+  })
+
+  it('color values are valid hex when present', () => {
+    for (const integration of Object.values(KNOWN_INTEGRATIONS)) {
+      if (integration.color) {
+        expect(integration.color).toMatch(/^#[0-9a-f]{6}$/i)
+      }
+    }
+  })
+})
+
+describe('TAG_PERMISSION_COPY', () => {
+  it('is a non-empty record', () => {
+    expect(Object.keys(TAG_PERMISSION_COPY).length).toBeGreaterThan(0)
+  })
+
+  it('every permission copy key exists in KNOWN_INTEGRATIONS', () => {
+    for (const key of Object.keys(TAG_PERMISSION_COPY)) {
+      expect(KNOWN_INTEGRATIONS[key]).toBeDefined()
+    }
+  })
+
+  it('permission copy is a full sentence (starts uppercase, non-empty)', () => {
+    for (const copy of Object.values(TAG_PERMISSION_COPY)) {
+      expect(copy.length).toBeGreaterThan(5)
+      expect(copy[0]).toBe(copy[0].toUpperCase())
+    }
+  })
+})
+
+describe('resolveIntegration', () => {
+  it('returns integration for known tags', () => {
+    const result = resolveIntegration('github')
+    expect(result).not.toBeNull()
+    expect(result!.label).toBe('GitHub')
+    expect(result!.icon).toBe('Github')
+  })
+
+  it('is case-insensitive', () => {
+    expect(resolveIntegration('GitHub')).not.toBeNull()
+    expect(resolveIntegration('SLACK')).not.toBeNull()
+  })
+
+  it('trims whitespace', () => {
+    expect(resolveIntegration('  github  ')).not.toBeNull()
+  })
+
+  it('returns null for unknown tags', () => {
+    expect(resolveIntegration('unknown-service')).toBeNull()
+    expect(resolveIntegration('')).toBeNull()
+  })
+})
+
+describe('resolvePermissionCopy', () => {
+  it('returns copy for known tags', () => {
+    const result = resolvePermissionCopy('github')
+    expect(result).not.toBeNull()
+    expect(result).toContain('repositories')
+  })
+
+  it('is case-insensitive', () => {
+    expect(resolvePermissionCopy('Gmail')).not.toBeNull()
+  })
+
+  it('trims whitespace', () => {
+    expect(resolvePermissionCopy('  slack  ')).not.toBeNull()
+  })
+
+  it('returns null for unknown tags', () => {
+    expect(resolvePermissionCopy('nonexistent')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- **PR 3** in the frontend coverage improvement series
- Adds unit tests for 3 previously uncovered modules in packages/shared-app:
  - chat/message-helpers.ts — extractTextContent, formatErrorMessage, isTunnelDisconnectError, formatToolName, getToolCategory
  - chat/useChatTransport.ts — buildChatApiUrl, buildChatTurnUrl (pure URL builders only; hook is excluded)
  - marketplace/integrations.ts — KNOWN_INTEGRATIONS registry, resolveIntegration, resolvePermissionCopy
  - marketplace/categories.ts — MARKETPLACE_CATEGORIES, findCategory, categoryLabel, categoryAccent

## Coverage Report

### Before (baseline)

| Metric | Value |
|--------|-------|
| % Functions | 80.21% |
| % Lines | 64.99% |
| Test files | 2 |
| Total tests | 34 |

### After

| Metric | Value | Delta |
|--------|-------|-------|
| % Functions | 87.85% | **+7.64%** |
| % Lines | 78.98% | **+13.99%** |
| Test files | 6 | +4 |
| Total tests | 99 | +65 |

### Per-file coverage

| File | % Funcs | % Lines |
|------|---------|---------|
| chat/message-helpers.ts | 100% | 100% |
| chat/useChatTransport.ts | 66.67% | 43.90% (only pure fns tested, hook excluded) |
| marketplace/categories.ts | 100% | 100% |
| marketplace/integrations.ts | 100% | 100% |

## New test files

- \src/chat/__tests__/message-helpers.test.ts\ (24 tests)
- \src/chat/__tests__/useChatTransport.test.ts\ (11 tests)
- \src/marketplace/__tests__/integrations.test.ts\ (11 tests)
- \src/marketplace/__tests__/categories.test.ts\ (15 tests, originally from the dynamic-app grouping but covers marketplace module)

## Test plan

- [x] All 99 tests pass (0 failures)
- [x] No source code changes — test-only PR
- [x] Coverage improved from 80.21%/64.99% to 87.85%/78.98%

Made with [Cursor](https://cursor.com)