### PR TITLE
bypass localhost login

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -6509,10 +6509,17 @@ if (process.env.SHOGO_LOCAL_MODE === 'true') {
         const crypto = require('crypto') as typeof import('crypto')
         const password = crypto.randomBytes(24).toString('base64')
 
+        // Allow overriding the seeded local user via env so a developer can
+        // sign in as their real cloud email locally (so cloud-side artifacts
+        // like ProjectAgent rows match by email when they later sync). Falls
+        // back to local@shogo.local for fresh installs that don't set it.
+        const seedEmail = process.env.SHOGO_LOCAL_USER_EMAIL || 'local@shogo.local'
+        const seedName = process.env.SHOGO_LOCAL_USER_NAME || 'Local User'
+
         const signUpRes = await auth.api.signUpEmail({
           body: {
-            name: 'Local User',
-            email: 'local@shogo.local',
+            name: seedName,
+            email: seedEmail,
             password,
           },
         })
@@ -6523,7 +6530,7 @@ if (process.env.SHOGO_LOCAL_MODE === 'true') {
             update: { value: password },
             create: { key: 'local_user_password', value: password },
           })
-          console.log('[LocalMode] Auto-seeded default user local@shogo.local')
+          console.log(`[LocalMode] Auto-seeded default user ${seedEmail}`)
         }
       }
     } catch (err: any) {

--- a/packages/agent/tsup.config.ts
+++ b/packages/agent/tsup.config.ts
@@ -33,8 +33,22 @@ export default defineConfig({
   // Copy bundled hook metadata (HOOK.md) into dist so loadAllHooks works
   // when the package is consumed from `dist/`. Source-mode consumers
   // (tsconfig paths, `development` export condition) read them from `src/`.
-  onSuccess:
-    'mkdir -p dist/hooks/bundled/command-logger dist/hooks/bundled/session-memory && ' +
-    'cp src/hooks/bundled/command-logger/HOOK.md dist/hooks/bundled/command-logger/HOOK.md && ' +
-    'cp src/hooks/bundled/session-memory/HOOK.md dist/hooks/bundled/session-memory/HOOK.md',
+  //
+  // Implemented via Node's fs.* (instead of `mkdir -p` / `cp`) so the build
+  // works on Windows PowerShell — the Unix shim was failing with "A
+  // subdirectory or file ... already exists" on incremental rebuilds, which
+  // bubbled up as a `bun run build:packages` failure.
+  onSuccess: async () => {
+    const { mkdirSync, copyFileSync } = await import('node:fs')
+    const { join } = await import('node:path')
+    const pairs: Array<[string, string]> = [
+      ['command-logger', 'HOOK.md'],
+      ['session-memory', 'HOOK.md'],
+    ]
+    for (const [hook, file] of pairs) {
+      const dstDir = join('dist', 'hooks', 'bundled', hook)
+      mkdirSync(dstDir, { recursive: true })
+      copyFileSync(join('src', 'hooks', 'bundled', hook, file), join(dstDir, file))
+    }
+  },
 })

--- a/scripts/dev-set-local-user.ts
+++ b/scripts/dev-set-local-user.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * dev-set-local-user — rewrite the local-mode user identity in-place.
+ *
+ * Reads from .env.local (loaded automatically by Bun via .env.local):
+ *   SHOGO_LOCAL_USER_EMAIL     — required, the email to display as
+ *   SHOGO_LOCAL_USER_NAME      — optional, defaults to existing
+ *   SHOGO_LOCAL_USER_PASSWORD  — optional, only needed if you want to also
+ *                                sign in MANUALLY via the /sign-in form
+ *                                (auto-sign-in works without this either way)
+ *
+ * Operates on the single existing user row in shogo.db. Does NOT delete or
+ * recreate, so all FK relations (workspaces, projects, chats, etc.) survive.
+ *
+ * Run AFTER `bun dev:all` has booted at least once (so the seed step has
+ * created the initial user). Restart the dev server after running so the
+ * in-memory Better Auth session cache picks up the new password.
+ *
+ *   bun scripts/dev-set-local-user.ts
+ */
+
+import { auth } from '../apps/api/src/auth'
+import { prisma } from '../apps/api/src/lib/prisma'
+
+const email = process.env.SHOGO_LOCAL_USER_EMAIL
+const name = process.env.SHOGO_LOCAL_USER_NAME
+const password = process.env.SHOGO_LOCAL_USER_PASSWORD
+
+if (!email) {
+  console.error('❌ SHOGO_LOCAL_USER_EMAIL is not set in .env.local')
+  process.exit(1)
+}
+if (process.env.SHOGO_LOCAL_MODE !== 'true') {
+  console.error('❌ SHOGO_LOCAL_MODE is not "true" — refusing to run against a non-local DB')
+  process.exit(1)
+}
+
+const user = await prisma.user.findFirst({ orderBy: { createdAt: 'asc' } })
+if (!user) {
+  console.error('❌ No user row found in shogo.db. Run `bun dev:all` once to seed the initial local user, then re-run this script.')
+  process.exit(1)
+}
+
+const oldEmail = user.email
+console.log(`📍 Found existing user: ${oldEmail} (id=${user.id})`)
+
+// ── Step 1: update user identity ───────────────────────────────────────────
+await prisma.user.update({
+  where: { id: user.id },
+  data: {
+    email,
+    name: name ?? user.name,
+    emailVerified: true,
+  },
+})
+console.log(`✅ Updated user.email → ${email}${name ? ` / name → ${name}` : ''}`)
+
+// ── Step 2: rotate password (optional) ─────────────────────────────────────
+if (password) {
+  const ctx = await (auth as any).$context
+  if (!ctx?.password?.hash) {
+    console.error("❌ Couldn't access Better Auth password hasher (auth.$context.password.hash). Aborting password update; email change above is preserved.")
+    process.exit(1)
+  }
+  const hash = await ctx.password.hash(password)
+
+  const cred = await prisma.account.findFirst({
+    where: { userId: user.id, providerId: 'credential' },
+  })
+  if (cred) {
+    await prisma.account.update({
+      where: { id: cred.id },
+      data: { password: hash, accountId: user.id, updatedAt: new Date() },
+    })
+    console.log('✅ Rotated credential password hash')
+  } else {
+    await prisma.account.create({
+      data: {
+        id: crypto.randomUUID(),
+        userId: user.id,
+        accountId: user.id,
+        providerId: 'credential',
+        password: hash,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    })
+    console.log('✅ Created credential account row with password hash')
+  }
+
+  // Keep auto-sign-in's stashed plaintext in sync so /api/local/auto-sign-in
+  // (which calls signInEmail with this value) keeps working unattended.
+  await (prisma as any).localConfig.upsert({
+    where: { key: 'local_user_password' },
+    update: { value: password },
+    create: { key: 'local_user_password', value: password },
+  })
+  console.log('✅ Synced localConfig.local_user_password for auto-sign-in')
+} else {
+  console.log('⊘ SHOGO_LOCAL_USER_PASSWORD not set — leaving password untouched. Auto-sign-in still works using the existing stashed password.')
+}
+
+console.log('')
+console.log('🎉 Done. Restart `bun dev:all` and reload localhost:5173 — auto-sign-in will log you in as ' + email)
+process.exit(0)


### PR DESCRIPTION
## Summary

Three independent changes that together let `bun dev:all` come up clean on a fresh Windows checkout and auto-sign you into the local Studio without ever showing the login screen.

- **`apps/api/src/server.ts`** — make the local-mode auto-seed user configurable via `SHOGO_LOCAL_USER_EMAIL` / `SHOGO_LOCAL_USER_NAME` so developers can present as their real cloud email locally without hand-editing `shogo.db`. Defaults to the existing `local@shogo.local` / `Local User` when unset, so this is a no-op for current dev environments.
- **`scripts/dev-set-local-user.ts`** *(new)* — idempotent in-place rewrite of the existing local user. Reads `SHOGO_LOCAL_USER_EMAIL` / `SHOGO_LOCAL_USER_NAME` / `SHOGO_LOCAL_USER_PASSWORD` from env, updates the `users` row, rotates the Better Auth credential password hash via `auth.$context.password.hash`, and keeps `localConfig.local_user_password` in sync so the existing `/api/local/auto-sign-in` flow keeps working unattended. Preserves all FK relations so projects/workspaces/chats survive a re-identification. Refuses to run unless `SHOGO_LOCAL_MODE=true`.
- **`packages/agent/tsup.config.ts`** — replace the Unix `mkdir -p` / `cp` `onSuccess` hook with a Node `fs` implementation. The shell shim was failing on Windows incremental rebuilds with *"A subdirectory or file already exists"*, which broke `bun run build:packages` and therefore every workspace consumer of `@shogo-ai/agent` whose `dist/` was missing (the symptom we hit was `[api] error: Cannot find module '@shogo-ai/sdk/model-catalog'` on `dev:all` startup, because the SDK's exports map only resolves to `dist/` files and the build was bailing out before it ever produced them).

## Test plan

- [ ] On Windows: `bun run build:packages` completes without the `mkdir`/`cp` error and produces `packages/*/dist/`.
- [ ] On Windows: `bun dev:all` starts the API on port 8002 (no `Cannot find module '@shogo-ai/sdk/...'` errors).
- [ ] With `EXPO_PUBLIC_LOCAL_MODE=true` set in `.env.local`, opening `http://localhost:5173` lands on the home screen without the login screen flashing.
- [ ] Without any `SHOGO_LOCAL_USER_*` env vars, the auto-seed still creates `local@shogo.local` (existing behavior).
- [ ] With `SHOGO_LOCAL_USER_EMAIL` and `SHOGO_LOCAL_USER_PASSWORD` set, `bun scripts/dev-set-local-user.ts` rewrites the existing user without dropping rows; auto-sign-in still works after restart; manual sign-in via `/sign-in` accepts the env-configured password.
- [ ] On macOS / Linux: `bun run build:packages` still produces the same `dist/hooks/bundled/{command-logger,session-memory}/HOOK.md` files as before.
