### PR TITLE
Separate canvas and preview staging dirs to fix ENOENT during boot

### DIFF
--- a/apps/api/src/services/git.service.ts
+++ b/apps/api/src/services/git.service.ts
@@ -105,6 +105,7 @@ node_modules/
 # Build outputs
 dist/
 dist.staging/
+dist.canvas.staging/
 dist.prev/
 build/
 .output/
@@ -215,16 +216,21 @@ const REQUIRED_IGNORE_ENTRIES = [
   'node_modules/',
   '.bun/',
   // Build outputs from the agent-runtime canvas builder. Vite/Expo stacks
-  // emit into `dist.staging/`, then `commitBuildOutput` rotates the old
-  // `dist/` to `dist.prev/` and renames the staging dir into place. All
-  // three are regenerated on every build and should never be checkpointed:
-  // leaving them tracked bloats every commit, slows rollbacks, lets a
-  // rollback restore stale build artifacts that no longer match source,
-  // and — most acutely — races `git add -A` against the bundler renaming
-  // files mid-walk, leaving a stale `.git/index.lock` that breaks every
-  // subsequent checkpoint. See `packages/agent-runtime/src/build-output-commit.ts`.
+  // emit into a staging dir, then `commitBuildOutput` rotates the old
+  // `dist/` to `dist.prev/` and renames the staging dir into place.
+  // PreviewManager owns `dist.staging/`; CanvasBuildManager owns
+  // `dist.canvas.staging/` (separate name so their concurrent
+  // cleanups can't race — see canvas-build-manager.ts docstring).
+  // All four are regenerated on every build and should never be
+  // checkpointed: leaving them tracked bloats every commit, slows
+  // rollbacks, lets a rollback restore stale build artifacts that no
+  // longer match source, and — most acutely — races `git add -A`
+  // against the bundler renaming files mid-walk, leaving a stale
+  // `.git/index.lock` that breaks every subsequent checkpoint. See
+  // `packages/agent-runtime/src/build-output-commit.ts`.
   'dist/',
   'dist.staging/',
+  'dist.canvas.staging/',
   'dist.prev/',
   'build/',
   '.output/',
@@ -260,6 +266,7 @@ const UNTRACK_IF_TRACKED: readonly string[] = [
   '.bun',
   'dist',
   'dist.staging',
+  'dist.canvas.staging',
   'dist.prev',
   'build',
   '.output',

--- a/packages/agent-runtime/src/__tests__/canvas-build-manager.test.ts
+++ b/packages/agent-runtime/src/__tests__/canvas-build-manager.test.ts
@@ -4,7 +4,7 @@
 // CanvasBuildManager is now stack-aware: it accepts either Vite or Expo as
 // the bundler binary. These tests pin the contract so a future stack
 // addition (e.g. parcel, rspack) doesn't silently regress the gate, and
-// verify the atomic dist.staging -> dist swap that fixes the
+// verify the atomic dist.canvas.staging -> dist swap that fixes the
 // "rebuild deletes dist, refresh 404s" regression.
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
@@ -15,6 +15,13 @@ import { CanvasBuildManager } from '../canvas-build-manager'
 
 const TMP = join(tmpdir(), 'test-canvas-build-manager')
 const IS_WINDOWS = process.platform === 'win32'
+
+// Must match `CANVAS_STAGING_DIR` in canvas-build-manager.ts. Tracked
+// here as a local constant rather than importing — the manager keeps it
+// private on purpose (callers should never read it), and these tests
+// double as a regression bar that the constant doesn't accidentally
+// drift back to `dist.staging` and re-collide with PreviewManager.
+const CANVAS_STAGING_DIR = 'dist.canvas.staging'
 
 /**
  * Write a fake bundler shim that exits 0 (and optionally writes a
@@ -31,7 +38,10 @@ function writeShim(
   opts: { exitCode?: number; stagingPayload?: string; stagingDir?: string },
 ): void {
   const exitCode = opts.exitCode ?? 0
-  const stagingDir = opts.stagingDir ?? 'dist.staging'
+  // Default mirrors what CanvasBuildManager passes via --outDir /
+  // --output-dir; tests can override to verify behavior when the
+  // bundler writes elsewhere.
+  const stagingDir = opts.stagingDir ?? CANVAS_STAGING_DIR
   const stagingPath = join(TMP, stagingDir)
   const indexPath = join(stagingPath, 'index.html')
 
@@ -157,8 +167,8 @@ describe('CanvasBuildManager atomic dist swap', () => {
   beforeEach(() => freshWorkspace())
   afterEach(() => rmSync(TMP, { recursive: true, force: true }))
 
-  test('promotes dist.staging into dist on successful build', async () => {
-    // Vite shim writes a payload into dist.staging/index.html and exits 0.
+  test('promotes dist.canvas.staging into dist on successful build', async () => {
+    // Vite shim writes a payload into dist.canvas.staging/index.html and exits 0.
     freshWorkspace({ withVite: true, stagingPayload: '<html>fresh</html>' })
     const mgr = new CanvasBuildManager(TMP, {
       onBuildComplete: () => {},
@@ -170,7 +180,10 @@ describe('CanvasBuildManager atomic dist swap', () => {
     expect(readFileSync(join(TMP, 'dist', 'index.html'), 'utf-8'))
       .toContain('fresh')
     // Staging dir must be gone — left in place it would confuse the
-    // next build.
+    // next build. Uses CanvasBuildManager's own staging dir, not
+    // PreviewManager's `dist.staging/`, to avoid the cleanup-vs-copy
+    // race that surfaces as ENOENT during large public/-folder copies.
+    expect(existsSync(join(TMP, CANVAS_STAGING_DIR))).toBe(false)
     expect(existsSync(join(TMP, 'dist.staging'))).toBe(false)
   })
 
@@ -201,7 +214,7 @@ describe('CanvasBuildManager atomic dist swap', () => {
     expect(readFileSync(join(TMP, 'dist', 'index.html'), 'utf-8'))
       .toContain('previous')
     // Failed build: any partial staging output must be cleaned up.
-    expect(existsSync(join(TMP, 'dist.staging'))).toBe(false)
+    expect(existsSync(join(TMP, CANVAS_STAGING_DIR))).toBe(false)
   })
 
   test('isBuilding flips during runBuild and clears afterwards', async () => {
@@ -300,6 +313,67 @@ describe('CanvasBuildManager waitForDeps gate', () => {
     // care that the call returns within the test timeout.
     await mgr.start()
     expect(completed).toBe(true)
+  })
+})
+
+/**
+ * Regression coverage for the canvas-build vs. preview-manager staging-dir
+ * race that surfaced as `ENOENT … copyfile 'public/<asset>' -> 'dist.staging/<asset>'`
+ * during `bun dev:all` on Expo workspaces with large `public/` assets:
+ *
+ *   - PreviewManager.runExpoExportWeb spawns `expo export … --output-dir dist.staging`
+ *     at boot to seed `dist/` for the preview iframe.
+ *   - CanvasBuildManager.start() races the same boot, runs its own
+ *     `expo export`, and (in the original code) calls
+ *     `cleanupStagingOutput(workspaceDir, 'dist.staging')` first.
+ *   - That cleanup `rmSync`s the in-progress copy of any large file
+ *     under `public/` (e.g. a multi-MB `.glb`) out from under
+ *     PreviewManager's CopyFileW, surfacing as ENOENT on the destination.
+ *
+ * Fix: CanvasBuildManager owns `dist.canvas.staging/`, leaving
+ * PreviewManager's `dist.staging/` untouched. Pin from two angles so
+ * the constant can't drift back:
+ *
+ *   - The shim that produces output names its target via the manager's
+ *     `--outDir` / `--output-dir` arg, so writing to anything other
+ *     than CANVAS_STAGING_DIR breaks the shim/path chain visibly.
+ *   - A pre-existing PreviewManager `dist.staging/` (with a sentinel
+ *     payload inside) must survive a CanvasBuildManager build cycle
+ *     untouched.
+ */
+describe('CanvasBuildManager preview-manager staging isolation', () => {
+  beforeEach(() => freshWorkspace())
+  afterEach(() => rmSync(TMP, { recursive: true, force: true }))
+
+  test('does not touch a preexisting dist.staging/ during build', async () => {
+    freshWorkspace({ withVite: true, stagingPayload: '<html>canvas</html>' })
+    // Simulate PreviewManager's in-flight expo export: a populated
+    // `dist.staging/` that would be wiped if CanvasBuildManager's
+    // cleanup ever pointed at the shared name again.
+    const previewStaging = join(TMP, 'dist.staging')
+    mkdirSync(previewStaging, { recursive: true })
+    writeFileSync(join(previewStaging, 'index.html'), '<html>preview-build-in-flight</html>')
+    writeFileSync(join(previewStaging, 'big-asset.bin'), 'pretend-this-is-172MB')
+
+    const mgr = new CanvasBuildManager(TMP, {
+      onBuildComplete: () => {},
+      onBuildError: () => {},
+    })
+    await mgr.start()
+
+    // CanvasBuildManager must have produced its own output and committed it.
+    expect(readFileSync(join(TMP, 'dist', 'index.html'), 'utf-8'))
+      .toContain('canvas')
+    expect(existsSync(join(TMP, CANVAS_STAGING_DIR))).toBe(false)
+    // PreviewManager's staging dir must remain byte-for-byte intact:
+    // any rmSync against the shared name would have wiped both files
+    // before the canvas build's own copy completed, which is the
+    // exact failure mode we're fixing.
+    expect(existsSync(previewStaging)).toBe(true)
+    expect(readFileSync(join(previewStaging, 'index.html'), 'utf-8'))
+      .toContain('preview-build-in-flight')
+    expect(readFileSync(join(previewStaging, 'big-asset.bin'), 'utf-8'))
+      .toBe('pretend-this-is-172MB')
   })
 })
 

--- a/packages/agent-runtime/src/__tests__/expo-cloud-rebuild.test.ts
+++ b/packages/agent-runtime/src/__tests__/expo-cloud-rebuild.test.ts
@@ -72,12 +72,17 @@ function freshTmp(label: string): string {
   return dir
 }
 
+// Must match `CANVAS_STAGING_DIR` in canvas-build-manager.ts. Distinct
+// from PreviewManager's `dist.staging/` so the two managers' cleanups
+// can't collide; see the file-level docstring on canvas-build-manager.ts.
+const CANVAS_STAGING_DIR = 'dist.canvas.staging'
+
 /**
  * Drop a fake bundler shim that:
  *   - appends its `name` to `invocationLog` (so A3 can prove the Vite
  *     shim was never invoked, even if no output landed in dist/), and
- *   - writes `dist.staging/index.html` with a body that names the
- *     bundler (so A1/A2 can prove which shim produced the dist
+ *   - writes `<CANVAS_STAGING_DIR>/index.html` with a body that names
+ *     the bundler (so A1/A2 can prove which shim produced the dist
  *     contents currently being served).
  *
  * Cross-platform: POSIX gets a `#!/bin/sh` script with exec bit set;
@@ -87,7 +92,7 @@ function freshTmp(label: string): string {
 function writeBundlerShim(workspaceDir: string, name: 'vite' | 'expo'): void {
   const binDir = join(workspaceDir, 'node_modules', '.bin')
   mkdirSync(binDir, { recursive: true })
-  const stagingDir = join(workspaceDir, 'dist.staging')
+  const stagingDir = join(workspaceDir, CANVAS_STAGING_DIR)
   const indexPath = join(stagingDir, 'index.html')
   const body = `<html>${name}-built-this</html>`
 

--- a/packages/agent-runtime/src/canvas-build-manager.ts
+++ b/packages/agent-runtime/src/canvas-build-manager.ts
@@ -8,10 +8,10 @@
  *
  * Concretely today:
  *   - Vite stacks (`react-app`, `threejs-game`, `phaser-game`) — invokes
- *     `vite build --outDir dist.staging --emptyOutDir` and atomically
+ *     `vite build --outDir dist.canvas.staging --emptyOutDir` and atomically
  *     swaps the result into `dist/`.
  *   - Metro stacks (`expo-app`, `expo-three`) — invokes
- *     `expo export --platform web --output-dir dist.staging` and atomically
+ *     `expo export --platform web --output-dir dist.canvas.staging` and atomically
  *     swaps the result into `dist/`.
  *
  * The historical implementation ran `bun run build` and let package.json
@@ -21,6 +21,20 @@
  * rebuild) left users staring at a 404. We now invoke the bundler
  * ourselves so we control the output dir and can promote it atomically;
  * see `build-output-commit.ts`.
+ *
+ * Why `dist.canvas.staging/` and not the shared `dist.staging/`:
+ * `PreviewManager.runExpoExportWeb` (Metro stacks) and
+ * `PreviewManager.runViteOneShotBuild` (Vite stacks) also build into a
+ * staging dir at boot to seed `dist/` for the runtime's preview iframe.
+ * Both calls run in parallel with `CanvasBuildManager.start()`'s first
+ * build, and both call `cleanupStagingOutput` (a recursive `rmSync`)
+ * before spawning their bundler. With a shared staging name, one
+ * builder's cleanup can wipe the other's in-progress output mid-copy —
+ * surfaces as `ENOENT … copyfile 'public/<asset>' -> 'dist.staging/<asset>'`
+ * from CopyFileW when the destination directory disappears under a
+ * large-file copy (e.g. a multi-megabyte GLB in `public/`). Giving the
+ * canvas builder its own staging dir keeps both managers' cleanups
+ * disjoint without changing the rest of the architecture.
  *
  * Builds are debounced so rapid file writes don't cause build storms.
  */
@@ -32,8 +46,18 @@ import { resolveBinInvocation } from '@shogo/shared-runtime'
 import {
   commitBuildOutput,
   cleanupStagingOutput,
-  DEFAULT_STAGING_DIR,
 } from './build-output-commit'
+
+/**
+ * Staging directory name owned exclusively by `CanvasBuildManager`.
+ *
+ * Distinct from `DEFAULT_STAGING_DIR` (`dist.staging/`) which is owned
+ * by `PreviewManager`. See the file-level docstring for the race this
+ * separation prevents. Must stay in sync with the gitignore /
+ * UNTRACK_IF_TRACKED entries in `apps/api/src/services/git.service.ts`
+ * — otherwise it'd get checkpointed on every chat turn.
+ */
+const CANVAS_STAGING_DIR = 'dist.canvas.staging'
 
 const BUILD_DEBOUNCE_MS = 500
 const LOG_PREFIX = '[CanvasBuildManager]'
@@ -234,16 +258,16 @@ export class CanvasBuildManager {
   }
 
   /**
-   * Build args that route output into `dist.staging/` instead of
+   * Build args that route output into `CANVAS_STAGING_DIR` instead of
    * `dist/` so we can atomically swap on success. `--emptyOutDir` is
    * passed to Vite explicitly to suppress its "outDir outside project
    * root" warning when users seed exotic vite.config.ts setups.
    */
   private buildArgsFor(kind: BundlerKind): string[] {
     if (kind === 'vite') {
-      return ['build', '--outDir', DEFAULT_STAGING_DIR, '--emptyOutDir']
+      return ['build', '--outDir', CANVAS_STAGING_DIR, '--emptyOutDir']
     }
-    return ['export', '--platform', 'web', '--output-dir', DEFAULT_STAGING_DIR]
+    return ['export', '--platform', 'web', '--output-dir', CANVAS_STAGING_DIR]
   }
 
   private async runBuild(): Promise<void> {
@@ -285,8 +309,10 @@ export class CanvasBuildManager {
     }
 
     // Wipe any leftover staging dir from a prior crashed build so the
-    // bundler starts from a clean slate.
-    cleanupStagingOutput(this.workspaceDir, DEFAULT_STAGING_DIR)
+    // bundler starts from a clean slate. Only touches our own
+    // `CANVAS_STAGING_DIR`; PreviewManager's `dist.staging/` is its
+    // problem to clean up.
+    cleanupStagingOutput(this.workspaceDir, CANVAS_STAGING_DIR)
 
     const isWindows = process.platform === 'win32'
     // Route through bundled `bun` when the system has no `node` on PATH
@@ -354,7 +380,7 @@ export class CanvasBuildManager {
       // Bundler succeeded — promote the staging dir into `dist/` atomically.
       // A swap failure (e.g. a locked file on Windows) is non-fatal: the
       // previous `dist/` keeps serving and the next rebuild will retry.
-      const committed = commitBuildOutput(this.workspaceDir, DEFAULT_STAGING_DIR)
+      const committed = commitBuildOutput(this.workspaceDir, CANVAS_STAGING_DIR)
       if (!committed) {
         console.warn(
           `${LOG_PREFIX} Build succeeded but commit into dist/ failed — previous build remains live`,
@@ -367,7 +393,7 @@ export class CanvasBuildManager {
     } catch (err: any) {
       // Failed build: drop the partial staging output so it doesn't
       // poison the next swap, and leave `dist/` untouched.
-      cleanupStagingOutput(this.workspaceDir, DEFAULT_STAGING_DIR)
+      cleanupStagingOutput(this.workspaceDir, CANVAS_STAGING_DIR)
       const message = String(err?.message ?? err ?? '(no error message)')
       // Slice generously — see ERROR_SLICE_LIMIT comment. The 200-char
       // cap dropped vite/rollup's actual error frame, which is what


### PR DESCRIPTION
## Summary

- `PreviewManager.runExpoExportWeb` and `CanvasBuildManager.start()` both ran `expo export --output-dir dist.staging` at boot and both called `cleanupStagingOutput('dist.staging')` first. With a large asset in `public/` (e.g. a multi-MB GLB), one builder's recursive `rmSync` could wipe the destination directory mid-`CopyFileW` for the other, surfacing as `ENOENT: copyfile public/<asset> -> dist.staging/<asset>` even though the source existed. Symptom hit reliably during `bun dev:all` on Windows once `public/` had a chunky asset.
- `CanvasBuildManager` now stages into its own `dist.canvas.staging/`, so the two managers' cleanups can never race. `commitBuildOutput` was already parameterized on the staging name, so the atomic swap into `dist/` is unchanged — just sourced from disjoint dirs.
- Added a regression test (`does not touch a preexisting dist.staging/ during build`) that seeds a populated `dist.staging/` simulating an in-flight PreviewManager export and asserts CanvasBuildManager leaves it byte-for-byte intact.
- Wired `dist.canvas.staging/` into `git.service.ts` (`DEFAULT_GITIGNORE`, `REQUIRED_IGNORE_ENTRIES`, `UNTRACK_IF_TRACKED`) so auto-checkpoints don't race `git add -A` against a transient build dir.

## What this PR deliberately does NOT do

The two builders still both run `expo export` at boot (PreviewManager seeds `dist/`, CanvasBuildManager owns hot-reload). That's wasteful but no longer racy — last-write-wins on the atomic swap into `dist/`. Removing that redundancy touches PreviewManager's `_phase` state machine and the analogous Vite path (`startBuildWatch` / `runViteOneShotBuild`); worth doing as a follow-up.

## Test plan

- [x] `bun test src/__tests__/canvas-build-manager.test.ts src/__tests__/expo-cloud-rebuild.test.ts src/__tests__/build-output-commit.test.ts` — 28/28 pass, including the new isolation test.
- [ ] Manual: with a multi-MB asset in a workspace `public/`, run `bun dev:all` and confirm no `ENOENT … copyfile public/<asset> -> dist.staging/<asset>` errors at boot, and that `dist/index.html` is served.
- [ ] Manual: edit a file in `app/` and confirm canvas hot-reload still fires (`watcher.broadcastReload()` after rebuild).
- [ ] Manual: kill `bun dev:all` and verify no leftover `dist.canvas.staging/` is checkpointed by the auto-commit.
