### PR TITLE
Branch port-cleanup shell commands on Windows to silence cmd.exe spam

### DIFF
--- a/apps/api/src/__tests__/runtime-manager-ports.test.ts
+++ b/apps/api/src/__tests__/runtime-manager-ports.test.ts
@@ -92,10 +92,25 @@ describe('RuntimeManager private port helpers', () => {
       return 0 as any
     }) as typeof setTimeout
     ;(rm as any).isPortListening = mock(async () => false)
-    execPlan = ['43210\n', '', '']
+    // The pid-discovery exec returns a single line containing "43210". On
+    // Windows that's the trailing column of a netstat -ano LISTENING row,
+    // on POSIX it's the bare lsof -t output. Both shapes parse to PID
+    // 43210 in the implementation.
+    const isWindows = process.platform === 'win32'
+    execPlan = isWindows
+      ? ['  TCP    127.0.0.1:37123        0.0.0.0:0              LISTENING       43210\n', '', '']
+      : ['43210\n', '', '']
 
     await expect(rm.killProcessOnPort(37123)).resolves.toBe(true)
-    expect(execCalls).toContain('kill -15 43210 2>/dev/null || true')
+    if (isWindows) {
+      // Windows path: taskkill /F goes straight to a hard kill — there's
+      // no SIGTERM-equivalent on win32, so killProcessOnPort skips the
+      // graceful step and only emits one taskkill.
+      expect(execCalls.some((cmd) => cmd.includes('taskkill /F /PID 43210'))).toBe(true)
+      expect(execCalls.some((cmd) => cmd.startsWith('kill '))).toBe(false)
+    } else {
+      expect(execCalls).toContain('kill -15 43210 2>/dev/null || true')
+    }
   })
 
   test('allocatePortAsync skips used ports, checks companion ports, and releases allocated ports', async () => {

--- a/apps/api/src/lib/runtime/manager.ts
+++ b/apps/api/src/lib/runtime/manager.ts
@@ -163,35 +163,120 @@ export class RuntimeManager implements IRuntimeManager {
       { start: PORT_RANGE_START + AGENT_PORT_OFFSET, end: PORT_RANGE_END + AGENT_PORT_OFFSET + 1 },
     ]
 
-    for (const range of rangesToClean) {
-      try {
-        const result = execSync(
-          `lsof -iTCP:${range.start}-${range.end} -sTCP:LISTEN -t 2>/dev/null || true`,
-          { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
-        ).trim()
+    const isWindows = process.platform === 'win32'
+    const selfPid = String(process.pid)
+    const parentPid = String(process.ppid)
 
-        const selfPid = String(process.pid)
-        const parentPid = String(process.ppid)
-        // Some lsof builds (notably inside the minimal runtime container
-        // images) silently ignore `-t` when another flag isn't honored and
-        // fall back to verbose tabular output. If any non-numeric tokens
-        // reach `kill -9`, sh will choke on unescaped characters like `(`
-        // and spray `/bin/sh: syntax error: unexpected "("` into the logs.
-        // Defensively keep only pure integer PIDs.
-        const pids = result
+    for (const range of rangesToClean) {
+      const pids = isWindows
+        ? this.findStalePidsWindows(range.start, range.end, selfPid, parentPid)
+        : this.findStalePidsPosix(range.start, range.end, selfPid, parentPid)
+
+      if (pids.length === 0) continue
+
+      console.log(`[RuntimeManager] Cleaning up ${pids.length} stale process(es) on ports ${range.start}-${range.end}: ${pids.join(', ')}`)
+      for (const pid of pids) {
+        try {
+          if (isWindows) {
+            // taskkill is the Windows equivalent of `kill -9`. We
+            // intentionally swallow stderr and stdio to keep the
+            // module-level cleanup quiet on a normal boot where
+            // every PID we found has already exited by the time
+            // we get here.
+            execSync(`taskkill /F /PID ${pid}`, { stdio: ['pipe', 'pipe', 'pipe'] })
+          } else {
+            execSync(`kill -9 ${pid} 2>/dev/null || true`)
+          }
+        } catch {
+          // Process already exited / permission denied — fine.
+        }
+      }
+    }
+  }
+
+  /**
+   * POSIX path of `cleanupStaleProcesses`. Some lsof builds (notably
+   * inside the minimal runtime container images) silently ignore
+   * `-t` when another flag isn't honored and fall back to verbose
+   * tabular output. If any non-numeric tokens reach `kill -9`, sh
+   * will choke on unescaped characters like `(` and spray
+   * `/bin/sh: syntax error: unexpected "("` into the logs.
+   * Defensively keep only pure integer PIDs.
+   */
+  private findStalePidsPosix(
+    start: number,
+    end: number,
+    selfPid: string,
+    parentPid: string,
+  ): string[] {
+    try {
+      const result = execSync(
+        `lsof -iTCP:${start}-${end} -sTCP:LISTEN -t 2>/dev/null || true`,
+        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+      ).trim()
+      return [...new Set(
+        result
           .split(/\s+/)
           .map((p) => p.trim())
-          .filter((p) => /^\d+$/.test(p) && p !== selfPid && p !== parentPid && p !== '1')
-
-        if (pids.length > 0) {
-          const uniquePids = [...new Set(pids)]
-          console.log(`[RuntimeManager] Cleaning up ${uniquePids.length} stale process(es) on ports ${range.start}-${range.end}: ${uniquePids.join(', ')}`)
-          for (const pid of uniquePids) {
-            try { execSync(`kill -9 ${pid} 2>/dev/null || true`) } catch {}
-          }
-        }
-      } catch {}
+          .filter((p) => /^\d+$/.test(p) && p !== selfPid && p !== parentPid && p !== '1'),
+      )]
+    } catch {
+      return []
     }
+  }
+
+  /**
+   * Windows path of `cleanupStaleProcesses`. The previous unconditional
+   * use of `lsof -iTCP:... -t 2>/dev/null || true` via execSync (which
+   * defaults to cmd.exe on Windows) sprayed `'true' is not recognized
+   * as an internal or external command` and `The system cannot find the
+   * path specified.` (×2 for the redirections) into the runtime log on
+   * every API-server boot — harmless but alarming and easy to mistake
+   * for an actual runtime crash.
+   *
+   * `netstat -ano` is universally available on Windows and emits lines
+   * shaped like
+   *   `  TCP    127.0.0.1:8080         0.0.0.0:0              LISTENING       12345`
+   * — the trailing whitespace-separated token is the PID. We piped
+   * through `findstr LISTENING` to drop CLOSE_WAIT/TIME_WAIT entries
+   * and then filter the port number ourselves so we can match a
+   * range rather than a single port.
+   */
+  private findStalePidsWindows(
+    start: number,
+    end: number,
+    selfPid: string,
+    parentPid: string,
+  ): string[] {
+    let stdout = ''
+    try {
+      stdout = execSync(
+        'netstat -ano | findstr LISTENING',
+        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+      )
+    } catch {
+      // findstr exits 1 when nothing matches — i.e. nothing is
+      // listening anywhere. Treat as empty rather than fatal.
+      return []
+    }
+
+    const out: string[] = []
+    for (const line of stdout.split(/\r?\n/)) {
+      const tokens = line.trim().split(/\s+/)
+      if (tokens.length < 4) continue
+      // Tokens: [proto, local, remote, state, pid]
+      // local is `IP:port` or `[::]:port`; pull the trailing `:port`.
+      const local = tokens[1]
+      const portMatch = /:(\d+)$/.exec(local)
+      if (!portMatch) continue
+      const port = Number(portMatch[1])
+      if (port < start || port > end) continue
+      const pid = tokens[tokens.length - 1]
+      if (!/^\d+$/.test(pid)) continue
+      if (pid === '0' || pid === selfPid || pid === parentPid) continue
+      out.push(pid)
+    }
+    return [...new Set(out)]
   }
 
   /**

--- a/packages/agent-runtime/src/__tests__/preview-manager-force-kill-port.test.ts
+++ b/packages/agent-runtime/src/__tests__/preview-manager-force-kill-port.test.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+//
+// Regression for the Windows runtime-exit log spam that surfaced as:
+//
+//   [api] [runtime:…] [preview-manager] API server exited (code=null, signal=SIGTERM)
+//   [api] [runtime:…] The system cannot find the path specified.
+//   [api] [runtime:…] The system cannot find the path specified.
+//   [api] [runtime:…] 'true' is not recognized as an internal or external command,
+//   [api] [runtime:…] operable program or batch file.
+//
+// Root cause: `PreviewManager.forceKillPort` shelled out via `execSync` with a
+// POSIX one-liner (`lsof -ti :PORT 2>/dev/null || fuser PORT/tcp 2>/dev/null
+// || true`). On Windows that runs through `cmd.exe`, which doesn't understand
+// `2>/dev/null` (path redirection) or `|| true` (`true` is a POSIX builtin,
+// not a Win32 binary). Every API-server restart — custom-routes save, schema
+// change, crash recovery — sprayed the four lines above into the runtime log.
+//
+// These tests pin the platform branching: on win32 we must use `netstat` /
+// `taskkill` and never fall through to the POSIX one-liner, regardless of
+// whether the platform path errors out.
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+const execCalls: string[] = []
+let execPlan: Array<string | Error> = []
+
+mock.module('child_process', () => ({
+  spawn: () => ({
+    stdout: { on: () => {} },
+    stderr: { on: () => {} },
+    on: () => {},
+    kill: () => true,
+    killed: false,
+    exitCode: null,
+    pid: 9999,
+  }),
+  execSync: (cmd: string) => {
+    execCalls.push(cmd)
+    const next = execPlan.shift()
+    if (next instanceof Error) throw next
+    return next ?? ''
+  },
+}))
+
+const { PreviewManager } = await import('../preview-manager')
+
+const originalPlatform = process.platform
+
+function setPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+}
+
+beforeAll(() => {
+  // Capture the real platform once so afterAll can put it back deterministically.
+})
+
+afterAll(() => {
+  setPlatform(originalPlatform)
+})
+
+beforeEach(() => {
+  execCalls.length = 0
+  execPlan = []
+})
+
+afterEach(() => {
+  setPlatform(originalPlatform)
+})
+
+function callForceKillPort(port: number): Promise<void> {
+  const pm = new PreviewManager({ workspaceDir: '/tmp/forceKillPort-fixture', runtimePort: 8080 }) as unknown as {
+    apiPort: number
+    forceKillPort: () => Promise<void>
+  }
+  pm.apiPort = port
+  return pm.forceKillPort()
+}
+
+describe('PreviewManager.forceKillPort platform branching', () => {
+  test('on POSIX: shells out to lsof/fuser', async () => {
+    setPlatform('linux')
+    execPlan = ['12345\n']
+
+    await callForceKillPort(37123)
+
+    expect(execCalls.length).toBe(1)
+    expect(execCalls[0]).toContain('lsof -ti :37123')
+    expect(execCalls[0]).toContain('fuser 37123/tcp')
+    expect(execCalls[0]).toContain('|| true')
+  })
+
+  test('on win32: never invokes the POSIX one-liner — must use netstat/taskkill', async () => {
+    setPlatform('win32')
+    // findstr exits 1 when nothing matches — modeled as a thrown error so the
+    // function takes the early-return branch and we don't accidentally try to
+    // taskkill a phantom PID.
+    execPlan = [new Error('findstr: no match')]
+
+    await callForceKillPort(37123)
+
+    // The exact failure mode we're regressing against:
+    expect(execCalls.some((c) => c.includes('lsof'))).toBe(false)
+    expect(execCalls.some((c) => c.includes('fuser'))).toBe(false)
+    expect(execCalls.some((c) => c.includes('2>/dev/null'))).toBe(false)
+    expect(execCalls.some((c) => c.includes('|| true'))).toBe(false)
+    // And we must reach for the Windows tooling instead.
+    expect(execCalls.length).toBe(1)
+    expect(execCalls[0]).toContain('netstat -ano')
+    expect(execCalls[0]).toContain('findstr :37123')
+    expect(execCalls[0]).toContain('LISTENING')
+  })
+
+  test('on win32 with a listening PID: invokes taskkill /F /PID, never kill', async () => {
+    setPlatform('win32')
+    // Realistic netstat output line shape; trailing token is the PID.
+    execPlan = [
+      '  TCP    127.0.0.1:37123        0.0.0.0:0              LISTENING       54321\r\n',
+      '', // taskkill returns nothing on success
+    ]
+
+    await callForceKillPort(37123)
+
+    expect(execCalls.length).toBe(2)
+    expect(execCalls[0]).toContain('netstat -ano')
+    expect(execCalls[1]).toBe('taskkill /F /PID 54321')
+    expect(execCalls.some((c) => c.startsWith('kill '))).toBe(false)
+  })
+
+  test('on win32: skips PID 0 (system idle), self pid, and parent pid', async () => {
+    setPlatform('win32')
+    const lines = [
+      `  TCP    127.0.0.1:37123        0.0.0.0:0              LISTENING       0`,
+      `  TCP    127.0.0.1:37123        0.0.0.0:0              LISTENING       ${process.pid}`,
+      `  TCP    127.0.0.1:37123        0.0.0.0:0              LISTENING       ${process.ppid}`,
+      `  TCP    127.0.0.1:37123        0.0.0.0:0              LISTENING       77777`,
+    ].join('\r\n')
+    execPlan = [lines, '']
+
+    await callForceKillPort(37123)
+
+    const taskkills = execCalls.filter((c) => c.startsWith('taskkill'))
+    expect(taskkills).toEqual(['taskkill /F /PID 77777'])
+  })
+})

--- a/packages/agent-runtime/src/preview-manager.ts
+++ b/packages/agent-runtime/src/preview-manager.ts
@@ -2044,15 +2044,34 @@ export class PreviewManager {
    * Force-kill any process listening on the API port. Used before
    * spawning a fresh server so a leaked previous process (or an
    * unrelated user-spawned binary) can't squat the port and EADDRINUSE
-   * the new spawn. Falls back to `lsof` and `fuser`; both are
-   * universally available on Linux pods and macOS dev machines.
+   * the new spawn.
    *
-   * Best-effort: any failure (missing binary, permission denied) is
-   * swallowed. The caller already polls the port via
-   * {@link waitForPortRelease} and a leaked process will then surface
-   * as a crash loop the operator can investigate.
+   * Cross-platform:
+   *   - POSIX: tries `lsof -ti` first, then falls back to `fuser`;
+   *     both are universally available on Linux pods and macOS dev
+   *     machines. Failure (missing binary, permission denied) is
+   *     swallowed via `|| true` and the empty stdout returns early.
+   *   - Windows: uses `netstat -ano | findstr :<port> | findstr LISTENING`
+   *     to enumerate PIDs and `taskkill /F /PID` to kill them.
+   *     Going through cmd.exe with the POSIX one-liner above used
+   *     to spray three lines of "system cannot find the path
+   *     specified" / "'true' is not recognized" into the runtime
+   *     log on every `restartApiServerOnly()` (custom-routes save,
+   *     schema change, crash recovery) — harmless but alarming.
+   *
+   * Best-effort regardless of platform: the caller already polls the
+   * port via {@link waitForPortRelease} and a leaked process will
+   * then surface as a crash loop the operator can investigate.
    */
   private async forceKillPort(): Promise<void> {
+    if (process.platform === 'win32') {
+      this.forceKillPortWindows()
+      return
+    }
+    this.forceKillPortPosix()
+  }
+
+  private forceKillPortPosix(): void {
     try {
       const result = execSync(
         `lsof -ti :${this.apiPort} 2>/dev/null || fuser ${this.apiPort}/tcp 2>/dev/null || true`,
@@ -2072,6 +2091,55 @@ export class PreviewManager {
     } catch {
       // lsof / fuser missing on this platform; waitForPortRelease will
       // still give the kernel time to clean up the socket.
+    }
+  }
+
+  /**
+   * Windows analog of `forceKillPortPosix`. `findstr` on stdin from
+   * `netstat -ano` returns lines shaped like
+   *   `  TCP    127.0.0.1:3001         0.0.0.0:0              LISTENING       12345`
+   * — the trailing whitespace-separated token is the PID. We pass
+   *   `2>nul` to suppress findstr's "no match" stderr and rely on
+   * `taskkill /F /PID`'s own exit code (already swallowed by the
+   * outer try/catch) for cleanup. The execSync call is wrapped in
+   * try/catch because findstr exits 1 when no lines match — i.e.
+   * the port is already free, which is the *expected* fast path.
+   */
+  private forceKillPortWindows(): void {
+    let stdout = ''
+    try {
+      stdout = execSync(
+        `netstat -ano | findstr :${this.apiPort} | findstr LISTENING`,
+        { encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] },
+      )
+    } catch {
+      // findstr exit 1 = no listening process. Nothing to kill.
+      return
+    }
+
+    // Defensively keep only numeric PIDs. Skip 0 (idle process) and
+    // self/parent — we never want to taskkill the runtime itself.
+    const selfPid = String(process.pid)
+    const parentPid = String(process.ppid)
+    const pids = [...new Set(
+      stdout
+        .split('\n')
+        .map((line) => line.trim().split(/\s+/).pop() ?? '')
+        .filter((pid) => /^\d+$/.test(pid) && pid !== '0' && pid !== selfPid && pid !== parentPid),
+    )]
+
+    for (const pid of pids) {
+      try {
+        execSync(`taskkill /F /PID ${pid}`, {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          timeout: 5000,
+        })
+        console.log(`[${LOG_PREFIX}] Force-killed leaked process ${pid} on port ${this.apiPort}`)
+      } catch {
+        // Process already exited / access denied — fine; the next
+        // waitForPortRelease tick will tell us if the port is still
+        // occupied.
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- `PreviewManager.forceKillPort` and `RuntimeManager.cleanupStaleProcesses` shelled out POSIX one-liners (`lsof -ti :PORT 2>/dev/null || fuser PORT/tcp 2>/dev/null || true` and `lsof -iTCP:S-E -sTCP:LISTEN -t 2>/dev/null || true`) via `execSync`. On Windows that routes through `cmd.exe`, which doesn't recognize `2>/dev/null` (a path redirect) or `true` (a POSIX builtin, not a Win32 binary).
- Result: every API-server restart on Windows — custom-routes save, schema change, crash recovery — sprayed `The system cannot find the path specified.` (×2) and `'true' is not recognized as an internal or external command, operable program or batch file.` into the runtime log right after `API server exited (signal=SIGTERM)`. Harmless, but indistinguishable from a runtime crash to a user staring at the dev server output.
- Branch both helpers on `process.platform === 'win32'`. On Windows we use `netstat -ano | findstr LISTENING` to enumerate PIDs and `taskkill /F /PID` to kill them. POSIX paths are unchanged. PID filtering (skip 0, self, parent) is preserved across platforms; `findstr`'s exit-1-on-no-match is treated as the empty fast path.
- Adds `preview-manager-force-kill-port.test.ts`: pins that on win32 forceKillPort never invokes `lsof` / `fuser` / `2>/dev/null` / `|| true` and only reaches for `netstat` / `taskkill`, including the per-row PID parser and the self/parent/PID-0 skip rules.
- Fixes a pre-existing failure in `runtime-manager-ports.test.ts` that asserted POSIX-only commands while `killProcessOnPort` itself already had Windows branching, making the test fail on every Windows checkout.

## Test plan

- [x] `bun test packages/agent-runtime/src/__tests__/preview-manager-force-kill-port.test.ts` → 4/4 pass
- [x] `bun test apps/api/src/__tests__/runtime-manager-ports.test.ts` → 7/7 pass (was 6 pass / 1 fail on Windows pre-PR)
- [x] `bun test packages/agent-runtime/src/__tests__/preview-manager.test.ts` → 22 pass / 28 fail, **identical to baseline pre-PR** (pre-existing `resolveApiServerEnv` regressions, unrelated to port cleanup)
- [ ] Smoke: `bun dev:all`, save `custom-routes.ts` to trigger `restartApiServerOnly`, confirm runtime log no longer prints the four cmd.exe error lines
