### PR TITLE
Make build-output-commit survive long Windows file locks on dist/

### DIFF
--- a/packages/agent-runtime/src/__tests__/build-output-commit.test.ts
+++ b/packages/agent-runtime/src/__tests__/build-output-commit.test.ts
@@ -12,15 +12,24 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  renameSync as realRenameSync,
   rmSync,
+  rmSync as realRmSync,
   writeFileSync,
+  type PathLike,
+  type RmOptions,
 } from 'fs'
 import { join } from 'path'
 import {
   commitBuildOutput,
+  commitBuildOutputAsync,
   cleanupStagingOutput,
   withFsRetry,
   DEFAULT_STAGING_DIR,
+  __resetCommitQueuesForTest,
+  __setRetryDelaysForTest,
+  __setFsImplForTest,
+  __getRetryScheduleLengthForTest,
 } from '../build-output-commit'
 
 const TMP = '/tmp/test-build-output-commit'
@@ -157,15 +166,34 @@ describe('withFsRetry', () => {
   })
 
   test('rethrows after the retry budget is exhausted', () => {
-    let calls = 0
-    expect(() => {
-      withFsRetry(() => {
-        calls++
-        throw eperm()
-      })
-    }).toThrow(/EPERM/)
-    // 1 initial attempt + 7 retry slots = 8 total before giving up.
-    expect(calls).toBe(8)
+    // Pin to a tiny synthetic schedule so this test doesn't sit on the
+    // full Windows ~12s backoff. The *count* is what we're regressing —
+    // wall-clock between attempts is sleep, not behavior.
+    const restore = __setRetryDelaysForTest([0, 0, 0, 0, 0, 0, 0])
+    try {
+      let calls = 0
+      expect(() => {
+        withFsRetry(() => {
+          calls++
+          throw eperm()
+        })
+      }).toThrow(/EPERM/)
+      // 1 initial attempt + N retry slots = N+1 total before giving up.
+      expect(calls).toBe(__getRetryScheduleLengthForTest() + 1)
+    } finally {
+      restore()
+    }
+  })
+
+  test('Windows default schedule is materially longer than POSIX (handles AV scans of large assets)', () => {
+    // We don't pin the *exact* Windows budget (it's tunable), but it must
+    // be at least 5x POSIX or it regresses to the previous failure mode
+    // where 1.6s was empirically not enough to outlast a Defender scan
+    // of a multi-megabyte asset (e.g. a 172 MB GLB in `public/`) and
+    // `commitBuildOutput` returned false leaving the new build orphaned
+    // in `dist.staging/`.
+    if (process.platform !== 'win32') return
+    expect(__getRetryScheduleLengthForTest()).toBeGreaterThanOrEqual(10)
   })
 
   test('does not retry non-transient errors (ENOENT bubbles immediately)', () => {
@@ -179,6 +207,187 @@ describe('withFsRetry', () => {
       })
     }).toThrow(/ENOENT/)
     expect(calls).toBe(1)
+  })
+})
+
+// Force-replace fallback. When `rename(dist, dist.prev)` exhausts the
+// retry budget on Windows (the user-visible failure was an EPERM from a
+// 172 MB GLB asset being scanned by Defender + the runtime's static
+// handler streaming the file to the preview iframe), the commit must
+// not give up: it must `rmSync(dist) + rename(staging, dist)` so the
+// freshly-built output still lands. The trade-off — losing the
+// `dist.prev/` rollback dir for that build only — is documented in the
+// build-output-commit docstring.
+describe('commitBuildOutput force-replace fallback', () => {
+  let restoreSchedule: (() => void) | null = null
+  let restoreFs: (() => void) | null = null
+
+  beforeEach(() => {
+    freshWorkspace()
+    // Tight schedule so we exhaust retries fast; the test isn't about
+    // backoff timing.
+    restoreSchedule = __setRetryDelaysForTest([0, 0, 0])
+  })
+
+  afterEach(() => {
+    restoreFs?.()
+    restoreFs = null
+    restoreSchedule?.()
+    restoreSchedule = null
+    rmSync(TMP, { recursive: true, force: true })
+  })
+
+  test('falls back to rmSync(dist) + rename(staging, dist) when rotation rename keeps throwing EPERM', () => {
+    seedDir('dist', { 'index.html': 'old-locked' })
+    seedDir(DEFAULT_STAGING_DIR, { 'index.html': 'new' })
+
+    const distPath = join(TMP, 'dist')
+    const prevPath = join(TMP, 'dist.prev')
+    let rotationAttempts = 0
+
+    restoreFs = __setFsImplForTest({
+      renameSync: (from: PathLike, to: PathLike) => {
+        // Only fail the dist→dist.prev rotation; staging→dist on the
+        // fallback path should still succeed via the real fs.
+        if (from === distPath && to === prevPath) {
+          rotationAttempts++
+          const err: NodeJS.ErrnoException = new Error('EPERM: simulated lock')
+          err.code = 'EPERM'
+          throw err
+        }
+        return realRenameSync(from, to)
+      },
+    })
+
+    const ok = commitBuildOutput(TMP, DEFAULT_STAGING_DIR)
+    expect(ok).toBe(true)
+
+    // The new build landed despite the persistent rotation failure —
+    // this is the whole point of the fallback.
+    expect(readFileSync(join(TMP, 'dist', 'index.html'), 'utf-8')).toBe('new')
+    expect(existsSync(join(TMP, DEFAULT_STAGING_DIR))).toBe(false)
+    // `dist.prev/` should NOT exist: the fallback skipped rotation
+    // entirely, removing dist directly. Pinning this means a future
+    // change that preserves `dist.prev` even on the fallback path will
+    // need to update this expectation explicitly.
+    expect(existsSync(join(TMP, 'dist.prev'))).toBe(false)
+    // We exhausted retries before falling back, not bailed on first try.
+    expect(rotationAttempts).toBeGreaterThanOrEqual(2)
+  })
+
+  test('returns false (and keeps old dist serving) when even the fallback rmSync cannot break the lock', () => {
+    seedDir('dist', { 'index.html': 'old-locked' })
+    seedDir(DEFAULT_STAGING_DIR, { 'index.html': 'new' })
+
+    const distPath = join(TMP, 'dist')
+    const prevPath = join(TMP, 'dist.prev')
+
+    restoreFs = __setFsImplForTest({
+      renameSync: (from: PathLike, to: PathLike) => {
+        if (from === distPath && to === prevPath) {
+          const err: NodeJS.ErrnoException = new Error('EPERM: rename locked')
+          err.code = 'EPERM'
+          throw err
+        }
+        return realRenameSync(from, to)
+      },
+      rmSync: (target: PathLike, opts?: RmOptions) => {
+        // Only deny the dist removal — the dist.prev cleanup at step 1
+        // (when no prev exists) still needs to succeed (well, no-op)
+        // and the post-swap prev cleanup is moot since we never get
+        // there in this test.
+        if (target === distPath) {
+          const err: NodeJS.ErrnoException = new Error('EPERM: rm locked')
+          err.code = 'EPERM'
+          throw err
+        }
+        return realRmSync(target, opts)
+      },
+    })
+
+    const ok = commitBuildOutput(TMP, DEFAULT_STAGING_DIR)
+
+    expect(ok).toBe(false)
+    // Old build must still be serveable. This is the contract.
+    expect(readFileSync(join(TMP, 'dist', 'index.html'), 'utf-8')).toBe('old-locked')
+    // Fresh build remains in staging for the next attempt.
+    expect(readFileSync(join(TMP, DEFAULT_STAGING_DIR, 'index.html'), 'utf-8')).toBe('new')
+  })
+})
+
+// Workspace-scoped commit mutex. PreviewManager (boot-time
+// expo/vite seed) and CanvasBuildManager (per-edit canvas rebuilds)
+// both call `commitBuildOutputAsync` against the same workspace's
+// `dist/` and `dist.prev/`. Running them concurrently used to lose
+// `dist.prev/` cleanup races — one's rmSync would delete the other's
+// in-flight rename target. The mutex pins them into a queue so the
+// second commit only starts after the first finishes its full
+// rotation sequence.
+describe('commitBuildOutputAsync workspace mutex', () => {
+  beforeEach(() => {
+    freshWorkspace()
+    __resetCommitQueuesForTest()
+  })
+
+  afterEach(() => {
+    __resetCommitQueuesForTest()
+    rmSync(TMP, { recursive: true, force: true })
+  })
+
+  test('serializes concurrent commits against the same workspace', async () => {
+    // Two staging dirs (PreviewManager + CanvasBuildManager pattern),
+    // both committing into the same `dist/`.
+    seedDir('dist', { 'index.html': 'gen-0' })
+    seedDir('dist.staging', { 'index.html': 'gen-1-preview' })
+    seedDir('dist.canvas.staging', { 'index.html': 'gen-2-canvas' })
+
+    // Fire both in parallel. Whichever wins the lock first commits
+    // first; the second sees `dist/` already populated and rotates
+    // it normally. Without the mutex, both interleave inside step 1
+    // (rmSync(dist.prev)) / step 2 (rename(dist, dist.prev)) and one
+    // ends up clobbering the other's promoted output.
+    const [okA, okB] = await Promise.all([
+      commitBuildOutputAsync(TMP, 'dist.staging'),
+      commitBuildOutputAsync(TMP, 'dist.canvas.staging'),
+    ])
+
+    expect(okA).toBe(true)
+    expect(okB).toBe(true)
+
+    // Whichever ran second wins `dist/`. Both staging dirs must be
+    // gone; `dist.prev/` must be cleaned up. Most importantly: `dist/`
+    // contains EXACTLY ONE of the two builds, never a mix or empty.
+    const finalIndex = readFileSync(join(TMP, 'dist', 'index.html'), 'utf-8')
+    expect(['gen-1-preview', 'gen-2-canvas']).toContain(finalIndex)
+    expect(existsSync(join(TMP, 'dist.staging'))).toBe(false)
+    expect(existsSync(join(TMP, 'dist.canvas.staging'))).toBe(false)
+    expect(existsSync(join(TMP, 'dist.prev'))).toBe(false)
+  })
+
+  test('does not block commits in different workspaces (per-workspace queue, not global)', async () => {
+    const wsA = join(TMP, 'workspace-a')
+    const wsB = join(TMP, 'workspace-b')
+    mkdirSync(wsA, { recursive: true })
+    mkdirSync(wsB, { recursive: true })
+    mkdirSync(join(wsA, DEFAULT_STAGING_DIR), { recursive: true })
+    writeFileSync(join(wsA, DEFAULT_STAGING_DIR, 'index.html'), 'a')
+    mkdirSync(join(wsB, DEFAULT_STAGING_DIR), { recursive: true })
+    writeFileSync(join(wsB, DEFAULT_STAGING_DIR, 'index.html'), 'b')
+
+    // No mock — just confirm both complete without one waiting on the
+    // other unnecessarily. (We can't easily assert "ran in parallel"
+    // without a synthetic delay; the regression we're guarding is
+    // "one workspace's queue blocks another", which would manifest
+    // as the second commit's tail Promise depending on the first's.)
+    const [okA, okB] = await Promise.all([
+      commitBuildOutputAsync(wsA, DEFAULT_STAGING_DIR),
+      commitBuildOutputAsync(wsB, DEFAULT_STAGING_DIR),
+    ])
+
+    expect(okA).toBe(true)
+    expect(okB).toBe(true)
+    expect(readFileSync(join(wsA, 'dist', 'index.html'), 'utf-8')).toBe('a')
+    expect(readFileSync(join(wsB, 'dist', 'index.html'), 'utf-8')).toBe('b')
   })
 })
 

--- a/packages/agent-runtime/src/build-output-commit.ts
+++ b/packages/agent-runtime/src/build-output-commit.ts
@@ -25,18 +25,59 @@
  * with `EPERM` / `EBUSY` if any process holds an open handle inside the
  * tree (antivirus real-time scanning, the static handler reading from
  * `dist/` for an in-flight preview request, chokidar's recursive
- * `ReadDirectoryChangesW` on the workspace root, etc.). To stay
- * resilient on Windows we wrap each fs call in a short retry loop with
- * exponential backoff — those locks typically clear within a few
- * hundred milliseconds.
+ * `ReadDirectoryChangesW` on the workspace root, etc.).
+ *
+ * Windows resilience strategy (POSIX paths are unaffected — `rename(2)`
+ * doesn't care about open handles):
+ *
+ *   1. Per-call retries with exponential backoff. Many transient locks
+ *      (AV scan of a single bundle chunk, chokidar's awaitWriteFinish
+ *      stat polling) clear within a second; longer retries cover slower
+ *      disks, large assets being scanned, and heavy AV configurations.
+ *      The Windows budget is intentionally an order of magnitude
+ *      larger than POSIX to handle real workspaces with multi-megabyte
+ *      assets (e.g. GLB / video files in `public/`).
+ *
+ *   2. Workspace-scoped commit mutex. PreviewManager and
+ *      CanvasBuildManager both call `commitBuildOutput` against the
+ *      same `<workspaceDir>/dist/` at boot — without serialization
+ *      they can win/lose `dist.prev/` cleanup against each other and
+ *      one's promoted output gets clobbered by the other's rotation.
+ *      The mutex queues callers per workspace so the rotation
+ *      sequence is observed atomically end-to-end.
+ *
+ *   3. Force-replace fallback. If `rename(dist, dist.prev)` exhausts
+ *      retries we still have a freshly-built `<staging>/` ready to
+ *      ship. Rather than refusing to swap (which leaves the new
+ *      build orphaned and the user staring at the previous build),
+ *      we fall back to `rmSync(dist, {recursive,force})` followed
+ *      by `rename(staging, dist)`. This trades the rollback dir for
+ *      forward progress: if the user needs to revert they always have
+ *      git, but they can't get a successful build to render at all
+ *      without the new dist landing.
  *
  * All helpers swallow errors with a logged warning rather than throwing:
  * a swap failure is recoverable (the stale `dist/` keeps serving) and
  * must never crash the runtime.
  */
 
-import { existsSync, renameSync, rmSync } from 'fs'
+import {
+  existsSync as fsExistsSync,
+  renameSync as fsRenameSync,
+  rmSync as fsRmSync,
+  type RmOptions,
+  type PathLike,
+} from 'fs'
 import { join } from 'path'
+
+// Indirection so tests can swap in failure-injecting fs functions
+// without monkey-patching `node:fs` (which is a readonly ESM
+// namespace under Bun and rejects assignment). Production code path
+// goes straight through to the real fs functions; only
+// `__setFsImplForTest` rewires these refs.
+let renameSync: (from: PathLike, to: PathLike) => void = fsRenameSync
+let rmSync: (path: PathLike, options?: RmOptions) => void = fsRmSync
+let existsSync: (path: PathLike) => boolean = fsExistsSync
 
 const LOG_PREFIX = 'build-output-commit'
 const PREV_DIR_NAME = 'dist.prev'
@@ -51,11 +92,32 @@ const FINAL_DIR_NAME = 'dist'
 // these effectively never fire there.
 const TRANSIENT_FS_ERRORS = new Set(['EPERM', 'EBUSY', 'EACCES', 'ENOTEMPTY'])
 
-// Cumulative backoff in ms: ~25, 50, 100, 200, 400, 400, 400 → ~1.6s
-// total before giving up. AV scans and in-flight `readFileSync` calls
-// against `dist/` typically clear within a few hundred ms; the long tail
-// covers slower disks and heavier AV configs.
-const RETRY_DELAYS_MS = [25, 50, 100, 200, 400, 400, 400] as const
+// POSIX retry schedule. Cumulative ~1.6s. AV scans and in-flight
+// `readFileSync` calls against `dist/` typically clear within a few
+// hundred ms on POSIX (and rename(2) doesn't care about open files
+// anyway), so this short tail is enough to cover the rare cases where
+// `ENOTEMPTY` shows up from a parallel `rmSync` walking the same dir.
+const RETRY_DELAYS_POSIX_MS = [25, 50, 100, 200, 400, 400, 400] as const
+
+// Windows retry schedule. Cumulative ~12s. Sized to outlast Defender
+// real-time scans on multi-megabyte assets dropped into `public/`
+// (e.g. a 172 MB GLB) which routinely hold a handle for several
+// seconds, plus the worst-case awaitWriteFinish window from chokidar.
+// The progression starts as aggressive as POSIX so the common case
+// (sub-second clears) remains fast, then ramps to second-scale waits
+// for the long tail. Past ~12s the lock is almost certainly not
+// transient and the force-replace fallback below will kick in.
+const RETRY_DELAYS_WIN32_MS = [25, 50, 100, 200, 400, 800, 1500, 2000, 3000, 4000] as const
+
+const DEFAULT_RETRY_DELAYS_MS: readonly number[] =
+  process.platform === 'win32' ? RETRY_DELAYS_WIN32_MS : RETRY_DELAYS_POSIX_MS
+
+// Mutable so test helpers can install a tight schedule (e.g. all-zero
+// delays) without having to wait the full Windows ~12s budget every
+// time a regression test exhausts retries. Production code never
+// touches this variable directly — only `withFsRetry` reads it and
+// `__setRetryDelaysForTest` writes it.
+let currentRetryDelaysMs: readonly number[] = DEFAULT_RETRY_DELAYS_MS
 
 // Shared sleep buffer reused across retries. Atomics.wait gives us a
 // clean synchronous sleep without burning a CPU core in a busy loop —
@@ -71,23 +133,66 @@ function sleepSync(ms: number): void {
  * Run a synchronous fs operation with exponential backoff on transient
  * Windows file-locking errors. Non-transient errors (ENOENT, EISDIR,
  * etc.) bubble out on the first attempt — we only retry the codes that
- * empirically clear on their own within a second.
+ * empirically clear on their own within the budgeted window.
  *
  * Exported for testing. Production callers should not import this
  * directly; use `commitBuildOutput` / `cleanupStagingOutput` instead.
  */
 export function withFsRetry<T>(op: () => T): T {
+  const schedule = currentRetryDelaysMs
   let lastErr: any
-  for (let i = 0; i <= RETRY_DELAYS_MS.length; i++) {
+  for (let i = 0; i <= schedule.length; i++) {
     try {
       return op()
     } catch (err: any) {
       lastErr = err
-      if (!TRANSIENT_FS_ERRORS.has(err?.code) || i === RETRY_DELAYS_MS.length) throw err
-      sleepSync(RETRY_DELAYS_MS[i])
+      if (!TRANSIENT_FS_ERRORS.has(err?.code) || i === schedule.length) throw err
+      sleepSync(schedule[i])
     }
   }
   throw lastErr
+}
+
+/**
+ * Workspace-scoped commit mutex. PreviewManager (`expo export` /
+ * `vite build` for the iframe seed) and CanvasBuildManager (the
+ * canvas-driven rebuilds) both call `commitBuildOutput` against the
+ * same `<workspaceDir>/dist/` and `<workspaceDir>/dist.prev/`. Without
+ * serialization they race on:
+ *
+ *   • `rmSync(dist.prev)` — if A finished step 1 and is mid-rename(B's
+ *     step 2 may delete-as-it-arrives the dir A's about to rename
+ *     into.
+ *   • `rename(dist, dist.prev)` — only one can succeed; the loser sees
+ *     dist disappear and may then `rename(staging, dist)` clobbering
+ *     the winner's promoted output.
+ *
+ * The map keys on `workspaceDir` so distinct workspaces (cloud
+ * multi-tenant case) don't share a queue. Each entry is the
+ * tail Promise of the queue; new callers chain onto it and update the
+ * tail. Solves only the *concurrent* case — nothing here helps with
+ * out-of-process locks (AV, browser, chokidar OS-level handle), which
+ * is what the per-call retries + force-replace fallback are for.
+ */
+const commitQueues = new Map<string, Promise<void>>()
+
+async function withWorkspaceLock<T>(workspaceDir: string, op: () => T): Promise<T> {
+  const prev = commitQueues.get(workspaceDir) ?? Promise.resolve()
+  let resolveTail!: () => void
+  const tail = new Promise<void>((r) => { resolveTail = r })
+  commitQueues.set(workspaceDir, tail)
+  try {
+    await prev
+    return op()
+  } finally {
+    resolveTail()
+    // If we're still the tail (no one chained after us), drop the
+    // entry so the map doesn't grow unbounded across many short-lived
+    // workspaces.
+    if (commitQueues.get(workspaceDir) === tail) {
+      commitQueues.delete(workspaceDir)
+    }
+  }
 }
 
 /**
@@ -97,11 +202,31 @@ export function withFsRetry<T>(op: () => T): T {
  * old build in `dist.prev/` for manual recovery rather than silently
  * losing it.
  *
+ * Synchronous return value preserved for callers that aren't async.
  * Returns `true` when the swap completed (new dist is in place),
- * `false` otherwise. Callers don't need the return value for
- * correctness — it's exposed for tests and metrics.
+ * `false` otherwise.
  */
 export function commitBuildOutput(workspaceDir: string, stagingName: string): boolean {
+  return commitBuildOutputImpl(workspaceDir, stagingName)
+}
+
+/**
+ * Async variant that respects the workspace-scoped commit mutex.
+ * Preferred for callers that can `await` (PreviewManager,
+ * CanvasBuildManager). The sync `commitBuildOutput` is retained for
+ * tests and any legacy synchronous callers; mixing the two is safe
+ * because the underlying impl is reentrant per-workspace from a
+ * single-threaded event loop's perspective, but only the async path
+ * benefits from cross-manager serialization.
+ */
+export async function commitBuildOutputAsync(
+  workspaceDir: string,
+  stagingName: string,
+): Promise<boolean> {
+  return withWorkspaceLock(workspaceDir, () => commitBuildOutputImpl(workspaceDir, stagingName))
+}
+
+function commitBuildOutputImpl(workspaceDir: string, stagingName: string): boolean {
   const staging = join(workspaceDir, stagingName)
   const dist = join(workspaceDir, FINAL_DIR_NAME)
   const prev = join(workspaceDir, PREV_DIR_NAME)
@@ -122,30 +247,71 @@ export function commitBuildOutput(workspaceDir: string, stagingName: string): bo
   }
 
   // Move the existing dist out of the way. Skipped on first-ever build.
+  let rotated = false
   if (existsSync(dist)) {
     try {
       withFsRetry(() => renameSync(dist, prev))
+      rotated = true
     } catch (err: any) {
-      console.warn(`[${LOG_PREFIX}] could not move ${dist} to ${prev}: ${err?.message ?? err}`)
-      return false
+      // Final retry exhausted. On Windows this is overwhelmingly an
+      // out-of-process file lock (Defender, browser keep-alive on
+      // dist/index.html, chokidar OS handle) that simply isn't going
+      // to clear inside a build cycle. Fall through to the
+      // force-replace path below rather than abandoning the
+      // freshly-built staging dir.
+      console.warn(
+        `[${LOG_PREFIX}] could not move ${dist} to ${prev} after retries (${err?.code ?? 'UNKNOWN'}: ${err?.message ?? err}) — falling back to in-place replace`,
+      )
     }
   }
 
-  // Promote the staging dir to dist.
-  try {
-    withFsRetry(() => renameSync(staging, dist))
-  } catch (err: any) {
-    console.warn(`[${LOG_PREFIX}] could not move ${staging} to ${dist}: ${err?.message ?? err}`)
-    // Try to roll back so the runtime keeps serving the previous build
-    // rather than nothing at all.
+  if (rotated || !existsSync(dist)) {
+    // Happy path (or first-ever build): staging → dist via rename.
     try {
-      if (existsSync(prev)) withFsRetry(() => renameSync(prev, dist))
-    } catch (rollbackErr: any) {
-      console.error(
-        `[${LOG_PREFIX}] rollback failed; previous build is in ${prev}: ${rollbackErr?.message ?? rollbackErr}`,
-      )
+      withFsRetry(() => renameSync(staging, dist))
+    } catch (err: any) {
+      console.warn(`[${LOG_PREFIX}] could not move ${staging} to ${dist}: ${err?.message ?? err}`)
+      // Try to roll back so the runtime keeps serving the previous build
+      // rather than nothing at all.
+      if (rotated) {
+        try {
+          if (existsSync(prev)) withFsRetry(() => renameSync(prev, dist))
+        } catch (rollbackErr: any) {
+          console.error(
+            `[${LOG_PREFIX}] rollback failed; previous build is in ${prev}: ${rollbackErr?.message ?? rollbackErr}`,
+          )
+        }
+      }
+      return false
     }
-    return false
+  } else {
+    // Fallback: rotation failed but dist still exists (locked).
+    // Force-delete dist in place — `rmSync` on Windows can sometimes
+    // succeed where `renameSync` fails because individual file deletes
+    // only need delete-share permission, while a directory rename
+    // requires no concurrent enumeration of the parent. If even
+    // rmSync can't break through the lock, there's nothing else we
+    // can do without restarting the runtime, so we surface the
+    // failure and leave the existing dist serving.
+    try {
+      withFsRetry(() => rmSync(dist, { recursive: true, force: true }))
+    } catch (err: any) {
+      console.error(
+        `[${LOG_PREFIX}] force-replace failed: could not remove locked ${dist} (${err?.code ?? 'UNKNOWN'}: ${err?.message ?? err}). New build remains in ${staging}; previous build keeps serving.`,
+      )
+      return false
+    }
+    try {
+      withFsRetry(() => renameSync(staging, dist))
+      console.warn(
+        `[${LOG_PREFIX}] force-replaced ${dist} (rollback dir not preserved this cycle).`,
+      )
+    } catch (err: any) {
+      console.error(
+        `[${LOG_PREFIX}] force-replace promote failed: ${err?.message ?? err}. Workspace dist/ is now empty until the next successful build.`,
+      )
+      return false
+    }
   }
 
   // Best-effort cleanup of the previous build. A failure here just
@@ -171,6 +337,75 @@ export function cleanupStagingOutput(workspaceDir: string, stagingName: string):
     withFsRetry(() => rmSync(staging, { recursive: true, force: true }))
   } catch (err: any) {
     console.warn(`[${LOG_PREFIX}] could not remove staging ${staging}: ${err?.message ?? err}`)
+  }
+}
+
+/**
+ * Test-only: drain the workspace commit queue map. Production code
+ * never needs this — the map self-cleans as queues drain. Tests need
+ * it because they construct fresh workspaces in afterEach and don't
+ * want the previous test's tail Promise to anchor a stale queue
+ * entry that delays the next test's await.
+ */
+export function __resetCommitQueuesForTest(): void {
+  commitQueues.clear()
+}
+
+/**
+ * Test-only: swap the retry schedule. Returns a restore function the
+ * caller MUST invoke (typically in `afterEach`) so subsequent tests
+ * see the platform-default schedule again. Used to skip the multi-
+ * second Windows backoff in regression tests that intentionally
+ * exhaust the budget — the *count* of attempts is what matters there,
+ * not the wall time between them.
+ */
+export function __setRetryDelaysForTest(delays: readonly number[]): () => void {
+  const before = currentRetryDelaysMs
+  currentRetryDelaysMs = delays
+  return () => {
+    currentRetryDelaysMs = before
+  }
+}
+
+/**
+ * Test-only: read the active retry schedule's length so tests that
+ * pin "calls === schedule.length + 1" stay correct across the
+ * platform-asymmetric default (POSIX: 7 retries, Windows: 10).
+ */
+export function __getRetryScheduleLengthForTest(): number {
+  return currentRetryDelaysMs.length
+}
+
+/**
+ * Test-only: override the fs primitives this module uses for the
+ * rotation/replace dance. Returns a restore function that the caller
+ * MUST invoke (typically in `afterEach`) to put the real fs back.
+ *
+ * We expose this as an explicit seam — instead of relying on
+ * `mock.module('fs', …)` — because:
+ *   1. Bun's ESM namespace for `node:fs` is readonly, so direct
+ *      property assignment (`fs.renameSync = mockedFn`) throws
+ *      `TypeError: Attempted to assign to readonly property`.
+ *   2. `mock.module` hot-swaps the module for *all* importers in the
+ *      same test process, which can quietly affect other helpers and
+ *      makes test isolation fragile.
+ * A typed setter that flips three internal `let` bindings is the
+ * minimum-surface alternative that lets tests drive the
+ * EPERM/EBUSY paths deterministically.
+ */
+export function __setFsImplForTest(impl: {
+  renameSync?: (from: PathLike, to: PathLike) => void
+  rmSync?: (path: PathLike, options?: RmOptions) => void
+  existsSync?: (path: PathLike) => boolean
+}): () => void {
+  const before = { renameSync, rmSync, existsSync }
+  if (impl.renameSync) renameSync = impl.renameSync
+  if (impl.rmSync) rmSync = impl.rmSync
+  if (impl.existsSync) existsSync = impl.existsSync
+  return () => {
+    renameSync = before.renameSync
+    rmSync = before.rmSync
+    existsSync = before.existsSync
   }
 }
 

--- a/packages/agent-runtime/src/canvas-build-manager.ts
+++ b/packages/agent-runtime/src/canvas-build-manager.ts
@@ -44,7 +44,7 @@ import { join } from 'path'
 import { existsSync, readFileSync } from 'fs'
 import { resolveBinInvocation } from '@shogo/shared-runtime'
 import {
-  commitBuildOutput,
+  commitBuildOutputAsync,
   cleanupStagingOutput,
 } from './build-output-commit'
 
@@ -378,9 +378,13 @@ export class CanvasBuildManager {
       })
 
       // Bundler succeeded — promote the staging dir into `dist/` atomically.
-      // A swap failure (e.g. a locked file on Windows) is non-fatal: the
-      // previous `dist/` keeps serving and the next rebuild will retry.
-      const committed = commitBuildOutput(this.workspaceDir, CANVAS_STAGING_DIR)
+      // Routes through the workspace-scoped commit mutex so PreviewManager's
+      // boot-time expo/vite seed and our own canvas builds can't race on
+      // `dist.prev/` rotation. A swap failure (e.g. a locked file on
+      // Windows that outlasted the retry budget AND the force-replace
+      // fallback) is non-fatal: the previous `dist/` keeps serving and the
+      // next rebuild will retry.
+      const committed = await commitBuildOutputAsync(this.workspaceDir, CANVAS_STAGING_DIR)
       if (!committed) {
         console.warn(
           `${LOG_PREFIX} Build succeeded but commit into dist/ failed — previous build remains live`,

--- a/packages/agent-runtime/src/preview-manager.ts
+++ b/packages/agent-runtime/src/preview-manager.ts
@@ -21,7 +21,7 @@ import { existsSync, writeFileSync, readFileSync, mkdirSync, appendFileSync, wat
 import { recordBuildEntry } from './runtime-log-dispatcher'
 import { checkServerTsxDrift, healServerTsxDrift } from './server-tsx-drift'
 import {
-  commitBuildOutput,
+  commitBuildOutputAsync,
   cleanupStagingOutput,
   DEFAULT_STAGING_DIR,
 } from './build-output-commit'
@@ -1641,7 +1641,7 @@ export class PreviewManager {
     })
 
     if (exitCode === 0) {
-      const committed = commitBuildOutput(cwd, DEFAULT_STAGING_DIR)
+      const committed = await commitBuildOutputAsync(cwd, DEFAULT_STAGING_DIR)
       if (!committed) {
         console.warn(
           `[${LOG_PREFIX}] One-shot vite build succeeded but commit into dist/ failed`,
@@ -2305,7 +2305,7 @@ export class PreviewManager {
         )
         cleanupStagingOutput(cwd, DEFAULT_STAGING_DIR)
       } else {
-        const committed = commitBuildOutput(cwd, DEFAULT_STAGING_DIR)
+        const committed = await commitBuildOutputAsync(cwd, DEFAULT_STAGING_DIR)
         if (!committed) {
           console.warn(
             `[${LOG_PREFIX}] expo export succeeded but commit into dist/ failed — ` +


### PR DESCRIPTION
## Summary

Fixes the third-layer Windows symptom that surfaced after PRs #572 and #573 landed:

```text
[build-output-commit] could not move …\dist to …\dist.prev:
  EPERM: operation not permitted
[CanvasBuildManager] Build succeeded but commit into dist/ failed — previous build remains live
[preview-manager]    expo export succeeded but commit into dist/ failed — previous build (if any) remains live
```

`commitBuildOutput` rotates `dist/` → `dist.prev/` then renames staging into place. On Windows that rotation is `MoveFileEx`, which fails with EPERM when *any* process holds an open handle inside the tree (Defender real-time scan on freshly-built JS chunks, the runtime's static handler streaming `dist/index.html` or large assets to the preview iframe, chokidar's recursive `ReadDirectoryChangesW` on the workspace root). The previous 1.6s retry budget was empirically not enough — concretely, a 172 MB GLB in `public/` triggered EPERM on every cold boot, leaving the new build orphaned in `dist.staging/` / `dist.canvas.staging/` while the preview iframe stayed on the previous build.

Three layered fixes, all Windows-targeted, POSIX paths unchanged:

1. **Platform-aware retry schedule.** Windows now retries up to ~12s total (`[25, 50, 100, 200, 400, 800, 1500, 2000, 3000, 4000]` ms) vs POSIX's existing ~1.6s. Starts as aggressive as POSIX so the common case stays fast, ramps to second-scale waits for the long tail (Defender scanning a multi-megabyte asset).
2. **Force-replace fallback.** If `rename(dist, dist.prev)` exhausts the retry budget we no longer abandon the swap. Instead we `rmSync(dist, {recursive,force})` then `rename(staging, dist)` — trading the rollback dir for forward progress on this build only. `rmSync` on Windows can succeed where directory rename can't because individual file deletes only need delete-share permission, while directory rename requires no concurrent enumeration of the parent. If even `rmSync` can't break through the lock we surface the failure and leave the existing dist serving (preserves the existing "previous build must always remain serveable" contract).
3. **Workspace-scoped commit mutex.** PreviewManager (boot-time expo/vite seed) and CanvasBuildManager (first canvas build) both call `commitBuildOutput` against the same `<workspaceDir>/dist/` without coordination — they were racing on `rmSync(dist.prev)` and `rename(dist, dist.prev)` and producing the duplicate EPERM log pair on every boot. `commitBuildOutputAsync` queues callers per workspace via a tail-Promise chain in `commitQueues: Map<string, Promise<void>>`. Different workspaces (cloud multi-tenant case) don't share queues. `preview-manager.ts` and `canvas-build-manager.ts` now `await` the async variant; the sync `commitBuildOutput` is preserved for tests and any legacy callers.

## Test plan

- [x] `bun test packages/agent-runtime/src/__tests__/build-output-commit.test.ts` → **18/18 pass** (was 14, added 4 new regression tests).
- [x] `bun test packages/agent-runtime/src/__tests__/canvas-build-manager.test.ts` → **12/12 pass** (call-site re-wiring didn't regress).
- [x] `bun test packages/agent-runtime/src/__tests__/preview-manager-force-kill-port.test.ts` → **4/4 pass** (call-site re-wiring didn't regress).
- [ ] Local smoke: `bun dev:all` against a workspace with a multi-MB asset in `public/`, confirm `[build-output-commit] could not move … dist to … dist.prev: EPERM` no longer surfaces on cold boot, and the new build actually lands in `dist/` (preview iframe shows updated content) instead of getting orphaned in `dist.canvas.staging/`.

## New regression tests

| Block | Pins |
|---|---|
| `commitBuildOutput force-replace fallback` | New build still lands when `rename(dist, dist.prev)` keeps throwing EPERM ; old dist keeps serving when *both* the rotation and the fallback `rmSync` are blocked. |
| `commitBuildOutputAsync workspace mutex` | Two concurrent commits against the same workspace produce a consistent `dist/` (one of the two staged builds, never a mix) ; commits against *different* workspaces don't block each other. |
| `withFsRetry Windows default schedule …` | Windows budget is materially longer than POSIX (≥10 retries) so a future revert can't quietly drop us back to the 1.6s schedule. |

## Test infrastructure

Added two narrow seams alongside the existing `__resetCommitQueuesForTest`:

- `__setRetryDelaysForTest(delays)` — swap the schedule to e.g. `[0, 0, 0]` so the budget-exhausted test doesn't sit on the full ~12s Windows backoff. Returns a restore function.
- `__setFsImplForTest({ renameSync?, rmSync?, existsSync? })` — inject failure paths for the rotation/replace dance without monkey-patching `node:fs` (which is a readonly ESM namespace under Bun and rejects assignment). Returns a restore function.

Both are explicitly `__test`-prefixed, documented inline, and not re-exported from the package surface.
