### PR TITLE
Align Project MST domain store with preferredInstance Prisma fields

### DIFF
--- a/packages/domain-stores/src/project.collection.ts
+++ b/packages/domain-stores/src/project.collection.ts
@@ -392,7 +392,7 @@ export const ProjectCollection = types
 // ============================================================================
 
 // Relation fields that expect IDs (safeReference)
-const relationFields = ["workspace","folder","members","inviteLinks","featureSessions","chatSessions","usageEvents","checkpoints","githubConnection","starredBy","agentConfig","meetings","marketplaceListing","agentCostMetrics","modelExperiments","subagentModelOverrides","agentEvalSets","voiceConfig","agents","projectFolders"]
+const relationFields = ["workspace","folder","members","inviteLinks","featureSessions","chatSessions","usageEvents","checkpoints","githubConnection","starredBy","agentConfig","meetings","marketplaceListing","agentCostMetrics","modelExperiments","subagentModelOverrides","agentEvalSets","voiceConfig","agents","projectFolders","preferredInstance"]
 
 /**
  * Transform API response for MST compatibility:

--- a/packages/domain-stores/src/project.model.ts
+++ b/packages/domain-stores/src/project.model.ts
@@ -49,6 +49,8 @@ export const ProjectModel = types
     workingMode: types.optional(types.string, ""),
     runtimeEnabled: types.optional(types.boolean, false),
     trustLevel: types.optional(types.string, ""),
+    preferredInstanceId: types.optional(types.string, ""),
+    preferredInstancePolicy: types.optional(types.string, ""),
     workspace: types.safeReference(types.late(() => WorkspaceModel)),
     folder: types.safeReference(types.late(() => FolderModel)),
     members: types.optional(types.array(types.safeReference(types.late(() => MemberModel))), []),

--- a/packages/domain-stores/src/project.types.ts
+++ b/packages/domain-stores/src/project.types.ts
@@ -40,6 +40,8 @@ export interface ProjectType {
   workingMode: string
   runtimeEnabled: boolean
   trustLevel: string
+  preferredInstanceId?: string
+  preferredInstancePolicy: string
 }
 
 export interface ProjectCreateInput {
@@ -65,6 +67,8 @@ export interface ProjectCreateInput {
   workingMode?: string
   runtimeEnabled?: boolean
   trustLevel?: string
+  preferredInstanceId?: string
+  preferredInstancePolicy?: string
 }
 
 export interface ProjectUpdateInput {
@@ -90,4 +94,6 @@ export interface ProjectUpdateInput {
   workingMode?: string
   runtimeEnabled?: boolean
   trustLevel?: string
+  preferredInstanceId?: string
+  preferredInstancePolicy?: string
 }


### PR DESCRIPTION
## Summary

Catch-up follow-up to the "agent proxy routing, instance tunnel relay, and external triggers" merge train. That change added two columns to `prisma/schema.prisma`'s `Project` model + a relation to `Instance`, and the backend (`agent-proxy-resolver.ts`, `tunnel-relay.ts`, `server.ts`) already reads them — but the MST front-end domain store in `packages/domain-stores/` wasn't updated, so the new fields had nowhere to deserialize into client-side.

Mirrors the schema 1:1:

- **`project.model.ts`** — adds `preferredInstanceId` and `preferredInstancePolicy` as `types.optional(types.string, "")`. Prisma's `@default("pinned")` is applied server-side; an empty MST default is fine since the API->MST mapping always populates the field.
- **`project.types.ts`** — adds the two fields to `ProjectType` (response shape) plus `ProjectCreateInput` / `ProjectUpdateInput` so callers can write them via the create/update REST endpoints.
- **`project.collection.ts`** — adds `preferredInstance` to `relationFields` so the API->MST transform treats an incoming `preferredInstance` payload as an Instance ID via `safeReference`, consistent with how `workspace`, `agentConfig`, etc. are already handled.

## Schema reference

```text
prisma/schema.prisma:208-232
  preferredInstanceId     String?
  preferredInstancePolicy String  @default("pinned")
  …
  preferredInstance       Instance? @relation("ProjectPreferredInstance",
                            fields: [preferredInstanceId],
                            references: [id],
                            onDelete: SetNull)
```

Behavior of `preferredInstancePolicy` (read by `agent-proxy-resolver.ts`):
- `pinned` (default) — return 503 when the preferred instance is offline; caller retries.
- `prefer` — fall back to the cloud pod when the preferred instance is offline.

## Test plan

- [x] Existing Projects deserialize unchanged (both new MST fields are optional with empty-string defaults — no migration needed for in-flight clients).
- [ ] Round-trip through the API: create a project with `preferredInstanceId` set, refresh client, verify the field surfaces in the MST `ProjectModel` instance.
- [ ] Verify `safeReference` treats an inbound `preferredInstance: "<instance-id>"` payload as an Instance reference (relationFields list).

No behavior change in this PR alone — purely the front-end source-of-truth catching up to a backend feature that's already shipped.
