### PR TITLE
fix(mobile): align EnvironmentPicker selectability with other pickers

### DIFF
--- a/apps/mobile/components/chat/EnvironmentPicker.tsx
+++ b/apps/mobile/components/chat/EnvironmentPicker.tsx
@@ -197,26 +197,22 @@ export function EnvironmentPicker({ disabled }: EnvironmentPickerProps) {
           {instances.map((inst) => {
             const isActive = activeInstance?.instanceId === inst.id
             const isConnecting = connecting === inst.id
-            const selectable = inst.status === "online" || isConnecting
             return (
               <Pressable
                 key={inst.id}
-                disabled={!selectable}
+                disabled={isConnecting}
                 onPress={async () => {
                   await select(inst)
                   setOpen(false)
                 }}
                 className={cn(
                   "flex-row items-center gap-2.5 px-3 py-2.5 active:bg-muted/60",
-                  !selectable && "opacity-60",
+                  isConnecting && "opacity-60",
                 )}
               >
                 <StatusDot status={inst.status} />
                 <View className="flex-1">
-                  <Text className={cn(
-                    "text-sm font-medium",
-                    selectable ? "text-foreground" : "text-muted-foreground",
-                  )}>
+                  <Text className="text-sm font-medium text-foreground">
                     {inst.name}
                   </Text>
                   <Text className="text-[10px] text-muted-foreground">


### PR DESCRIPTION
## Description (Required)

`EnvironmentPicker` previously gated row clickability on
`inst.status === "online"`, which made `heartbeat`-status instances
unclickable. Because the click is what fires
`POST /api/instances/:id/request-connect` (which sets `wsRequestedAt`
and prompts the worker to upgrade its HTTP heartbeat poll to a
persistent WebSocket), a worker that registers in `heartbeat` mode
could never be activated from the UI — a chicken-and-egg deadlock
between picker readiness and the activation handshake.

This PR aligns `EnvironmentPicker` with the two other instance pickers
already in the repo (`apps/mobile/components/layout/InstancePicker.tsx`
and `packages/shared-ui/src/screens/InstancePickerPopover.tsx`), both
of which gate only on `isConnecting`, not on `status`. The hook
(`useInstancePicker.select`) and the API route already correctly
handle non-`online` statuses; the bug was purely a UI gate.

Concretely, in `apps/mobile/components/chat/EnvironmentPicker.tsx`:
- Drop the `selectable = inst.status === "online" || isConnecting`
  local (no consumers outside the row).
- `disabled={isConnecting}` on the row (was `disabled={!selectable}`).
- `opacity-60` keyed off `isConnecting` directly.
- Drop the conditional text color on the instance name; use
  `text-foreground` unconditionally, matching the other two pickers.

No changes to the hook, API route, worker tunnel, or any tests.

## Related Issue (Required)

https://odin-ai.atlassian.net/browse/EN-3771

## Type of Change (Required)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring (no functional changes, no test changes)
- [ ] Added new tests

## How Has This Been Tested? (Required)

Manual reproduction of the deadlock and verification of the fix on
staging (`https://studio.staging.shogo.ai`) with a self-hosted CLI
worker attached to project `e0f8d09a-ba20-4543-bff2-3814fa4ae3e5`.

**Repro of the original bug (without this fix):**
1. Run `shogo worker start --worker-dir <dir> --cloud-url https://studio.staging.shogo.ai --project <id>` on a fresh machine.
2. Wait until the worker logs `[WorkerTunnel] Starting heartbeat polling to Shogo Cloud...`.
3. In Studio, open the "Run Agent On" picker. The worker appears with the yellow heartbeat dot, greyed out, and is unclickable. `GET /api/instances?workspaceId=...` returns the row with `status: "heartbeat"`, `wsRequestedAt: null`, `activeProjects: 0`.

**Equivalent of the click (used to confirm the API path was healthy all along):**
```js
fetch('/api/instances/<instance-id>/request-connect', {
  method: 'POST',
  credentials: 'include',
}).then(r => r.json()).then(console.log)
// → {ok: true, status: "requested"}

Within ~5s the worker logs Cloud requested WebSocket — connecting... → WebSocket connected — session active, and the picker row flips to green/online.