### PR TITLE
fix(ci): unbreak v1.7.5 release builds (desktop + worker)

### DIFF
--- a/.github/workflows/desktop-release-macos.yml
+++ b/.github/workflows/desktop-release-macos.yml
@@ -179,6 +179,17 @@ jobs:
       - name: Build workspace packages
         run: bun run build:packages
 
+      # `apps/api/src/generated/admin-routes.ts` is git-ignored and produced
+      # by `bun run generate:routes`. The root postinstall tries to run this
+      # during `bun install`, but `@shogo-ai/cli` (which `packages/sdk/bin/shogo.ts`
+      # imports as `@shogo-ai/cli/pkg`) isn't built yet at that point, so it
+      # silently no-ops. Re-running it here — after `build:packages` has built
+      # the CLI — guarantees the generated files exist before `bundle-api.mjs`
+      # imports them at apps/api/src/server.ts:81. Without this, the bundler
+      # fails with `Could not resolve "./generated/admin-routes"`.
+      - name: Generate Hono routes
+        run: bun run generate:routes
+
       - name: Generate Prisma clients (PG + SQLite)
         run: bun run db:generate:all
 

--- a/.github/workflows/desktop-release-windows.yml
+++ b/.github/workflows/desktop-release-windows.yml
@@ -125,6 +125,19 @@ jobs:
         shell: bash
         run: bun run build:packages
 
+      # `apps/api/src/generated/admin-routes.ts` is git-ignored and produced
+      # by `bun run generate:routes`. The root postinstall tries to run this
+      # during `bun install`, but `@shogo-ai/cli` (which `packages/sdk/bin/shogo.ts`
+      # imports as `@shogo-ai/cli/pkg`) isn't built yet at that point —
+      # especially under `bun install --linker=isolated` on Windows — so it
+      # silently no-ops. Re-running it here — after `build:packages` has built
+      # the CLI — guarantees the generated files exist before `bundle-api.mjs`
+      # imports them at apps/api/src/server.ts:81. Without this, the bundler
+      # fails with `Could not resolve "./generated/admin-routes"`.
+      - name: Generate Hono routes
+        shell: bash
+        run: bun run generate:routes
+
       - name: Generate Prisma clients (PG + SQLite)
         shell: bash
         run: bun run db:generate:all

--- a/.github/workflows/publish-shogo-worker.yml
+++ b/.github/workflows/publish-shogo-worker.yml
@@ -147,6 +147,18 @@ jobs:
           node -e "const p=require('./packages/shogo-worker/package.json'); p.version=process.env.VERSION; require('fs').writeFileSync('packages/shogo-worker/package.json', JSON.stringify(p, null, 2)+'\n')"
           echo "Set @shogo-ai/worker version to $VERSION"
 
+      # The worker `Typecheck` step below runs `tsc --noEmit`, which resolves
+      # the workspace dep `@shogo-ai/sdk` via its `exports.types` field —
+      # `./dist/index.d.ts`. Without an explicit build, that file doesn't
+      # exist in CI and every `import ... from '@shogo-ai/sdk'` blows up
+      # with TS2307 "Cannot find module" (which in turn surfaces downstream
+      # implicit-any errors). `build:packages` builds the SDK and its
+      # transitive workspace deps in dependency order so the typecheck —
+      # and the subsequent `build:js` / `bun build --compile` steps — have
+      # the type information they need.
+      - name: Build workspace packages (so @shogo-ai/sdk types resolve)
+        run: bun run build:packages
+
       - name: Typecheck
         run: bun run --filter @shogo-ai/worker typecheck
 

--- a/packages/shogo-worker/src/lib/runtime-manager.ts
+++ b/packages/shogo-worker/src/lib/runtime-manager.ts
@@ -713,7 +713,7 @@ export class WorkerRuntimeManager implements RuntimeResolver {
         localDir: projectDir,
       });
       const manifest = await transport.listManifest();
-      const shogoEntries = manifest.filter((e) => e.path === '.shogo' || e.path.startsWith('.shogo/'));
+      const shogoEntries = manifest.filter((e: { path: string }) => e.path === '.shogo' || e.path.startsWith('.shogo/'));
       if (shogoEntries.length === 0) return;
       const stats = await transport.downloadFiles(shogoEntries);
       log.log(

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -46,11 +46,31 @@ execSync("bun scripts/db-generate-all.ts", { stdio: "inherit" });
 //
 // Skipped when the SDK package isn't present (e.g. published-package consumers
 // of `shogo-ai` that don't ship the generator).
+//
+// `packages/sdk/bin/shogo.ts` imports `@shogo-ai/cli/pkg`, which only resolves
+// once `bun run build:cli` (part of `bun run build:packages`) has produced
+// `packages/cli/dist/`. On a fresh clone or under `bun install --linker=isolated`
+// in CI, that build hasn't happened yet, so the generator throws
+// `Cannot find module '@shogo-ai/cli/pkg'` and skips. That's expected, but a
+// silent skip leaves `apps/api/src/generated/admin-routes.ts` missing, which
+// blows up later bundle/typecheck steps with confusing errors. Print a loud
+// warning so the failure is visible — CI release workflows now re-invoke
+// `bun run generate:routes` explicitly after `build:packages`, and local devs
+// can do the same.
 if (existsSync("packages/sdk/bin/shogo.ts") && existsSync("shogo.config.json")) {
   try {
     execSync("bun run generate:routes", { stdio: "inherit" });
-  } catch {
-    // Non-fatal — `bun run generate:routes` can be run manually if this fails
-    // (e.g. transient TS errors during schema migration).
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn("");
+    console.warn("⚠️  postinstall: `bun run generate:routes` failed.");
+    console.warn(`    ${msg.split("\n")[0]}`);
+    console.warn("");
+    console.warn("    Generated files under apps/api/src/generated/ may be");
+    console.warn("    missing or stale. If you're building from a fresh clone,");
+    console.warn("    run the following once the workspace packages are built:");
+    console.warn("");
+    console.warn("      bun run build:packages && bun run generate:routes");
+    console.warn("");
   }
 }


### PR DESCRIPTION
## Summary

The v1.7.5 tag run had 6 of 7 workflows fail. Of those, three were pre-existing on `main` (iOS, Android, a deploy webhook flake) and are out of scope here. The other three — **Desktop Release (macOS)**, **Desktop Release (Windows)**, and **Publish shogo-worker** — only run on `push: tags: v*`, so the same commit on `main` never exercised them. This PR fixes all three.

### Root cause

`packages/sdk/bin/shogo.ts` imports `@shogo-ai/cli/pkg`, which only resolves once `bun run build:cli` (part of `bun run build:packages`) has produced `packages/cli/dist/`. But `scripts/postinstall.ts` invokes `bun run generate:routes` *during* `bun install` — before any package has been built — so:

```
error: Cannot find module '@shogo-ai/cli/pkg' from 'packages/sdk/bin/shogo.ts'
error: script "generate:routes" exited with code 1
```

…and the `try/catch` in `postinstall.ts` swallows it. Consequence: the git-ignored `apps/api/src/generated/admin-routes.ts` is never produced. Downstream:

| Workflow | Failure |
|---|---|
| Desktop Release (macOS/Windows) | `Bundle API server into resources` → `bun build` fails at `apps/api/src/server.ts:81` with `Could not resolve "./generated/admin-routes"`. |
| Publish shogo-worker | `tsc --noEmit` fails with TS2307 on every `@shogo-ai/sdk` import (its `exports.types` → `./dist/index.d.ts` was never built), plus a cascading TS7006 implicit-any in `runtime-manager.ts:716`. |

The deploy path on `main` was unaffected because it goes through a pre-baked `shogo-workspace-deps` image that already has `build:packages` + `generate:routes` applied (see `apps/api/Dockerfile` comment).

### Fixes

1. **`desktop-release-macos.yml` / `desktop-release-windows.yml`** — add a `Generate Hono routes` step after `Build workspace packages` so the generated files exist before the API bundle step.
2. **`publish-shogo-worker.yml`** — add a `Build workspace packages` step before `Typecheck` so `@shogo-ai/sdk` types resolve.
3. **`scripts/postinstall.ts`** — stop silently swallowing the generator failure; log a clear warning so future regressions surface during `bun install` instead of much later in a release.
4. **`packages/shogo-worker/src/lib/runtime-manager.ts`** — add an explicit `(e: { path: string }) =>` annotation on the filter callback so the file typechecks deterministically (also fixes the TS7006 that surfaces when SDK types can't resolve).

### Out of scope (separate follow-ups recommended)

- **iOS** — pre-existing on `main`: `packages/sdk/src/projects/cloud-file-transport.ts` imports `node:fs/promises`, which Metro can't resolve for the RN bundle.
- **Android** — pre-existing on `main`: `react-native-iap@12.16.4` references `ReactContext.currentActivity`, which doesn't exist in the pinned RN version.
- **Build, Test, and Deploy** — transient Knative admission webhook race (`resourceVersion: 0`) on the production-us cluster; rerun the failed `Deploy to US (primary)` job.

## Test plan

- [x] Local `bun run --filter @shogo-ai/worker typecheck` passes (was failing in CI on tag).
- [x] Local `bun run packages/sdk/bin/shogo.ts generate` succeeds (generated 95 files for 18 models).
- [x] `python3 -c "import yaml; ..."` parses all three workflow YAMLs cleanly.
- [x] `git diff` shows only the intended additions; no unrelated changes.
- [ ] After merge, cut a fresh `v*` tag (or trigger the three workflows via `workflow_dispatch`) and confirm Desktop macOS, Desktop Windows, and `Publish shogo-worker` all go green.


Made with [Cursor](https://cursor.com)