### PR TITLE
fix(android+sdk): unblock RN 0.80 iap Kotlin compile and Metro node:fs/promises bundling

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -600,6 +600,7 @@
   },
   "patchedDependencies": {
     "@react-navigation/routers@7.5.3": "patches/@react-navigation%2Frouters@7.5.3.patch",
+    "react-native-iap@12.16.4": "patches/react-native-iap@12.16.4.patch",
     "react-native-css-interop@0.2.2": "patches/react-native-css-interop@0.2.2.patch",
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
   },
   "patchedDependencies": {
     "react-native-css-interop@0.2.2": "patches/react-native-css-interop@0.2.2.patch",
-    "@react-navigation/routers@7.5.3": "patches/@react-navigation%2Frouters@7.5.3.patch"
+    "@react-navigation/routers@7.5.3": "patches/@react-navigation%2Frouters@7.5.3.patch",
+    "react-native-iap@12.16.4": "patches/react-native-iap@12.16.4.patch"
   }
 }

--- a/packages/sdk/src/projects/cloud-file-transport.ts
+++ b/packages/sdk/src/projects/cloud-file-transport.ts
@@ -122,6 +122,24 @@ export interface FsAdapter {
  * Lazy default `FsAdapter` backed by `node:fs/promises`. Only loaded
  * inside Node-like environments (when `globalThis.process` exists).
  * Throws a friendly error if called in a browser bundle.
+ *
+ * IMPORTANT — why `new Function(...)` instead of a plain `await import(...)`:
+ *
+ * Metro (React Native), webpack, esbuild and rollup all perform STATIC
+ * module-graph analysis on `import()` calls whose argument is a string
+ * literal. A literal `await import('node:fs/promises')` here is treated
+ * as a hard dependency of the bundle even though it's only reachable in
+ * Node at runtime. RN's bundler then fails the iOS / Android bundle with
+ *   `Unable to resolve module fs/promises from packages/sdk/dist/index.js`
+ * because Metro doesn't understand the `node:` scheme and tsup strips
+ * the prefix in `dist/index.js`. (See android-build run #26016279560.)
+ *
+ * Wrapping the dynamic import in `new Function(...)` makes the argument
+ * an opaque string literal inside a function body — bundlers do not look
+ * inside `Function` constructors, so the spec is invisible to static
+ * analysis. At runtime, the host's native `import()` still resolves it
+ * exactly as before in Node/Bun, and the surrounding `isNode` guard
+ * guarantees we never reach this line in a browser/RN runtime.
  */
 async function getDefaultFs(): Promise<FsAdapter> {
   const isNode = typeof globalThis !== 'undefined' && typeof (globalThis as any).process?.versions?.node === 'string'
@@ -131,7 +149,10 @@ async function getDefaultFs(): Promise<FsAdapter> {
         'Provide `fs` in CloudFileTransportOptions when running outside Node/Bun.',
     )
   }
-  const mod = await import('node:fs/promises')
+  const bundlerOpaqueImport = new Function('s', 'return import(s)') as (
+    spec: string,
+  ) => Promise<typeof import('node:fs/promises')>
+  const mod = await bundlerOpaqueImport('node:fs/promises')
   return {
     readFile: (p) => mod.readFile(p),
     writeFile: (p, d) => mod.writeFile(p, d),

--- a/patches/react-native-iap@12.16.4.patch
+++ b/patches/react-native-iap@12.16.4.patch
@@ -1,0 +1,18 @@
+diff --git a/android/src/play/java/com/dooboolab/rniap/RNIapModule.kt b/android/src/play/java/com/dooboolab/rniap/RNIapModule.kt
+index 0000000000000000000000000000000000000000..1111111111111111111111111111111111111111 100644
+--- a/android/src/play/java/com/dooboolab/rniap/RNIapModule.kt
++++ b/android/src/play/java/com/dooboolab/rniap/RNIapModule.kt
+@@ -461,7 +461,12 @@ class RNIapModule(
+         isOfferPersonalized: Boolean, // New parameter in V5
+         promise: Promise,
+     ) {
+-        val activity = currentActivity
++        // React Native 0.80 converted ReactContextBaseJavaModule from Java to
++        // Kotlin. `getCurrentActivity()` is now a Kotlin function (not a Java
++        // getter), so the implicit `currentActivity` property accessor no
++        // longer exists on this class. Go through reactApplicationContext,
++        // whose `currentActivity` Kotlin property still resolves to Activity?.
++        val activity = reactApplicationContext.currentActivity
+         if (activity == null) {
+             promise.safeReject(PromiseUtils.E_UNKNOWN, "getCurrentActivity returned null")
+             return


### PR DESCRIPTION
Closes #582.

## What this PR does

Fixes the two pre-existing CI failures on `main`:

| Job | Run before this PR | Failure |
|---|---|---|
| Android Build & Update | [`26016279560`](https://github.com/shogo-labs/shogo-ai/actions/runs/26016279560) | Kotlin: `Unresolved reference 'currentActivity'` in `react-native-iap@12.16.4` |
| iOS Build & Update | [`26016279557`](https://github.com/shogo-labs/shogo-ai/actions/runs/26016279557) | Metro: `Unable to resolve module fs/promises from packages/sdk/dist/index.js` |

Two unrelated root causes, both surfacing through React Native's build pipeline. Each is fixed at its source — no skip flags, no `continue-on-error`, no commented-out workflows.

Issue #582 has the full investigation; this PR description is a focused reviewer guide.

---

## Commit 1 — `fix(sdk): hide node:fs/promises dynamic import from Metro static analysis`

**File:** `packages/sdk/src/projects/cloud-file-transport.ts` (+22 / −1)

### Root cause (one-paragraph version)

`CloudFileTransport`'s default `FsAdapter` did `await import('node:fs/promises')` with a **string-literal** specifier. Metro (and every modern bundler) treats string-literal `import()` as a static module-graph edge regardless of the runtime `if (!isNode) throw` guard above it. `tsup` additionally strips the `node:` prefix in the emitted `dist/index.js`, leaving `import("fs/promises")` — which Metro cannot resolve in an RN target. Because `src/index.ts` re-exports `CloudFileTransport` from the SDK's main barrel, every RN consumer (e.g. `apps/mobile/app/(app)/api-keys.tsx`) drags the Node-only module into the bundle and the whole build aborts.

### What the change does

Constructs the importer at runtime through `new Function`, which bundlers cannot statically traverse:

```ts
const bundlerOpaqueImport = new Function('s', 'return import(s)') as (
  spec: string,
) => Promise<typeof import('node:fs/promises')>
const mod = await bundlerOpaqueImport('node:fs/promises')
```

- `new Function(...)` body is a string — no AST node for Metro to walk into. The specifier becomes invisible to static analysis.
- `typeof import('node:fs/promises')` is a TS **type-only** import — erased at compile time, never reaches JS.
- At runtime in Node/Bun the host's native `import()` still resolves `node:fs/promises` normally. The existing `isNode` runtime guard above keeps the RN/browser path on the friendly-error branch.

An in-source doc comment explains *why* this looks unusual, so the next refactor doesn't "simplify" it back into a regression.

### Why not just move `CloudFileTransport` to a subpath export?

That would also work and is arguably more architectural — but it's a public-API change. The `Function`-wrapped import fixes the build with zero surface change and stands on its own; the subpath split can land separately if/when desired.

---

## Commit 2 — `fix(android): patch react-native-iap@12.16.4 for RN 0.80 Kotlin migration`

**Files:** `patches/react-native-iap@12.16.4.patch` (new), `package.json`, `bun.lock`

### Root cause (one-paragraph version)

React Native 0.80 rewrote `ReactContextBaseJavaModule` from Java to Kotlin. The old Java method `public Activity getCurrentActivity()` had a Kotlin-synthesized property accessor `currentActivity`. Kotlin **only** synthesizes property accessors for Java getters — not for Kotlin functions — so after the upstream migration the bare `currentActivity` reference inside `react-native-iap@12.16.4`'s `RNIapModule.kt` no longer resolves. `val activity = currentActivity` then becomes `Any?`, and `launchBillingFlow(activity: Activity, …)` 76 lines later fails the type check as a downstream consequence. `apps/mobile` is on `react-native@0.81.5`, so every Android build hits this.

### What the change does

A single-hunk patch routing through `ReactApplicationContext.currentActivity` (still a real Kotlin property of type `Activity?`):

```diff
-        val activity = currentActivity
+        // React Native 0.80 converted ReactContextBaseJavaModule from Java to
+        // Kotlin. `getCurrentActivity()` is now a Kotlin function (not a Java
+        // getter), so the implicit `currentActivity` property accessor no
+        // longer exists on this class. Go through reactApplicationContext,
+        // whose `currentActivity` Kotlin property still resolves to Activity?.
+        val activity = reactApplicationContext.currentActivity
```

Both Kotlin errors disappear from one line of change: the reference resolves, and `activity` is inferred as `Activity?` so the `launchBillingFlow` call type-checks.

Delivered through `bun`'s native `patchedDependencies` mechanism — matches the existing convention in `patches/` (`react-native-css-interop@0.2.2`, `@react-navigation/routers@7.5.3`). No `patch-package` postinstall hook needed; `bun install` applies it automatically everywhere including CI.

### Why not bump `react-native-iap`?

`react-native-iap@13.x` / `14.x` have breaking API changes (different module signatures, expo-modules-based architecture). Bumping is the right *long-term* move but is out of scope for unblocking CI today; a targeted line-level patch is the minimum-risk fix.

---

## Verification

Performed locally on this branch before pushing:

**Android patch**
- `bun install` → patch applies cleanly via `patchedDependencies`.
- `node_modules/.bun/react-native-iap@12.16.4+…/RNIapModule.kt` shows the patched line on disk.
- The previously-unresolved reference now points at `ReactApplicationContext.currentActivity: Activity?`.

**SDK bundle fix**
- `packages/sdk` → `bun run build` succeeds.
- `grep -nE "import\(['\"](node:)?fs/promises" dist/index.{js,cjs}` → **zero matches**. The only occurrence of the spec in the compiled output is inside the opaque `new Function("s", "return import(s)")` body, exactly as intended.
- `bun test src/projects` → **22 / 22 pass**, including the 13 `cloud-file-transport` tests that exercise the Node code path. Node runtime behavior is byte-for-byte unchanged.

Once this PR's CI completes, the green Android + iOS build runs replace runs `26016279560` / `26016279557` referenced in the issue.

---

## Risk

- **SDK change** is contained to one function in `cloud-file-transport.ts`. The function only runs when the caller doesn't pass an `FsAdapter` and `process.versions.node` is set — i.e. Node CLI usage. Unit tests covering that path all pass. No public API change.
- **Android patch** is a single line inside the `react-native-iap` module Kotlin source. Runtime behavior is identical: `reactApplicationContext.currentActivity` returns the same `Activity?` the original `currentActivity` accessor used to return. Worst case if the patch ever fails to apply (e.g. a future iap version bump), `bun install` will fail loudly; it won't silently produce a broken APK.

## Scope / non-goals

- No bump of `react-native-iap` (breaking).
- No restructuring of the SDK barrel to move `CloudFileTransport` behind a subpath export (separate cleanup, not required for the fix).
- No CI workflow changes — the failing jobs are unmodified; they will simply pass after these two commits land.
