### PR TITLE
fix(ci): use Developer ID Application cert for desktop macOS notarization

### DIFF
--- a/.github/workflows/desktop-release-macos.yml
+++ b/.github/workflows/desktop-release-macos.yml
@@ -220,22 +220,32 @@ jobs:
         # See apps/desktop/scripts/bundle-main.mjs for details.
         run: npx tsc && npm run bundle:main
 
+      # Desktop notarization (xcrun notarytool) requires a "Developer ID
+      # Application" certificate, which is distinct from the "Apple
+      # Distribution" cert used by `.github/workflows/ios.yml` for App Store
+      # submissions. We keep them as separate GitHub secrets so the two
+      # pipelines never collide: iOS keeps using APPLE_CERTIFICATE_BASE64
+      # (Apple Distribution); macOS desktop uses
+      # APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 (Developer ID Application).
+      # If anyone ever reuses APPLE_CERTIFICATE_BASE64 here, notarization
+      # will reject every Mach-O in the .app with "The binary is not signed
+      # with a valid Developer ID certificate."
       - name: Prepare macOS Code Signing
         env:
-          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_DEVELOPER_ID_CERTIFICATE_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 }}
+          APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
         run: |
-          if [ -n "$APPLE_CERTIFICATE_BASE64" ]; then
+          if [ -n "$APPLE_DEVELOPER_ID_CERTIFICATE_BASE64" ]; then
             KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
             KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
             CERT_PATH="$RUNNER_TEMP/certificate.p12"
 
-            echo "$APPLE_CERTIFICATE_BASE64" | base64 --decode > "$CERT_PATH"
+            echo "$APPLE_DEVELOPER_ID_CERTIFICATE_BASE64" | base64 --decode > "$CERT_PATH"
 
             security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
             security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
             security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-            security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" \
+            security import "$CERT_PATH" -P "$APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD" \
               -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
             security set-key-partition-list -S apple-tool:,apple:,codesign: \
               -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
@@ -244,16 +254,37 @@ jobs:
 
             rm "$CERT_PATH"
             echo "Apple certificate imported into temporary keychain."
+            echo "--- All codesigning identities in keychain ---"
             security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+            # Fail fast (saves ~10 min of CI) if the secret holds the wrong
+            # cert type — e.g. "Apple Distribution" (App Store), "Apple
+            # Development" (local), or "Developer ID Installer" (pkg only).
+            # Only "Developer ID Application" passes notarization for the
+            # direct-distribution .app/.dmg this workflow ships.
+            DEVELOPER_ID_LINE=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+              | grep -E '"Developer ID Application: ' \
+              | head -1 || true)
+            if [ -z "$DEVELOPER_ID_LINE" ]; then
+              echo "::error title=Wrong macOS signing certificate::APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 must contain a 'Developer ID Application' certificate. Apple notarization will reject anything else."
+              echo "::error::See https://developer.apple.com/account/resources/certificates → '+' → 'Developer ID Application' to generate the correct cert type."
+              exit 1
+            fi
+            DEVELOPER_ID_HASH=$(echo "$DEVELOPER_ID_LINE" | awk '{print $2}')
+            DEVELOPER_ID_NAME=$(echo "$DEVELOPER_ID_LINE" | sed -E 's/^[[:space:]]*[0-9]+\)[[:space:]]+[A-F0-9]+[[:space:]]+"(Developer ID Application: [^"]+)".*/\1/')
+            echo "Using Developer ID identity: $DEVELOPER_ID_NAME ($DEVELOPER_ID_HASH)"
+
             echo "SIGNING_KEYCHAIN=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+            echo "SIGNING_IDENTITY_HASH=$DEVELOPER_ID_HASH" >> "$GITHUB_ENV"
+            echo "SIGNING_IDENTITY_NAME=$DEVELOPER_ID_NAME" >> "$GITHUB_ENV"
           else
-            echo "No Apple certificate provided. Skipping macOS code signing."
+            echo "No Developer ID Application certificate provided. Skipping macOS code signing."
           fi
 
       - name: Codesign Go VM helper
-        if: env.APPLE_CERTIFICATE_BASE64 != ''
+        if: env.APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 != ''
         env:
-          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_DEVELOPER_ID_CERTIFICATE_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 }}
         run: |
           GO_ARCH=${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
           VM_HELPER="apps/desktop/resources/vm-helper/shogo-vm-$GO_ARCH"
@@ -275,8 +306,14 @@ jobs:
         working-directory: apps/desktop
         run: |
           set -euo pipefail
-          HASH=$(security find-identity -v -p codesigning "$SIGNING_KEYCHAIN" | head -1 | awk '{print $2}')
-          echo "Signing identity: $HASH"
+          # SIGNING_IDENTITY_HASH/_NAME come from "Prepare macOS Code
+          # Signing", which already filtered for "Developer ID Application:"
+          # and verified there was a match. Reusing them here (instead of
+          # re-running `find-identity | head -1`) makes the codesign step
+          # deterministic when the keychain ever holds more than one
+          # identity, and surfaces a useful name in the log.
+          HASH="$SIGNING_IDENTITY_HASH"
+          echo "Signing identity: $SIGNING_IDENTITY_NAME ($HASH)"
           APP_PATH=$(find out -name "Shogo.app" -maxdepth 4 -type d | head -1)
           if [ -z "$APP_PATH" ]; then
             echo "ERROR: Shogo.app not found in out/"


### PR DESCRIPTION
## Summary

The macOS desktop release and `ios.yml` were sharing one `APPLE_CERTIFICATE_BASE64` secret. That secret holds an **Apple Distribution** cert (correct for iOS App Store submissions) which Apple's notary service correctly refuses for direct-distribution `.app`/`.dmg` notarization — every Mach-O fails with:

```
"The binary is not signed with a valid Developer ID certificate."
```

This PR splits the cert per delivery path:

- **iOS** (`ios.yml`) — keeps using `APPLE_CERTIFICATE_BASE64` (Apple Distribution). Untouched.
- **Desktop macOS** (`desktop-release-macos.yml`) — switches to a new secret pair `APPLE_DEVELOPER_ID_CERTIFICATE_BASE64` + `APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD` holding a **Developer ID Application** cert.

Both secrets are already provisioned on `shogo-labs/shogo-ai` (uploaded from the local Mac's keychain — `Developer ID Application: Russell LaCour (854988Q336)`, team ID matches the existing `APPLE_TEAM_ID`).

The PR also tightens the macOS signing logic:

1. **Fail fast** at `Prepare macOS Code Signing` with a clear `::error::` annotation and a doc link if the imported cert isn't `"Developer ID Application:"`. Saves ~10 min of CI per release if the wrong cert is ever pasted in again.
2. **Explicit identity selection** — `find-identity` is filtered for `"Developer ID Application: "` instead of `head -1`, so a future second cert in the keychain can't be picked accidentally.
3. **Reuse the validated identity in `Codesign app bundle`** — the prep step exports `SIGNING_IDENTITY_HASH`/`SIGNING_IDENTITY_NAME` and codesign now uses them deterministically, plus prints the human-readable name in the log.

## Out of scope

- iOS / Android failures (separate root causes — `node:fs/promises` in `@shogo-ai/sdk` reaching the RN bundle and `react-native-iap@12.16.4` Kotlin incompatibility, both pre-existing on `main`).

## Test plan

- [x] Local `python3 -c 'import yaml; ...'` parses the YAML cleanly.
- [x] `gh secret list` confirms both `APPLE_DEVELOPER_ID_CERTIFICATE_*` secrets are present.
- [x] `security find-identity -v -p codesigning` on the local Mac returns exactly the cert that was uploaded.
- [ ] After merge, re-run **Desktop Release (macOS)** for `v1.7.7` (or cut `v1.7.8`) and confirm:
  - `Prepare macOS Code Signing` prints `Using Developer ID identity: Developer ID Application: ...`.
  - `Codesign app bundle` succeeds (logs show the same identity name).
  - `Notarize app bundle` succeeds (no "valid Developer ID certificate" errors).
  - `Build distribution artifacts` produces signed, notarized, stapled `.app` + `.dmg`.


Made with [Cursor](https://cursor.com)