### PR TITLE
fix(marketplace): polish browse UI — dropdown, sort, search, grid/list, and See all

### DIFF
--- a/apps/mobile/app/(app)/marketplace/index.tsx
+++ b/apps/mobile/app/(app)/marketplace/index.tsx
@@ -36,6 +36,13 @@ import {
   type CreatorTier,
 } from '../../../components/marketplace'
 import { MARKETPLACE_CATEGORIES, type MarketplaceCategory } from '@shogo/shared-app'
+import { cn } from '@shogo/shared-ui/primitives'
+import {
+  Popover,
+  PopoverBackdrop,
+  PopoverBody,
+  PopoverContent,
+} from '@/components/ui/popover'
 import { useGridColumns } from '../../../hooks/useGridColumns'
 
 interface ListingFromAPI {
@@ -762,39 +769,45 @@ function SortMenu({
   onChange: (v: SortMode) => void
 }) {
   return (
-    <View className="relative">
-      <Pressable
-        onPress={() => onOpenChange(!open)}
-        className="flex-row items-center gap-1.5 px-3 h-11 rounded-xl border border-border bg-card"
-      >
-        <Text className="text-xs font-medium text-foreground">
-          {SORT_LABELS[value]}
-        </Text>
-        <ChevronDown size={12} color="#71717a" />
-      </Pressable>
-      {open && (
-        <View
-          className="absolute right-0 top-12 rounded-xl border border-border bg-card overflow-hidden shadow-lg"
-          style={{ width: 160, zIndex: 50 }}
+    <Popover
+      placement="bottom right"
+      isOpen={open}
+      onOpen={() => onOpenChange(true)}
+      onClose={() => onOpenChange(false)}
+      trigger={(triggerProps) => (
+        <Pressable
+          {...triggerProps}
+          className="flex-row items-center gap-1.5 px-3 h-11 rounded-xl border border-input bg-card"
         >
+          <Text className="text-xs font-medium text-foreground">
+            {SORT_LABELS[value]}
+          </Text>
+          <ChevronDown size={12} color="#71717a" />
+        </Pressable>
+      )}
+    >
+      <PopoverBackdrop />
+      <PopoverContent className="p-0 min-w-[160px]">
+        <PopoverBody>
           {(Object.keys(SORT_LABELS) as SortMode[]).map((k) => (
             <Pressable
               key={k}
               onPress={() => onChange(k)}
-              className={`px-3 py-2.5 active:bg-muted ${k === value ? 'bg-muted/50' : ''}`}
+              className={cn('px-3 py-2 active:bg-muted', k === value && 'bg-accent')}
             >
               <Text
-                className={`text-xs ${
-                  k === value ? 'text-foreground font-semibold' : 'text-foreground'
-                }`}
+                className={cn(
+                  'text-xs',
+                  k === value ? 'text-foreground font-medium' : 'text-foreground',
+                )}
               >
                 {SORT_LABELS[k]}
               </Text>
             </Pressable>
           ))}
-        </View>
-      )}
-    </View>
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
   )
 }
 

--- a/apps/mobile/app/(app)/marketplace/index.tsx
+++ b/apps/mobile/app/(app)/marketplace/index.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2026 Shogo Technologies, Inc.
 
-import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import {
   View,
   Text,
@@ -11,6 +11,7 @@ import {
   FlatList,
   ActivityIndicator,
   Image,
+  Platform,
 } from 'react-native'
 import * as Lucide from 'lucide-react-native'
 import { observer } from 'mobx-react-lite'
@@ -114,6 +115,25 @@ const SORT_SECTION_TITLES: Record<SortMode, string> = {
   featured: 'Featured first',
 }
 
+/** Rail "See all" targets — sort API param may differ from the section label. */
+type BrowseFocus = 'trending' | 'newest'
+
+const BROWSE_FOCUS_META: Record<
+  BrowseFocus,
+  { title: string; subtitle: string; sort: SortMode }
+> = {
+  trending: {
+    title: 'Trending this week',
+    subtitle: 'Most-installed agents over the last 7 days',
+    sort: 'popular',
+  },
+  newest: {
+    title: 'New & noteworthy',
+    subtitle: 'Recently published agents from the community',
+    sort: 'newest',
+  },
+}
+
 function toTileListing(item: ListingFromAPI): AgentTileListing {
   return {
     slug: item.slug,
@@ -164,6 +184,8 @@ export default observer(function MarketplaceHomeScreen() {
   const [filterFree, setFilterFree] = useState(false)
   const [viewMode, setViewMode] = useState<ViewMode>('grid')
   const [sortMenuOpen, setSortMenuOpen] = useState(false)
+  /** Which rail's "See all" expanded the full browse grid (null = editorial home). */
+  const [browseFocus, setBrowseFocus] = useState<BrowseFocus | null>(null)
 
   const [featured, setFeatured] = useState<ListingFromAPI[]>([])
   const [trending, setTrending] = useState<ListingFromAPI[]>([])
@@ -185,10 +207,34 @@ export default observer(function MarketplaceHomeScreen() {
     searchQuery.trim() !== debouncedSearchTrimmed
   const showRails =
     sortMode === 'popular' &&
+    browseFocus === null &&
     !isSearching &&
     activeCategory === 'all' &&
     !filterFeatured &&
     !filterFree
+
+  const browseSectionMeta = useMemo(() => {
+    if (filterFeatured) {
+      return { title: 'Built for Shogo', subtitle: undefined as string | undefined }
+    }
+    if (filterFree) {
+      return { title: 'Free agents', subtitle: undefined }
+    }
+    if (activeCategory !== 'all') {
+      return {
+        title:
+          MARKETPLACE_CATEGORIES.find((c) => c.slug === activeCategory)?.label ?? 'Browse',
+        subtitle: undefined,
+      }
+    }
+    if (browseFocus) {
+      return {
+        title: BROWSE_FOCUS_META[browseFocus].title,
+        subtitle: BROWSE_FOCUS_META[browseFocus].subtitle,
+      }
+    }
+    return { title: SORT_SECTION_TITLES[sortMode], subtitle: undefined }
+  }, [activeCategory, browseFocus, filterFeatured, filterFree, sortMode])
 
   const loadGrid = useCallback(
     async (pageNum: number, append = false) => {
@@ -261,8 +307,40 @@ export default observer(function MarketplaceHomeScreen() {
   }, [activeCategory, sortMode, filterFeatured, filterFree, debouncedSearchQuery])
 
   useEffect(() => {
+    setBrowseFocus(null)
+  }, [activeCategory, filterFeatured, filterFree, debouncedSearchQuery])
+
+  useEffect(() => {
     loadEditorial()
   }, [loadEditorial])
+
+  const browseListRef = useRef<FlatList>(null)
+
+  const scrollBrowseToTop = useCallback(() => {
+    const scroll = () => {
+      browseListRef.current?.scrollToOffset({ offset: 0, animated: false })
+      if (Platform.OS === 'web' && typeof window !== 'undefined') {
+        window.scrollTo({ top: 0, left: 0, behavior: 'auto' })
+      }
+    }
+    requestAnimationFrame(() => {
+      scroll()
+      requestAnimationFrame(scroll)
+    })
+  }, [])
+
+  const focusBrowse = useCallback(
+    (focus: BrowseFocus) => {
+      setSortMode(BROWSE_FOCUS_META[focus].sort)
+      setBrowseFocus(focus)
+    },
+    [],
+  )
+
+  useEffect(() => {
+    if (!browseFocus && !filterFeatured && !filterFree && activeCategory === 'all') return
+    scrollBrowseToTop()
+  }, [browseFocus, filterFeatured, filterFree, activeCategory, viewMode, scrollBrowseToTop])
 
   const spotlight = featured[0]
   const builtForShogo = featured.slice(1, 6)
@@ -380,7 +458,7 @@ export default observer(function MarketplaceHomeScreen() {
             viewMode={viewMode}
             title="Trending this week"
             subtitle="Most-installed agents over the last 7 days"
-            onSeeAll={() => setSortMode('popular')}
+            onSeeAll={() => focusBrowse('trending')}
             items={trending}
             onPress={handleCardPress}
           />
@@ -392,7 +470,7 @@ export default observer(function MarketplaceHomeScreen() {
             viewMode={viewMode}
             title="New & noteworthy"
             subtitle="Recently published agents from the community"
-            onSeeAll={() => setSortMode('newest')}
+            onSeeAll={() => focusBrowse('newest')}
             items={newAgents}
             onPress={handleCardPress}
           />
@@ -474,19 +552,12 @@ export default observer(function MarketplaceHomeScreen() {
         {/* Bottom grid header */}
         <View className="px-5 mt-2 mb-3">
           <SectionHeader
-            title={
-              filterFeatured
-                ? 'Built for Shogo'
-                : filterFree
-                  ? 'Free agents'
-                  : activeCategory === 'all'
-                    ? SORT_SECTION_TITLES[sortMode]
-                    : MARKETPLACE_CATEGORIES.find((c) => c.slug === activeCategory)?.label ?? 'Browse'
-            }
+            title={browseSectionMeta.title}
             subtitle={
               loading
                 ? 'Loading…'
-                : `${listings.length} agent${listings.length === 1 ? '' : 's'}`
+                : browseSectionMeta.subtitle ??
+                  `${listings.length} agent${listings.length === 1 ? '' : 's'}`
             }
             padded={false}
           />
@@ -499,6 +570,8 @@ export default observer(function MarketplaceHomeScreen() {
     listings.length,
     debouncedSearchTrimmed,
     isSearchPending,
+    browseFocus,
+    browseSectionMeta,
     showRails,
     spotlight,
     builtForShogo,
@@ -578,6 +651,7 @@ export default observer(function MarketplaceHomeScreen() {
             onOpenChange={setSortMenuOpen}
             onChange={(v) => {
               setSortMode(v)
+              setBrowseFocus(null)
               setSortMenuOpen(false)
             }}
           />
@@ -640,6 +714,7 @@ export default observer(function MarketplaceHomeScreen() {
       ) : (
         viewMode === 'grid' ? (
           <FlatList
+            ref={browseListRef}
             key={`grid-${numColumns}-${sortMode}`}
             data={paddedData}
             keyExtractor={(item, index) => item?.slug ?? `spacer-${index}`}
@@ -690,6 +765,7 @@ export default observer(function MarketplaceHomeScreen() {
           />
         ) : (
           <FlatList
+            ref={browseListRef}
             key={`list-${sortMode}`}
             data={tileListings}
             keyExtractor={(item) => item.slug}

--- a/apps/mobile/app/(app)/marketplace/index.tsx
+++ b/apps/mobile/app/(app)/marketplace/index.tsx
@@ -344,6 +344,25 @@ export default observer(function MarketplaceHomeScreen() {
     scrollBrowseToTop()
   }, [browseFocus, filterFeatured, filterFree, activeCategory, viewMode, scrollBrowseToTop])
 
+  const returnToEditorialHome = useCallback(() => {
+    setBrowseFocus(null)
+    setSortMode('popular')
+    setFilterFeatured(false)
+    setFilterFree(false)
+    setActiveCategory('all')
+    setSearchQuery('')
+    setSortMenuOpen(false)
+    scrollBrowseToTop()
+  }, [scrollBrowseToTop])
+
+  const handleTopBarBack = useCallback(() => {
+    if (showRails) {
+      router.back()
+    } else {
+      returnToEditorialHome()
+    }
+  }, [showRails, router, returnToEditorialHome])
+
   const spotlight = featured[0]
   const builtForShogo = featured.slice(1, 6)
 
@@ -410,6 +429,20 @@ export default observer(function MarketplaceHomeScreen() {
 
     return (
       <View>
+        {!showRails && !isSearching && (
+          <View className="px-5 pt-2 pb-3">
+            <Pressable
+              onPress={returnToEditorialHome}
+              className="flex-row items-center gap-1.5 self-start active:opacity-70"
+              accessibilityRole="button"
+              accessibilityLabel="Back to marketplace"
+            >
+              <ArrowLeft size={16} color="#e27927" />
+              <Text className="text-sm font-medium text-primary">Back to marketplace</Text>
+            </Pressable>
+          </View>
+        )}
+
         {/* Spotlight */}
         {spotlight && showRails && (
           <View className="px-5 mt-2 mb-8">
@@ -592,6 +625,7 @@ export default observer(function MarketplaceHomeScreen() {
     filterFeatured,
     filterFree,
     sortMode,
+    returnToEditorialHome,
     handleCardPress,
     router,
     numColumns,
@@ -602,7 +636,7 @@ export default observer(function MarketplaceHomeScreen() {
     <View className="flex-1 bg-background">
       {/* Top bar */}
       <View className="flex-row items-center gap-3 px-5 pt-3 pb-2">
-        <Pressable onPress={() => router.back()} hitSlop={6} className="p-1">
+        <Pressable onPress={handleTopBarBack} hitSlop={6} className="p-1">
           <ArrowLeft size={20} color="#71717a" />
         </Pressable>
         <Text className="text-base font-semibold text-foreground flex-1">

--- a/apps/mobile/app/(app)/marketplace/index.tsx
+++ b/apps/mobile/app/(app)/marketplace/index.tsx
@@ -331,10 +331,12 @@ export default observer(function MarketplaceHomeScreen() {
 
   const focusBrowse = useCallback(
     (focus: BrowseFocus) => {
-      setSortMode(BROWSE_FOCUS_META[focus].sort)
+      const meta = BROWSE_FOCUS_META[focus]
       setBrowseFocus(focus)
+      setSortMode(meta.sort)
+      scrollBrowseToTop()
     },
-    [],
+    [scrollBrowseToTop],
   )
 
   useEffect(() => {
@@ -433,7 +435,10 @@ export default observer(function MarketplaceHomeScreen() {
             viewMode={viewMode}
             title="Built for Shogo"
             subtitle="Editor-curated agents that meet our quality bar"
-            onSeeAll={() => setFilterFeatured(true)}
+            onSeeAll={() => {
+              setBrowseFocus(null)
+              setFilterFeatured(true)
+            }}
             items={builtForShogo}
             railTileSize="featured"
             railItemWidth={260}
@@ -482,7 +487,10 @@ export default observer(function MarketplaceHomeScreen() {
             viewMode={viewMode}
             title="Free agents"
             subtitle="Try without paying anything"
-            onSeeAll={() => setFilterFree(true)}
+            onSeeAll={() => {
+              setBrowseFocus(null)
+              setFilterFree(true)
+            }}
             items={freeAgents}
             onPress={handleCardPress}
           />
@@ -715,11 +723,11 @@ export default observer(function MarketplaceHomeScreen() {
         viewMode === 'grid' ? (
           <FlatList
             ref={browseListRef}
-            key={`grid-${numColumns}-${sortMode}`}
+            key={`grid-${numColumns}-${sortMode}-${browseFocus ?? 'home'}`}
             data={paddedData}
             keyExtractor={(item, index) => item?.slug ?? `spacer-${index}`}
             renderItem={renderGridItem}
-            extraData={sortMode}
+            extraData={`${sortMode}-${browseFocus ?? 'home'}`}
             numColumns={numColumns}
             columnWrapperStyle={numColumns > 1 ? { gap: 0 } : undefined}
             contentContainerStyle={{ paddingBottom: 32, paddingHorizontal: 12 }}
@@ -766,11 +774,11 @@ export default observer(function MarketplaceHomeScreen() {
         ) : (
           <FlatList
             ref={browseListRef}
-            key={`list-${sortMode}`}
+            key={`list-${sortMode}-${browseFocus ?? 'home'}`}
             data={tileListings}
             keyExtractor={(item) => item.slug}
             renderItem={renderListItem}
-            extraData={sortMode}
+            extraData={`${sortMode}-${browseFocus ?? 'home'}`}
             contentContainerStyle={{ paddingBottom: 32 }}
             ListHeaderComponent={ListHeader}
             onEndReached={handleLoadMore}
@@ -841,7 +849,9 @@ function AgentCollectionSection({
 }) {
   return (
     <View className="mb-8">
-      <SectionHeader title={title} subtitle={subtitle} onSeeAll={onSeeAll} />
+      <View className="relative z-20 bg-background">
+        <SectionHeader title={title} subtitle={subtitle} onSeeAll={onSeeAll} />
+      </View>
       {viewMode === 'grid' ? (
         <HorizontalRail
           items={items}

--- a/apps/mobile/app/(app)/marketplace/index.tsx
+++ b/apps/mobile/app/(app)/marketplace/index.tsx
@@ -261,26 +261,15 @@ export default observer(function MarketplaceHomeScreen() {
   const tileListings = useMemo(() => listings.map(toTileListing), [listings])
 
   const paddedData = useMemo(() => {
-    if (viewMode === 'list' || numColumns <= 1) return tileListings
+    if (numColumns <= 1) return tileListings
     const remainder = tileListings.length % numColumns
     if (remainder === 0) return tileListings
     return [...tileListings, ...Array(numColumns - remainder).fill(null)]
-  }, [tileListings, numColumns, viewMode])
+  }, [tileListings, numColumns])
 
   const renderGridItem = useCallback(
     ({ item }: { item: AgentTileListing | null }) => {
       if (!item) return <View className="flex-1 m-1.5" />
-      if (viewMode === 'list') {
-        return (
-          <View className="px-5 pb-3">
-            <AgentTile
-              size="compact"
-              listing={item}
-              onPress={() => handleCardPress(item.slug)}
-            />
-          </View>
-        )
-      }
       return (
         <AgentTile
           size="medium"
@@ -289,7 +278,20 @@ export default observer(function MarketplaceHomeScreen() {
         />
       )
     },
-    [handleCardPress, viewMode],
+    [handleCardPress],
+  )
+
+  const renderListItem = useCallback(
+    ({ item }: { item: AgentTileListing }) => (
+      <View className="px-5 pb-3">
+        <AgentTile
+          size="compact"
+          listing={item}
+          onPress={() => handleCardPress(item.slug)}
+        />
+      </View>
+    ),
+    [handleCardPress],
   )
 
   const ListHeader = useMemo(() => {
@@ -310,126 +312,81 @@ export default observer(function MarketplaceHomeScreen() {
         {/* Spotlight */}
         {spotlight && showRails && (
           <View className="px-5 mt-2 mb-8">
-            <AgentTile
-              size="spotlight"
-              listing={toTileListing(spotlight)}
-              onPress={() => handleCardPress(spotlight.slug)}
-            />
+            {viewMode === 'grid' ? (
+              <AgentTile
+                size="spotlight"
+                listing={toTileListing(spotlight)}
+                onPress={() => handleCardPress(spotlight.slug)}
+              />
+            ) : (
+              <AgentTile
+                size="compact"
+                listing={toTileListing(spotlight)}
+                onPress={() => handleCardPress(spotlight.slug)}
+              />
+            )}
           </View>
         )}
 
         {/* Built for Shogo */}
         {builtForShogo.length > 0 && showRails && (
-          <View className="mb-8">
-            <SectionHeader
-              title="Built for Shogo"
-              subtitle="Editor-curated agents that meet our quality bar"
-              onSeeAll={() => setFilterFeatured(true)}
-            />
-            <HorizontalRail
-              items={builtForShogo}
-              keyExtractor={(item) => item.slug}
-              itemWidth={260}
-              renderItem={(item) => (
-                <AgentTile
-                  size="featured"
-                  listing={toTileListing(item)}
-                  onPress={() => handleCardPress(item.slug)}
-                />
-              )}
-            />
-          </View>
+          <AgentCollectionSection
+            viewMode={viewMode}
+            title="Built for Shogo"
+            subtitle="Editor-curated agents that meet our quality bar"
+            onSeeAll={() => setFilterFeatured(true)}
+            items={builtForShogo}
+            railTileSize="featured"
+            railItemWidth={260}
+            onPress={handleCardPress}
+          />
         )}
 
         {/* Recommended for you */}
         {recommended.length > 0 && showRails && (
-          <View className="mb-8">
-            <SectionHeader
-              title="Recommended for you"
-              subtitle="Popular agents that match how you work"
-            />
-            <HorizontalRail
-              items={recommended}
-              keyExtractor={(item) => item.slug}
-              itemWidth={220}
-              renderItem={(item) => (
-                <AgentTile
-                  size="medium"
-                  listing={toTileListing(item)}
-                  onPress={() => handleCardPress(item.slug)}
-                />
-              )}
-            />
-          </View>
+          <AgentCollectionSection
+            viewMode={viewMode}
+            title="Recommended for you"
+            subtitle="Popular agents that match how you work"
+            items={recommended}
+            onPress={handleCardPress}
+          />
         )}
 
         {/* Trending */}
         {trending.length > 0 && showRails && (
-          <View className="mb-8">
-            <SectionHeader
-              title="Trending this week"
-              subtitle="Most-installed agents over the last 7 days"
-              onSeeAll={() => setSortMode('popular')}
-            />
-            <HorizontalRail
-              items={trending}
-              keyExtractor={(item) => item.slug}
-              itemWidth={220}
-              renderItem={(item) => (
-                <AgentTile
-                  size="medium"
-                  listing={toTileListing(item)}
-                  onPress={() => handleCardPress(item.slug)}
-                />
-              )}
-            />
-          </View>
+          <AgentCollectionSection
+            viewMode={viewMode}
+            title="Trending this week"
+            subtitle="Most-installed agents over the last 7 days"
+            onSeeAll={() => setSortMode('popular')}
+            items={trending}
+            onPress={handleCardPress}
+          />
         )}
 
         {/* New & noteworthy */}
         {newAgents.length > 0 && showRails && (
-          <View className="mb-8">
-            <SectionHeader
-              title="New & noteworthy"
-              subtitle="Recently published agents from the community"
-              onSeeAll={() => setSortMode('newest')}
-            />
-            <HorizontalRail
-              items={newAgents}
-              keyExtractor={(item) => item.slug}
-              itemWidth={220}
-              renderItem={(item) => (
-                <AgentTile
-                  size="medium"
-                  listing={toTileListing(item)}
-                  onPress={() => handleCardPress(item.slug)}
-                />
-              )}
-            />
-          </View>
+          <AgentCollectionSection
+            viewMode={viewMode}
+            title="New & noteworthy"
+            subtitle="Recently published agents from the community"
+            onSeeAll={() => setSortMode('newest')}
+            items={newAgents}
+            onPress={handleCardPress}
+          />
         )}
 
         {/* Free agents */}
         {freeAgents.length > 0 && showRails && (
-          <View className="mb-8">
-            <SectionHeader
-              title="Free agents"
-              subtitle="Try without paying anything"
-              onSeeAll={() => setFilterFree(true)}
-            />
-            <HorizontalRail
-              items={freeAgents}
-              keyExtractor={(item) => item.slug}
-              itemWidth={220}
-              renderItem={(item) => (
-                <AgentTile
-                  size="medium"
-                  listing={toTileListing(item)}
-                  onPress={() => handleCardPress(item.slug)}
-                />
-              )}
-            />
-          </View>
+          <AgentCollectionSection
+            viewMode={viewMode}
+            title="Free agents"
+            subtitle="Try without paying anything"
+            onSeeAll={() => setFilterFree(true)}
+            items={freeAgents}
+            onPress={handleCardPress}
+          />
         )}
 
         {/* Top creators */}
@@ -440,19 +397,33 @@ export default observer(function MarketplaceHomeScreen() {
               subtitle="Builders earning the most reputation this season"
               onSeeAll={() => router.push('/(app)/marketplace/creators' as any)}
             />
-            <HorizontalRail
-              items={topCreators}
-              keyExtractor={(c) => c.id}
-              itemWidth={210}
-              renderItem={(c) => (
-                <CreatorRailCard
-                  creator={c}
-                  onPress={() =>
-                    router.push(`/(app)/marketplace/creators/${c.id}` as any)
-                  }
-                />
-              )}
-            />
+            {viewMode === 'grid' ? (
+              <HorizontalRail
+                items={topCreators}
+                keyExtractor={(c) => c.id}
+                itemWidth={210}
+                renderItem={(c) => (
+                  <CreatorRailCard
+                    creator={c}
+                    onPress={() =>
+                      router.push(`/(app)/marketplace/creators/${c.id}` as any)
+                    }
+                  />
+                )}
+              />
+            ) : (
+              <View className="px-5 gap-3">
+                {topCreators.map((c) => (
+                  <CreatorRailCard
+                    key={c.id}
+                    creator={c}
+                    onPress={() =>
+                      router.push(`/(app)/marketplace/creators/${c.id}` as any)
+                    }
+                  />
+                ))}
+              </View>
+            )}
           </View>
         )}
 
@@ -520,6 +491,7 @@ export default observer(function MarketplaceHomeScreen() {
     handleCardPress,
     router,
     numColumns,
+    viewMode,
   ])
 
   return (
@@ -643,62 +615,160 @@ export default observer(function MarketplaceHomeScreen() {
           </Pressable>
         </View>
       ) : (
-        <FlatList
-          key={`grid-${viewMode}-${numColumns}`}
-          data={paddedData}
-          keyExtractor={(item, index) => item?.slug ?? `spacer-${index}`}
-          renderItem={renderGridItem}
-          numColumns={viewMode === 'list' ? 1 : numColumns}
-          contentContainerStyle={{
-            paddingBottom: 32,
-            paddingHorizontal: viewMode === 'list' ? 0 : 12,
-          }}
-          ListHeaderComponent={ListHeader}
-          onEndReached={handleLoadMore}
-          onEndReachedThreshold={0.5}
-          ListFooterComponent={
-            loadingMore ? (
-              <View className="py-4 items-center">
-                <ActivityIndicator size="small" />
-              </View>
-            ) : null
-          }
-          ListEmptyComponent={
-            !loading ? (
-              <View className="items-center justify-center py-20 px-6">
-                <Search size={32} color="#a1a1aa" />
-                <Text className="text-foreground font-medium mt-3 mb-1">
-                  No agents found
-                </Text>
-                <Text className="text-muted-foreground text-sm text-center mb-4">
-                  {isSearching
-                    ? `No results for “${searchQuery}”`
-                    : 'Nothing matches the current filters yet.'}
-                </Text>
-                {(filterFeatured || filterFree || activeCategory !== 'all') && (
-                  <Pressable
-                    onPress={() => {
-                      setFilterFeatured(false)
-                      setFilterFree(false)
-                      setActiveCategory('all')
-                    }}
-                    className="border border-border rounded-lg px-3 py-1.5"
-                  >
-                    <Text className="text-xs font-medium text-foreground">
-                      Clear filters
-                    </Text>
-                  </Pressable>
-                )}
-              </View>
-            ) : null
-          }
-        />
+        viewMode === 'grid' ? (
+          <FlatList
+            key={`grid-${numColumns}`}
+            data={paddedData}
+            keyExtractor={(item, index) => item?.slug ?? `spacer-${index}`}
+            renderItem={renderGridItem}
+            numColumns={numColumns}
+            columnWrapperStyle={numColumns > 1 ? { gap: 0 } : undefined}
+            contentContainerStyle={{ paddingBottom: 32, paddingHorizontal: 12 }}
+            ListHeaderComponent={ListHeader}
+            onEndReached={handleLoadMore}
+            onEndReachedThreshold={0.5}
+            ListFooterComponent={
+              loadingMore ? (
+                <View className="py-4 items-center">
+                  <ActivityIndicator size="small" />
+                </View>
+              ) : null
+            }
+            ListEmptyComponent={
+              !loading ? (
+                <View className="items-center justify-center py-20 px-6">
+                  <Search size={32} color="#a1a1aa" />
+                  <Text className="text-foreground font-medium mt-3 mb-1">
+                    No agents found
+                  </Text>
+                  <Text className="text-muted-foreground text-sm text-center mb-4">
+                    {isSearching
+                      ? `No results for “${searchQuery}”`
+                      : 'Nothing matches the current filters yet.'}
+                  </Text>
+                  {(filterFeatured || filterFree || activeCategory !== 'all') && (
+                    <Pressable
+                      onPress={() => {
+                        setFilterFeatured(false)
+                        setFilterFree(false)
+                        setActiveCategory('all')
+                      }}
+                      className="border border-border rounded-lg px-3 py-1.5"
+                    >
+                      <Text className="text-xs font-medium text-foreground">
+                        Clear filters
+                      </Text>
+                    </Pressable>
+                  )}
+                </View>
+              ) : null
+            }
+          />
+        ) : (
+          <FlatList
+            key="list"
+            data={tileListings}
+            keyExtractor={(item) => item.slug}
+            renderItem={renderListItem}
+            contentContainerStyle={{ paddingBottom: 32 }}
+            ListHeaderComponent={ListHeader}
+            onEndReached={handleLoadMore}
+            onEndReachedThreshold={0.5}
+            ListFooterComponent={
+              loadingMore ? (
+                <View className="py-4 items-center">
+                  <ActivityIndicator size="small" />
+                </View>
+              ) : null
+            }
+            ListEmptyComponent={
+              !loading ? (
+                <View className="items-center justify-center py-20 px-6">
+                  <Search size={32} color="#a1a1aa" />
+                  <Text className="text-foreground font-medium mt-3 mb-1">
+                    No agents found
+                  </Text>
+                  <Text className="text-muted-foreground text-sm text-center mb-4">
+                    {isSearching
+                      ? `No results for “${searchQuery}”`
+                      : 'Nothing matches the current filters yet.'}
+                  </Text>
+                  {(filterFeatured || filterFree || activeCategory !== 'all') && (
+                    <Pressable
+                      onPress={() => {
+                        setFilterFeatured(false)
+                        setFilterFree(false)
+                        setActiveCategory('all')
+                      }}
+                      className="border border-border rounded-lg px-3 py-1.5"
+                    >
+                      <Text className="text-xs font-medium text-foreground">
+                        Clear filters
+                      </Text>
+                    </Pressable>
+                  )}
+                </View>
+              ) : null
+            }
+          />
+        )
       )}
     </View>
   )
 })
 
 // ── Sub-components ─────────────────────────────────────────────────
+
+function AgentCollectionSection({
+  viewMode,
+  title,
+  subtitle,
+  items,
+  onSeeAll,
+  onPress,
+  railTileSize = 'medium',
+  railItemWidth = 220,
+}: {
+  viewMode: ViewMode
+  title: string
+  subtitle: string
+  items: ListingFromAPI[]
+  onSeeAll?: () => void
+  onPress: (slug: string) => void
+  railTileSize?: 'featured' | 'medium'
+  railItemWidth?: number
+}) {
+  return (
+    <View className="mb-8">
+      <SectionHeader title={title} subtitle={subtitle} onSeeAll={onSeeAll} />
+      {viewMode === 'grid' ? (
+        <HorizontalRail
+          items={items}
+          keyExtractor={(item) => item.slug}
+          itemWidth={railItemWidth}
+          renderItem={(item) => (
+            <AgentTile
+              size={railTileSize}
+              listing={toTileListing(item)}
+              onPress={() => onPress(item.slug)}
+            />
+          )}
+        />
+      ) : (
+        <View className="px-5 gap-3">
+          {items.map((item) => (
+            <AgentTile
+              key={item.slug}
+              size="compact"
+              listing={toTileListing(item)}
+              onPress={() => onPress(item.slug)}
+            />
+          ))}
+        </View>
+      )}
+    </View>
+  )
+}
 
 function CategoryPill({
   active,

--- a/apps/mobile/app/(app)/marketplace/index.tsx
+++ b/apps/mobile/app/(app)/marketplace/index.tsx
@@ -107,6 +107,13 @@ const SORT_LABELS: Record<SortMode, string> = {
   featured: 'Featured first',
 }
 
+const SORT_SECTION_TITLES: Record<SortMode, string> = {
+  popular: 'Popular this month',
+  rating: 'Top rated',
+  newest: 'Newest',
+  featured: 'Featured first',
+}
+
 function toTileListing(item: ListingFromAPI): AgentTileListing {
   return {
     slug: item.slug,
@@ -176,13 +183,22 @@ export default observer(function MarketplaceHomeScreen() {
   const isSearching = debouncedSearchTrimmed.length > 0
   const isSearchPending =
     searchQuery.trim() !== debouncedSearchTrimmed
-  const showRails = !isSearching && activeCategory === 'all' && !filterFeatured && !filterFree
+  const showRails =
+    sortMode === 'popular' &&
+    !isSearching &&
+    activeCategory === 'all' &&
+    !filterFeatured &&
+    !filterFree
 
   const loadGrid = useCallback(
     async (pageNum: number, append = false) => {
       try {
-        if (pageNum === 1) setLoading(true)
-        else setLoadingMore(true)
+        if (pageNum === 1) {
+          setLoading(true)
+          if (!append) setListings([])
+        } else {
+          setLoadingMore(true)
+        }
 
         const params = new URLSearchParams()
         params.set('page', String(pageNum))
@@ -464,7 +480,7 @@ export default observer(function MarketplaceHomeScreen() {
                 : filterFree
                   ? 'Free agents'
                   : activeCategory === 'all'
-                    ? 'Popular this month'
+                    ? SORT_SECTION_TITLES[sortMode]
                     : MARKETPLACE_CATEGORIES.find((c) => c.slug === activeCategory)?.label ?? 'Browse'
             }
             subtitle={
@@ -494,6 +510,7 @@ export default observer(function MarketplaceHomeScreen() {
     activeCategory,
     filterFeatured,
     filterFree,
+    sortMode,
     handleCardPress,
     router,
     numColumns,
@@ -623,10 +640,11 @@ export default observer(function MarketplaceHomeScreen() {
       ) : (
         viewMode === 'grid' ? (
           <FlatList
-            key={`grid-${numColumns}`}
+            key={`grid-${numColumns}-${sortMode}`}
             data={paddedData}
             keyExtractor={(item, index) => item?.slug ?? `spacer-${index}`}
             renderItem={renderGridItem}
+            extraData={sortMode}
             numColumns={numColumns}
             columnWrapperStyle={numColumns > 1 ? { gap: 0 } : undefined}
             contentContainerStyle={{ paddingBottom: 32, paddingHorizontal: 12 }}
@@ -672,10 +690,11 @@ export default observer(function MarketplaceHomeScreen() {
           />
         ) : (
           <FlatList
-            key="list"
+            key={`list-${sortMode}`}
             data={tileListings}
             keyExtractor={(item) => item.slug}
             renderItem={renderListItem}
+            extraData={sortMode}
             contentContainerStyle={{ paddingBottom: 32 }}
             ListHeaderComponent={ListHeader}
             onEndReached={handleLoadMore}

--- a/apps/mobile/app/(app)/marketplace/index.tsx
+++ b/apps/mobile/app/(app)/marketplace/index.tsx
@@ -43,6 +43,7 @@ import {
   PopoverBody,
   PopoverContent,
 } from '@/components/ui/popover'
+import { useDebouncedValue } from '../../../hooks/useDebouncedValue'
 import { useGridColumns } from '../../../hooks/useGridColumns'
 
 interface ListingFromAPI {
@@ -149,6 +150,7 @@ export default observer(function MarketplaceHomeScreen() {
   const numColumns = useGridColumns()
 
   const [searchQuery, setSearchQuery] = useState('')
+  const debouncedSearchQuery = useDebouncedValue(searchQuery)
   const [activeCategory, setActiveCategory] = useState<string>('all')
   const [sortMode, setSortMode] = useState<SortMode>('popular')
   const [filterFeatured, setFilterFeatured] = useState(false)
@@ -170,7 +172,10 @@ export default observer(function MarketplaceHomeScreen() {
   const [totalPages, setTotalPages] = useState(1)
   const [loadingMore, setLoadingMore] = useState(false)
 
-  const isSearching = searchQuery.trim().length > 0
+  const debouncedSearchTrimmed = debouncedSearchQuery.trim()
+  const isSearching = debouncedSearchTrimmed.length > 0
+  const isSearchPending =
+    searchQuery.trim() !== debouncedSearchTrimmed
   const showRails = !isSearching && activeCategory === 'all' && !filterFeatured && !filterFree
 
   const loadGrid = useCallback(
@@ -188,7 +193,7 @@ export default observer(function MarketplaceHomeScreen() {
 
         let url: string
         if (isSearching) {
-          params.set('q', searchQuery.trim())
+          params.set('q', debouncedSearchTrimmed)
           url = `/api/marketplace/search?${params.toString()}`
         } else {
           url = `/api/marketplace?${params.toString()}`
@@ -211,7 +216,7 @@ export default observer(function MarketplaceHomeScreen() {
         setLoadingMore(false)
       }
     },
-    [http, sortMode, activeCategory, filterFeatured, filterFree, isSearching, searchQuery],
+    [http, sortMode, activeCategory, filterFeatured, filterFree, isSearching, debouncedSearchTrimmed],
   )
 
   const loadEditorial = useCallback(async () => {
@@ -237,7 +242,7 @@ export default observer(function MarketplaceHomeScreen() {
 
   useEffect(() => {
     loadGrid(1)
-  }, [activeCategory, sortMode, filterFeatured, filterFree, searchQuery])
+  }, [activeCategory, sortMode, filterFeatured, filterFree, debouncedSearchQuery])
 
   useEffect(() => {
     loadEditorial()
@@ -299,9 +304,9 @@ export default observer(function MarketplaceHomeScreen() {
       return (
         <View className="px-5 mb-3">
           <Text className="text-sm text-muted-foreground">
-            {loading
+            {loading || isSearchPending
               ? 'Searching…'
-              : `${listings.length} result${listings.length === 1 ? '' : 's'} for “${searchQuery.trim()}”`}
+              : `${listings.length} result${listings.length === 1 ? '' : 's'} for “${debouncedSearchTrimmed}”`}
           </Text>
         </View>
       )
@@ -476,7 +481,8 @@ export default observer(function MarketplaceHomeScreen() {
     isSearching,
     loading,
     listings.length,
-    searchQuery,
+    debouncedSearchTrimmed,
+    isSearchPending,
     showRails,
     spotlight,
     builtForShogo,
@@ -643,7 +649,7 @@ export default observer(function MarketplaceHomeScreen() {
                   </Text>
                   <Text className="text-muted-foreground text-sm text-center mb-4">
                     {isSearching
-                      ? `No results for “${searchQuery}”`
+                      ? `No results for “${debouncedSearchTrimmed}”`
                       : 'Nothing matches the current filters yet.'}
                   </Text>
                   {(filterFeatured || filterFree || activeCategory !== 'all') && (
@@ -690,7 +696,7 @@ export default observer(function MarketplaceHomeScreen() {
                   </Text>
                   <Text className="text-muted-foreground text-sm text-center mb-4">
                     {isSearching
-                      ? `No results for “${searchQuery}”`
+                      ? `No results for “${debouncedSearchTrimmed}”`
                       : 'Nothing matches the current filters yet.'}
                   </Text>
                   {(filterFeatured || filterFree || activeCategory !== 'all') && (

--- a/apps/mobile/app/(app)/marketplace/index.tsx
+++ b/apps/mobile/app/(app)/marketplace/index.tsx
@@ -534,7 +534,7 @@ export default observer(function MarketplaceHomeScreen() {
           <View className="flex-row items-center bg-card border border-input rounded-xl px-3 h-11 flex-1">
             <Search size={16} color="#71717a" />
             <TextInput
-              className="flex-1 ml-2 text-sm text-foreground web:outline-none"
+              className="flex-1 ml-2 text-sm text-foreground web:outline-none no-focus-ring"
               placeholder="Search agents…"
               placeholderTextColor="#71717a"
               value={searchQuery}

--- a/apps/mobile/components/marketplace/AgentTile.tsx
+++ b/apps/mobile/components/marketplace/AgentTile.tsx
@@ -117,7 +117,7 @@ function SpotlightTile({ listing, onPress }: { listing: AgentTileListing; onPres
               />
               <View className="flex-row items-center gap-1 rounded-full bg-foreground px-3 py-1.5">
                 <Text className="text-xs font-semibold text-background">View</Text>
-                <ArrowRight size={12} color="#fff" />
+                <ArrowRight size={12} className="text-background" />
               </View>
             </View>
           </View>

--- a/apps/mobile/components/marketplace/SectionHeader.tsx
+++ b/apps/mobile/components/marketplace/SectionHeader.tsx
@@ -55,9 +55,17 @@ export function SectionHeader({
       </View>
       {onSeeAll && (
         <Pressable
-          onPress={onSeeAll}
-          hitSlop={6}
-          className="flex-row items-center gap-1 active:opacity-60"
+          onPress={(e) => {
+            if ('stopPropagation' in e && typeof e.stopPropagation === 'function') {
+              e.stopPropagation()
+            }
+            onSeeAll()
+          }}
+          hitSlop={10}
+          className="flex-row items-center gap-1 active:opacity-60 relative z-20"
+          style={Platform.OS === 'web' ? { cursor: 'pointer' } : undefined}
+          accessibilityRole="button"
+          accessibilityLabel={`${seeAllLabel} ${title}`}
         >
           <Text className="text-sm font-medium text-primary">{seeAllLabel}</Text>
           <ChevronRight size={14} color="#e27927" />

--- a/apps/mobile/hooks/useDebouncedValue.ts
+++ b/apps/mobile/hooks/useDebouncedValue.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { useEffect, useState } from 'react'
+
+/** Default debounce delay for search fields (ms). */
+export const SEARCH_DEBOUNCE_MS = 300
+
+/**
+ * Returns a debounced copy of `value`, updated after `delayMs` without changes.
+ */
+export function useDebouncedValue<T>(value: T, delayMs = SEARCH_DEBOUNCE_MS): T {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(value), delayMs)
+    return () => clearTimeout(handle)
+  }, [value, delayMs])
+
+  return debounced
+}


### PR DESCRIPTION
## Summary

Fixes multiple marketplace home UX issues on web and mobile: the sort dropdown now uses the shared Popover (opaque, correct layering), grid/list toggle works with matching content, search is debounced, sort and **See all** update the visible browse view, and users can return to the editorial home after drilling in.

<img width="1236" height="343" alt="image" src="https://github.com/user-attachments/assets/ff2aa171-70a8-4aa9-8d78-1a8f6746f96a" />
<img width="1665" height="700" alt="image" src="https://github.com/user-attachments/assets/22cfd063-aff1-4131-955c-7b2bf87568e9" />
<img width="1636" height="573" alt="image" src="https://github.com/user-attachments/assets/6633a2aa-eec1-4427-ad06-e796c6d491c4" />
<img width="1334" height="887" alt="image" src="https://github.com/user-attachments/assets/181566e3-5962-4426-bf88-b875e65cdda3" />


## Changes

### Sort dropdown
- Replaced custom absolute-positioned sort menu with shared `Popover` (same as Projects)
- Fixes transparent menu and filter pills rendering on top of the dropdown

### Grid / list view
- Use separate `FlatList`s for grid vs list (avoids unreliable `numColumns` toggling on web)
- List view keeps editorial sections with compact rows; grid keeps horizontal rails
- Section title updates with selected sort; editorial rails show only on default **Popular** browse

### Search
- Added `useDebouncedValue` hook (300ms) to avoid one API request per keystroke
- Removed orange focus ring on search input via `no-focus-ring` (matches chat inputs)

### Spotlight card
- **View** arrow uses `text-background` so it’s visible in light and dark themes

### Sort selection feedback
- Changing sort updates section title, clears stale results, and remounts the list
- Non-popular sorts hide editorial rails so the sorted grid is obvious

### Rail **See all** (Trending, New & noteworthy, etc.)
- **Trending** → **Trending this week** (not “Popular this month”)
- **New** → **New & noteworthy** with correct subtitle
- Scroll list and page to top after expanding
- Improved **See all** click targets on web (`z-index`, hit area)
- **Back to marketplace** link + smart top-bar ← to return to editorial home (spotlight, rails, filters reset)

## Files touched
- `apps/mobile/app/(app)/marketplace/index.tsx`
- `apps/mobile/components/marketplace/AgentTile.tsx`
- `apps/mobile/components/marketplace/SectionHeader.tsx`
- `apps/mobile/hooks/useDebouncedValue.ts` (new)

## Test plan
- [ ] Open marketplace — sort dropdown is opaque and layers above filter pills
- [ ] Toggle grid/list — layout and card style change; list still shows editorial sections
- [ ] Type in search — one API call after pause, no orange inner border on focus
- [ ] Spotlight **View** arrow visible in light and dark mode
- [ ] Change sort (Popular / Top rated / Newest / Featured) — title and grid order update
- [ ] **Trending this week → See all** — shows trending title, scrolls to top, **Back to marketplace** restores home
- [ ] **New & noteworthy → See all** — same behavior
- [ ] Top ← on expanded view returns to editorial home; on home, navigates away as before
