### PR TITLE
Auto-rebuild packages/sdk in dev:all to prevent stale-dist crashes

### DIFF
--- a/scripts/dev-all.ts
+++ b/scripts/dev-all.ts
@@ -9,7 +9,11 @@
  *  3. Regenerate the Prisma client(s) so any new models added to the
  *     schema since the last `bun install` are visible at runtime.
  *  4. Generate SDK routes/types/stores from the Prisma schema.
- *  5. Start the API and web dev servers via concurrently.
+ *  5. Build `packages/sdk` so its `dist/` is in sync with `src/` before
+ *     the API boots. The API imports `@shogo-ai/sdk` from `dist/index.js`
+ *     and a stale dist surfaces as an opaque "Export named 'X' not found"
+ *     SyntaxError that crash-loops watch-api. Skip with SHOGO_SKIP_SDK_BUILD=1.
+ *  6. Start the API and web dev servers via concurrently.
  */
 
 import { spawn, spawnSync, type Subprocess } from "bun";
@@ -230,7 +234,41 @@ async function generateRoutes() {
 }
 
 // ---------------------------------------------------------------------------
-// 5. Start API + web dev servers
+// 5. Build packages/sdk so dist/ matches src/
+//
+// `apps/api` (and downstream consumers like `packages/agent-runtime`) imports
+// `@shogo-ai/sdk` and resolves to `packages/sdk/dist/index.js` per the
+// package's `exports` map. If `dist/` is stale relative to `src/` — which
+// happens after pulling main, deleting node_modules, or aborting an install
+// mid-postinstall — the API crash-loops with a `SyntaxError: Export named
+// 'X' not found in module .../sdk/dist/index.js`. Always rebuilding here
+// keeps `dev:all` self-healing without forcing devs to remember a manual
+// `bun run build:sdk`. tsup's incremental cache makes warm rebuilds cheap.
+// ---------------------------------------------------------------------------
+
+async function buildSdk() {
+  if (process.env.SHOGO_SKIP_SDK_BUILD === "1") {
+    console.log("[dev:all] SHOGO_SKIP_SDK_BUILD=1 — skipping SDK build.");
+    return;
+  }
+  console.log("[dev:all] Building packages/sdk…");
+  const proc = spawn({
+    cmd: ["bun", "run", "--cwd", "packages/sdk", "build"],
+    cwd: ROOT,
+    stdout: "inherit",
+    stderr: "inherit",
+    env: { ...process.env },
+  });
+  const code = await proc.exited;
+  if (code !== 0) {
+    console.error("[dev:all] SDK build failed — aborting.");
+    process.exit(code);
+  }
+  console.log("[dev:all] SDK built.");
+}
+
+// ---------------------------------------------------------------------------
+// 6. Start API + web dev servers
 // ---------------------------------------------------------------------------
 
 async function startDevServers() {
@@ -287,4 +325,5 @@ await Promise.all([killProcessOnPort(API_PORT), killProcessOnPort(WEB_PORT)]);
 await migrate();
 await generatePrismaClients();
 await generateRoutes();
+await buildSdk();
 await startDevServers();


### PR DESCRIPTION
## Summary
- Adds a `buildSdk` step to `scripts/dev-all.ts` between SDK route generation and `concurrently` starting `api:dev` + `web:dev`.
- Runs `bun run --cwd packages/sdk build` (same command as the existing root `build:sdk` script).
- Aborts `dev:all` if the build fails, with the error inherited from tsup.
- Skippable via `SHOGO_SKIP_SDK_BUILD=1` for tight inner loops.

## Why
`apps/api` (and downstream consumers like `packages/agent-runtime`) import `@shogo-ai/sdk`, which resolves to `packages/sdk/dist/index.js` per the package's `exports` map. A stale `dist/` — produced by pulling main, deleting `node_modules`, or an interrupted `bun install` — surfaces as an opaque

```
SyntaxError: Export named '<name>' not found in module .../sdk/dist/index.js
```

that crash-loops `watch-api`. Because the web frontend on `:8081` keeps serving, the user sees a working browser tab whose `/api/*` calls all fail, dropping them into the unconfigured/onboarding fallback as if they had no account.

Recovery today is a manual `bun run build:sdk`, which isn't discoverable. Folding it into `dev:all` makes the dev environment self-healing without changing production builds.

## Cross-platform impact
Additive — same step on macOS/Linux/Windows, no `process.platform` branching. ~24s on a cold `tsup` build, a few seconds on a warm cache. `SHOGO_SKIP_SDK_BUILD=1` is the escape hatch for tight inner loops.

## Test plan
- [ ] `bun dev:all` from a clean clone — confirm SDK builds, then API + web come up.
- [ ] Touch a file in `packages/sdk/src/`, restart `bun dev:all` — confirm rebuilt `dist/` is picked up.
- [ ] `SHOGO_SKIP_SDK_BUILD=1 bun dev:all` — confirm step is skipped.
- [ ] Reproduce the original failure: delete `packages/sdk/dist/`, run `bun dev:all` — confirm it auto-recovers instead of crash-looping.
