### PR TITLE
Keep local agent-runtime warm while streams are flowing

### DIFF
--- a/apps/api/src/__tests__/runtime-manager-touch.test.ts
+++ b/apps/api/src/__tests__/runtime-manager-touch.test.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Regression coverage for the long-lived-stream / idle-eviction bug.
+ *
+ * Symptom: a `/agent/canvas/stream` SSE that lasted longer than
+ * `WorkerRuntimeManager`'s 15-minute idle window got SIGTERM'd
+ * mid-stream, producing the cascade
+ *
+ *     [WorkerRuntimeManager] idle-evicting <pid> after 900s
+ *     error: ECONNRESET
+ *     [ProjectChat] EOF without turn-complete ... server-side resume from buffer
+ *     [AgentProxy] GET /agent/canvas/stream failed after 24 attempts
+ *
+ * spamming the API log every few seconds while the front-end's auto-
+ * reconnecting EventSource hammered a dead localhost port.
+ *
+ * Root cause: the embedded WorkerRuntimeManager only resets its idle
+ * timer on `touch()`, and `touch()` was only called during fresh proxy
+ * resolution (`resolveLocalUrl()`). A long-lived stream that opened
+ * once and then quietly streamed bytes for 30 minutes never re-touched
+ * the timer.
+ *
+ * Fix:
+ *   1. `IRuntimeManager.touch(projectId)` is part of the public
+ *      contract, with explicit "must not throw on unknown projectId"
+ *      semantics — the agent-proxy can call it on every chunk
+ *      without first checking whether the request was routed to a
+ *      local runtime vs. a cloud pod.
+ *   2. `RuntimeManager.touch()` delegates to the embedded
+ *      `WorkerRuntimeManager.touch()`, which is the slot that owns the
+ *      `setTimeout` we want to re-arm.
+ *
+ * These tests pin both invariants so a future refactor can't silently
+ * regress the streaming-keepalive contract.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { WorkerRuntimeManager } from '@shogo-ai/worker/runtime-manager'
+import { RuntimeManager } from '../lib/runtime'
+
+describe('RuntimeManager.touch', () => {
+  test('is a no-op for unknown project IDs (does not throw)', () => {
+    const rm = new RuntimeManager()
+    // Cloud-pod / k8s mode: nothing has been spawned locally for this
+    // project ID. The agent-proxy still calls touch() on every stream
+    // heartbeat — that must not throw.
+    expect(() => rm.touch('proj-that-was-never-spawned')).not.toThrow()
+  })
+
+  test('delegates to the embedded WorkerRuntimeManager', () => {
+    const rm = new RuntimeManager()
+    const calls: string[] = []
+    const original = WorkerRuntimeManager.prototype.touch
+    WorkerRuntimeManager.prototype.touch = function (this: unknown, projectId: string) {
+      calls.push(projectId)
+      // Don't actually call original — it would noop on an empty slot
+      // map, which is fine, but spying via in-place override is the
+      // cheapest way to make the assertion observable without exposing
+      // `agentManager` for testing.
+    }
+
+    try {
+      rm.touch('proj-1')
+      rm.touch('proj-2')
+      expect(calls).toEqual(['proj-1', 'proj-2'])
+    } finally {
+      WorkerRuntimeManager.prototype.touch = original
+    }
+  })
+
+  test('swallows downstream errors instead of propagating them up the proxy', () => {
+    const rm = new RuntimeManager()
+    const original = WorkerRuntimeManager.prototype.touch
+    WorkerRuntimeManager.prototype.touch = function () {
+      // Simulate a future refactor where touch() can throw — e.g. if
+      // the slot map gets re-keyed and a stale projectId hits a
+      // type assertion. The proxy must still keep streaming.
+      throw new Error('boom')
+    }
+
+    try {
+      // Silence the warn so test output stays clean; we still want to
+      // exercise the catch branch.
+      const original_warn = console.warn
+      console.warn = () => {}
+      try {
+        expect(() => rm.touch('proj-1')).not.toThrow()
+      } finally {
+        console.warn = original_warn
+      }
+    } finally {
+      WorkerRuntimeManager.prototype.touch = original
+    }
+  })
+})

--- a/apps/api/src/lib/runtime/manager.ts
+++ b/apps/api/src/lib/runtime/manager.ts
@@ -1768,6 +1768,25 @@ export class ShogoErrorBoundary extends Component<Props, State> {
     })
   }
 
+  /**
+   * Reset the idle-eviction timer on the embedded {@link WorkerRuntimeManager}'s
+   * slot for `projectId`. Safe to call for unknown project IDs — the
+   * downstream `WorkerRuntimeManager.touch()` already short-circuits when
+   * it has no slot, so the agent-proxy can fire this on every stream
+   * heartbeat without first checking whether the request was routed to a
+   * local runtime vs. a cloud pod.
+   */
+  touch(projectId: string): void {
+    try {
+      this.agentManager.touch(projectId)
+    } catch (err: any) {
+      // Defensive: a future refactor that makes touch() throw must not
+      // be allowed to abort an in-flight stream just because the keep-
+      // alive ping failed.
+      console.warn(`[RuntimeManager] touch(${projectId}) failed: ${err?.message ?? err}`)
+    }
+  }
+
   private startHealthCheck(projectId: string): void {
     const timer = setInterval(() => {
       this.getHealth(projectId).catch((err) =>

--- a/apps/api/src/lib/runtime/types.ts
+++ b/apps/api/src/lib/runtime/types.ts
@@ -102,4 +102,22 @@ export interface IRuntimeManager {
    * Get list of all active project IDs.
    */
   getActiveProjects(): string[]
+
+  /**
+   * Mark a project's runtime as recently used so its idle-eviction
+   * timer is reset.
+   *
+   * Called from the agent-proxy streaming path so that long-lived SSE
+   * responses (e.g. `/agent/canvas/stream`, `/agent/chat`) keep the
+   * underlying child process alive while bytes are still flowing — the
+   * embedded `WorkerRuntimeManager` only auto-resets the timer when a
+   * fresh proxy resolution happens, so a single stream that lasts
+   * longer than `RUNTIME_IDLE_MS` would otherwise be SIGTERM'd
+   * mid-flight.
+   *
+   * Implementations MUST be safe to call for project IDs that have no
+   * locally-managed runtime (cloud-pod / k8s mode) — the call should
+   * be a no-op rather than throwing.
+   */
+  touch(projectId: string): void
 }

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2233,7 +2233,38 @@ app.all('/api/projects/:projectId/agent-proxy/*', async (c) => {
         (response.body && responseContentType.includes('text/plain'))
       if (isStreaming && response.body) {
         activeProxyConnections++
+
+        // Keep the locally-managed agent-runtime warm while bytes flow.
+        // The embedded WorkerRuntimeManager only resets its idle timer
+        // on fresh proxy resolutions, so a long-lived SSE that lasts
+        // longer than RUNTIME_IDLE_MS (15min by default) would get
+        // SIGTERM'd mid-stream and produce a cascade of `ECONNRESET`
+        // → `Resume fetch failed` → `[AgentProxy] failed after 24
+        // attempts` errors. Throttled to once per 60s — calling on
+        // every chunk would hit the manager hundreds of times per
+        // second on an active stream. No-op in cloud-pod / k8s mode
+        // because RuntimeManager.touch() short-circuits on unknown
+        // project IDs.
+        let lastRuntimeTouchAt = Date.now()
+        const RUNTIME_TOUCH_INTERVAL_MS = 60_000
+
         let outBody: ReadableStream<Uint8Array> = response.body.pipeThrough(new TransformStream({
+          transform(chunk, controller) {
+            controller.enqueue(chunk)
+            const now = Date.now()
+            if (now - lastRuntimeTouchAt >= RUNTIME_TOUCH_INTERVAL_MS) {
+              lastRuntimeTouchAt = now
+              try {
+                getRuntimeManager().touch(projectId)
+              } catch {
+                // Best-effort: a touch failure must never abort the
+                // user-visible stream. RuntimeManager.touch already
+                // catches downstream errors; this is a final guard
+                // for the (unlikely) case that getRuntimeManager()
+                // itself throws during shutdown.
+              }
+            }
+          },
           flush() { activeProxyConnections-- },
         }))
         // For chat-stream calls, tee the body through the billing tracker


### PR DESCRIPTION
## Summary

A long-lived `/agent/canvas/stream` or `/agent/chat` SSE that lasted longer than `WorkerRuntimeManager`'s `RUNTIME_IDLE_MS` window (default 15 min) was getting SIGTERM'd mid-stream because nothing reset the runtime's idle timer once the proxy had finished its initial resolution. The visible symptom was the cascade

```text
[WorkerRuntimeManager] idle-evicting <id> after 900s
error: ECONNRESET   path: "http://localhost:<port>/agent/canvas/stream"
[ProjectChat] EOF without turn-complete (lastObservedSeq=...) — server-side resume from buffer
[ProjectChat] Resume fetch failed: Unable to connect.
[AgentProxy] GET /agent/canvas/stream failed after 24 attempts (×N)
```

with the front-end's auto-reconnecting EventSource hammering the dead localhost port until the user gave up.

## Root cause

`WorkerRuntimeManager.touch()` resets the idle `setTimeout`, but it's only called from `resolveLocalUrl()` and `ensureRunning()` — i.e. once per fresh proxy resolution. A stream that opened once and quietly streamed events for 30 minutes only touched the timer at minute 0; the 15-minute timeout fired in the middle of an actively-running turn.

## Fix (Option A from the chat thread)

- Add `touch(projectId)` to the `IRuntimeManager` contract, with explicit "**must not throw** on unknown projectId" semantics — the agent-proxy can call it on every chunk without first checking whether the request was routed to a local runtime vs. a cloud pod.
- `RuntimeManager.touch()` delegates to the embedded `WorkerRuntimeManager` and swallows downstream errors so a future refactor can't take down an in-flight stream.
- The agent-proxy streaming branch in `apps/api/src/server.ts` wraps the response body in a `TransformStream` that calls `getRuntimeManager().touch(projectId)` once every 60s as bytes flow. Throttling avoids hammering the manager hundreds of times per second on an active stream.

The 60s heartbeat keeps `lastUsedAt` well within the 15-minute idle window for the lifetime of a stream. No-op in cloud-pod / k8s mode because the local manager doesn't know those project IDs and short-circuits.

## What's in this PR

- `apps/api/src/lib/runtime/types.ts` — new `touch(projectId)` on `IRuntimeManager`.
- `apps/api/src/lib/runtime/manager.ts` — implementation that delegates to the embedded `WorkerRuntimeManager`.
- `apps/api/src/server.ts` — `TransformStream` heartbeat in the agent-proxy streaming branch.
- `apps/api/src/__tests__/runtime-manager-touch.test.ts` — regression coverage for: delegation, unknown-projectId no-op, and swallow-downstream-errors guarantees.

## Cross-platform impact

Pure runtime-keepalive logic — no `process.platform` branching. The streaming change touches the local manager only; tunnel relay (paired-instance projects) and cloud-pod / k8s modes are untouched.

## Test plan

- [x] `bun test apps/api/src/__tests__/runtime-manager-touch.test.ts` — 3 pass.
- [x] `bun test apps/api/src/__tests__/runtime-manager-singleton.test.ts apps/api/src/__tests__/resolve-pod-url.test.ts apps/api/src/__tests__/agent-proxy-resolver.test.ts` — 66 pass, 0 fail.
- [ ] Manual: `bun dev:all`, prompt a chat session, leave the canvas stream open for >15 minutes (e.g. by walking away during a long agent turn) and confirm no `idle-evicting` log line and no `[AgentProxy] failed after 24 attempts` cascade.
