### PR TITLE
fix(runtime): reset agent-runtime idle window on user/agent activity

### DIFF
--- a/apps/api/src/lib/runtime/manager.ts
+++ b/apps/api/src/lib/runtime/manager.ts
@@ -137,6 +137,17 @@ export class RuntimeManager implements IRuntimeManager {
         if (!existsSync(path)) return null
         return { path, source: 'env' as const }
       },
+      // Local/desktop mode is single-user with no resource pressure to
+      // recycle for; the default 15-min idle eviction was killing
+      // in-flight chat streams whenever the agent-proxy didn't see a
+      // fresh request inside the window. The activity-touch hooks in
+      // server.ts (agent-proxy) and routes/ai-proxy.ts (AI proxy)
+      // refresh `lastUsedAt` on every chunk forwarded and every model
+      // call from the agent, so cloud's 15-min reaper now only fires
+      // on a genuinely-idle slot. Local mode additionally disables
+      // the reaper outright as a belt-and-suspenders since there is
+      // no resource motivation to ever reap there.
+      idleMs: process.env.SHOGO_LOCAL_MODE === 'true' ? 0 : undefined,
     })
   }
 
@@ -1766,6 +1777,30 @@ export class ShogoErrorBoundary extends Component<Props, State> {
       const runtime = this.runtimes.get(id)
       return runtime && (runtime.status === 'running' || runtime.status === 'starting')
     })
+  }
+
+  /**
+   * Mark a project as recently active so the embedded
+   * {@link WorkerRuntimeManager} resets its idle-eviction window.
+   *
+   * Production bug this exists to fix: a long Opus / Claude turn (or
+   * any chat stream that runs >15min without a fresh agent-proxy
+   * request) was getting reaped mid-stream by `WorkerRuntimeManager`
+   * because nothing in the proxy hot path refreshed `lastUsedAt`.
+   * Callers (agent-proxy in `server.ts`, AI proxy in
+   * `routes/ai-proxy.ts`) now invoke this on every forwarded SSE
+   * chunk and on every project-scoped model call so the reaper only
+   * sees a slot as "idle" when the user really has stepped away.
+   *
+   * Safe no-op if `projectId` has no runtime.
+   */
+  touch(projectId: string): void {
+    if (!projectId || projectId === 'api-key') return
+    try {
+      this.agentManager.touch(projectId)
+    } catch (err: any) {
+      console.warn(`[RuntimeManager] touch(${projectId}) failed: ${err?.message ?? err}`)
+    }
   }
 
   private startHealthCheck(projectId: string): void {

--- a/apps/api/src/lib/runtime/types.ts
+++ b/apps/api/src/lib/runtime/types.ts
@@ -102,4 +102,19 @@ export interface IRuntimeManager {
    * Get list of all active project IDs.
    */
   getActiveProjects(): string[]
+
+  /**
+   * Mark a project as recently active. Resets the idle-eviction
+   * window in the underlying agent-runtime manager so a long chat
+   * stream / background tool call doesn't get reaped at 15 minutes.
+   *
+   * Called from:
+   *   - the `/api/projects/:id/agent-proxy/*` request path on every
+   *     incoming request and on every forwarded SSE chunk, and
+   *   - the AI proxy after a project-scoped token decodes, so the
+   *     agent's outbound model calls also keep its runtime alive.
+   *
+   * Safe no-op if no runtime exists for `projectId`.
+   */
+  touch(projectId: string): void
 }

--- a/apps/api/src/routes/ai-proxy.ts
+++ b/apps/api/src/routes/ai-proxy.ts
@@ -38,6 +38,7 @@ import { verifyRuntimeToken } from '../lib/runtime-token'
 import { resolveApiKey } from './api-keys'
 import { wipeCloudKey } from '../lib/cloud-key-wipe'
 import { getShogoCloudUrl } from '../lib/cloud-urls'
+import { getRuntimeManager } from '../lib/runtime'
 import {
   MODEL_CATALOG,
   MODEL_ALIASES,
@@ -1775,6 +1776,30 @@ export function aiProxyRoutes() {
   }
 
   /**
+   * Refresh the agent-runtime idle window for a successful proxy auth.
+   *
+   * Every successful `/ai/v1/*` or `/ai/anthropic/v1/*` request is the
+   * agent inside that project actively making a model call (tool use,
+   * streaming completion, embeddings) — that is the strongest possible
+   * signal that the runtime is alive and being used. Touching here
+   * means a long Opus turn whose only outbound traffic is one big
+   * model call still resets the 15-min reaper, even though the user's
+   * agent-proxy connection is silent during that span.
+   *
+   * `'api-key'` payloads come from workspace-scoped Shogo API keys
+   * (no project context) and have no local runtime to touch — skip.
+   */
+  function touchRuntimeFor(payload: ProxyTokenPayload | null): void {
+    if (!payload || !payload.projectId || payload.projectId === 'api-key') return
+    try {
+      getRuntimeManager().touch(payload.projectId)
+    } catch {
+      // RuntimeManager isn't local, isn't constructed yet, or threw —
+      // never block an auth on the touch hook.
+    }
+  }
+
+  /**
    * Middleware: Validate proxy token on all /ai/v1/* routes.
    * Accepts:
    *   - Shogo API keys (`shogo_sk_*`, workspace-scoped),
@@ -1782,6 +1807,12 @@ export function aiProxyRoutes() {
    *   - signed project-scoped proxy JWTs (legacy / browser previews).
    */
   async function validateProxyAuth(c: any): Promise<ProxyTokenPayload | null> {
+    const payload = await validateProxyAuthImpl(c)
+    touchRuntimeFor(payload)
+    return payload
+  }
+
+  async function validateProxyAuthImpl(c: any): Promise<ProxyTokenPayload | null> {
     const authHeader = c.req.header('Authorization')
     if (!authHeader?.startsWith('Bearer ')) {
       return null
@@ -2332,6 +2363,12 @@ export function aiProxyRoutes() {
    *   - signed project-scoped proxy JWTs.
    */
   async function validateAnthropicAuth(c: any): Promise<ProxyTokenPayload | null> {
+    const payload = await validateAnthropicAuthImpl(c)
+    touchRuntimeFor(payload)
+    return payload
+  }
+
+  async function validateAnthropicAuthImpl(c: any): Promise<ProxyTokenPayload | null> {
     const apiKey = c.req.header('x-api-key')
     if (!apiKey) {
       return null

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2066,6 +2066,14 @@ app.all('/api/projects/:projectId/agent-proxy/*', async (c) => {
   // each LLM round-trip would emit its own `ai_proxy_completion` row.
   const isChatStream = c.req.method === 'POST' && path === '/agent/chat' && !!authedWorkspaceId && !!authedUserId
 
+  // Refresh the idle-eviction window before fan-out. Every proxied
+  // request — chat turn, sidebar refresh, file fetch, runtime
+  // health check — counts as the user "interacting with the
+  // project", so the embedded WorkerRuntimeManager should not see
+  // the slot as idle. Stream chunks separately reset the timer
+  // below so a single 16-minute Opus turn also stays alive.
+  try { getRuntimeManager().touch(projectId) } catch { /* runtime not local */ }
+
   const { resolveAgentProxyPodUrl } = await import('./lib/agent-proxy-resolver')
   const resolution = await resolveAgentProxyPodUrl(projectId)
   if (!resolution.ok) {
@@ -2233,7 +2241,16 @@ app.all('/api/projects/:projectId/agent-proxy/*', async (c) => {
         (response.body && responseContentType.includes('text/plain'))
       if (isStreaming && response.body) {
         activeProxyConnections++
+        // Each forwarded chunk is direct evidence the agent is still
+        // producing output — refresh the idle window so the runtime
+        // isn't reaped at 15 min during a long Opus turn. The
+        // `try/catch` keeps a future RuntimeManager change that
+        // throws on `touch()` from breaking active streams.
         let outBody: ReadableStream<Uint8Array> = response.body.pipeThrough(new TransformStream({
+          transform(chunk, controller) {
+            try { getRuntimeManager().touch(projectId) } catch { /* ignore */ }
+            controller.enqueue(chunk)
+          },
           flush() { activeProxyConnections-- },
         }))
         // For chat-stream calls, tee the body through the billing tracker

--- a/packages/shogo-worker/src/lib/__tests__/runtime-manager-idle-eviction.test.ts
+++ b/packages/shogo-worker/src/lib/__tests__/runtime-manager-idle-eviction.test.ts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Coverage for `WorkerRuntimeManager` idle eviction.
+ *
+ * The "chat cut mid-stream" symptom in production was: the agent-proxy
+ * never refreshed `lastUsedAt` on a long stream, so a 16-minute Opus
+ * turn looked identical to a 16-minute idle slot to the manager and
+ * `stop()` fired mid-stream. The reaper itself is correct — it's
+ * `lastUsedAt` that wasn't being kept fresh by the surrounding HTTP
+ * code.
+ *
+ * The reproduction here pins both halves of the contract:
+ *
+ *   1. With NO `touch()` calls inside the idle window, the reaper
+ *      DOES fire — the slot is killed, the process is SIGTERM'd, and
+ *      the runtimes map is cleared. This is the bug surface.
+ *
+ *   2. With periodic `touch()` calls (modelling the agent-proxy
+ *      forwarding chunks / the AI proxy receiving tool-call requests),
+ *      the reaper NEVER fires across multiple idle windows — each
+ *      touch resets the timer.
+ *
+ * The remaining tests pin the desktop / `SHOGO_LOCAL_MODE=true` opt-out:
+ * `idleMs: 0` (or any non-finite value) disables the reaper without
+ * ever arming a timer, so a long chat in local mode is not bounded by
+ * the cloud's 15-minute window even if a touch hook breaks somewhere.
+ */
+import { describe, expect, it } from 'bun:test';
+import { WorkerRuntimeManager } from '../runtime-manager.ts';
+
+interface FakeProc {
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  killed: boolean;
+  pid: number;
+  kill: (signal?: NodeJS.Signals | number) => boolean;
+  once: (event: string, cb: (...args: unknown[]) => void) => FakeProc;
+  on: (event: string, cb: (...args: unknown[]) => void) => FakeProc;
+}
+
+function makeFakeProc(): FakeProc {
+  const proc: FakeProc = {
+    // `waitForExit` short-circuits when `exitCode !== null`, so a
+    // synchronous "already exited" fake keeps stop() from blocking on
+    // an exit listener that never fires.
+    exitCode: 0,
+    signalCode: null,
+    killed: false,
+    pid: 99999,
+    kill(_signal?: NodeJS.Signals | number) {
+      proc.killed = true;
+      return true;
+    },
+    once(_event, _cb) {
+      return proc;
+    },
+    on(_event, _cb) {
+      return proc;
+    },
+  };
+  return proc;
+}
+
+function insertRunningSlot(mgr: WorkerRuntimeManager, projectId: string) {
+  const proc = makeFakeProc();
+  const slot = {
+    projectId,
+    // 0 short-circuits releasePort and avoids polluting usedPorts.
+    agentPort: 0,
+    apiServerPort: 0,
+    status: 'running' as const,
+    proc,
+    startedAt: Date.now(),
+    lastUsedAt: Date.now(),
+    restarts: 0,
+    restartTimer: null,
+    idleTimer: null,
+    spawnConfig: {} as never,
+    startPromise: null,
+  };
+  // The runtimes map and armIdleTimer are private; tests reach in
+  // deliberately because the public surface (ensureRunning) requires a
+  // real binary on disk.
+  (mgr as unknown as { runtimes: Map<string, typeof slot> }).runtimes.set(
+    projectId,
+    slot,
+  );
+  return slot;
+}
+
+function armIdle(mgr: WorkerRuntimeManager, slot: ReturnType<typeof insertRunningSlot>): void {
+  (mgr as unknown as { armIdleTimer: (s: typeof slot) => void }).armIdleTimer(slot);
+}
+
+const SILENT = { log: () => {}, warn: () => {}, error: () => {} } as const;
+
+describe('WorkerRuntimeManager idle eviction', () => {
+  it('reproduction: with no touches inside the idle window, the reaper kills the runtime (mid-stream cut)', async () => {
+    // 50ms idle window stands in for the production 15min — what we
+    // want to pin is "no `touch()` for >= idleMs ⇒ stop() fires", not
+    // the magnitude.
+    const mgr = new WorkerRuntimeManager({ idleMs: 50, logger: SILENT });
+    const slot = insertRunningSlot(mgr, 'proj-stream');
+
+    armIdle(mgr, slot);
+    expect(slot.idleTimer).not.toBeNull();
+
+    // Simulate an agent-proxy that forwards bytes for >idleMs but
+    // never calls `touch()` — exactly the production bug. The
+    // manager has no notion of in-flight HTTP, so it evicts.
+    await new Promise((r) => setTimeout(r, 120));
+
+    const runtimes = (mgr as unknown as { runtimes: Map<string, unknown> }).runtimes;
+    expect(runtimes.has('proj-stream')).toBe(false);
+    expect(slot.proc.killed).toBe(true);
+  });
+
+  it('fix: periodic touch() inside the idle window keeps the runtime alive across multiple windows', async () => {
+    const idleMs = 50;
+    const mgr = new WorkerRuntimeManager({ idleMs, logger: SILENT });
+    const slot = insertRunningSlot(mgr, 'proj-active');
+
+    armIdle(mgr, slot);
+
+    // Models the activity hooks the API server will install:
+    //   - agent-proxy `touch(projectId)` on each forwarded SSE chunk,
+    //   - AI proxy `touch(projectId)` after token decode.
+    // We tick every (idleMs / 5) for ~3x the idle window so the
+    // assertion lands well past where an unfixed reaper would fire.
+    const touchInterval = setInterval(() => mgr.touch('proj-active'), Math.max(5, idleMs / 5));
+    await new Promise((r) => setTimeout(r, idleMs * 3));
+    clearInterval(touchInterval);
+
+    const runtimes = (mgr as unknown as { runtimes: Map<string, unknown> }).runtimes;
+    expect(runtimes.has('proj-active')).toBe(true);
+    expect(slot.proc.killed).toBe(false);
+
+    // Sanity: once activity stops, the reaper does fire — the slot is
+    // not somehow "stuck alive". This pins the resume-eviction-on-idle
+    // half of the contract so a future regression that disables the
+    // reaper outright still gets caught.
+    await new Promise((r) => setTimeout(r, idleMs * 3));
+    expect(runtimes.has('proj-active')).toBe(false);
+    expect(slot.proc.killed).toBe(true);
+  });
+
+  it('touch() on an unknown projectId is a safe no-op', () => {
+    const mgr = new WorkerRuntimeManager({ idleMs: 50, logger: SILENT });
+    expect(() => mgr.touch('does-not-exist')).not.toThrow();
+  });
+
+  it('idleMs=0 disables the reaper (no timer is armed) — desktop opt-out', async () => {
+    const mgr = new WorkerRuntimeManager({ idleMs: 0, logger: SILENT });
+    const slot = insertRunningSlot(mgr, 'proj-local');
+
+    armIdle(mgr, slot);
+    expect(slot.idleTimer).toBeNull();
+
+    await new Promise((r) => setTimeout(r, 50));
+    const runtimes = (mgr as unknown as { runtimes: Map<string, unknown> }).runtimes;
+    expect(runtimes.has('proj-local')).toBe(true);
+    expect(slot.proc.killed).toBe(false);
+  });
+
+  it('idleMs=Infinity also disables the reaper', () => {
+    const mgr = new WorkerRuntimeManager({
+      idleMs: Number.POSITIVE_INFINITY,
+      logger: SILENT,
+    });
+    const slot = insertRunningSlot(mgr, 'proj-inf');
+
+    armIdle(mgr, slot);
+    expect(slot.idleTimer).toBeNull();
+  });
+
+  it('negative idleMs disables the reaper (defensive)', () => {
+    const mgr = new WorkerRuntimeManager({ idleMs: -1, logger: SILENT });
+    const slot = insertRunningSlot(mgr, 'proj-neg');
+
+    armIdle(mgr, slot);
+    expect(slot.idleTimer).toBeNull();
+  });
+
+  it('idleMs > 0 still arms a timer (cloud regression)', () => {
+    const mgr = new WorkerRuntimeManager({ idleMs: 1_000, logger: SILENT });
+    const slot = insertRunningSlot(mgr, 'proj-cloud');
+
+    armIdle(mgr, slot);
+    expect(slot.idleTimer).not.toBeNull();
+    if (slot.idleTimer) {
+      clearTimeout(slot.idleTimer);
+      slot.idleTimer = null;
+    }
+  });
+});

--- a/packages/shogo-worker/src/lib/runtime-manager.ts
+++ b/packages/shogo-worker/src/lib/runtime-manager.ts
@@ -116,7 +116,16 @@ export type RuntimeBinResolver = () => ResolvedRuntime | null;
 export interface WorkerRuntimeManagerOptions {
   /** `--runtime-bin <path>` flag value if any (forwarded to resolveRuntime). */
   runtimeBin?: string;
-  /** Idle window in ms before evicting an unused runtime (default 15min). */
+  /**
+   * Idle window in ms before evicting an unused runtime (default 15min).
+   *
+   * Pass `0`, a negative number, or `Infinity` to disable idle eviction
+   * entirely. The desktop / `SHOGO_LOCAL_MODE=true` path uses this to
+   * keep long-running chat streams alive past 15min of agent-proxy
+   * silence — eviction in that environment cuts the user's stream
+   * mid-flight (only one user, no resource pressure to recycle for).
+   * Cloud workers leave this unset so the default still fires.
+   */
   idleMs?: number;
   /** Optional logger. Defaults to console. */
   logger?: Pick<Console, 'log' | 'warn' | 'error'>;
@@ -994,8 +1003,15 @@ export class WorkerRuntimeManager implements RuntimeResolver {
   }
 
   private armIdleTimer(slot: InternalRuntime): void {
-    if (slot.idleTimer) clearTimeout(slot.idleTimer);
+    if (slot.idleTimer) {
+      clearTimeout(slot.idleTimer);
+      slot.idleTimer = null;
+    }
     const idleMs = this.opts.idleMs ?? RUNTIME_IDLE_MS;
+    // `idleMs <= 0` or non-finite disables eviction. Used by desktop /
+    // `SHOGO_LOCAL_MODE=true` where reaping a "stale" runtime really
+    // means killing the in-flight chat stream of the only user.
+    if (!Number.isFinite(idleMs) || idleMs <= 0) return;
     slot.idleTimer = setTimeout(() => {
       const since = Date.now() - slot.lastUsedAt;
       if (since < idleMs) {


### PR DESCRIPTION
## Summary

Fixes the `[WorkerRuntimeManager] idle-evicting <projectId> after 900s` mid-stream cut. The 15-min reaper was firing during a long Opus turn because nothing in the agent-proxy or AI-proxy hot path refreshed `lastUsedAt`. Activity hooks now keep the runtime alive while the user or agent is interacting with the project; the reaper resumes once the slot is genuinely idle.

- **Reset on user activity** — every `/api/projects/:id/agent-proxy/*` request and every forwarded SSE chunk now calls `runtimeManager.touch(projectId)` ([apps/api/src/server.ts](apps/api/src/server.ts)). A long chat stream re-arms the timer on every chunk it forwards back, so a 16-minute Opus turn no longer gets reaped.
- **Reset on agent activity** — `validateProxyAuth` and `validateAnthropicAuth` in [apps/api/src/routes/ai-proxy.ts](apps/api/src/routes/ai-proxy.ts) now wrap a `touchRuntimeFor(payload)` helper, so every project-scoped model call from the agent (tool use, completion, embeddings) refreshes the window even if the outer user-facing stream is silent during a thinking phase.
- **`IRuntimeManager.touch`** added in [apps/api/src/lib/runtime/types.ts](apps/api/src/lib/runtime/types.ts); `RuntimeManager.touch()` in [apps/api/src/lib/runtime/manager.ts](apps/api/src/lib/runtime/manager.ts) delegates to the embedded `WorkerRuntimeManager` and swallows errors so a touch failure can never abort an HTTP request.
- **Local opt-out** — `apps/api/src/lib/runtime/manager.ts` keeps `idleMs: 0` when `SHOGO_LOCAL_MODE=true` (single user, no resource pressure to recycle for). `WorkerRuntimeManager.armIdleTimer` in [packages/shogo-worker/src/lib/runtime-manager.ts](packages/shogo-worker/src/lib/runtime-manager.ts) treats `idleMs <= 0` or non-finite as "disabled" instead of scheduling `setTimeout(fn, 0)` which would have evicted on the very next tick.

## Test plan

New unit test [`packages/shogo-worker/src/lib/__tests__/runtime-manager-idle-eviction.test.ts`](packages/shogo-worker/src/lib/__tests__/runtime-manager-idle-eviction.test.ts) pins both halves of the contract:

- [x] `reproduction: with no touches inside the idle window, the reaper kills the runtime (mid-stream cut)` — without `touch()`, slot is evicted; this is the bug surface.
- [x] `fix: periodic touch() inside the idle window keeps the runtime alive across multiple windows` — periodic touches keep slot alive; once activity stops, the reaper resumes and evicts.
- [x] `touch() on an unknown projectId is a safe no-op`.
- [x] `idleMs=0 disables the reaper (no timer is armed) — desktop opt-out`.
- [x] `idleMs=Infinity also disables the reaper`.
- [x] `negative idleMs disables the reaper (defensive)`.
- [x] `idleMs > 0 still arms a timer (cloud regression)`.

Manual:

- [ ] Run a >15-min chat (Opus extended thinking) and confirm no `idle-evicting` log line and the stream completes end-to-end.
- [ ] Confirm cloud workers (`packages/shogo-worker/src/commands/start.ts`) still get the default 15-min reaper armed (no `idleMs` override there, so behavior is unchanged for genuinely-idle slots).

## Notes

- Cloud-side wired automatically since the activity hooks live in the shared API layer, not in the desktop opt-out.
- No behavior change for `'api-key'` payloads (workspace-scoped Shogo API keys with no project context) — `touchRuntimeFor` skips them.
