### PR TITLE
feat(billing): let super-admin credit grants confer a paid plan tier

### DIFF
--- a/apps/api/src/__tests__/billing-service.test.ts
+++ b/apps/api/src/__tests__/billing-service.test.ts
@@ -150,11 +150,36 @@ mock.module('../config/usage-plans', () => ({
   DAILY_INCLUDED_USD: 1,
   MONTHLY_DAILY_CAP_USD: 30,
   PLAN_INCLUDED_USD: { free: 0, basic: 5, pro: 20, business: 40 },
+  PLAN_RANK: { free: 0, basic: 1, pro: 2, business: 3, enterprise: 4 },
   getMonthlyIncludedForPlan: (plan: string, seats: number) => {
     if (plan === 'basic') return 5
     if (plan === 'pro') return 20 * seats
     if (plan === 'business') return 40 * seats
+    if (plan === 'enterprise') return 2000 * seats
     return 0
+  },
+  normalizePlanId: (planId: string | null | undefined) => {
+    if (!planId) return null
+    const lc = String(planId).toLowerCase().trim()
+    if (lc.startsWith('enterprise')) return 'enterprise'
+    if (lc.startsWith('business')) return 'business'
+    if (lc.startsWith('pro')) return 'pro'
+    if (lc.startsWith('basic')) return 'basic'
+    if (lc.startsWith('free')) return 'free'
+    return null
+  },
+  comparePlanRank: (a: string | null | undefined, b: string | null | undefined) => {
+    const rank: Record<string, number> = { free: 0, basic: 1, pro: 2, business: 3, enterprise: 4 }
+    const norm = (v: string | null | undefined) => {
+      if (!v) return 'free'
+      const lc = String(v).toLowerCase().trim()
+      if (lc.startsWith('enterprise')) return 'enterprise'
+      if (lc.startsWith('business')) return 'business'
+      if (lc.startsWith('pro')) return 'pro'
+      if (lc.startsWith('basic')) return 'basic'
+      return 'free'
+    }
+    return (rank[norm(a)] ?? 0) - (rank[norm(b)] ?? 0)
   },
 }))
 
@@ -305,6 +330,7 @@ describe('getActiveGrantsForWorkspace', () => {
     const g = await billing.getActiveGrantsForWorkspace('ws-1')
     expect(g.freeSeats).toBe(3)
     expect(g.monthlyIncludedUsd).toBe(15)
+    expect(g.planId).toBeNull()
     expect(g.rowCount).toBe(2)
   })
 
@@ -312,7 +338,18 @@ describe('getActiveGrantsForWorkspace', () => {
     const g = await billing.getActiveGrantsForWorkspace('ws-none')
     expect(g.freeSeats).toBe(0)
     expect(g.monthlyIncludedUsd).toBe(0)
+    expect(g.planId).toBeNull()
     expect(g.rowCount).toBe(0)
+  })
+
+  test('picks the highest-tier planId across stacked grants', async () => {
+    grantsByWs.set('ws-1', [
+      { freeSeats: 0, monthlyIncludedUsd: 0, planId: 'pro' },
+      { freeSeats: 0, monthlyIncludedUsd: 0, planId: 'business' },
+      { freeSeats: 0, monthlyIncludedUsd: 0, planId: null },
+    ])
+    const g = await billing.getActiveGrantsForWorkspace('ws-1')
+    expect(g.planId).toBe('business')
   })
 })
 
@@ -343,21 +380,42 @@ describe('allocateFreeWallet', () => {
 
 describe('applyGrantMonthlyAllocation', () => {
   test('upserts a wallet with the active grant USD', async () => {
-    grantsByWs.set('ws-1', [{ freeSeats: 0, monthlyIncludedUsd: 100 }])
+    grantsByWs.set('ws-1', [{ freeSeats: 0, monthlyIncludedUsd: 100, planId: null }])
     const wallet = await billing.applyGrantMonthlyAllocation('ws-1')
     expect(wallet.monthlyIncludedUsd).toBe(100)
+    // Credit-only grant on a free workspace doesn't flip overage on.
+    expect(wallet.overageEnabled).toBe(false)
   })
 
   test('resets daily / overage counters when refreshing an existing wallet', async () => {
     seedWallet('ws-1', {
       dailyUsedThisMonthUsd: 7, overageAccumulatedUsd: 99, overageBilledUsd: 100,
     })
-    grantsByWs.set('ws-1', [{ freeSeats: 0, monthlyIncludedUsd: 25 }])
+    grantsByWs.set('ws-1', [{ freeSeats: 0, monthlyIncludedUsd: 25, planId: null }])
     const wallet = await billing.applyGrantMonthlyAllocation('ws-1')
     expect(wallet.monthlyIncludedUsd).toBe(25)
     expect(wallet.dailyUsedThisMonthUsd).toBe(0)
     expect(wallet.overageAccumulatedUsd).toBe(0)
     expect(wallet.overageBilledUsd).toBe(0)
+  })
+
+  test('grant-conferred Pro plan allocates per-seat USD + flips overage on', async () => {
+    grantsByWs.set('ws-1', [
+      { freeSeats: 3, monthlyIncludedUsd: 10, planId: 'pro' },
+    ])
+    const wallet = await billing.applyGrantMonthlyAllocation('ws-1')
+    // 3 seats * $20 (Pro per-seat) + $10 stacked credits.
+    expect(wallet.monthlyIncludedUsd).toBe(70)
+    expect(wallet.overageEnabled).toBe(true)
+  })
+
+  test('grant-conferred Business plan with zero freeSeats still gets 1 seat of USD', async () => {
+    grantsByWs.set('ws-1', [
+      { freeSeats: 0, monthlyIncludedUsd: 0, planId: 'business' },
+    ])
+    const wallet = await billing.applyGrantMonthlyAllocation('ws-1')
+    expect(wallet.monthlyIncludedUsd).toBe(40)
+    expect(wallet.overageEnabled).toBe(true)
   })
 })
 
@@ -418,6 +476,49 @@ describe('hasPaidSubscription / hasAdvancedModelAccess / isBusinessOrHigherPlan'
   test('Enterprise plan ID is treated as business-or-higher', async () => {
     subsByWs.set('ws-1', [{ id: 's-1', workspaceId: 'ws-1', status: 'active', planId: 'Enterprise-Annual' }])
     expect(await billing.isBusinessOrHigherPlan('ws-1')).toBe(true)
+  })
+
+  test('grant-conferred Pro lifts a workspace with no subscription to advanced access', async () => {
+    grantsByWs.set('ws-1', [{ freeSeats: 0, monthlyIncludedUsd: 0, planId: 'pro' }])
+    expect(await billing.hasPaidSubscription('ws-1')).toBe(true)
+    expect(await billing.hasAdvancedModelAccess('ws-1')).toBe(true)
+    expect(await billing.isBusinessOrHigherPlan('ws-1')).toBe(false)
+  })
+
+  test('grant-conferred Business lifts a workspace with no subscription to business+', async () => {
+    grantsByWs.set('ws-1', [{ freeSeats: 0, monthlyIncludedUsd: 0, planId: 'business' }])
+    expect(await billing.isBusinessOrHigherPlan('ws-1')).toBe(true)
+  })
+
+  test('credit-only grant (no planId) does not change plan tier', async () => {
+    grantsByWs.set('ws-1', [{ freeSeats: 0, monthlyIncludedUsd: 500, planId: null }])
+    expect(await billing.hasPaidSubscription('ws-1')).toBe(false)
+    expect(await billing.hasAdvancedModelAccess('ws-1')).toBe(false)
+  })
+
+  test('paid subscription wins over a grant-conferred plan', async () => {
+    // Subscription is Basic; grant says Business. Sub wins → not advanced.
+    subsByWs.set('ws-1', [{ id: 's-1', workspaceId: 'ws-1', status: 'active', planId: 'basic' }])
+    grantsByWs.set('ws-1', [{ freeSeats: 0, monthlyIncludedUsd: 0, planId: 'business' }])
+    expect(await billing.hasAdvancedModelAccess('ws-1')).toBe(false)
+    expect(await billing.isBusinessOrHigherPlan('ws-1')).toBe(false)
+  })
+})
+
+describe('getEffectivePlanId', () => {
+  test("falls back to 'free' when no sub and no grant", async () => {
+    expect(await billing.getEffectivePlanId('ws-1')).toBe('free')
+  })
+
+  test('returns the subscription plan when present (ignores grant)', async () => {
+    subsByWs.set('ws-1', [{ id: 's-1', workspaceId: 'ws-1', status: 'active', planId: 'Business-Annual' }])
+    grantsByWs.set('ws-1', [{ freeSeats: 0, monthlyIncludedUsd: 0, planId: 'enterprise' }])
+    expect(await billing.getEffectivePlanId('ws-1')).toBe('business')
+  })
+
+  test('returns the grant planId when there is no subscription', async () => {
+    grantsByWs.set('ws-1', [{ freeSeats: 0, monthlyIncludedUsd: 0, planId: 'pro' }])
+    expect(await billing.getEffectivePlanId('ws-1')).toBe('pro')
   })
 })
 

--- a/apps/api/src/__tests__/grant-monthly-refill.test.ts
+++ b/apps/api/src/__tests__/grant-monthly-refill.test.ts
@@ -22,6 +22,7 @@ interface GrantRow {
   id: string
   workspaceId: string
   monthlyIncludedUsd: number
+  planId?: string | null
   startsAt: Date
   expiresAt: Date | null
   workspace: { subscriptions: Array<{ status: string }> }
@@ -41,13 +42,31 @@ mock.module('../lib/prisma', () => ({
     workspaceGrant: {
       findMany: async ({ where }: any) => {
         const now: Date = where.startsAt?.lte ?? new Date()
-        return grantRows.filter((g) => {
-          if (where.monthlyIncludedUsd?.gt != null && g.monthlyIncludedUsd <= where.monthlyIncludedUsd.gt) {
+        // The real `where` is shaped as `{ startsAt, workspace, AND: [
+        //   { OR: [{ monthlyIncludedUsd: { gt: 0 } }, { planId: { not: null } }] },
+        //   { OR: [{ expiresAt: null }, { expiresAt: { gt: now } }] },
+        // ] }`. Walk both AND clauses so seat-only grants still get
+        // excluded but plan-only grants pass through.
+        const andClauses: any[] = Array.isArray(where.AND) ? where.AND : []
+        const allowsMonthlyOrPlan = (g: GrantRow): boolean => {
+          const clause = andClauses[0]?.OR
+          if (!clause) return true
+          return clause.some((sub: any) => {
+            if (sub.monthlyIncludedUsd?.gt != null) {
+              return g.monthlyIncludedUsd > sub.monthlyIncludedUsd.gt
+            }
+            if (sub.planId?.not === null) return g.planId != null
             return false
-          }
+          })
+        }
+        const expiryClauseOk = (g: GrantRow): boolean => {
           if (g.startsAt > now) return false
           if (g.expiresAt && g.expiresAt <= now) return false
-          // No active paid subscription.
+          return true
+        }
+        return grantRows.filter((g) => {
+          if (!allowsMonthlyOrPlan(g)) return false
+          if (!expiryClauseOk(g)) return false
           const hasActivePaid = g.workspace.subscriptions.some((s) =>
             ['active', 'trialing'].includes(s.status),
           )
@@ -214,7 +233,7 @@ describe('runGrantMonthlyRefill', () => {
     expect(applyCalls).toHaveLength(0)
   })
 
-  test('grants with $0 monthly USD (seat-only) are excluded', async () => {
+  test('seat-only grants ($0 USD, no planId) are excluded', async () => {
     const now = new Date('2026-05-15T12:00:00Z')
     const past = new Date('2020-01-01T00:00:00Z')
     grantRows = [
@@ -222,6 +241,7 @@ describe('runGrantMonthlyRefill', () => {
         id: 'g_seats_only',
         workspaceId: 'ws_seats',
         monthlyIncludedUsd: 0,
+        planId: null,
         startsAt: past,
         expiresAt: null,
         workspace: { subscriptions: [] },
@@ -235,5 +255,31 @@ describe('runGrantMonthlyRefill', () => {
 
     expect(summary.candidates).toBe(0)
     expect(applyCalls).toHaveLength(0)
+  })
+
+  test('plan-only grants ($0 USD, planId set) are refilled so the per-seat USD lands', async () => {
+    const now = new Date('2026-05-15T12:00:00Z')
+    const past = new Date('2020-01-01T00:00:00Z')
+    grantRows = [
+      {
+        id: 'g_plan_only',
+        workspaceId: 'ws_plan',
+        monthlyIncludedUsd: 0,
+        planId: 'pro',
+        startsAt: past,
+        expiresAt: null,
+        workspace: { subscriptions: [] },
+      },
+    ]
+    walletRows = [
+      { workspaceId: 'ws_plan', lastMonthlyReset: new Date('2026-04-01T00:00:00Z') },
+    ]
+
+    const summary = await runGrantMonthlyRefill({ now })
+
+    expect(summary.candidates).toBe(1)
+    expect(summary.refilled).toBe(1)
+    expect(applyCalls).toHaveLength(1)
+    expect(applyCalls[0].workspaceId).toBe('ws_plan')
   })
 })

--- a/apps/api/src/config/usage-plans.ts
+++ b/apps/api/src/config/usage-plans.ts
@@ -70,6 +70,60 @@ export const PLAN_INCLUDED_USD = {
 } as const
 
 /**
+ * Tier order for comparing plan ids. Used to resolve the "effective"
+ * plan for a workspace when both a paid subscription and one or more
+ * `WorkspaceGrant` rows are present, and to compare granted plans
+ * against each other.
+ *
+ * Tier names match `SEAT_INCLUDED_USD` keys; legacy / decorated plan
+ * ids (`pro_200`, `Business-Annual`, etc.) are normalized via
+ * `normalizePlanId` before lookup so any caller of `comparePlanRank`
+ * can be planId-agnostic.
+ */
+export const PLAN_RANK = {
+  free: 0,
+  basic: 1,
+  pro: 2,
+  business: 3,
+  enterprise: 4,
+} as const satisfies Record<PlanId, number>
+
+/**
+ * Normalize an arbitrary planId string to one of the canonical tier
+ * names in `PLAN_RANK`. Handles the legacy underscored ids
+ * (`pro_200`, `business_1200`) and the various
+ * `business-monthly`/`Business-Annual` / `Enterprise-XL` decorations
+ * by prefix-matching against the canonical name.
+ *
+ * Returns `null` for ids that don't resolve to a known tier. Callers
+ * that want a falsy fallback should use `?? 'free'` themselves.
+ */
+export function normalizePlanId(planId: string | null | undefined): PlanId | null {
+  if (!planId) return null
+  const lc = planId.toLowerCase().trim()
+  if (lc.startsWith('enterprise')) return 'enterprise'
+  if (lc.startsWith('business')) return 'business'
+  if (lc.startsWith('pro')) return 'pro'
+  if (lc.startsWith('basic')) return 'basic'
+  if (lc.startsWith('free')) return 'free'
+  return null
+}
+
+/**
+ * Compare two plan ids by tier rank. Returns a number suitable for
+ * `Array.sort`: negative if `a < b`, zero if equal, positive if
+ * `a > b`. Unknown plans rank as `free` (`0`).
+ */
+export function comparePlanRank(
+  a: string | null | undefined,
+  b: string | null | undefined,
+): number {
+  const ra = PLAN_RANK[normalizePlanId(a) ?? 'free']
+  const rb = PLAN_RANK[normalizePlanId(b) ?? 'free']
+  return ra - rb
+}
+
+/**
  * Voice / telephony raw provider rates (Mode B only). All values are USD.
  * The workspace is charged these rates times `MARKUP_MULTIPLIER` on top
  * of whatever daily/monthly included pool they have.

--- a/apps/api/src/jobs/grant-monthly-refill.ts
+++ b/apps/api/src/jobs/grant-monthly-refill.ts
@@ -39,18 +39,25 @@ export async function runGrantMonthlyRefill(
   const now = options.now ?? new Date()
   const period = startOfMonthUtc(now)
 
-  // Find workspaces that have at least one currently-active grant with a
-  // monthly USD allotment and no active paid subscription.
+  // Find workspaces that have at least one currently-active grant that
+  // contributes to the monthly allotment — either a monthly USD amount
+  // or a `planId` that confers per-seat included USD — and no active
+  // paid subscription. Seat-only grants (`freeSeats > 0`, no USD, no
+  // planId) are excluded because their only effect is reducing the
+  // Stripe seat quantity, which is irrelevant when there's no Stripe
+  // subscription.
   const grants = await prisma.workspaceGrant.findMany({
     where: {
-      monthlyIncludedUsd: { gt: 0 },
       startsAt: { lte: now },
-      OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
       workspace: {
         subscriptions: {
           none: { status: { in: ['active', 'trialing'] } },
         },
       },
+      AND: [
+        { OR: [{ monthlyIncludedUsd: { gt: 0 } }, { planId: { not: null } }] },
+        { OR: [{ expiresAt: null }, { expiresAt: { gt: now } }] },
+      ],
     },
     select: { workspaceId: true },
   })

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -6094,6 +6094,8 @@ app.post(
     if (paidSub) {
       // Paid path: re-allocate using current plan + paid seat count;
       // grant USD/seats are stacked inside `allocateMonthlyIncluded`.
+      // The grant's own `planId` is ignored here because the Stripe
+      // subscription is the authoritative billed plan.
       await billingService.allocateMonthlyIncluded(workspaceId, paidSub.planId, paidSub.seats)
       // Push the new effective Stripe seat quantity (members - freeSeats).
       const sync = await billingService.syncSeatsFromMembership(workspaceId)
@@ -6106,10 +6108,14 @@ app.post(
       })
     }
 
+    // Grant-only path: `applyGrantMonthlyAllocation` honors the grant's
+    // `planId` (if set) so workspaces upgraded purely via a credit grant
+    // get the right per-seat USD + trust-first overage.
     const wallet = await billingService.applyGrantMonthlyAllocation(workspaceId)
     return c.json({
       ok: true,
-      path: 'free',
+      path: grant.planId ? 'grant_plan' : 'free',
+      grantPlanId: grant.planId ?? null,
       monthlyIncludedUsd: wallet.monthlyIncludedUsd,
     })
   },

--- a/apps/api/src/services/billing.service.ts
+++ b/apps/api/src/services/billing.service.ts
@@ -21,7 +21,10 @@ import {
   DAILY_INCLUDED_USD,
   MONTHLY_DAILY_CAP_USD,
   PLAN_INCLUDED_USD,
+  PLAN_RANK,
+  comparePlanRank,
   getMonthlyIncludedForPlan,
+  normalizePlanId,
 } from '../config/usage-plans';
 import { getOveragePriceConfig } from '../config/stripe-prices';
 const isLocalMode = process.env.SHOGO_LOCAL_MODE === 'true'
@@ -65,26 +68,68 @@ export async function getUsageWallet(workspaceId: string) {
  * "Active" means `startsAt <= now AND (expiresAt IS NULL OR expiresAt > now)`.
  * Multiple grants are summed so an admin can stack (e.g. a base 5 free
  * seats grant plus a one-off $500 promo).
+ *
+ * `planId` is the *highest* tier among any active grants that declared
+ * one (via `comparePlanRank`). It's the plan the workspace should be
+ * treated as on when there is no active paid subscription; the caller
+ * is responsible for skipping it when a paid sub exists. `null` when
+ * no grant has a planId — preserving the legacy "additive credit only"
+ * semantics for callers that don't care about plan upgrades.
  */
 export async function getActiveGrantsForWorkspace(
   workspaceId: string,
   now: Date = new Date(),
-): Promise<{ freeSeats: number; monthlyIncludedUsd: number; rowCount: number }> {
+): Promise<{
+  freeSeats: number
+  monthlyIncludedUsd: number
+  planId: string | null
+  rowCount: number
+}> {
   const rows = await prisma.workspaceGrant.findMany({
     where: {
       workspaceId,
       startsAt: { lte: now },
       OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
     },
-    select: { freeSeats: true, monthlyIncludedUsd: true },
+    select: { freeSeats: true, monthlyIncludedUsd: true, planId: true },
   })
   let freeSeats = 0
   let monthlyIncludedUsd = 0
+  let planId: string | null = null
   for (const r of rows) {
     freeSeats += r.freeSeats
     monthlyIncludedUsd += r.monthlyIncludedUsd
+    if (r.planId && comparePlanRank(r.planId, planId) > 0) {
+      planId = r.planId
+    }
   }
-  return { freeSeats, monthlyIncludedUsd, rowCount: rows.length }
+  return { freeSeats, monthlyIncludedUsd, planId, rowCount: rows.length }
+}
+
+/**
+ * Resolve the "effective" plan id for a workspace given its active
+ * paid subscription (if any) and active grants. Returns the highest
+ * tier from either source; falls back to `'free'` when neither is
+ * present. Normalized via `normalizePlanId`, so callers get one of
+ * `free|basic|pro|business|enterprise`.
+ *
+ * A paid subscription always wins over a grant's `planId` (the
+ * subscription is what Stripe is actually billing); the grant only
+ * meaningfully upgrades workspaces without a paid sub.
+ */
+export async function getEffectivePlanId(
+  workspaceId: string,
+  now: Date = new Date(),
+): Promise<keyof typeof PLAN_RANK> {
+  const sub = await prisma.subscription.findFirst({
+    where: { workspaceId, status: { in: ['active', 'trialing'] } },
+    select: { planId: true },
+  })
+  if (sub) {
+    return normalizePlanId(sub.planId) ?? 'free'
+  }
+  const grant = await getActiveGrantsForWorkspace(workspaceId, now)
+  return normalizePlanId(grant.planId) ?? 'free'
 }
 
 /**
@@ -125,19 +170,34 @@ export async function allocateFreeWallet(workspaceId: string) {
  * call repeatedly.
  *
  * Behavior:
- * - Resets `monthlyIncludedUsd` / `monthlyIncludedAllocationUsd` to
- *   `PLAN_INCLUDED_USD.free + grant.monthlyIncludedUsd` (the grant value
- *   alone for free workspaces, since `PLAN_INCLUDED_USD.free === 0`).
+ * - Resolves the wallet's plan tier from the highest active grant
+ *   `planId` (falling back to `free`), then computes monthly USD as
+ *   `getMonthlyIncludedForPlan(plan, max(1, freeSeats)) +
+ *   grant.monthlyIncludedUsd`. For grants with no `planId` this reduces
+ *   to `PLAN_INCLUDED_USD.free + grant.monthlyIncludedUsd` — the legacy
+ *   behavior.
  * - Resets `dailyUsedThisMonthUsd`, `overageAccumulatedUsd`,
  *   `overageBilledUsd` so the new period starts clean.
- * - Advances `lastMonthlyReset` to `now`.
+ * - Advances `lastMonthlyReset` to `now`. When a grant confers a paid
+ *   plan we also turn `overageEnabled` on so trust-first overage applies
+ *   the same as for paid Stripe plans.
  */
 export async function applyGrantMonthlyAllocation(
   workspaceId: string,
   now: Date = new Date(),
 ) {
   const grant = await getActiveGrantsForWorkspace(workspaceId, now)
-  const monthlyIncludedUsd = PLAN_INCLUDED_USD.free + grant.monthlyIncludedUsd
+  const plan = normalizePlanId(grant.planId) ?? 'free'
+  // Grant-conferred seats count toward the plan's per-seat included USD.
+  // Free seats default to 1 so a plan-only grant still allocates at
+  // least one seat's worth of USD.
+  const grantSeats = Math.max(1, grant.freeSeats || 0)
+  const monthlyIncludedUsd =
+    getMonthlyIncludedForPlan(plan, grantSeats) + grant.monthlyIncludedUsd
+  // Trust-first overage matches the paid-plan path only for grants that
+  // actually confer a paid tier. Pure additive credit grants on free
+  // workspaces stay on the prior `overageEnabled` value (handled below).
+  const isPaidGrant = PLAN_RANK[plan] >= PLAN_RANK.basic
 
   return prisma.usageWallet.upsert({
     where: { workspaceId },
@@ -149,6 +209,7 @@ export async function applyGrantMonthlyAllocation(
       anniversaryDay: now.getDate(),
       lastDailyReset: now,
       lastMonthlyReset: now,
+      overageEnabled: isPaidGrant,
     },
     update: {
       monthlyIncludedUsd,
@@ -157,6 +218,7 @@ export async function applyGrantMonthlyAllocation(
       overageAccumulatedUsd: 0,
       overageBilledUsd: 0,
       lastMonthlyReset: now,
+      ...(isPaidGrant ? { overageEnabled: true } : {}),
     },
   })
 }
@@ -247,56 +309,42 @@ export async function allocateMonthlyIncluded(
 }
 
 /**
- * Check if workspace has an active paid subscription (pro, business, enterprise).
- * Free users have no subscription record.
+ * Check if workspace has an active paid plan (pro, business, enterprise).
+ * Either an active Stripe subscription or a super-admin `WorkspaceGrant`
+ * with a `planId` qualifies — grants are first-class plan upgrades, not
+ * just additive credits. Free users have neither.
+ *
  * In local mode we treat all workspaces as paid so devs can use any model.
  */
 export async function hasPaidSubscription(workspaceId: string): Promise<boolean> {
   if (isLocalMode) return true
-  const sub = await prisma.subscription.findFirst({
-    where: {
-      workspaceId,
-      status: { in: ['active', 'trialing'] },
-    },
-  });
-  return !!sub;
+  const plan = await getEffectivePlanId(workspaceId)
+  return PLAN_RANK[plan] >= PLAN_RANK.basic
 }
 
 /**
  * Check if workspace has a plan that grants access to advanced (non-economy) models.
- * Returns true for Pro, Business, Enterprise. Returns false for Basic and free.
+ * Returns true for Pro, Business, Enterprise (whether granted via a paid
+ * subscription or via a super-admin grant's `planId`). Returns false for
+ * Basic and free.
  * In local mode returns true so all features are accessible during development.
  */
 export async function hasAdvancedModelAccess(workspaceId: string): Promise<boolean> {
   if (isLocalMode) return true
-  const sub = await prisma.subscription.findFirst({
-    where: {
-      workspaceId,
-      status: { in: ['active', 'trialing'] },
-    },
-    select: { planId: true },
-  });
-  if (!sub) return false
-  return sub.planId !== 'basic'
+  const plan = await getEffectivePlanId(workspaceId)
+  return PLAN_RANK[plan] >= PLAN_RANK.pro
 }
 
 /**
- * Check if workspace has a Business or Enterprise plan (active/trialing).
- * Returns false for Pro, free, or no subscription.
+ * Check if workspace has a Business or Enterprise plan, whether via
+ * Stripe subscription or super-admin grant. Returns false for Pro,
+ * free, or unconfigured workspaces.
  * In local mode returns true so all features are accessible during development.
  */
 export async function isBusinessOrHigherPlan(workspaceId: string): Promise<boolean> {
   if (isLocalMode) return true
-  const sub = await prisma.subscription.findFirst({
-    where: {
-      workspaceId,
-      status: { in: ['active', 'trialing'] },
-    },
-    select: { planId: true },
-  });
-  if (!sub) return false
-  const plan = sub.planId.toLowerCase()
-  return plan.startsWith('business') || plan.startsWith('enterprise')
+  const plan = await getEffectivePlanId(workspaceId)
+  return PLAN_RANK[plan] >= PLAN_RANK.business
 }
 
 /**

--- a/apps/desktop/prisma/migrations/20260518000000_grant_plan_tier/migration.sql
+++ b/apps/desktop/prisma/migrations/20260518000000_grant_plan_tier/migration.sql
@@ -1,0 +1,6 @@
+-- Migration: add `workspace_grants.planId` (SQLite / desktop variant).
+-- Mirror of prisma/migrations/20260518000000_grant_plan_tier/migration.sql.
+-- See that file for full semantics.
+
+ALTER TABLE "workspace_grants"
+  ADD COLUMN "planId" TEXT;

--- a/apps/mobile/app/(admin)/grants/[id].tsx
+++ b/apps/mobile/app/(admin)/grants/[id].tsx
@@ -41,6 +41,12 @@ interface AdminGrant {
   workspaceId: string
   freeSeats: number
   monthlyIncludedUsd: number
+  /**
+   * Optional paid plan tier this grant confers when the workspace has
+   * no active Stripe subscription. Mirrors the `WorkspaceGrant.planId`
+   * Prisma field; `null` = additive credit only (legacy behavior).
+   */
+  planId: GrantPlanId | null
   startsAt: string
   expiresAt: string | null
   note: string | null
@@ -48,6 +54,21 @@ interface AdminGrant {
   createdAt: string
   updatedAt: string
 }
+
+/**
+ * Plan tiers a super-admin can pick for a grant. Kept in lockstep with
+ * `PLAN_RANK` in `apps/api/src/config/usage-plans.ts`. Order here is
+ * also the order shown in the picker.
+ */
+const GRANT_PLAN_OPTIONS = [
+  { id: null, label: 'None (credits only)' },
+  { id: 'basic', label: 'Basic' },
+  { id: 'pro', label: 'Pro' },
+  { id: 'business', label: 'Business' },
+  { id: 'enterprise', label: 'Enterprise' },
+] as const
+
+type GrantPlanId = Exclude<(typeof GRANT_PLAN_OPTIONS)[number]['id'], null>
 
 interface WorkspaceLite {
   id: string
@@ -122,6 +143,7 @@ export default function AdminGrantDetailPage() {
   const [workspaceId, setWorkspaceId] = useState(params.workspaceId ?? '')
   const [freeSeats, setFreeSeats] = useState('0')
   const [monthlyIncludedUsd, setMonthlyIncludedUsd] = useState('0')
+  const [planId, setPlanId] = useState<GrantPlanId | null>(null)
   const [startsAt, setStartsAt] = useState('')
   const [expiresAt, setExpiresAt] = useState('')
   const [note, setNote] = useState('')
@@ -134,6 +156,7 @@ export default function AdminGrantDetailPage() {
       setWorkspaceId(data.workspaceId)
       setFreeSeats(String(data.freeSeats))
       setMonthlyIncludedUsd(String(data.monthlyIncludedUsd))
+      setPlanId(data.planId ?? null)
       setStartsAt(toDateInput(data.startsAt))
       setExpiresAt(toDateInput(data.expiresAt))
       setNote(data.note ?? '')
@@ -170,6 +193,7 @@ export default function AdminGrantDetailPage() {
       workspaceId: workspaceId.trim(),
       freeSeats: Math.max(0, parseInt(freeSeats || '0', 10) || 0),
       monthlyIncludedUsd: Math.max(0, parseFloat(monthlyIncludedUsd || '0') || 0),
+      planId,
       startsAt: fromDateInput(startsAt) ?? new Date().toISOString(),
       expiresAt: fromDateInput(expiresAt),
       note: note.trim() || null,
@@ -355,6 +379,8 @@ export default function AdminGrantDetailPage() {
             </View>
           </View>
 
+          <PlanPicker value={planId} onChange={setPlanId} />
+
           <View className={cn(isWide ? 'flex-row gap-4' : 'gap-4')}>
             <View className="flex-1">
               <Field
@@ -462,6 +488,52 @@ export default function AdminGrantDetailPage() {
         )}
       </View>
     </ScrollView>
+  )
+}
+
+function PlanPicker({
+  value,
+  onChange,
+}: {
+  value: GrantPlanId | null
+  onChange: (v: GrantPlanId | null) => void
+}) {
+  return (
+    <View>
+      <Text className="text-xs font-medium text-muted-foreground mb-1.5">
+        Plan upgrade
+      </Text>
+      <View className="flex-row flex-wrap gap-2">
+        {GRANT_PLAN_OPTIONS.map((opt) => {
+          const active = value === opt.id
+          return (
+            <Pressable
+              key={opt.label}
+              onPress={() => onChange(opt.id)}
+              className={cn(
+                'px-3 py-1.5 rounded-md border',
+                active
+                  ? 'bg-primary border-primary'
+                  : 'bg-card border-border active:bg-muted/40',
+              )}
+            >
+              <Text
+                className={cn(
+                  'text-xs font-medium',
+                  active ? 'text-primary-foreground' : 'text-foreground',
+                )}
+              >
+                {opt.label}
+              </Text>
+            </Pressable>
+          )
+        })}
+      </View>
+      <Text className="text-[11px] text-muted-foreground mt-1">
+        Upgrades the workspace to this plan when it has no active Stripe
+        subscription. Ignored if Stripe already has an active sub.
+      </Text>
+    </View>
   )
 }
 

--- a/apps/mobile/app/(admin)/workspaces/[workspaceId].tsx
+++ b/apps/mobile/app/(admin)/workspaces/[workspaceId].tsx
@@ -85,6 +85,11 @@ interface WorkspaceGrant {
   workspaceId: string
   freeSeats: number
   monthlyIncludedUsd: number
+  /**
+   * Paid plan tier this grant upgrades the workspace to (when no
+   * active Stripe subscription exists). `null` = additive credit only.
+   */
+  planId: string | null
   startsAt: string
   expiresAt: string | null
   note: string | null
@@ -545,7 +550,7 @@ export default function AdminWorkspaceDetailPage() {
           </View>
           {grants.length === 0 ? (
             <Text className="text-sm text-muted-foreground">
-              No grants. Use "New grant" to give this workspace free seats and/or monthly USD.
+              No grants. Use "New grant" to give this workspace free seats, monthly USD, or a plan upgrade.
             </Text>
           ) : (
             <View className="gap-2">
@@ -569,6 +574,13 @@ export default function AdminWorkspaceDetailPage() {
                             : 'No expiry'}
                       </Text>
                     </View>
+                    {g.planId && (
+                      <View className="px-2 py-0.5 rounded-full mr-2 bg-primary/10">
+                        <Text className="text-[10px] font-medium capitalize text-primary">
+                          {g.planId}
+                        </Text>
+                      </View>
+                    )}
                     <View
                       className={cn(
                         'px-2 py-0.5 rounded-full mr-2',

--- a/packages/domain-stores/src/workspace-grant.model.ts
+++ b/packages/domain-stores/src/workspace-grant.model.ts
@@ -21,6 +21,7 @@ export const WorkspaceGrantModel = types
     workspaceId: types.string,
     freeSeats: types.optional(types.number, 0),
     monthlyIncludedUsd: types.optional(types.number, 0),
+    planId: types.optional(types.string, ""),
     startsAt: types.optional(types.number, 0),
     expiresAt: types.optional(types.number, 0),
     note: types.optional(types.string, ""),

--- a/packages/domain-stores/src/workspace-grant.types.ts
+++ b/packages/domain-stores/src/workspace-grant.types.ts
@@ -11,6 +11,7 @@ export interface WorkspaceGrantType {
   workspaceId: string
   freeSeats: number
   monthlyIncludedUsd: number
+  planId?: string | null
   startsAt: Date
   expiresAt?: Date
   note?: string
@@ -23,6 +24,7 @@ export interface WorkspaceGrantCreateInput {
   workspaceId: string
   freeSeats?: number
   monthlyIncludedUsd?: number
+  planId?: string | null
   startsAt?: Date
   expiresAt?: Date
   note?: string
@@ -33,6 +35,7 @@ export interface WorkspaceGrantUpdateInput {
   workspaceId?: string
   freeSeats?: number
   monthlyIncludedUsd?: number
+  planId?: string | null
   startsAt?: Date
   expiresAt?: Date
   note?: string

--- a/prisma/migrations/20260518000000_grant_plan_tier/migration.sql
+++ b/prisma/migrations/20260518000000_grant_plan_tier/migration.sql
@@ -1,0 +1,12 @@
+-- Migration: add `workspace_grants.planId` so a super-admin credit grant
+-- can also upgrade a workspace to a paid plan tier (basic|pro|business|
+-- enterprise) without a Stripe subscription.
+--
+-- Backwards-compatible: existing rows keep `planId = NULL`, which
+-- preserves the original "free seats + monthly USD" only behavior.
+-- When a paid Stripe subscription is present on the workspace it
+-- always wins; the grant's `planId` only takes effect for workspaces
+-- without an active subscription.
+
+ALTER TABLE "workspace_grants"
+  ADD COLUMN "planId" TEXT;

--- a/prisma/schema.local.prisma
+++ b/prisma/schema.local.prisma
@@ -483,11 +483,17 @@ model Subscription {
 /// minimum of 1 paid seat) plus a monthly USD allotment that stacks on
 /// top of any plan-included USD. Multiple active grants on the same
 /// workspace are summed. Mirrors prisma/schema.prisma WorkspaceGrant.
+///
+/// `planId` optionally upgrades the workspace to a paid plan tier
+/// (basic|pro|business|enterprise) for the duration of the grant when
+/// no active paid subscription exists. See prisma/schema.prisma for
+/// full semantics.
 model WorkspaceGrant {
   id                 String    @id @default(uuid())
   workspaceId        String
   freeSeats          Int       @default(0)
   monthlyIncludedUsd Float     @default(0)
+  planId             String?
   startsAt           DateTime  @default(now())
   expiresAt          DateTime?
   note               String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -650,11 +650,23 @@ enum UsageSource {
 /// minimum of 1 paid seat) plus a monthly USD allotment that stacks on
 /// top of any plan-included USD. Multiple active grants on the same
 /// workspace are summed.
+///
+/// `planId` optionally upgrades the workspace to a paid plan tier
+/// (basic|pro|business|enterprise) for the duration of the grant *when
+/// no active paid Stripe subscription exists*. The wallet allocation
+/// then uses `getMonthlyIncludedForPlan(planId, max(1, freeSeats)) +
+/// monthlyIncludedUsd`, and the plan-gate helpers
+/// (`hasPaidSubscription`, `hasAdvancedModelAccess`,
+/// `isBusinessOrHigherPlan`) treat the workspace as on that plan.
+/// `planId = null` keeps the legacy "free seats + monthly USD" only
+/// behavior. If a paid subscription exists, the subscription's plan
+/// always takes precedence (the grant's `planId` is ignored).
 model WorkspaceGrant {
   id                 String    @id @default(uuid())
   workspaceId        String
   freeSeats          Int       @default(0)
   monthlyIncludedUsd Float     @default(0)
+  planId             String?
   startsAt           DateTime  @default(now())
   expiresAt          DateTime?
   note               String?


### PR DESCRIPTION
## Summary

A `WorkspaceGrant` now optionally carries a `planId` (`basic|pro|business|enterprise`). When set on a workspace **with no active Stripe subscription** the grant lifts the workspace to that tier for the duration of the grant — so super-admins can hand someone Pro/Business access without putting them through Stripe.

- Plan-gate helpers (`hasPaidSubscription`, `hasAdvancedModelAccess`, `isBusinessOrHigherPlan`) route through a new `getEffectivePlanId` that returns the highest of (paid sub, active grant). Paid Stripe sub always wins.
- `applyGrantMonthlyAllocation` allocates per-seat included USD for the granted plan plus the existing flat `monthlyIncludedUsd` stack, and flips trust-first overage on for paid-tier grants.
- Monthly-refill cron now also refills plan-only grants (`planId` set, `monthlyIncludedUsd=0`) so the per-seat USD lands each cycle. Seat-only grants stay excluded.
- Admin UI: plan picker on the grant create/edit screen, plan-tier badge on workspace detail grant rows.
- New `comparePlanRank` / `normalizePlanId` helpers in `usage-plans.ts` handle decorated planIds (`Business-Annual`, `pro_200`, etc.).
- Schema/migration adds nullable `workspace_grants.planId TEXT` for both Postgres and SQLite. `NULL` preserves legacy "free seats + monthly USD only" behavior, so existing grants are unaffected.

## Test plan

- [x] `billing-service.test.ts` — grant-conferred plan lift in plan-gate helpers, highest-tier resolution across stacked grants, allocation math (Pro/Business with/without freeSeats), credit-only grant doesn't change tier, paid sub wins over grant tier.
- [x] `grant-monthly-refill.test.ts` — plan-only-grant refill case + renamed seat-only case.
- [x] All 89 tests in `billing-service.test.ts` + `grant-monthly-refill.test.ts` pass locally.
- [ ] Staging: confirm `20260518000000_grant_plan_tier` migration runs and `workspace_grants.planId` exists.
- [ ] Staging: super-admin creates a Pro grant on a free workspace → `hasAdvancedModelAccess` returns true; Business grant → `isBusinessOrHigherPlan` returns true.
- [ ] Staging: existing grants (planId NULL) keep working — additive credit only.

## Notes

Stacks on the missing-`workspace_grants`-table production fix discussed earlier. Both migrations need to land in every region — the suggested explicit `prisma migrate deploy` step for `deploy-us` (mirroring EU/India) is still worth adding, but the entrypoint will also pick this up.


Made with [Cursor](https://cursor.com)