### PR TITLE
fix(generators): bigint-safe JSON in generated admin + per-model routes

### DIFF
--- a/packages/sdk/src/generators/__tests__/routes-generator.test.ts
+++ b/packages/sdk/src/generators/__tests__/routes-generator.test.ts
@@ -137,7 +137,7 @@ describe('Routes Generator', () => {
         expect(result!.code).toContain('if (hooks.beforeList) {')
         expect(result!.code).toContain('const result = await hooks.beforeList(ctx)')
         expect(result!.code).toContain('if (result && !result.ok) {')
-        expect(result!.code).toContain('return c.json({ error: result.error }, 400)')
+        expect(result!.code).toContain('return sendJson(c, { error: result.error }, 400)')
       })
 
       it('should allow hook to override where clause', () => {
@@ -168,7 +168,7 @@ describe('Routes Generator', () => {
       it('should return items and total in response', () => {
         const result = generateModelRoutes(mockProjectModel)
 
-        expect(result!.code).toContain('return c.json({ ok: true, items, total })')
+        expect(result!.code).toContain('return sendJson(c, { ok: true, items, total })')
       })
 
       it('should include error handling', () => {
@@ -176,7 +176,7 @@ describe('Routes Generator', () => {
 
         expect(result!.code).toContain('} catch (error: any) {')
         expect(result!.code).toContain('console.error("[Project] List error:", error)')
-        expect(result!.code).toContain('return c.json({ error: { code: "list_failed", message: error.message } }, 500)')
+        expect(result!.code).toContain('return sendJson(c, { error: { code: "list_failed", message: error.message } }, 500)')
       })
     })
 
@@ -200,7 +200,7 @@ describe('Routes Generator', () => {
         const result = generateModelRoutes(mockProjectModel)
 
         expect(result!.code).toContain('if (!item) {')
-        expect(result!.code).toContain('return c.json({ error: { code: "not_found", message: "Project not found" } }, 404)')
+        expect(result!.code).toContain('return sendJson(c, { error: { code: "not_found", message: "Project not found" } }, 404)')
       })
     })
 
@@ -229,7 +229,7 @@ describe('Routes Generator', () => {
       it('should return 201 status', () => {
         const result = generateModelRoutes(mockProjectModel)
 
-        expect(result!.code).toContain('return c.json({ ok: true, data: item }, 201)')
+        expect(result!.code).toContain('return sendJson(c, { ok: true, data: item }, 201)')
       })
     })
 
@@ -487,7 +487,31 @@ describe('Routes Generator', () => {
       expect(result.code).toContain('router.post("/workspaces"')
       expect(result.code).toContain('prisma.project.create({')
       expect(result.code).toContain('prisma.workspace.create({')
-      expect(result.code).toContain('return c.json({ ok: true, data: item }, 201)')
+      expect(result.code).toContain('return sendJson(c, { ok: true, data: item }, 201)')
+    })
+
+    it('should emit a BigInt-safe sendJson helper', () => {
+      const result = generateAdminRoutes([mockProjectModel, mockWorkspaceModel])
+
+      // The helper coerces native BigInt values to strings so Hono\'s default
+      // JSON.stringify path (which throws on bare BigInts) does not 500 on
+      // responses that include columns like StorageUsage.totalBytes.
+      expect(result.code).toContain('const bigIntReplacer = (_key: string, value: unknown) =>')
+      expect(result.code).toContain('typeof value === "bigint" ? value.toString() : value')
+      expect(result.code).toContain('function sendJson(c: any, body: unknown, status: number = 200) {')
+      expect(result.code).toContain('c.body(JSON.stringify(body, bigIntReplacer), status,')
+      // And no raw c.json call sites should leak through.
+      expect(result.code).not.toContain('return c.json(')
+    })
+  })
+
+  describe('generateModelRoutes BigInt safety', () => {
+    it('should emit a BigInt-safe sendJson helper in per-model routes', () => {
+      const result = generateModelRoutes(mockProjectModel)
+
+      expect(result!.code).toContain('const bigIntReplacer = (_key: string, value: unknown) =>')
+      expect(result!.code).toContain('function sendJson(c: any, body: unknown, status: number = 200) {')
+      expect(result!.code).not.toContain('return c.json(')
     })
   })
 })

--- a/packages/sdk/src/generators/admin-routes-generator.ts
+++ b/packages/sdk/src/generators/admin-routes-generator.ts
@@ -100,6 +100,22 @@ export function generateAdminRoutes(
     '',
     'import { Hono } from "hono"',
     '',
+    '// JSON replacer that coerces native BigInt values to strings so they can',
+    '// be serialized by JSON.stringify (and therefore by Hono\'s default json',
+    '// helper, which throws on bare BigInt values). Strings preserve full',
+    '// precision for very large counts (e.g. byte totals). Consumers that need',
+    '// a numeric should coerce explicitly.',
+    'const bigIntReplacer = (_key: string, value: unknown) =>',
+    '  typeof value === "bigint" ? value.toString() : value',
+    '',
+    '// Drop-in replacement for c.json that uses bigIntReplacer. Keeps the same',
+    '// (body, status?) ergonomics as c.json so call sites are mechanical.',
+    'function sendJson(c: any, body: unknown, status: number = 200) {',
+    '  return c.body(JSON.stringify(body, bigIntReplacer), status, {',
+    '    "content-type": "application/json; charset=UTF-8",',
+    '  })',
+    '}',
+    '',
     'export interface AdminRoutesConfig {',
     '  /** Prisma client instance */',
     '  prisma: any',
@@ -215,10 +231,10 @@ export function generateAdminRoutes(
     lines.push('')
     // Use camelCase plural for the data key (routePath is kebab-case for URLs only)
     const dataKey = modelLower + 's'
-    lines.push(`      return c.json({ ok: true, data: { ${dataKey}: items, total, page, limit } })`)
+    lines.push(`      return sendJson(c, { ok: true, data: { ${dataKey}: items, total, page, limit } })`)
     lines.push('    } catch (error: any) {')
     lines.push(`      console.error("[Admin] List ${modelName} error:", error)`)
-    lines.push('      return c.json({ error: { code: "list_failed", message: error.message } }, 500)')
+    lines.push('      return sendJson(c, { error: { code: "list_failed", message: error.message } }, 500)')
     lines.push('    }')
     lines.push('  })')
     lines.push('')
@@ -233,10 +249,10 @@ export function generateAdminRoutes(
     lines.push('        data: body,')
     lines.push('      })')
     lines.push('')
-    lines.push('      return c.json({ ok: true, data: item }, 201)')
+    lines.push('      return sendJson(c, { ok: true, data: item }, 201)')
     lines.push('    } catch (error: any) {')
     lines.push(`      console.error("[Admin] Create ${modelName} error:", error)`)
-    lines.push('      return c.json({ error: { code: "create_failed", message: error.message } }, 500)')
+    lines.push('      return sendJson(c, { error: { code: "create_failed", message: error.message } }, 500)')
     lines.push('    }')
     lines.push('  })')
     lines.push('')
@@ -269,13 +285,13 @@ export function generateAdminRoutes(
 
     lines.push('')
     lines.push('      if (!item) {')
-    lines.push(`        return c.json({ error: { code: "not_found", message: "${modelName} not found" } }, 404)`)
+    lines.push(`        return sendJson(c, { error: { code: "not_found", message: "${modelName} not found" } }, 404)`)
     lines.push('      }')
     lines.push('')
-    lines.push('      return c.json({ ok: true, data: item })')
+    lines.push('      return sendJson(c, { ok: true, data: item })')
     lines.push('    } catch (error: any) {')
     lines.push(`      console.error("[Admin] Get ${modelName} error:", error)`)
-    lines.push('      return c.json({ error: { code: "get_failed", message: error.message } }, 500)')
+    lines.push('      return sendJson(c, { error: { code: "get_failed", message: error.message } }, 500)')
     lines.push('    }')
     lines.push('  })')
     lines.push('')
@@ -292,10 +308,10 @@ export function generateAdminRoutes(
     lines.push('        data: body,')
     lines.push('      })')
     lines.push('')
-    lines.push('      return c.json({ ok: true, data: item })')
+    lines.push('      return sendJson(c, { ok: true, data: item })')
     lines.push('    } catch (error: any) {')
     lines.push(`      console.error("[Admin] Update ${modelName} error:", error)`)
-    lines.push('      return c.json({ error: { code: "update_failed", message: error.message } }, 500)')
+    lines.push('      return sendJson(c, { error: { code: "update_failed", message: error.message } }, 500)')
     lines.push('    }')
     lines.push('  })')
     lines.push('')
@@ -305,11 +321,11 @@ export function generateAdminRoutes(
     lines.push(`  router.delete("/${routePath}/:id", async (c) => {`)
     lines.push('    try {')
     lines.push('      const id = c.req.param("id")')
-    lines.push(`      await prisma.${modelLower}.delete({ where: { id } })`)
-    lines.push('      return c.json({ ok: true })')
+      lines.push(`      await prisma.${modelLower}.delete({ where: { id } })`)
+    lines.push('      return sendJson(c, { ok: true })')
     lines.push('    } catch (error: any) {')
     lines.push(`      console.error("[Admin] Delete ${modelName} error:", error)`)
-    lines.push('      return c.json({ error: { code: "delete_failed", message: error.message } }, 500)')
+    lines.push('      return sendJson(c, { error: { code: "delete_failed", message: error.message } }, 500)')
     lines.push('    }')
     lines.push('  })')
     lines.push('')
@@ -333,7 +349,7 @@ export function generateAdminRoutes(
   }
   lines.push('      ])')
   lines.push('')
-  lines.push('      return c.json({')
+  lines.push('      return sendJson(c, {')
   lines.push('        ok: true,')
   lines.push('        data: {')
   for (const model of routeModels) {
@@ -344,7 +360,7 @@ export function generateAdminRoutes(
   lines.push('      })')
   lines.push('    } catch (error: any) {')
   lines.push('      console.error("[Admin] Stats error:", error)')
-  lines.push('      return c.json({ error: { code: "stats_failed", message: error.message } }, 500)')
+  lines.push('      return sendJson(c, { error: { code: "stats_failed", message: error.message } }, 500)')
   lines.push('    }')
   lines.push('  })')
   lines.push('')

--- a/packages/sdk/src/generators/routes-generator.ts
+++ b/packages/sdk/src/generators/routes-generator.ts
@@ -96,6 +96,22 @@ export function generateModelRoutes(
     'import { PrismaClient } from "./prisma/client"',
     `import type { ${modelName}Hooks } from "./${toFileName(modelName)}.hooks"`,
     '',
+    '// JSON replacer that coerces native BigInt values to strings so they can',
+    '// be serialized by JSON.stringify (and therefore by Hono\'s default json',
+    '// helper, which throws on bare BigInt values). Strings preserve full',
+    '// precision for very large counts (e.g. byte totals). Consumers that need',
+    '// a numeric should coerce explicitly.',
+    'const bigIntReplacer = (_key: string, value: unknown) =>',
+    '  typeof value === "bigint" ? value.toString() : value',
+    '',
+    '// Drop-in replacement for c.json that uses bigIntReplacer. Keeps the same',
+    '// (body, status?) ergonomics as c.json so call sites are mechanical.',
+    'function sendJson(c: any, body: unknown, status: number = 200) {',
+    '  return c.body(JSON.stringify(body, bigIntReplacer), status, {',
+    '    "content-type": "application/json; charset=UTF-8",',
+    '  })',
+    '}',
+    '',
     '// Prisma client instance (injected)',
     'let prisma: PrismaClient | null = null',
     '',
@@ -179,7 +195,7 @@ export function generateModelRoutes(
       lines.push('      if (hooks.beforeList) {')
       lines.push('        const result = await hooks.beforeList(ctx)')
       lines.push('        if (result && !result.ok) {')
-      lines.push('          return c.json({ error: result.error }, 400)')
+      lines.push('          return sendJson(c, { error: result.error }, 400)')
       lines.push('        }')
       lines.push('        if (result?.data) {')
       lines.push('          where = result.data.where || where')
@@ -199,10 +215,10 @@ export function generateModelRoutes(
   lines.push(`        prisma.${modelLower}.count({ where }),`)
   lines.push('      ])')
   lines.push('')
-  lines.push('      return c.json({ ok: true, items, total })')
+  lines.push('      return sendJson(c, { ok: true, items, total })')
   lines.push('    } catch (error: any) {')
   lines.push(`      console.error("[${modelName}] List error:", error)`)
-  lines.push('      return c.json({ error: { code: "list_failed", message: error.message } }, 500)')
+  lines.push('      return sendJson(c, { error: { code: "list_failed", message: error.message } }, 500)')
   lines.push('    }')
   lines.push('  })')
   lines.push('')
@@ -219,7 +235,7 @@ export function generateModelRoutes(
   lines.push('      if (hooks.beforeGet) {')
   lines.push('        const result = await hooks.beforeGet(id, ctx)')
   lines.push('        if (result && !result.ok) {')
-  lines.push('          return c.json({ error: result.error }, result.error?.code === "not_found" ? 404 : 400)')
+  lines.push('          return sendJson(c, { error: result.error }, result.error?.code === "not_found" ? 404 : 400)')
   lines.push('        }')
   lines.push('      }')
   lines.push('')
@@ -228,13 +244,13 @@ export function generateModelRoutes(
   lines.push('      })')
   lines.push('')
   lines.push('      if (!item) {')
-  lines.push(`        return c.json({ error: { code: "not_found", message: "${modelName} not found" } }, 404)`)
+  lines.push(`        return sendJson(c, { error: { code: "not_found", message: "${modelName} not found" } }, 404)`)
   lines.push('      }')
   lines.push('')
-  lines.push('      return c.json({ ok: true, data: item })')
+  lines.push('      return sendJson(c, { ok: true, data: item })')
   lines.push('    } catch (error: any) {')
   lines.push(`      console.error("[${modelName}] Get error:", error)`)
-  lines.push('      return c.json({ error: { code: "get_failed", message: error.message } }, 500)')
+  lines.push('      return sendJson(c, { error: { code: "get_failed", message: error.message } }, 500)')
   lines.push('    }')
   lines.push('  })')
   lines.push('')
@@ -251,7 +267,7 @@ export function generateModelRoutes(
   lines.push('      if (hooks.beforeCreate) {')
   lines.push('        const result = await hooks.beforeCreate(body, ctx)')
   lines.push('        if (result && !result.ok) {')
-  lines.push('          return c.json({ error: result.error }, 400)')
+  lines.push('          return sendJson(c, { error: result.error }, 400)')
   lines.push('        }')
   lines.push('        if (result?.data) {')
   lines.push('          body = result.data')
@@ -267,10 +283,10 @@ export function generateModelRoutes(
   lines.push('        await hooks.afterCreate(item, ctx)')
   lines.push('      }')
   lines.push('')
-  lines.push('      return c.json({ ok: true, data: item }, 201)')
+  lines.push('      return sendJson(c, { ok: true, data: item }, 201)')
   lines.push('    } catch (error: any) {')
   lines.push(`      console.error("[${modelName}] Create error:", error)`)
-  lines.push('      return c.json({ error: { code: "create_failed", message: error.message } }, 500)')
+  lines.push('      return sendJson(c, { error: { code: "create_failed", message: error.message } }, 500)')
   lines.push('    }')
   lines.push('  })')
   lines.push('')
@@ -288,7 +304,7 @@ export function generateModelRoutes(
   lines.push('      if (hooks.beforeUpdate) {')
   lines.push('        const result = await hooks.beforeUpdate(id, body, ctx)')
   lines.push('        if (result && !result.ok) {')
-  lines.push('          return c.json({ error: result.error }, 400)')
+  lines.push('          return sendJson(c, { error: result.error }, 400)')
   lines.push('        }')
   lines.push('        if (result?.data) {')
   lines.push('          body = result.data')
@@ -305,10 +321,10 @@ export function generateModelRoutes(
   lines.push('        await hooks.afterUpdate(item, ctx)')
   lines.push('      }')
   lines.push('')
-  lines.push('      return c.json({ ok: true, data: item })')
+  lines.push('      return sendJson(c, { ok: true, data: item })')
   lines.push('    } catch (error: any) {')
   lines.push(`      console.error("[${modelName}] Update error:", error)`)
-  lines.push('      return c.json({ error: { code: "update_failed", message: error.message } }, 500)')
+  lines.push('      return sendJson(c, { error: { code: "update_failed", message: error.message } }, 500)')
   lines.push('    }')
   lines.push('  })')
   lines.push('')
@@ -325,7 +341,7 @@ export function generateModelRoutes(
   lines.push('      if (hooks.beforeDelete) {')
   lines.push('        const result = await hooks.beforeDelete(id, ctx)')
   lines.push('        if (result && !result.ok) {')
-  lines.push('          return c.json({ error: result.error }, 400)')
+  lines.push('          return sendJson(c, { error: result.error }, 400)')
   lines.push('        }')
   lines.push('      }')
   lines.push('')
@@ -338,10 +354,10 @@ export function generateModelRoutes(
   lines.push('        await hooks.afterDelete(id, ctx)')
   lines.push('      }')
   lines.push('')
-  lines.push('      return c.json({ ok: true })')
+  lines.push('      return sendJson(c, { ok: true })')
   lines.push('    } catch (error: any) {')
   lines.push(`      console.error("[${modelName}] Delete error:", error)`)
-  lines.push('      return c.json({ error: { code: "delete_failed", message: error.message } }, 500)')
+  lines.push('      return sendJson(c, { error: { code: "delete_failed", message: error.message } }, 500)')
   lines.push('    }')
   lines.push('  })')
   lines.push('')


### PR DESCRIPTION
## Summary
- The auto-generated admin routes (`apps/api/src/generated/admin-routes.ts`) and per-model CRUD routes (`*.routes.ts`) called `c.json(...)`, which uses native `JSON.stringify` and throws `TypeError: JSON.stringify cannot serialize BigInt.` on any Prisma row containing a `BigInt` column (e.g. `StorageUsage.totalBytes`). The route's catch block returned 500, and the mobile admin UI's `fetchAdminJson` mapped the 500 to `null`, rendering "workspace not found" to the operator — exactly the symptom we hit in prod-US for workspace `b5c1129c-5d79-4361-ab94-bb8bf207cb18`.
- Both generators now emit a top-level `bigIntReplacer` + `sendJson(c, body, status?)` helper, and every `c.json(...)` call site is rewritten to `sendJson(c, ...)`. BigInts are serialized as JSON strings, preserving full precision for very large counts.
- Generator tests assert the helper is emitted and no raw `c.json(` leaks through (admin + per-model). All 257 SDK generator tests pass.

## Test plan
- [x] `bun test packages/sdk/src/generators/__tests__/routes-generator.test.ts` — 55/55 pass
- [x] Full SDK generator suite — 257/257 pass
- [x] End-to-end live test: bootstrapped `createAdminRoutes` with a fake Prisma returning `totalBytes: 3163032n`; `GET /api/admin/workspaces/:id` returned 200 with `"totalBytes":"3163032"`
- [ ] Post-deploy: `GET /api/admin/workspaces/b5c1129c-5d79-4361-ab94-bb8bf207cb18` in prod-US returns 200 with grants + storageUsage visible

Made with [Cursor](https://cursor.com)