### PR TITLE
fix(billing): surface grant-conferred plans in workspace UI

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -5096,10 +5096,23 @@ app.get('/api/billing/workspace-plan', async (c) => {
         ? await prisma.member.findMany({ where: { userId, workspaceId: { in: ids } }, select: { workspaceId: true } })
         : []
       const allowedIds = new Set(memberships.map((m: any) => m.workspaceId))
-      const plans: Record<string, { planId: string; status: string | null }> = {}
+      // `planId` here is the *effective* plan: a paid Stripe subscription
+      // wins, otherwise an active super-admin grant's `planId` confers the
+      // tier. `source` lets the client distinguish so it doesn't try to send
+      // a grant-only workspace through Stripe portal/checkout flows.
+      const plans: Record<string, { planId: string; status: string | null; source: 'subscription' | 'grant' | 'free' }> = {}
       await Promise.all(ids.filter(id => allowedIds.has(id)).map(async (id) => {
-        const sub = await billingService.getSubscription(id)
-        plans[id] = { planId: sub?.planId ?? 'free', status: sub?.status ?? null }
+        const [sub, effective] = await Promise.all([
+          billingService.getSubscription(id),
+          billingService.getEffectivePlanId(id),
+        ])
+        const source: 'subscription' | 'grant' | 'free' =
+          sub ? 'subscription' : effective !== 'free' ? 'grant' : 'free'
+        plans[id] = {
+          planId: sub?.planId ?? effective,
+          status: sub?.status ?? (source === 'grant' ? 'active' : null),
+          source,
+        }
       }))
       return c.json({ ok: true, plans })
     }
@@ -5109,12 +5122,21 @@ app.get('/api/billing/workspace-plan', async (c) => {
     if (!await verifyWorkspaceMembership(c, workspaceId)) {
       return c.json({ error: { code: 'forbidden', message: 'Access denied to this workspace' } }, 403)
     }
-    const sub = await billingService.getSubscription(workspaceId)
-    const wallet = await billingService.getUsageWallet(workspaceId)
+    const [sub, wallet, effective] = await Promise.all([
+      billingService.getSubscription(workspaceId),
+      billingService.getUsageWallet(workspaceId),
+      billingService.getEffectivePlanId(workspaceId),
+    ])
+    const source: 'subscription' | 'grant' | 'free' =
+      sub ? 'subscription' : effective !== 'free' ? 'grant' : 'free'
     return c.json({
       ok: true,
-      planId: sub?.planId ?? 'free',
-      status: sub?.status ?? null,
+      // Effective plan: subscription wins, else grant tier, else 'free'.
+      planId: sub?.planId ?? effective,
+      // `source` tells the client whether this came from Stripe or a grant
+      // so portal/checkout buttons can adapt without inferring from shape.
+      source,
+      status: sub?.status ?? (source === 'grant' ? 'active' : null),
       billingInterval: sub?.billingInterval ?? null,
       seats: (sub as any)?.seats ?? 1,
       monthlyIncludedUsd: wallet?.monthlyIncludedUsd ?? 0,

--- a/apps/mobile/app/(app)/billing.tsx
+++ b/apps/mobile/app/(app)/billing.tsx
@@ -92,7 +92,13 @@ export default observer(function BillingPage() {
     isLoading: isBillingLoading,
     refetchSubscription,
     refetchUsageWallet,
+    planSource,
   } = useBillingData(currentWorkspace?.id)
+  // A grant-conferred plan has no Stripe customer / portal, so hide
+  // "Manage" / Stripe-only affordances and let "Free Plan"-style copy
+  // adapt by checking `planSource === 'subscription'` instead of just
+  // `subscription` truthiness.
+  const hasStripeSubscription = planSource === 'subscription'
 
   const [billingInterval, setBillingInterval] = useState<'monthly' | 'annual'>('monthly')
   const [proSeats, setProSeats] = useState(1)
@@ -551,7 +557,7 @@ export default observer(function BillingPage() {
               </View>
             </View>
             <View className="flex-row items-center gap-2">
-              {subscription && (
+              {hasStripeSubscription && (
                 <Button
                   variant="outline"
                   size="sm"

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -143,7 +143,7 @@ export const api = {
   },
 
   async getWorkspacePlans(http: HttpClient, workspaceIds: string[]) {
-    const res = await http.get<{ ok?: boolean; plans?: Record<string, { planId: string; status: string | null }> }>(
+    const res = await http.get<{ ok?: boolean; plans?: Record<string, { planId: string; status: string | null; source?: 'subscription' | 'grant' | 'free' }> }>(
       `/api/billing/workspace-plan?workspaceIds=${workspaceIds.join(',')}`
     )
     return res.data?.plans ?? {}

--- a/packages/shared-app/src/hooks/useBillingData.ts
+++ b/packages/shared-app/src/hooks/useBillingData.ts
@@ -7,7 +7,7 @@
  */
 
 import { useState, useEffect, useCallback, useMemo } from "react"
-import { useSDKDomain } from "../domain"
+import { useSDKDomain, useSDKHttp } from "../domain"
 import type { IDomainStore } from "@shogo/domain-stores"
 
 export interface EffectiveBalance {
@@ -19,6 +19,8 @@ export interface EffectiveBalance {
   overageHardLimitUsd: number | null
   total: number
 }
+
+export type PlanSource = "subscription" | "grant" | "free"
 
 export interface BillingDataState {
   subscription: any | undefined
@@ -33,10 +35,18 @@ export interface BillingDataState {
   refetchSubscription: () => void
   refetchUsageWallet: () => void
   refetchUsageEvents: () => void
+  // The plan the workspace is effectively on right now. A paid Stripe
+  // subscription wins; otherwise an active super-admin grant's `planId`
+  // confers a tier; otherwise 'free'.
+  effectivePlanId: string
+  // Where the effective plan came from. Lets callers distinguish a grant
+  // upgrade (no Stripe customer to send to portal) from a real subscription.
+  planSource: PlanSource
 }
 
 export function useBillingData(workspaceId: string | undefined): BillingDataState {
   const store = useSDKDomain() as IDomainStore
+  const http = useSDKHttp()
 
   const [isLoadingSubscription, setIsLoadingSubscription] = useState(false)
   const [isLoadingUsageWallet, setIsLoadingUsageWallet] = useState(false)
@@ -47,16 +57,48 @@ export function useBillingData(workspaceId: string | undefined): BillingDataStat
   const [usageWalletRefetchCounter, setUsageWalletRefetchCounter] = useState(0)
   const [usageEventsRefetchCounter, setUsageEventsRefetchCounter] = useState(0)
 
+  // The /api/billing/workspace-plan endpoint resolves the *effective* plan
+  // for the workspace: a paid Stripe subscription wins, otherwise an active
+  // super-admin grant's `planId` confers the tier, otherwise 'free'. We
+  // fetch it alongside the store-backed Subscription row because grants
+  // are not persisted as Subscription rows but still need to surface in the
+  // UI as the current plan.
+  const [effectivePlan, setEffectivePlan] = useState<{ planId: string; source: PlanSource } | null>(null)
+
   useEffect(() => {
     if (!workspaceId || !store?.subscriptionCollection) { setIsLoadingSubscription(false); return }
     let cancelled = false
     setIsLoadingSubscription(true)
     setError(null)
-    store.subscriptionCollection.loadAll({ workspaceId })
+    // Load the Prisma Subscription row (Stripe-backed) AND the effective
+    // plan resolver in parallel. The effective resolver is the only place
+    // grant-conferred tiers (planId set on workspace_grants) become visible
+    // to the client.
+    Promise.all([
+      store.subscriptionCollection.loadAll({ workspaceId }),
+      http
+        .get<{ ok?: boolean; planId?: string; source?: PlanSource }>(
+          `/api/billing/workspace-plan?workspaceId=${encodeURIComponent(workspaceId)}`,
+        )
+        .then((res) => {
+          if (cancelled) return
+          const data = (res as any)?.data ?? res
+          if (data && data.ok && typeof data.planId === "string") {
+            setEffectivePlan({
+              planId: data.planId,
+              source: (data.source as PlanSource) ?? (data.planId === "free" ? "free" : "subscription"),
+            })
+          }
+        })
+        .catch(() => {
+          // Non-fatal: if the endpoint fails the UI just falls back to the
+          // store-backed subscription view (current behavior pre-grants).
+        }),
+    ])
       .catch((err: any) => { if (!cancelled) setError(err instanceof Error ? err : new Error("Failed to load subscription")) })
       .finally(() => { if (!cancelled) setIsLoadingSubscription(false) })
     return () => { cancelled = true }
-  }, [workspaceId, store, subscriptionRefetchCounter])
+  }, [workspaceId, store, subscriptionRefetchCounter, http])
 
   useEffect(() => {
     const wallet = (store as any)?.usageWalletCollection
@@ -84,12 +126,32 @@ export function useBillingData(workspaceId: string | undefined): BillingDataStat
   const refetchUsageEvents = useCallback(() => setUsageEventsRefetchCounter((c) => c + 1), [])
 
   const subsLength = store?.subscriptionCollection?.all?.length ?? 0
-  const subscription = useMemo(() => {
+  const realSubscription = useMemo(() => {
     if (!workspaceId || !store?.subscriptionCollection) return undefined
     try {
       return store.subscriptionCollection.all.filter((s: any) => s.workspaceId === workspaceId)[0]
     } catch { return undefined }
   }, [workspaceId, store, isLoadingSubscription, subsLength])
+
+  // When a super-admin grant confers a paid plan but no Stripe subscription
+  // exists, synthesize a subscription-shaped object so the rest of the UI
+  // (which everywhere uses `subscription?.planId`, `subscription?.seats`,
+  // etc.) lights up correctly. The synthetic record is clearly marked with
+  // `source: 'grant'` and lacks Stripe-specific fields (no stripeCustomerId,
+  // no currentPeriodEnd) so portal/checkout buttons can opt-out cleanly.
+  const subscription = useMemo<any | undefined>(() => {
+    if (realSubscription) return realSubscription
+    if (!workspaceId) return undefined
+    if (!effectivePlan || effectivePlan.source !== "grant") return undefined
+    return {
+      workspaceId,
+      planId: effectivePlan.planId,
+      status: "active",
+      seats: 1,
+      billingInterval: null,
+      source: "grant" as const,
+    }
+  }, [realSubscription, workspaceId, effectivePlan])
 
   const walletLength = (store as any)?.usageWalletCollection?.all?.length ?? 0
   const usageWallet = useMemo(() => {
@@ -133,6 +195,12 @@ export function useBillingData(workspaceId: string | undefined): BillingDataStat
     } catch { return [] }
   }, [workspaceId, store, isLoadingUsageEvents])
 
+  // Resolve the effective plan + source once, with the synthetic
+  // subscription (if any) and the server's effective resolver as fallbacks.
+  const effectivePlanId = effectivePlan?.planId ?? subscription?.planId ?? "free"
+  const planSource: PlanSource =
+    effectivePlan?.source ?? (realSubscription ? "subscription" : "free")
+
   const hasActiveSubscription = subscription?.status === 'active' || subscription?.status === 'trialing'
   const hasAdvancedModelAccess = hasActiveSubscription && subscription?.planId !== 'basic'
 
@@ -149,5 +217,7 @@ export function useBillingData(workspaceId: string | undefined): BillingDataStat
     refetchSubscription,
     refetchUsageWallet,
     refetchUsageEvents,
+    effectivePlanId,
+    planSource,
   }
 }


### PR DESCRIPTION
## Summary
A super-admin credit grant can confer a paid plan tier (basic/pro/business/enterprise) on a workspace without a Stripe subscription, but the workspace's user-facing billing UI still rendered "Free Plan" because the read path only consulted the Prisma `Subscription` row. This PR pipes the effective plan all the way through to the UI.

### Server: `/api/billing/workspace-plan`
- Single + bulk paths now call `billingService.getEffectivePlanId(...)` and return `planId` from the resolver (subscription wins, else grant tier, else `'free'`).
- Adds a `source: 'subscription' | 'grant' | 'free'` discriminator on the response.
- `status` falls back to `'active'` for grant-only access so the existing sidebar `isPaidPlan` logic (`planId !== 'free' && status === 'active'`) lights up.

### Client: `useBillingData` hook + `billing.tsx`
- Hook fetches `/api/billing/workspace-plan` in parallel with the Subscription collection.
- When a grant confers a paid tier with no Stripe sub, the hook synthesizes a subscription-shaped object: `{ planId, status: 'active', seats: 1, billingInterval: null, source: 'grant' }`. Every existing `subscription?.planId` reference (workspace billing page, settings, compute tab, project layout, sidebar) transparently lights up the granted plan.
- New typed return fields: `effectivePlanId: string` and `planSource: 'subscription' | 'grant' | 'free'`.
- The Stripe-portal **Manage** button on the billing page now gates on `planSource === 'subscription'` instead of `subscription` truthiness, so grant-only users don't get routed into a broken portal session.

## Test plan
- [x] `bun test apps/api/src/__tests__/billing-service.test.ts` — 82/82 pass
- [x] Lint clean on touched files
- [ ] Post-deploy: workspace `b5c1129c-5d79-4361-ab94-bb8bf207cb18` (business grant, no Stripe sub) renders "Business Plan" in the billing screen + sidebar badge, no "Manage" button shown

Made with [Cursor](https://cursor.com)