### PR TITLE
fix(mobile): scope project lists to the active workspace

### DIFF
--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -39,6 +39,8 @@ import {
 import { loadModelPreference, saveModelPreference } from '../../lib/agent-mode-preference'
 import { setPendingFiles } from '../../lib/pending-image-store'
 import { useActiveWorkspace } from '../../hooks/useActiveWorkspace'
+import { workspaceProjectFilter } from '../../lib/project-load'
+import { getActiveWorkspaceId } from '../../lib/workspace-store'
 import { useBillingData } from '@shogo/shared-app/hooks'
 import { usePlatformConfig } from '../../lib/platform-config'
 import { api, getOnboardingMessage } from '../../lib/api'
@@ -415,14 +417,17 @@ const HomeScreen = observer(function HomeScreen() {
     })
   }, [])
 
+  const currentWorkspace = useActiveWorkspace()
+
   useEffect(() => {
     if (!isAuthenticated) return
     let cancelled = false
 
     async function loadData(attempt = 0) {
       setWorkspaceError(false)
+      const projectFilter = workspaceProjectFilter()
       const results = await Promise.allSettled([
-        projects.loadAll(),
+        projectFilter ? projects.loadAll(projectFilter) : Promise.resolve(),
         workspaces.loadAll(),
         user?.id ? membersColl.loadAll({ userId: user.id }) : Promise.resolve(),
       ])
@@ -450,9 +455,7 @@ const HomeScreen = observer(function HomeScreen() {
     loadData()
 
     return () => { cancelled = true }
-  }, [isAuthenticated, user?.id])
-
-  const currentWorkspace = useActiveWorkspace()
+  }, [isAuthenticated, user?.id, currentWorkspace?.id])
   const billingData = useBillingData(currentWorkspace?.id)
   const hasAdvancedModelAccess = billingData.hasAdvancedModelAccess
 
@@ -494,7 +497,9 @@ const HomeScreen = observer(function HomeScreen() {
   const myProjects = useMemo((): IProject[] => {
     try {
       const all = projects?.all
+      const workspaceId = currentWorkspace?.id ?? getActiveWorkspaceId()
       return [...(Array.isArray(all) ? all : [])]
+        .filter((p) => !workspaceId || p.workspaceId === workspaceId)
         .sort((a: any, b: any) => {
           const aTime = a.updatedAt ? new Date(a.updatedAt).getTime() : 0
           const bTime = b.updatedAt ? new Date(b.updatedAt).getTime() : 0
@@ -503,7 +508,7 @@ const HomeScreen = observer(function HomeScreen() {
     } catch {
       return []
     }
-  }, [projects?.all])
+  }, [projects?.all, currentWorkspace?.id])
 
   const sharedProjects = useMemo((): IProject[] => {
     if (!user?.id) return []
@@ -692,7 +697,8 @@ const HomeScreen = observer(function HomeScreen() {
       if (files && files.length > 0) {
         setPendingFiles(files)
       }
-      projects.loadAll()
+      const filter = workspaceProjectFilter(currentWorkspace.id)
+      if (filter) projects.loadAll(filter)
       const consumed = draft
       // Consume the draft so subsequent home interactions create a new one.
       draftRef.current = null
@@ -754,7 +760,8 @@ const HomeScreen = observer(function HomeScreen() {
       if (!draft) return
 
       trackEvent(posthog, EVENTS.PROJECT_CREATED, { source: 'voice' })
-      projects.loadAll()
+      const filter = workspaceProjectFilter(currentWorkspace.id)
+      if (filter) projects.loadAll(filter)
       const consumed = draft
       draftRef.current = null
       router.push({
@@ -820,7 +827,8 @@ const HomeScreen = observer(function HomeScreen() {
       // we let the project layout fetch them from /api/marketplace/:slug
       // when `showIntegrations=1` is set, so always pass it through and
       // let the layout decide whether to actually render the card.
-      projects.loadAll()
+      const filter = workspaceProjectFilter(currentWorkspace.id)
+      if (filter) projects.loadAll(filter)
       router.push({
         pathname: '/(app)/projects/[id]',
         params: {

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -55,6 +55,7 @@ import { useAuth } from '../../../../contexts/auth'
 import { useDomainHttp } from '../../../../contexts/domain'
 import { authClient } from '../../../../lib/auth-client'
 import { API_URL, api } from '../../../../lib/api'
+import { workspaceProjectFilter } from '../../../../lib/project-load'
 import { usePlatformConfig } from '../../../../lib/platform-config'
 import { consumePendingFiles } from '../../../../lib/pending-image-store'
 import { isNativePhoneIntegrationsLayout } from '../../../../lib/native-phone-layout'
@@ -628,7 +629,12 @@ export default observer(function ProjectLayout() {
 
       try {
         await store.workspaceCollection.loadAll({ userId: user!.id })
-        store.projectCollection.loadAll().catch((e) => console.error('[ProjectLayout] Failed to preload projects:', e))
+        const projectFilter = workspaceProjectFilter()
+        if (projectFilter) {
+          store.projectCollection
+            .loadAll(projectFilter)
+            .catch((e) => console.error('[ProjectLayout] Failed to preload projects:', e))
+        }
         const proj = await store.projectCollection.loadById(projectId)
 
         if (cancelled) return

--- a/apps/mobile/components/layout/AppSidebar.tsx
+++ b/apps/mobile/components/layout/AppSidebar.tsx
@@ -101,6 +101,7 @@ import {
 import { api } from '../../lib/api'
 import { trackPurchase } from '../../lib/tracking'
 import { getActiveWorkspaceId, setActiveWorkspaceId } from '../../lib/workspace-store'
+import { workspaceProjectFilter } from '../../lib/project-load'
 import { usePlatformConfig } from '../../lib/platform-config'
 import { invitationEvents } from '../../lib/invitation-events'
 
@@ -1052,7 +1053,10 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
 
   useEffect(() => {
     workspaces.loadAll().catch((e) => console.error('[AppSidebar] Failed to load workspaces:', e))
-    projects.loadAll().catch((e) => console.error('[AppSidebar] Failed to load projects:', e))
+    const filter = workspaceProjectFilter()
+    if (filter) {
+      projects.loadAll(filter).catch((e) => console.error('[AppSidebar] Failed to load projects:', e))
+    }
   }, [])
 
   const loadInvites = useCallback(() => {
@@ -1100,13 +1104,15 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
   let currentWorkspace: any
   try {
     if (selectedWorkspaceId) {
-      currentWorkspace = workspaces?.all?.find((w: any) => w.id === selectedWorkspaceId) ?? workspaces?.all?.[0]
+      currentWorkspace = workspaces?.all?.find((w: any) => w.id === selectedWorkspaceId)
     } else {
       currentWorkspace = workspaces?.all?.[0]
     }
   } catch {
     currentWorkspace = undefined
   }
+
+  const activeWorkspaceId = currentWorkspace?.id ?? selectedWorkspaceId
 
   const billingData = useBillingData(features.billing ? currentWorkspace?.id : undefined)
 
@@ -1115,7 +1121,10 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
   let recentProjects: any[]
   try {
     const all = projects?.all ?? []
-    recentProjects = [...all]
+    const workspaceScoped = activeWorkspaceId
+      ? all.filter((p: any) => p.workspaceId === activeWorkspaceId)
+      : all
+    recentProjects = [...workspaceScoped]
       .sort((a: any, b: any) => {
         const aTime = a.lastMessageAt || a.updatedAt || 0
         const bTime = b.lastMessageAt || b.updatedAt || 0
@@ -1168,7 +1177,12 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
       trackEvent(posthog, EVENTS.WORKSPACE_SWITCHED)
       setSelectedWorkspaceId(workspaceId)
       setActiveWorkspaceId(workspaceId)
-      projects.loadAll({ workspaceId }).catch((e) => console.error('[AppSidebar] Failed to load projects after workspace switch:', e))
+      projects.clear()
+      projects
+        .loadAll({ workspaceId })
+        .catch((e) =>
+          console.error('[AppSidebar] Failed to load projects after workspace switch:', e),
+        )
     },
     [projects, posthog]
   )
@@ -1194,7 +1208,9 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
         if (newWorkspace?.id) {
           trackEvent(posthog, EVENTS.WORKSPACE_CREATED)
           setSelectedWorkspaceId(newWorkspace.id)
+          setActiveWorkspaceId(newWorkspace.id)
           await workspaces.loadAll()
+          projects.clear()
           await projects.loadAll({ workspaceId: newWorkspace.id })
         }
       } catch (e) {

--- a/apps/mobile/lib/project-load.ts
+++ b/apps/mobile/lib/project-load.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import { getActiveWorkspaceId } from './workspace-store'
+
+/** Query params for `ProjectCollection.loadAll` scoped to the active workspace. */
+export function workspaceProjectFilter(
+  workspaceId?: string | null,
+): { workspaceId: string } | undefined {
+  const id = workspaceId ?? getActiveWorkspaceId()
+  return id ? { workspaceId: id } : undefined
+}

--- a/packages/domain-stores/src/domain-actions.ts
+++ b/packages/domain-stores/src/domain-actions.ts
@@ -146,7 +146,9 @@ export function createDomainActions(store: IDomainStore) {
       if (!projectId) return null
       // Refresh the project collection so the navigator can find the
       // newly-installed project by id without a manual reload.
-      await store.projectCollection.loadAll().catch(() => undefined)
+      await store.projectCollection
+        .loadAll({ workspaceId })
+        .catch(() => undefined)
       return { projectId, installId: res.data?.install?.id }
     },
 

--- a/packages/domain-stores/src/project.collection.ts
+++ b/packages/domain-stores/src/project.collection.ts
@@ -79,6 +79,8 @@ export const ProjectCollection = types
     const pendingCreates = new Map<string, any>()
     const pendingUpdates = new Map<string, any>()
     const pendingDeletes = new Set<string>()
+    // Ignore stale loadAll responses when a newer request was started (e.g. workspace switch).
+    let loadAllGeneration = 0
 
     return {
       /** Set loading state */
@@ -120,6 +122,7 @@ export const ProjectCollection = types
        * Uses merge strategy to preserve existing MST node references
        */
       loadAll: flow(function* (filter?: Record<string, any>) {
+        const generation = ++loadAllGeneration
         self.isLoading = true
         self.error = null
 
@@ -129,6 +132,11 @@ export const ProjectCollection = types
           const url = params ? `${ENDPOINT}?${params}` : ENDPOINT
 
           const response = yield env.http.get<{ ok: boolean; items?: any[] }>(url)
+
+          if (generation !== loadAllGeneration) {
+            self.isLoading = false
+            return self.all
+          }
 
           if (response.data?.ok && response.data.items) {
             // Use merge strategy to preserve existing node references


### PR DESCRIPTION
## Summary
- Fixes intermittent cross-workspace project leakage in Home **My projects** and sidebar **Recent** when switching workspaces (e.g. "test" showing projects from "preeti Personal").
- Scopes `ProjectCollection.loadAll` calls to the active workspace, filters UI by workspace, clears the store on workspace switch, and ignores stale `loadAll` responses that could overwrite a scoped load.

## Root cause
Unscoped `loadAll()` requests return projects from all workspaces the user belongs to. Multiple components share one MobX store; whichever request finished last won, and Home/Recent did not filter by workspace.

## Changes (6 files)
- `apps/mobile/lib/project-load.ts` — helper for workspace-scoped load params
- `apps/mobile/app/(app)/index.tsx` — scoped loads + My projects filter
- `apps/mobile/components/layout/AppSidebar.tsx` — Recent filter, clear on switch
- `apps/mobile/app/(app)/projects/[id]/_layout.tsx` — scoped preload
- `packages/domain-stores/src/domain-actions.ts` — scoped reload after marketplace install
- `packages/domain-stores/src/project.collection.ts` — stale response guard

## Test plan
- [ ] Create or switch to a workspace with only one project
- [ ] Confirm Home **My projects** and sidebar **Recent** show only that workspace's projects
- [ ] Switch to another workspace and confirm lists update immediately (no projects from the previous workspace)
- [ ] Hard refresh after switch — lists should remain correct
- [ ] Install a marketplace listing — new project appears without other workspaces' projects leaking in

Made with [Cursor](https://cursor.com)