### PR TITLE
feat(api): federate instance traffic through local-mode cloud session

### DIFF
--- a/apps/api/src/__tests__/instances-federation.test.ts
+++ b/apps/api/src/__tests__/instances-federation.test.ts
@@ -1,0 +1,429 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Federation fallback tests for `apps/api/src/routes/instances.ts`.
+ *
+ * Covers the SHOGO_LOCAL_MODE branches added so the local API can
+ * transparently proxy instance traffic to the cloud upstream it's
+ * already signed in to:
+ *   - GET /instances                  merges local + cloud rows
+ *   - GET /instances/:id              forwards on local-miss
+ *   - POST /instances/:id/request-connect / /proxy / /proxy/stream / /p/*
+ *                                     forwarded on local-miss
+ *   - 401 from cloud flips the cloudKeyRejected flag observed by the
+ *     existing /local/cloud-login/status banner
+ *   - Federation gating: with SHOGO_LOCAL_MODE unset, behavior is
+ *     identical to the original local-only handler (404)
+ *
+ *   bun test apps/api/src/__tests__/instances-federation.test.ts
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test'
+import { Hono } from 'hono'
+import { withPrismaExports } from './helpers/prisma-mock-exports'
+
+// Enable local-mode + a stored cloud credential before instances.ts loads.
+process.env.SHOGO_LOCAL_MODE = 'true'
+process.env.SHOGO_API_KEY = 'shogo_sk_test'
+process.env.SHOGO_CLOUD_URL = 'https://cloud.test'
+
+// ─── In-memory Prisma stub ──────────────────────────────────────────────────
+
+type Instance = {
+  id: string
+  workspaceId: string
+  hostname: string
+  name: string
+  os: string | null
+  arch: string | null
+  lastSeenAt: Date
+  metadata: any
+  wsRequestedAt: Date | null
+  createdAt: Date
+  updatedAt: Date
+  kind: string
+}
+const instancesById = new Map<string, Instance>()
+const membersByUserWs = new Map<string, { id: string; userId: string; workspaceId: string }>()
+const memberKey = (u: string, w: string) => `${u}::${w}`
+
+const localConfigMap = new Map<string, string>()
+
+const mockPrisma = {
+  instance: {
+    findUnique: async (args: any) => {
+      const inst = instancesById.get(args.where.id)
+      return inst ? { ...inst } : null
+    },
+    findMany: async (args: any) =>
+      [...instancesById.values()].filter((i) => i.workspaceId === args.where.workspaceId),
+    update: async (args: any) => {
+      const inst = instancesById.get(args.where.id)
+      if (!inst) throw new Error('not found')
+      Object.assign(inst, args.data, { updatedAt: new Date() })
+      return { ...inst }
+    },
+  },
+  member: {
+    findFirst: async (args: any) => membersByUserWs.get(memberKey(args.where.userId, args.where.workspaceId)) ?? null,
+  },
+  localConfig: {
+    findUnique: async (args: any) => {
+      const v = localConfigMap.get(args.where.key)
+      return v != null ? { key: args.where.key, value: v } : null
+    },
+    deleteMany: async (args: any) => {
+      const existed = localConfigMap.delete(args.where.key)
+      return { count: existed ? 1 : 0 }
+    },
+  },
+}
+
+// Stub the instance-tunnel module that local-auth's signout imports
+// lazily — the test only needs the call to succeed, not actually do
+// anything.
+mock.module('../lib/instance-tunnel', () => ({
+  stopInstanceTunnel: () => {},
+}))
+
+mock.module('../lib/prisma', () => withPrismaExports({ prisma: mockPrisma }))
+
+mock.module('../routes/api-keys', () => ({
+  resolveApiKey: async () => null,
+}))
+
+mock.module('../lib/push-notifications', () => ({
+  sendPushToInstance: async () => {},
+}))
+
+const { instanceRoutes, _testing } = await import('../routes/instances')
+const { _resetInstanceCache, _resetUpstreamCredentialCache } = await import('../lib/federated-upstream')
+// Importing local-auth at module load installs its onUpstreamRejection
+// subscription. The cloudKeyRejected test below depends on this hook
+// already being wired before the federated fetch fires its 401.
+const { localAuthRoutes } = await import('../routes/local-auth')
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const auth = { id: 'u-1', userId: 'u-1', email: 'u@x', role: 'super_admin' }
+
+function buildApp() {
+  const app = new Hono()
+  app.use('*', async (c, next) => {
+    ;(c as any).set('auth', auth)
+    await next()
+  })
+  app.route('/api', instanceRoutes())
+  return app
+}
+
+function seedLocalInstance(overrides: Partial<Instance> = {}): Instance {
+  const inst: Instance = {
+    id: 'local-i-1',
+    workspaceId: 'ws-1',
+    hostname: 'mac',
+    name: 'Local Mac',
+    os: 'darwin',
+    arch: 'arm64',
+    lastSeenAt: new Date(),
+    metadata: {},
+    wsRequestedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    kind: 'desktop',
+    ...overrides,
+  }
+  instancesById.set(inst.id, inst)
+  return inst
+}
+
+// ─── Fetch stub ─────────────────────────────────────────────────────────────
+
+type FetchCall = { url: string; init?: RequestInit }
+const realFetch = globalThis.fetch
+let fetchCalls: FetchCall[] = []
+
+function installFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  globalThis.fetch = (async (url: any, init?: RequestInit) => {
+    fetchCalls.push({ url: String(url), init })
+    return handler(String(url), init)
+  }) as unknown as typeof fetch
+}
+
+function jsonResp(body: any, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  })
+}
+
+// ─── Lifecycle ──────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  instancesById.clear()
+  membersByUserWs.clear()
+  _testing.tunnels.clear()
+  _testing.activeViewers.clear()
+  fetchCalls = []
+  process.env.SHOGO_LOCAL_MODE = 'true'
+  process.env.SHOGO_API_KEY = 'shogo_sk_test'
+  localConfigMap.clear()
+  // Default: a cloud workspace is linked so the list-merge path runs.
+  // Detail / proxy / p/* fallbacks don't read SHOGO_KEY_INFO — they only
+  // need a credential — so this seed doesn't affect those tests.
+  localConfigMap.set('SHOGO_KEY_INFO', JSON.stringify({ workspace: { id: 'cloud-ws-1' } }))
+  _resetInstanceCache()
+  _resetUpstreamCredentialCache()
+})
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+})
+
+// ─── GET /instances (merge) ────────────────────────────────────────────────
+
+describe('GET /instances — federated merge', () => {
+  test('returns local rows tagged origin=local plus cloud rows tagged with cloud host', async () => {
+    membersByUserWs.set(memberKey('u-1', 'ws-1'), { id: 'm-1', userId: 'u-1', workspaceId: 'ws-1' })
+    seedLocalInstance({ id: 'local-i-1', name: 'Mine' })
+
+    installFetch((url) => {
+      // Local workspaceId 'ws-1' is translated to the cloud workspaceId
+      // from SHOGO_KEY_INFO ('cloud-ws-1') before forwarding — staging
+      // would 403 a foreign local id.
+      expect(url).toBe('https://cloud.test/api/instances?workspaceId=cloud-ws-1')
+      return jsonResp({ instances: [
+        { id: 'cloud-1', workspaceId: 'cloud-ws-1', name: 'VPS', status: 'online', kind: 'cli-worker' },
+      ] })
+    })
+
+    const res = await buildApp().fetch(new Request('http://x/api/instances?workspaceId=ws-1'))
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { instances: any[] }
+
+    expect(body.instances).toHaveLength(2)
+    const local = body.instances.find((i) => i.id === 'local-i-1')
+    const remote = body.instances.find((i) => i.id === 'cloud-1')
+    expect(local.origin).toBe('local')
+    expect(remote.origin).toBe('cloud.test')
+    expect(remote.name).toBe('VPS')
+  })
+
+  test('local row wins on id collision (cloud duplicate is dropped)', async () => {
+    membersByUserWs.set(memberKey('u-1', 'ws-1'), { id: 'm-1', userId: 'u-1', workspaceId: 'ws-1' })
+    seedLocalInstance({ id: 'shared-id', name: 'Local Copy' })
+
+    installFetch(() => jsonResp({ instances: [
+      { id: 'shared-id', workspaceId: 'ws-1', name: 'Cloud Copy' },
+    ] }))
+
+    const res = await buildApp().fetch(new Request('http://x/api/instances?workspaceId=ws-1'))
+    const body = (await res.json()) as { instances: any[] }
+    expect(body.instances).toHaveLength(1)
+    expect(body.instances[0].name).toBe('Local Copy')
+    expect(body.instances[0].origin).toBe('local')
+  })
+
+  test('returns only local rows when SHOGO_LOCAL_MODE is unset', async () => {
+    delete process.env.SHOGO_LOCAL_MODE
+    membersByUserWs.set(memberKey('u-1', 'ws-1'), { id: 'm-1', userId: 'u-1', workspaceId: 'ws-1' })
+    seedLocalInstance()
+    installFetch(() => { throw new Error('upstream must not be hit when federation is off') })
+
+    const res = await buildApp().fetch(new Request('http://x/api/instances?workspaceId=ws-1'))
+    const body = (await res.json()) as { instances: any[] }
+    expect(body.instances).toHaveLength(1)
+    expect(fetchCalls).toHaveLength(0)
+  })
+
+  test('cloud error degrades gracefully (local rows still returned)', async () => {
+    membersByUserWs.set(memberKey('u-1', 'ws-1'), { id: 'm-1', userId: 'u-1', workspaceId: 'ws-1' })
+    seedLocalInstance()
+    installFetch(() => new Response('', { status: 500 }))
+
+    const res = await buildApp().fetch(new Request('http://x/api/instances?workspaceId=ws-1'))
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { instances: any[] }
+    expect(body.instances).toHaveLength(1)
+    expect(body.instances[0].origin).toBe('local')
+  })
+})
+
+// ─── GET /instances/:id ────────────────────────────────────────────────────
+
+describe('GET /instances/:id — federated detail fallback', () => {
+  test('local hit returns local row with origin=local', async () => {
+    membersByUserWs.set(memberKey('u-1', 'ws-1'), { id: 'm-1', userId: 'u-1', workspaceId: 'ws-1' })
+    seedLocalInstance()
+    installFetch(() => { throw new Error('upstream must not be hit when local has the row') })
+
+    const res = await buildApp().fetch(new Request('http://x/api/instances/local-i-1'))
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as any
+    expect(body.id).toBe('local-i-1')
+    expect(body.origin).toBe('local')
+  })
+
+  test('local miss + federation on forwards to cloud and returns its response', async () => {
+    installFetch((url) => {
+      expect(url).toBe('https://cloud.test/api/instances/remote-only')
+      return jsonResp({ id: 'remote-only', workspaceId: 'ws-1', name: 'VPS', status: 'online' })
+    })
+
+    const res = await buildApp().fetch(new Request('http://x/api/instances/remote-only'))
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as any
+    expect(body.id).toBe('remote-only')
+    expect(body.name).toBe('VPS')
+  })
+
+  test('local miss + cloud 404 returns 404', async () => {
+    installFetch(() => jsonResp({ error: { code: 'not_found' } }, 404))
+    const res = await buildApp().fetch(new Request('http://x/api/instances/nope'))
+    expect(res.status).toBe(404)
+  })
+
+  test('local miss with SHOGO_LOCAL_MODE unset returns 404 (no fetch)', async () => {
+    delete process.env.SHOGO_LOCAL_MODE
+    installFetch(() => { throw new Error('upstream must not be hit') })
+    const res = await buildApp().fetch(new Request('http://x/api/instances/never-existed'))
+    expect(res.status).toBe(404)
+    expect(fetchCalls).toHaveLength(0)
+  })
+})
+
+// ─── POST /instances/:id/request-connect ───────────────────────────────────
+
+describe('POST /instances/:id/request-connect — federated fallback', () => {
+  test('local miss forwards to cloud verbatim', async () => {
+    installFetch((url, init) => {
+      expect(url).toBe('https://cloud.test/api/instances/remote-only/request-connect')
+      expect(init?.method).toBe('POST')
+      const auth = new Headers(init?.headers as any).get('authorization')
+      expect(auth).toBe('Bearer shogo_sk_test')
+      return jsonResp({ ok: true, status: 'requested' })
+    })
+
+    const res = await buildApp().fetch(new Request('http://x/api/instances/remote-only/request-connect', {
+      method: 'POST',
+    }))
+    expect(res.status).toBe(200)
+    expect((await res.json() as any).status).toBe('requested')
+  })
+
+  test('local miss + federation off returns 404', async () => {
+    delete process.env.SHOGO_LOCAL_MODE
+    installFetch(() => { throw new Error('no fetch when off') })
+    const res = await buildApp().fetch(new Request('http://x/api/instances/remote-only/request-connect', {
+      method: 'POST',
+    }))
+    expect(res.status).toBe(404)
+  })
+})
+
+// ─── POST /instances/:id/proxy ─────────────────────────────────────────────
+
+describe('POST /instances/:id/proxy — federated fallback', () => {
+  test('local miss forwards the body to cloud and pipes the response back', async () => {
+    installFetch((url, init) => {
+      expect(url).toBe('https://cloud.test/api/instances/remote-only/proxy')
+      expect(init?.method).toBe('POST')
+      return jsonResp({ status: 200, body: '{"ok":true}', headers: { 'content-type': 'application/json' } })
+    })
+
+    const res = await buildApp().fetch(new Request('http://x/api/instances/remote-only/proxy', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ method: 'GET', path: '/health' }),
+    }))
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as any
+    expect(body.body).toBe('{"ok":true}')
+  })
+})
+
+// ─── POST /instances/:id/proxy/stream ──────────────────────────────────────
+
+describe('POST /instances/:id/proxy/stream — federated streaming pipe', () => {
+  test('local miss pipes SSE chunks back without buffering', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('data: hello\n\n'))
+        controller.enqueue(new TextEncoder().encode('data: world\n\n'))
+        controller.close()
+      },
+    })
+    installFetch(() => new Response(stream, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+    }))
+
+    const res = await buildApp().fetch(new Request('http://x/api/instances/remote-only/proxy/stream', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ method: 'POST', path: '/agent/chat' }),
+    }))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('text/event-stream')
+    const text = await res.text()
+    expect(text).toBe('data: hello\n\ndata: world\n\n')
+  })
+})
+
+// ─── /instances/:id/p/* transparent proxy ──────────────────────────────────
+
+describe('ALL /instances/:id/p/* — federated transparent proxy', () => {
+  test('local miss forwards entire path + querystring + body to cloud', async () => {
+    installFetch((url, init) => {
+      expect(url).toBe('https://cloud.test/api/instances/remote-only/p/api/projects?cursor=x')
+      expect(init?.method).toBe('POST')
+      return jsonResp({ ok: true })
+    })
+
+    const res = await buildApp().fetch(new Request(
+      'http://x/api/instances/remote-only/p/api/projects?cursor=x',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ hello: 'world' }),
+      },
+    ))
+    expect(res.status).toBe(200)
+    expect((await res.json() as any).ok).toBe(true)
+  })
+
+  test('local miss + federation off returns 404', async () => {
+    delete process.env.SHOGO_LOCAL_MODE
+    const res = await buildApp().fetch(new Request(
+      'http://x/api/instances/remote-only/p/api/projects',
+      { method: 'GET' },
+    ))
+    expect(res.status).toBe(404)
+  })
+})
+
+// ─── 401 → cloudKeyRejected wiring ─────────────────────────────────────────
+
+describe('401 from cloud flips cloudKeyRejected', () => {
+  test('a forwarded 401 surfaces through /api/local/cloud-login/status', async () => {
+    // Trigger a 401 via the federated detail handler.
+    installFetch(() => jsonResp({ error: 'unauthorized' }, 401))
+    const res = await buildApp().fetch(new Request('http://x/api/instances/remote-only'))
+    // The forwarded 401 is propagated to the client as-is.
+    expect(res.status).toBe(401)
+
+    // The local-auth status route should now report cloudKeyRejected:true
+    // because the federated module emitted an onUpstreamRejection event
+    // which local-auth subscribes to at module load (installed above).
+    localConfigMap.set('SHOGO_API_KEY', 'shogo_sk_test')
+    const authApp = new Hono()
+    authApp.route('/api', localAuthRoutes())
+    const statusRes = await authApp.fetch(new Request('http://x/api/local/cloud-login/status'))
+    expect(statusRes.status).toBe(200)
+    const body = (await statusRes.json()) as any
+    expect(body.cloudKeyRejected).toBe(true)
+
+    // Reset the flag by calling signout so subsequent tests don't see it.
+    await authApp.fetch(new Request('http://x/api/local/cloud-login/signout', { method: 'POST' }))
+  })
+})

--- a/apps/api/src/lib/__tests__/federated-upstream.test.ts
+++ b/apps/api/src/lib/__tests__/federated-upstream.test.ts
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Unit tests for `apps/api/src/lib/federated-upstream.ts` — the helper
+ * that lets the local-mode API proxy instance traffic through to the
+ * cloud upstream it's already signed in to.
+ *
+ *   bun test apps/api/src/lib/__tests__/federated-upstream.test.ts
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test'
+import { Hono } from 'hono'
+
+// ─── Prisma mock (only `localConfig.findUnique` is used by this module) ─────
+
+const findUniqueMock = mock(async (_: any): Promise<any> => null)
+mock.module('../prisma', () => ({
+  prisma: {
+    localConfig: { findUnique: findUniqueMock },
+  },
+}))
+
+mock.module('../cloud-urls', () => ({
+  getShogoCloudUrl: () => 'https://cloud.test',
+}))
+
+const {
+  getUpstreamCredential,
+  getUpstreamWorkspaceId,
+  isFederatedEnabled,
+  getUpstreamOrigin,
+  listCloudInstancesForWorkspace,
+  lookupCloudInstance,
+  invalidateCloudInstance,
+  forwardToUpstream,
+  copyResponseHeaders,
+  onUpstreamRejection,
+  _resetUpstreamCredentialCache,
+  _resetInstanceCache,
+} = await import('../federated-upstream')
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const realFetch = globalThis.fetch
+const ORIG_API_KEY = process.env.SHOGO_API_KEY
+const ORIG_LOCAL_MODE = process.env.SHOGO_LOCAL_MODE
+
+type FetchCall = { url: string; init?: RequestInit }
+let fetchCalls: FetchCall[] = []
+
+function installFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    fetchCalls.push({ url: String(url), init })
+    return handler(String(url), init)
+  }) as unknown as typeof fetch
+}
+
+function jsonResponse(body: any, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  })
+}
+
+beforeEach(() => {
+  process.env.SHOGO_LOCAL_MODE = 'true'
+  process.env.SHOGO_API_KEY = 'shogo_sk_test'
+  findUniqueMock.mockReset()
+  findUniqueMock.mockImplementation(async () => null)
+  fetchCalls = []
+  _resetUpstreamCredentialCache()
+  _resetInstanceCache()
+})
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+  if (ORIG_API_KEY === undefined) delete process.env.SHOGO_API_KEY
+  else process.env.SHOGO_API_KEY = ORIG_API_KEY
+  if (ORIG_LOCAL_MODE === undefined) delete process.env.SHOGO_LOCAL_MODE
+  else process.env.SHOGO_LOCAL_MODE = ORIG_LOCAL_MODE
+})
+
+// ─── Credential resolution ─────────────────────────────────────────────────
+
+describe('getUpstreamCredential', () => {
+  test('reads from process.env first', async () => {
+    process.env.SHOGO_API_KEY = 'env-key'
+    findUniqueMock.mockImplementation(async () => ({ value: 'db-key' }))
+    expect(await getUpstreamCredential()).toBe('env-key')
+    expect(findUniqueMock).not.toHaveBeenCalled()
+  })
+
+  test('falls back to localConfig when env var is empty', async () => {
+    delete process.env.SHOGO_API_KEY
+    findUniqueMock.mockImplementation(async () => ({ value: 'db-key' }))
+    expect(await getUpstreamCredential()).toBe('db-key')
+  })
+
+  test('returns null when neither env nor db has a key', async () => {
+    delete process.env.SHOGO_API_KEY
+    findUniqueMock.mockImplementation(async () => null)
+    expect(await getUpstreamCredential()).toBeNull()
+  })
+
+  test('handles prisma throwing gracefully', async () => {
+    delete process.env.SHOGO_API_KEY
+    findUniqueMock.mockImplementation(async () => { throw new Error('db down') })
+    expect(await getUpstreamCredential()).toBeNull()
+  })
+})
+
+// ─── Local mode gating ─────────────────────────────────────────────────────
+
+describe('isFederatedEnabled', () => {
+  test('false when SHOGO_LOCAL_MODE is not set', async () => {
+    delete process.env.SHOGO_LOCAL_MODE
+    expect(await isFederatedEnabled()).toBe(false)
+  })
+
+  test('false when local mode is on but no credential', async () => {
+    delete process.env.SHOGO_API_KEY
+    findUniqueMock.mockImplementation(async () => null)
+    expect(await isFederatedEnabled()).toBe(false)
+  })
+
+  test('true when both gates pass', async () => {
+    expect(await isFederatedEnabled()).toBe(true)
+  })
+})
+
+describe('getUpstreamOrigin', () => {
+  test('returns the host portion of the configured cloud URL', () => {
+    expect(getUpstreamOrigin()).toBe('cloud.test')
+  })
+})
+
+// ─── List + lookup ──────────────────────────────────────────────────────────
+
+describe('getUpstreamWorkspaceId', () => {
+  test('reads workspace.id from SHOGO_KEY_INFO json', async () => {
+    findUniqueMock.mockImplementation(async ({ where }: any) => {
+      if (where.key === 'SHOGO_KEY_INFO') {
+        return { value: JSON.stringify({ workspace: { id: 'cloud-ws-1', name: 'Cloud' } }) }
+      }
+      return null
+    })
+    expect(await getUpstreamWorkspaceId()).toBe('cloud-ws-1')
+  })
+
+  test('returns null when SHOGO_KEY_INFO is missing', async () => {
+    findUniqueMock.mockImplementation(async () => null)
+    expect(await getUpstreamWorkspaceId()).toBeNull()
+  })
+
+  test('returns null when SHOGO_KEY_INFO is malformed JSON', async () => {
+    findUniqueMock.mockImplementation(async () => ({ value: 'not-json' }))
+    expect(await getUpstreamWorkspaceId()).toBeNull()
+  })
+})
+
+describe('listCloudInstancesForWorkspace', () => {
+  beforeEach(() => {
+    // Default: cloud workspace id is set so the federation path runs.
+    findUniqueMock.mockImplementation(async ({ where }: any) => {
+      if (where.key === 'SHOGO_KEY_INFO') {
+        return { value: JSON.stringify({ workspace: { id: 'cloud-ws-1' } }) }
+      }
+      return null
+    })
+  })
+
+  test('returns [] without making a fetch when federation is off', async () => {
+    delete process.env.SHOGO_LOCAL_MODE
+    installFetch(() => { throw new Error('should not be called') })
+    expect(await listCloudInstancesForWorkspace('local-ws-7')).toEqual([])
+    expect(fetchCalls).toHaveLength(0)
+  })
+
+  test('returns [] when no cloud workspace is linked (SHOGO_KEY_INFO missing)', async () => {
+    findUniqueMock.mockImplementation(async () => null)
+    installFetch(() => { throw new Error('should not be called') })
+    expect(await listCloudInstancesForWorkspace('local-ws-7')).toEqual([])
+    expect(fetchCalls).toHaveLength(0)
+  })
+
+  test('forwards the CLOUD workspaceId from SHOGO_KEY_INFO (not the local one)', async () => {
+    installFetch(() => jsonResponse({ instances: [{ id: 'i1', workspaceId: 'cloud-ws-1' }] }))
+    const out = await listCloudInstancesForWorkspace('local-ws-7')
+    expect(out).toHaveLength(1)
+    expect(fetchCalls[0].url).toBe('https://cloud.test/api/instances?workspaceId=cloud-ws-1')
+    const auth = new Headers(fetchCalls[0].init?.headers as any).get('authorization')
+    expect(auth).toBe('Bearer shogo_sk_test')
+  })
+
+  test('populates the lookup cache for each returned id', async () => {
+    installFetch(() => jsonResponse({ instances: [{ id: 'i1', workspaceId: 'cloud-ws-1', name: 'one' }] }))
+    await listCloudInstancesForWorkspace('local-ws-7')
+    installFetch(() => { throw new Error('cache miss') })
+    const cached = await lookupCloudInstance('i1')
+    expect(cached?.name).toBe('one')
+  })
+
+  test('returns [] when upstream errors (no throw)', async () => {
+    installFetch(() => new Response('boom', { status: 500 }))
+    expect(await listCloudInstancesForWorkspace('local-ws-7')).toEqual([])
+  })
+})
+
+describe('lookupCloudInstance', () => {
+  test('caches the fetched row for 60s', async () => {
+    installFetch(() => jsonResponse({ id: 'i1', workspaceId: 'ws-1', name: 'cached' }))
+    const a = await lookupCloudInstance('i1')
+    expect(a?.name).toBe('cached')
+    installFetch(() => { throw new Error('should hit cache') })
+    const b = await lookupCloudInstance('i1')
+    expect(b?.name).toBe('cached')
+  })
+
+  test('caches null on 404 (negative cache evicted on invalidate)', async () => {
+    installFetch(() => new Response('', { status: 404 }))
+    expect(await lookupCloudInstance('missing')).toBeNull()
+    installFetch(() => jsonResponse({ id: 'missing', workspaceId: 'ws-1' }))
+    // Still cached null.
+    expect(await lookupCloudInstance('missing')).toBeNull()
+    invalidateCloudInstance('missing')
+    expect((await lookupCloudInstance('missing'))?.id).toBe('missing')
+  })
+
+  test('returns null when federation is off (no fetch)', async () => {
+    delete process.env.SHOGO_LOCAL_MODE
+    installFetch(() => { throw new Error('should not fetch') })
+    expect(await lookupCloudInstance('anything')).toBeNull()
+  })
+})
+
+// ─── 401 rejection observer ────────────────────────────────────────────────
+
+describe('onUpstreamRejection', () => {
+  test('fires when upstream returns 401, unsubscribe stops further calls', async () => {
+    const seen: string[] = []
+    const unsubscribe = onUpstreamRejection((reason) => seen.push(reason))
+
+    installFetch(() => new Response('', { status: 401 }))
+    await lookupCloudInstance('any')
+    expect(seen.length).toBeGreaterThan(0)
+
+    unsubscribe()
+    seen.length = 0
+    _resetInstanceCache()
+    await lookupCloudInstance('another')
+    expect(seen).toHaveLength(0)
+  })
+})
+
+// ─── forwardToUpstream ─────────────────────────────────────────────────────
+
+describe('forwardToUpstream', () => {
+  function appWith(handler: (c: any) => Promise<Response>) {
+    const app = new Hono()
+    app.all('*', handler)
+    return app
+  }
+
+  test('forwards method, path, querystring, allow-listed headers, and body', async () => {
+    installFetch(() =>
+      jsonResponse({ ok: true }, 200, { 'x-shogo-trace': 'abc' }),
+    )
+
+    const app = appWith(async (c) => forwardToUpstream(c))
+    const res = await app.request(
+      '/api/instances/some-id/proxy?foo=bar',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-shogo-custom': 'preserved',
+          'cookie': 'should-not-leak',
+          'accept': 'application/json',
+        },
+        body: JSON.stringify({ hello: 'world' }),
+      },
+    )
+    expect(res.status).toBe(200)
+
+    expect(fetchCalls[0].url).toBe(
+      'https://cloud.test/api/instances/some-id/proxy?foo=bar',
+    )
+    const headers = new Headers(fetchCalls[0].init?.headers as any)
+    expect(headers.get('authorization')).toBe('Bearer shogo_sk_test')
+    expect(headers.get('content-type')).toBe('application/json')
+    expect(headers.get('x-shogo-custom')).toBe('preserved')
+    expect(headers.get('cookie')).toBeNull()
+    expect(headers.get('host')).toBeNull()
+
+    const sent = await new Response(fetchCalls[0].init?.body as any).text()
+    expect(sent).toBe('{"hello":"world"}')
+  })
+
+  test('GET requests do not forward a body', async () => {
+    installFetch(() => jsonResponse({ ok: true }))
+    const app = appWith(async (c) => forwardToUpstream(c))
+    await app.request('/api/instances/i1', { method: 'GET' })
+    expect(fetchCalls[0].init?.body).toBeUndefined()
+  })
+
+  test('pipes the raw response body (streaming-friendly)', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('chunk-1'))
+        controller.enqueue(new TextEncoder().encode('chunk-2'))
+        controller.close()
+      },
+    })
+    installFetch(() => new Response(stream, {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    }))
+
+    const app = appWith(async (c) => {
+      const upstream = await forwardToUpstream(c)
+      return new Response(upstream.body, {
+        status: upstream.status,
+        headers: copyResponseHeaders(upstream),
+      })
+    })
+    const res = await app.request('/api/instances/i1/p/agent/chat', { method: 'POST' })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('text/event-stream')
+    expect(await res.text()).toBe('chunk-1chunk-2')
+  })
+})
+
+describe('copyResponseHeaders', () => {
+  test('strips hop-by-hop headers but keeps the rest', () => {
+    const resp = new Response('', {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+        'content-length': '12',
+        'transfer-encoding': 'chunked',
+        'connection': 'keep-alive',
+        'x-shogo-trace': 'abc',
+      },
+    })
+    const headers = copyResponseHeaders(resp)
+    expect(headers['content-type']).toBe('application/json')
+    expect(headers['x-shogo-trace']).toBe('abc')
+    expect(headers['content-length']).toBeUndefined()
+    expect(headers['transfer-encoding']).toBeUndefined()
+    expect(headers['connection']).toBeUndefined()
+  })
+})

--- a/apps/api/src/lib/federated-upstream.ts
+++ b/apps/api/src/lib/federated-upstream.ts
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Federated Upstream — pass instance traffic through to the cloud the
+ * local-mode API is already signed in to.
+ *
+ * Local mode (SHOGO_LOCAL_MODE=true) already maintains an authenticated
+ * session against a single cloud endpoint:
+ *
+ *   - URL:        `getShogoCloudUrl()` (env-pinned, see lib/cloud-urls.ts)
+ *   - Credential: `process.env.SHOGO_API_KEY`, populated by
+ *                 `PUT /api/local/shogo-key` (server.ts) and persisted
+ *                 to `localConfig.SHOGO_API_KEY` (see routes/local-auth.ts).
+ *
+ * The same credential drives the AI proxy and the instance-tunnel
+ * client. This module reuses it to act as a *consumer* of cloud-side
+ * instance endpoints — so a worker registered against staging can be
+ * listed and driven from `localhost:8002` without re-registering.
+ *
+ * Public surface:
+ *   isFederatedEnabled()           — gate; respects SHOGO_LOCAL_MODE.
+ *   listCloudInstancesForWorkspace(workspaceId)
+ *   lookupCloudInstance(id)        — 60s LRU cache; evicts on 401/404.
+ *   forwardToUpstream(c, opts?)    — pipe a Hono request through to cloud,
+ *                                    returning the raw fetch Response so
+ *                                    callers can buffer or stream.
+ *   onUpstreamRejection(handler)   — observe 401s so the existing
+ *                                    cloudKeyRejected banner can flip.
+ */
+
+import type { Context } from 'hono'
+import { prisma } from './prisma'
+import { getShogoCloudUrl } from './cloud-urls'
+
+// ─── Auth + gate ────────────────────────────────────────────────────────────
+
+const CREDENTIAL_TTL_MS = 30_000
+let cachedCredential: { value: string | null; expiresAt: number } | null = null
+let cachedCloudWorkspaceId: { value: string | null; expiresAt: number } | null = null
+
+/**
+ * Resolve the cloud credential local mode uses. Reads `process.env`
+ * first (populated by `PUT /api/local/shogo-key` and the auto-load in
+ * server.ts), falling back to a prisma read of `localConfig.SHOGO_API_KEY`
+ * for the narrow window where the env var has been cleared but the row
+ * is still authoritative. Short TTL keeps the fallback cheap.
+ */
+export async function getUpstreamCredential(): Promise<string | null> {
+  const envKey = process.env.SHOGO_API_KEY
+  if (envKey) return envKey
+
+  const now = Date.now()
+  if (cachedCredential && cachedCredential.expiresAt > now) {
+    return cachedCredential.value
+  }
+
+  let value: string | null = null
+  try {
+    const row = await (prisma as any).localConfig
+      .findUnique({ where: { key: 'SHOGO_API_KEY' } })
+      .catch(() => null)
+    value = row?.value || null
+  } catch {
+    value = null
+  }
+  cachedCredential = { value, expiresAt: now + CREDENTIAL_TTL_MS }
+  return value
+}
+
+/** Test-only: drop the credential cache. */
+export function _resetUpstreamCredentialCache(): void {
+  cachedCredential = null
+  cachedCloudWorkspaceId = null
+}
+
+/**
+ * Resolve the *cloud* workspace ID the local SHOGO_API_KEY is scoped to,
+ * persisted as `localConfig.SHOGO_KEY_INFO` by `PUT /api/local/shogo-key`
+ * (see server.ts). The local app's Better Auth workspace IDs do not
+ * match cloud workspace IDs in general — staging will reject any list
+ * call that passes a foreign workspace ID, so we translate before
+ * forwarding `GET /api/instances?workspaceId=...`.
+ */
+export async function getUpstreamWorkspaceId(): Promise<string | null> {
+  const now = Date.now()
+  if (cachedCloudWorkspaceId && cachedCloudWorkspaceId.expiresAt > now) {
+    return cachedCloudWorkspaceId.value
+  }
+  let value: string | null = null
+  try {
+    const row = await (prisma as any).localConfig
+      .findUnique({ where: { key: 'SHOGO_KEY_INFO' } })
+      .catch(() => null)
+    if (row?.value) {
+      try {
+        const info = JSON.parse(row.value)
+        const id = info?.workspace?.id
+        if (typeof id === 'string' && id) value = id
+      } catch { /* malformed json; treat as unset */ }
+    }
+  } catch {
+    value = null
+  }
+  cachedCloudWorkspaceId = { value, expiresAt: now + CREDENTIAL_TTL_MS }
+  return value
+}
+
+/** Federation is on when local mode is active and we have a credential. */
+export function isLocalMode(): boolean {
+  return process.env.SHOGO_LOCAL_MODE === 'true'
+}
+
+export async function isFederatedEnabled(): Promise<boolean> {
+  if (!isLocalMode()) return false
+  const key = await getUpstreamCredential()
+  return !!key
+}
+
+/** Hostname of the configured upstream, used as the `origin` tag on
+ *  federated instance rows. */
+export function getUpstreamOrigin(): string {
+  try {
+    return new URL(getShogoCloudUrl()).host
+  } catch {
+    return getShogoCloudUrl()
+  }
+}
+
+// ─── 401 observer (wires into the existing cloudKeyRejected banner) ─────────
+
+type RejectionHandler = (reason: string) => void
+const rejectionHandlers = new Set<RejectionHandler>()
+
+export function onUpstreamRejection(handler: RejectionHandler): () => void {
+  rejectionHandlers.add(handler)
+  return () => rejectionHandlers.delete(handler)
+}
+
+function notifyRejection(reason: string): void {
+  for (const handler of rejectionHandlers) {
+    try { handler(reason) } catch { /* observer threw; ignore */ }
+  }
+}
+
+// ─── Instance lookup cache ──────────────────────────────────────────────────
+
+export interface CloudInstance {
+  id: string
+  workspaceId: string
+  hostname?: string
+  name?: string
+  os?: string | null
+  arch?: string | null
+  kind?: string
+  status?: string
+  lastSeenAt?: string | null
+  [k: string]: unknown
+}
+
+const LOOKUP_TTL_MS = 60_000
+interface CacheEntry { value: CloudInstance | null; expiresAt: number }
+const instanceCache = new Map<string, CacheEntry>()
+
+/** Test-only: clear the lookup cache. */
+export function _resetInstanceCache(): void {
+  instanceCache.clear()
+}
+
+function cacheGet(id: string): CloudInstance | null | undefined {
+  const entry = instanceCache.get(id)
+  if (!entry) return undefined
+  if (entry.expiresAt < Date.now()) {
+    instanceCache.delete(id)
+    return undefined
+  }
+  return entry.value
+}
+
+function cacheSet(id: string, value: CloudInstance | null): void {
+  instanceCache.set(id, { value, expiresAt: Date.now() + LOOKUP_TTL_MS })
+}
+
+// ─── HTTP helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Headers we forward to cloud. Cookie, host, content-length are deliberately
+ * dropped: cookie is a local-only Better Auth credential, host belongs to
+ * the upstream, content-length is recomputed by fetch.
+ *
+ * The allow-list is permissive so streaming (`accept: text/event-stream`)
+ * and protocol-handshake headers used by the transparent proxy
+ * (`x-remote-control`, `x-remote-protocol-version`, `x-sync-version`,
+ * `x-client-version`, `x-chat-session-id`, `x-tunnel-auth-*`) pass through.
+ */
+const HEADER_ALLOWLIST = new Set([
+  'content-type',
+  'accept',
+  'accept-encoding',
+  'accept-language',
+  'cache-control',
+  'x-remote-control',
+  'x-remote-protocol-version',
+  'x-sync-version',
+  'x-client-version',
+  'x-chat-session-id',
+  'x-runtime-token',
+  'x-tunnel-auth-user-id',
+  'x-tunnel-auth-email',
+  'x-tunnel-auth-name',
+])
+
+const HEADER_PREFIX_ALLOWLIST = ['x-shogo-']
+
+function isAllowedHeader(name: string): boolean {
+  const lower = name.toLowerCase()
+  if (HEADER_ALLOWLIST.has(lower)) return true
+  return HEADER_PREFIX_ALLOWLIST.some((p) => lower.startsWith(p))
+}
+
+/** Build the upstream Authorization header from `process.env.SHOGO_API_KEY`. */
+async function buildAuthHeader(): Promise<Record<string, string>> {
+  const key = await getUpstreamCredential()
+  if (!key) return {}
+  return { Authorization: `Bearer ${key}` }
+}
+
+function buildUpstreamUrl(path: string, search: string): string {
+  const base = getShogoCloudUrl()
+  const cleanPath = path.startsWith('/') ? path : `/${path}`
+  return `${base}${cleanPath}${search || ''}`
+}
+
+async function fetchUpstream(
+  path: string,
+  init: RequestInit & { search?: string } = {},
+): Promise<Response> {
+  const url = buildUpstreamUrl(path, init.search ?? '')
+  const auth = await buildAuthHeader()
+  const headers = new Headers(init.headers ?? undefined)
+  for (const [k, v] of Object.entries(auth)) headers.set(k, v)
+  const resp = await fetch(url, { ...init, headers })
+  if (resp.status === 401) {
+    notifyRejection(`upstream ${path} returned 401`)
+  }
+  return resp
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * GET cloud's instance list scoped to the cloud workspace the local
+ * SHOGO_API_KEY is bound to. Returns `[]` if federation is off, no
+ * cloud workspace is linked, or the upstream rejects.
+ *
+ * The `_localWorkspaceId` argument is accepted for parity with the
+ * route handler signature but is intentionally NOT forwarded: cloud
+ * uses Better Auth memberships keyed by cloud workspace IDs, which
+ * don't match the local DB's IDs. Forwarding the local id would
+ * always 403 on the cloud's `member.findFirst` check.
+ *
+ * Cache is populated for each id so subsequent `lookupCloudInstance`
+ * calls are free.
+ */
+export async function listCloudInstancesForWorkspace(
+  _localWorkspaceId: string,
+): Promise<CloudInstance[]> {
+  if (!(await isFederatedEnabled())) return []
+
+  const cloudWorkspaceId = await getUpstreamWorkspaceId()
+  if (!cloudWorkspaceId) return []
+
+  try {
+    const resp = await fetchUpstream(
+      '/api/instances',
+      { method: 'GET', search: `?workspaceId=${encodeURIComponent(cloudWorkspaceId)}` },
+    )
+    if (!resp.ok) return []
+    const body = (await resp.json().catch(() => null)) as { instances?: CloudInstance[] } | null
+    const list = body?.instances ?? []
+    for (const inst of list) {
+      if (inst?.id) cacheSet(inst.id, inst)
+    }
+    return list
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Look up a single instance on cloud. Cached for 60s; 401/404 evict the
+ * entry immediately so a re-link or a worker reconnect is reflected in
+ * the next call.
+ */
+export async function lookupCloudInstance(id: string): Promise<CloudInstance | null> {
+  if (!(await isFederatedEnabled())) return null
+
+  const cached = cacheGet(id)
+  if (cached !== undefined) return cached
+
+  try {
+    const resp = await fetchUpstream(`/api/instances/${encodeURIComponent(id)}`, { method: 'GET' })
+    if (resp.status === 404 || resp.status === 401) {
+      cacheSet(id, null)
+      return null
+    }
+    if (!resp.ok) return null
+    const body = (await resp.json().catch(() => null)) as CloudInstance | null
+    cacheSet(id, body)
+    return body
+  } catch {
+    return null
+  }
+}
+
+/** Invalidate the cache for a single instance — useful when a write
+ *  endpoint succeeds and the next read should bypass the TTL. */
+export function invalidateCloudInstance(id: string): void {
+  instanceCache.delete(id)
+}
+
+export interface ForwardOptions {
+  /** Override the upstream path. Defaults to `c.req.path`. */
+  path?: string
+  /** Override the upstream querystring (including leading `?`). Defaults
+   *  to whatever the client sent. */
+  search?: string
+}
+
+/**
+ * Forward the current Hono request to the configured cloud upstream.
+ * Returns the raw fetch `Response` so callers can either:
+ *   - `await resp.text()` / `await resp.json()` for buffered responses, or
+ *   - pipe `resp.body` back to the client untouched for SSE/streams.
+ *
+ * Path/search default to the original request's. Method, body, and the
+ * allow-listed subset of headers are forwarded. `Authorization` is set
+ * to the local-mode cloud credential; cookie/host are dropped.
+ */
+export async function forwardToUpstream(
+  c: Context,
+  opts: ForwardOptions = {},
+): Promise<Response> {
+  const url = new URL(c.req.url)
+  const path = opts.path ?? url.pathname
+  const search = opts.search ?? url.search
+
+  const method = c.req.method
+  const hasBody = method !== 'GET' && method !== 'HEAD'
+
+  const fwdHeaders = new Headers()
+  c.req.raw.headers.forEach((value, name) => {
+    if (isAllowedHeader(name)) fwdHeaders.set(name, value)
+  })
+
+  let body: BodyInit | undefined
+  if (hasBody) {
+    // Read raw bytes so JSON and binary streams both round-trip; cloud
+    // will reparse using `content-type`.
+    body = await c.req.raw.arrayBuffer()
+  }
+
+  return fetchUpstream(path, {
+    method,
+    headers: fwdHeaders,
+    body,
+    search,
+  })
+}
+
+/**
+ * Copy upstream response headers we want to surface back to the client.
+ * Strips hop-by-hop headers that would confuse the framework or the
+ * browser when re-emitted from the local API.
+ */
+const RESPONSE_HEADER_DENYLIST = new Set([
+  'connection',
+  'keep-alive',
+  'transfer-encoding',
+  'content-encoding',
+  'content-length',
+])
+
+export function copyResponseHeaders(resp: Response): Record<string, string> {
+  const out: Record<string, string> = {}
+  resp.headers.forEach((value, name) => {
+    if (RESPONSE_HEADER_DENYLIST.has(name.toLowerCase())) return
+    out[name] = value
+  })
+  return out
+}

--- a/apps/api/src/routes/instances.ts
+++ b/apps/api/src/routes/instances.ts
@@ -45,6 +45,14 @@ import {
 import { sendPushToInstance } from '../lib/push-notifications'
 import { openSession, closeSession, hasSession } from '../lib/proxy-billing-session'
 import { trackChatStreamForBilling } from '../lib/chat-usage-tracker'
+import {
+  isFederatedEnabled,
+  listCloudInstancesForWorkspace,
+  lookupCloudInstance,
+  forwardToUpstream,
+  copyResponseHeaders,
+  getUpstreamOrigin,
+} from '../lib/federated-upstream'
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -730,8 +738,16 @@ export function instanceRoutes() {
       return c.json({ error: { code: 'unauthorized', message: 'Authentication required' } }, 401)
     }
 
-    const instance = await prisma.instance.findUnique({ where: { id: c.req.param('id') } })
+    const id = c.req.param('id')
+    const instance = await prisma.instance.findUnique({ where: { id } })
     if (!instance) {
+      if (await isFederatedEnabled()) {
+        const upstream = await forwardToUpstream(c)
+        return new Response(upstream.body, {
+          status: upstream.status,
+          headers: copyResponseHeaders(upstream),
+        })
+      }
       return c.json({ error: { code: 'not_found', message: 'Instance not found' } }, 404)
     }
 
@@ -788,9 +804,27 @@ export function instanceRoutes() {
       status: tunnels.has(inst.id) || await isTunnelConnectedAnywhere(inst.id)
         ? 'online'
         : (isRecentlySeenViaHeartbeat(inst.lastSeenAt) ? 'heartbeat' : 'offline'),
+      origin: 'local' as const,
     })))
 
-    return c.json({ instances: withLiveStatus })
+    // Local mode: merge in any instances registered against the cloud
+    // upstream this local API is signed in to. Local rows win on id
+    // collision; cloud rows are tagged with the upstream hostname so
+    // the UI can render a badge.
+    let merged: Array<Record<string, unknown>> = withLiveStatus
+    if (await isFederatedEnabled()) {
+      const cloud = await listCloudInstancesForWorkspace(workspaceId)
+      if (cloud.length) {
+        const origin = getUpstreamOrigin()
+        const localIds = new Set(withLiveStatus.map((i) => i.id))
+        const tagged = cloud
+          .filter((inst) => !localIds.has(inst.id))
+          .map((inst) => ({ ...inst, origin }))
+        merged = [...withLiveStatus, ...tagged]
+      }
+    }
+
+    return c.json({ instances: merged })
   })
 
 
@@ -845,8 +879,20 @@ export function instanceRoutes() {
       return c.json({ error: { code: 'unauthorized', message: 'Authentication required' } }, 401)
     }
 
-    const instance = await prisma.instance.findUnique({ where: { id: c.req.param('id') } })
+    const id = c.req.param('id')
+    const instance = await prisma.instance.findUnique({ where: { id } })
     if (!instance) {
+      // Local DB miss: in local mode, fall through to the cloud upstream
+      // the local API is already signed in to. The forwarded response
+      // carries the cloud's own membership + status checks; we surface
+      // it verbatim so the UI sees the same shape as the local branch.
+      if (await isFederatedEnabled()) {
+        const upstream = await forwardToUpstream(c)
+        return new Response(upstream.body, {
+          status: upstream.status,
+          headers: copyResponseHeaders(upstream),
+        })
+      }
       return c.json({ error: { code: 'not_found', message: 'Instance not found' } }, 404)
     }
 
@@ -864,6 +910,7 @@ export function instanceRoutes() {
       status: tunnels.has(instance.id) || await isTunnelConnectedAnywhere(instance.id)
         ? 'online'
         : (isRecentlySeenViaHeartbeat(instance.lastSeenAt) ? 'heartbeat' : 'offline'),
+      origin: 'local' as const,
       controllers: controllers.map((c) => ({
         userId: c.userId,
         lastSeenAt: c.lastSeenAt,
@@ -934,8 +981,16 @@ export function instanceRoutes() {
       return c.json({ error: { code: 'unauthorized', message: 'Authentication required' } }, 401)
     }
 
-    const instance = await prisma.instance.findUnique({ where: { id: c.req.param('id') } })
+    const id = c.req.param('id')
+    const instance = await prisma.instance.findUnique({ where: { id } })
     if (!instance) {
+      if (await isFederatedEnabled()) {
+        const upstream = await forwardToUpstream(c)
+        return new Response(upstream.body, {
+          status: upstream.status,
+          headers: copyResponseHeaders(upstream),
+        })
+      }
       return c.json({ error: { code: 'not_found', message: 'Instance not found' } }, 404)
     }
 
@@ -1037,8 +1092,16 @@ export function instanceRoutes() {
       return c.json({ error: { code: 'unauthorized', message: 'Authentication required' } }, 401)
     }
 
-    const instance = await prisma.instance.findUnique({ where: { id: c.req.param('id') } })
+    const id = c.req.param('id')
+    const instance = await prisma.instance.findUnique({ where: { id } })
     if (!instance) {
+      if (await isFederatedEnabled()) {
+        const upstream = await forwardToUpstream(c)
+        return new Response(upstream.body, {
+          status: upstream.status,
+          headers: copyResponseHeaders(upstream),
+        })
+      }
       return c.json({ error: { code: 'not_found', message: 'Instance not found' } }, 404)
     }
 
@@ -1181,6 +1244,16 @@ export function instanceRoutes() {
     const instanceId = c.req.param('id')
     const instance = await prisma.instance.findUnique({ where: { id: instanceId } })
     if (!instance) {
+      // Federated transparent proxy: forward the entire request (incl. body
+      // and headers) to cloud and pipe the response back. Streaming responses
+      // (SSE/chunked) flow through `Response.body` without buffering.
+      if (await isFederatedEnabled()) {
+        const upstream = await forwardToUpstream(c)
+        return new Response(upstream.body, {
+          status: upstream.status,
+          headers: copyResponseHeaders(upstream),
+        })
+      }
       return c.json({ error: { code: 'not_found', message: 'Instance not found' } }, 404)
     }
 

--- a/apps/api/src/routes/local-auth.ts
+++ b/apps/api/src/routes/local-auth.ts
@@ -32,11 +32,33 @@
 import { Hono } from 'hono'
 import { prisma } from '../lib/prisma'
 import { getShogoCloudUrl } from '../lib/cloud-urls'
+import { onUpstreamRejection } from '../lib/federated-upstream'
 
 /** Tracks whether the cloud has rejected our key so the UI can show a
  * degraded-connection banner without wiping credentials. Only an explicit
  * user-initiated sign-out deletes the stored key. */
 let cloudKeyRejected = false
+
+/**
+ * Set the cloudKeyRejected flag from outside this module. Used by the
+ * federated-upstream proxy when a forwarded request returns 401 — same
+ * UX as the heartbeat path detecting a revoked key, just driven by
+ * actual user traffic instead of the periodic ping.
+ */
+export function markCloudKeyRejected(reason?: string): void {
+  if (!cloudKeyRejected) {
+    console.warn(
+      `[CloudLogin] Cloud rejected API key${reason ? ` (${reason})` : ''} — key may be revoked or expired. User must re-sign-in.`,
+    )
+  }
+  cloudKeyRejected = true
+}
+
+// Wire the federated-upstream observer once at module load so any 401
+// surfaced from a federated proxy call flips the same flag the
+// heartbeat path uses. The `/local/cloud-login/status` endpoint and the
+// sign-out flow are the single source of truth for clearing it.
+onUpstreamRejection((reason) => markCloudKeyRejected(reason))
 
 async function readStoredKey(localDb: any): Promise<string | null> {
   const row = await localDb.localConfig.findUnique({ where: { key: 'SHOGO_API_KEY' } }).catch(() => null)

--- a/apps/mobile/components/layout/InstancePicker.tsx
+++ b/apps/mobile/components/layout/InstancePicker.tsx
@@ -142,6 +142,12 @@ export function InstancePicker({ workspaceId, collapsed }: InstancePickerProps) 
       {!loading && instances.map((inst) => {
         const isActive = activeInstance?.instanceId === inst.id
         const isConnecting = connecting === inst.id
+        // `origin` is set by the federated proxy on the local API: 'local'
+        // for rows owned by this local DB, hostname (e.g.
+        // 'studio.staging.shogo.ai') for rows pulled from the cloud the
+        // local API is signed in to. Surface a small badge so users can
+        // tell paired-locally vs federated-from-cloud at a glance.
+        const isFederated = !!inst.origin && inst.origin !== 'local'
 
         return (
           <Pressable
@@ -155,9 +161,21 @@ export function InstancePicker({ workspaceId, collapsed }: InstancePickerProps) 
           >
             <Laptop size={16} className="text-muted-foreground" />
             <View className="flex-1 min-w-0">
-              <Text className="text-sm text-foreground" numberOfLines={1}>
-                {inst.name}
-              </Text>
+              <View className="flex-row items-center gap-1.5">
+                <Text className="text-sm text-foreground flex-shrink" numberOfLines={1}>
+                  {inst.name}
+                </Text>
+                {isFederated && (
+                  <View className="px-1.5 py-0.5 rounded bg-muted">
+                    <Text
+                      className="text-[9px] font-semibold uppercase tracking-wider text-muted-foreground"
+                      numberOfLines={1}
+                    >
+                      {inst.origin}
+                    </Text>
+                  </View>
+                )}
+              </View>
               <View className="flex-row items-center gap-1.5 mt-0.5">
                 <StatusDot status={inst.status} />
                 <Text className="text-[11px] text-muted-foreground">

--- a/apps/mobile/components/project/panels/ChannelsPanel.tsx
+++ b/apps/mobile/components/project/panels/ChannelsPanel.tsx
@@ -53,6 +53,13 @@ interface RunOnInstance {
   hostname: string
   kind: 'desktop' | 'cli_worker' | string
   status: 'online' | 'heartbeat' | 'offline' | string
+  /**
+   * Where this row came from. `'local'` for rows in the local API's own
+   * registry, hostname (e.g. `studio.staging.shogo.ai`) for rows the
+   * local API federated from its configured cloud upstream. Populated
+   * by `GET /api/instances` when `SHOGO_LOCAL_MODE=true`.
+   */
+  origin?: string
 }
 
 interface RunOnState {
@@ -494,6 +501,7 @@ export function ChannelsPanel({ projectId, workspaceId, agentUrl, visible, hasAd
                 runOn.candidates.map((inst) => {
                   const selected = runOn.pinnedInstance?.id === inst.id
                   const offline = inst.status === 'offline'
+                  const isFederated = !!inst.origin && inst.origin !== 'local'
                   return (
                     <Pressable
                       key={inst.id}
@@ -512,7 +520,16 @@ export function ChannelsPanel({ projectId, workspaceId, agentUrl, visible, hasAd
                         }`}
                       />
                       <View className="flex-1">
-                        <Text className="text-xs text-foreground">{inst.name}</Text>
+                        <View className="flex-row items-center gap-1.5">
+                          <Text className="text-xs text-foreground flex-shrink">{inst.name}</Text>
+                          {isFederated && (
+                            <View className="px-1 py-0.5 rounded bg-muted">
+                              <Text className="text-[8px] font-semibold uppercase tracking-wider text-muted-foreground">
+                                {inst.origin}
+                              </Text>
+                            </View>
+                          )}
+                        </View>
                         <Text className="text-[10px] text-muted-foreground">
                           {inst.kind === 'cli_worker' ? 'Worker' : 'Desktop'} · {inst.hostname}
                           {offline ? ' · offline' : ''}

--- a/packages/shared-app/src/hooks/useActiveInstance.tsx
+++ b/packages/shared-app/src/hooks/useActiveInstance.tsx
@@ -60,6 +60,17 @@ export interface ActiveInstance {
    * window where this is unknown is at most one poll.
    */
   kind?: InstanceKind
+  /**
+   * Where this instance came from. `'local'` (or `undefined` for
+   * older persisted state) means the local API's own registry;
+   * any other value is the hostname of the cloud upstream the
+   * local API federated the row from (e.g.
+   * `studio.staging.shogo.ai`). Used by `useInstancePicker` to
+   * decide whether the auto-clear-on-workspace-change effect
+   * applies — federated rows are cloud-scoped and survive local
+   * workspace switches.
+   */
+  origin?: string
 }
 
 export type InstanceStatus = 'online' | 'heartbeat' | 'offline' | 'unknown'

--- a/packages/shared-app/src/hooks/useInstancePicker.ts
+++ b/packages/shared-app/src/hooks/useInstancePicker.ts
@@ -29,6 +29,14 @@ export interface Instance {
    * cloud backend (cli-worker).
    */
   kind?: 'desktop' | 'cli-worker'
+  /**
+   * Where this instance row came from. `'local'` means the local API's
+   * own registry; any other value is the hostname of the upstream cloud
+   * the local API federated the row from (e.g. `studio.staging.shogo.ai`).
+   * Set by `GET /api/instances` when `SHOGO_LOCAL_MODE=true` and a
+   * cloud upstream is configured.
+   */
+  origin?: string
 }
 
 export interface UseInstancePickerOptions {
@@ -80,9 +88,17 @@ export function useInstancePicker({
   const [connecting, setConnecting] = useState<string | null>(null)
   const [connectError, setConnectError] = useState<string | null>(null)
 
-  // Auto-clear when workspace changes
+  // Auto-clear when workspace changes. Federated instances (origin set
+  // to the cloud host instead of `'local'`) are cloud-scoped: their
+  // workspaceId is the cloud's, which never matches the local one.
+  // Clearing them on every local workspace switch would defeat the
+  // whole point of federation, so skip them here — the user can pick
+  // a different machine explicitly via the picker.
   useEffect(() => {
-    if (activeInstance && workspaceId && activeInstance.workspaceId !== workspaceId) {
+    if (!activeInstance || !workspaceId) return
+    const isFederated = !!activeInstance.origin && activeInstance.origin !== 'local'
+    if (isFederated) return
+    if (activeInstance.workspaceId !== workspaceId) {
       clearInstance()
     }
   }, [activeInstance, workspaceId, clearInstance])
@@ -132,8 +148,12 @@ export function useInstancePicker({
 
           for (let i = 0; i < connectPollCount; i++) {
             await new Promise((r) => setTimeout(r, connectPollIntervalMs))
+            // Poll the local API's list endpoint with the picker's
+            // (local) workspaceId — NOT inst.workspaceId, which for
+            // federated rows is the cloud workspace id the local
+            // membership check would reject as 403.
             const listRes = await fetchFn(
-              `${apiUrl}/api/instances?workspaceId=${encodeURIComponent(inst.workspaceId)}`,
+              `${apiUrl}/api/instances?workspaceId=${encodeURIComponent(workspaceId ?? inst.workspaceId)}`,
               { ...fetchOptions },
             )
             if (!listRes.ok) continue
@@ -147,6 +167,7 @@ export function useInstancePicker({
                 hostname: found.hostname,
                 workspaceId: found.workspaceId,
                 kind: found.kind,
+                origin: found.origin,
               })
               setInstances(updated)
               setConnecting(null)
@@ -173,10 +194,11 @@ export function useInstancePicker({
         hostname: inst.hostname,
         workspaceId: inst.workspaceId,
         kind: inst.kind,
+        origin: inst.origin,
       })
       setIsOpen(false)
     },
-    [apiUrl, fetchFn, fetchOptions, setInstance, connectPollCount, connectPollIntervalMs],
+    [apiUrl, fetchFn, fetchOptions, setInstance, connectPollCount, connectPollIntervalMs, workspaceId],
   )
 
   const disconnect = useCallback(() => {


### PR DESCRIPTION
When SHOGO_LOCAL_MODE=true, make the local API a transparent proxy for instance traffic registered against the cloud upstream the user is already signed in to. No new env vars, no client-side credential handling, no new UI for keys — reuses localConfig.SHOGO_API_KEY + localConfig.SHOGO_KEY_INFO.workspace.id (already populated by PUT /api/local/shogo-key in server.ts).

Lets a worker registered against staging be listed and driven from a local dev studio without re-registering it locally.

apps/api/src/lib/federated-upstream.ts (new)
  - getUpstreamCredential / getUpstreamWorkspaceId — env-first reads with 30s prisma fallback for both the SHOGO_API_KEY and the SHOGO_KEY_INFO-derived cloud workspace id.
  - isFederatedEnabled — gates everything on SHOGO_LOCAL_MODE + creds.
  - lookupCloudInstance / listCloudInstancesForWorkspace — bearer-auth cloud reads with a 60s LRU cache (404/401 evict). The list helper translates the caller's local workspaceId to the CLOUD workspaceId from SHOGO_KEY_INFO before forwarding; staging's member.findFirst would 403 a foreign local id.
  - forwardToUpstream — pipes a Hono request through to cloud and returns the raw fetch Response so callers can stream the body untouched. Strict header allow-list (cookie / host stripped, Authorization injected, x-shogo-* / x-remote-* / x-chat-session-id preserved).
  - onUpstreamRejection — observer surface that local-auth subscribes to so a forwarded 401 flips the existing cloudKeyRejected flag the /local/cloud-login/status banner already surfaces.

apps/api/src/routes/instances.ts
  - GET /instances merges local + cloud rows. Local rows are tagged origin: 'local'; cloud rows are tagged with the upstream hostname. Local wins on id collision.
  - GET /instances/:id, POST /instances/:id/request-connect, /proxy, /proxy/stream, and ALL /instances/:id/p/* fall through to forwardToUpstream on local DB miss when isFederatedEnabled(). Streaming responses pipe Response.body verbatim so SSE chunks flow through without buffering.

apps/api/src/routes/local-auth.ts
  - Subscribes to onUpstreamRejection at module load. A forwarded 401 flips the same cloudKeyRejected flag the heartbeat path already surfaces, so the existing degraded-connection banner in the admin Settings view picks it up without any new UI.

packages/shared-app/src/hooks/useInstancePicker.ts
  - Instance type gains origin?: string.
  - Auto-clear-on-workspace-change effect skips federated rows (origin !== 'local'); they're cloud-scoped and must survive local workspace switches.
  - Connect-poll loop uses the picker's local workspaceId (not inst.workspaceId, which for federated rows is the cloud id the local membership check would 403).
  - setInstance now persists origin so the auto-clear gate works.

packages/shared-app/src/hooks/useActiveInstance.tsx
  - ActiveInstance gains origin?: string with a comment explaining the federation interaction.

apps/mobile/components/layout/InstancePicker.tsx
apps/mobile/components/project/panels/ChannelsPanel.tsx
  - Render a small uppercase hostname pill next to instance names when origin is set and not 'local', so users can tell paired- locally vs federated-from-cloud at a glance.

Tests
  - apps/api/src/lib/__tests__/federated-upstream.test.ts: 23 tests covering credential + workspace-id resolution (env first, prisma fallback, malformed JSON), gating, list/lookup cache TTL + 404 eviction, 401 observer subscribe/unsubscribe, header allow-list (cookie/host stripped, bearer injected), GET-without-body, stream pass-through, hop-by-hop header stripping.
  - apps/api/src/__tests__/instances-federation.test.ts: 15 tests covering list merge with origin tagging, local-wins-on-collision, cloud-workspace-id translation, gating-off no-fetch, cloud-error degradation, detail forward + 404 propagation, request-connect / proxy / proxy-stream / transparent-proxy fallbacks, SSE chunk pass-through, and the end-to-end 401 -> cloudKeyRejected -> /local/cloud-login/status wiring.

## Summary

<!-- Brief description of the changes and why they're needed -->

## Changes

<!-- List the key changes made -->

-

## Testing

<!-- How were these changes tested? -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Verified no regressions

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
