### PR TITLE
Marketplace ui ux fixess

### DIFF
--- a/apps/mobile/app/(app)/marketplace/creators/index.tsx
+++ b/apps/mobile/app/(app)/marketplace/creators/index.tsx
@@ -137,7 +137,7 @@ export default observer(function CreatorsDirectoryScreen() {
           <View className="flex-row items-center bg-card border border-input rounded-xl px-3 h-11 flex-1">
             <Search size={16} color="#71717a" />
             <TextInput
-              className="flex-1 ml-2 text-sm text-foreground web:outline-none"
+              className="flex-1 ml-2 text-sm text-foreground web:outline-none no-focus-ring"
               placeholder="Search creators…"
               placeholderTextColor="#71717a"
               value={search}

--- a/apps/mobile/app/(app)/marketplace/creators/index.tsx
+++ b/apps/mobile/app/(app)/marketplace/creators/index.tsx
@@ -25,6 +25,13 @@ import {
   type CreatorTier,
 } from '../../../../components/marketplace'
 import { useGridColumns } from '../../../../hooks/useGridColumns'
+import { cn } from '@shogo/shared-ui/primitives'
+import {
+  Popover,
+  PopoverBackdrop,
+  PopoverBody,
+  PopoverContent,
+} from '@/components/ui/popover'
 
 interface LeaderboardCreator {
   id: string
@@ -144,36 +151,15 @@ export default observer(function CreatorsDirectoryScreen() {
               </Pressable>
             )}
           </View>
-          <View className="relative">
-            <Pressable
-              onPress={() => setSortOpen((v) => !v)}
-              className="flex-row items-center gap-1.5 px-3 h-11 rounded-xl border border-border bg-card"
-            >
-              <Text className="text-xs font-medium text-foreground">
-                {SORT_LABELS[sortMode]}
-              </Text>
-              <ChevronDown size={12} color="#71717a" />
-            </Pressable>
-            {sortOpen && (
-              <View
-                className="absolute right-0 top-12 rounded-xl border border-border bg-card overflow-hidden shadow-lg"
-                style={{ width: 170, zIndex: 50 }}
-              >
-                {(Object.keys(SORT_LABELS) as SortMode[]).map((k) => (
-                  <Pressable
-                    key={k}
-                    onPress={() => {
-                      setSortMode(k)
-                      setSortOpen(false)
-                    }}
-                    className={`px-3 py-2.5 active:bg-muted ${k === sortMode ? 'bg-muted/50' : ''}`}
-                  >
-                    <Text className="text-xs text-foreground">{SORT_LABELS[k]}</Text>
-                  </Pressable>
-                ))}
-              </View>
-            )}
-          </View>
+          <SortMenu
+            value={sortMode}
+            open={sortOpen}
+            onOpenChange={setSortOpen}
+            onChange={(v) => {
+              setSortMode(v)
+              setSortOpen(false)
+            }}
+          />
         </View>
 
         {/* Tier filter pills */}
@@ -429,4 +415,58 @@ function formatCount(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`
   if (n >= 1000) return `${(n / 1000).toFixed(1).replace(/\.0$/, '')}k`
   return String(n)
+}
+
+function SortMenu({
+  value,
+  open,
+  onOpenChange,
+  onChange,
+}: {
+  value: SortMode
+  open: boolean
+  onOpenChange: (v: boolean) => void
+  onChange: (v: SortMode) => void
+}) {
+  return (
+    <Popover
+      placement="bottom right"
+      isOpen={open}
+      onOpen={() => onOpenChange(true)}
+      onClose={() => onOpenChange(false)}
+      trigger={(triggerProps) => (
+        <Pressable
+          {...triggerProps}
+          className="flex-row items-center gap-1.5 px-3 h-11 rounded-xl border border-border bg-card"
+        >
+          <Text className="text-xs font-medium text-foreground">
+            {SORT_LABELS[value]}
+          </Text>
+          <ChevronDown size={12} color="#71717a" />
+        </Pressable>
+      )}
+    >
+      <PopoverBackdrop />
+      <PopoverContent className="p-0 min-w-[170px]">
+        <PopoverBody>
+          {(Object.keys(SORT_LABELS) as SortMode[]).map((k) => (
+            <Pressable
+              key={k}
+              onPress={() => onChange(k)}
+              className={cn('px-3 py-2.5 active:bg-muted', k === value && 'bg-accent')}
+            >
+              <Text
+                className={cn(
+                  'text-xs',
+                  k === value ? 'text-foreground font-medium' : 'text-foreground',
+                )}
+              >
+                {SORT_LABELS[k]}
+              </Text>
+            </Pressable>
+          ))}
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  )
 }


### PR DESCRIPTION
## Summary
<img width="1780" height="714" alt="image" src="https://github.com/user-attachments/assets/e2758557-8257-47ef-9a66-d26e85eacdf7" />


Fixes two UX issues on the **Creators** directory page (`/marketplace/creators`):

- **Sort dropdown clicks** — Replaces the custom absolutely positioned sort menu (inside the `FlatList` header) with the shared `Popover` + backdrop pattern already used on the main marketplace page. On web, list content below the header could intercept clicks, making sort options intermittently unclickable.
- **Search focus ring** — Adds `no-focus-ring` to the creators search `TextInput` so the global orange focus outline no longer appears when the field is focused, matching the main marketplace search bar.

Sorting behavior is unchanged: client-side sort by reputation, installs, or agents published.

## Test plan

- [ ] Open `/marketplace/creators` on web (`localhost:8081`)
- [ ] Open the **Top reputation** sort dropdown and select each option — all three should be consistently clickable; menu should close after selection
- [ ] Click into **Search creators…** — confirm no orange focus border/outline on the search field
- [ ] With multiple creators in the directory, verify list order changes when switching between **Top reputation**, **Most installs**, and **Most agents**
- [ ] Smoke-check tier filter pills and search still work as before