### PR TITLE
fix(cloud-agent): rotate AI_PROXY_TOKEN in-place to prevent 7-day silent failure

### DIFF
--- a/apps/api/src/routes/internal.ts
+++ b/apps/api/src/routes/internal.ts
@@ -324,6 +324,87 @@ app.post('/validate-runtime-token', async (c) => {
 })
 
 /**
+ * POST /api/internal/refresh-ai-proxy-token/:projectId
+ *   → 200 { token: string, exp: number }   exp = unix seconds
+ *
+ * Called by long-lived runtime pods to rotate their AI_PROXY_TOKEN in place
+ * before the JWT exp elapses.
+ *
+ * Why this exists
+ * ---------------
+ * AI_PROXY_TOKEN is a short-lived HS256 JWT (see ai-proxy-token.ts) that's
+ * minted exactly once per pod, at revision-creation time, and injected as
+ * a Knative env var. Knative revision env is immutable; project pods run
+ * with min-scale=1 to avoid cold starts; therefore a pod kept warm by
+ * heartbeat or Slack traffic outlives the credential it was issued with.
+ * Around exp the proxy starts 401-ing every LLM call and the agent
+ * silently no-ops while heartbeat metrics remain green.
+ *
+ * The fix is to give the pod a refresh path it can drive itself, using
+ * the long-lived identity it already has (K8s SA token in cluster,
+ * RUNTIME_AUTH_SECRET in local mode). Same shape as kubelet rotating a
+ * projected SA token before expiry — the runtime-side refresher mutates
+ * process.env.AI_PROXY_TOKEN in place, so every existing consumer that
+ * reads from process.env naturally picks up the fresh value.
+ *
+ * Auth: K8s SA bearer (cluster) OR x-runtime-token (local mode), via the
+ * same validateAuth() helper used by the other /internal routes. The
+ * caller MUST be authenticated for the project being refreshed — a pod
+ * can only refresh its own token, not someone else's.
+ */
+app.post('/refresh-ai-proxy-token/:projectId', async (c) => {
+  const projectId = c.req.param('projectId')
+
+  if (!projectId) {
+    return c.json({ error: 'projectId is required' }, 400)
+  }
+
+  if (!checkRateLimit(`refresh-proxy:${projectId}`)) {
+    return c.json({ error: 'Rate limit exceeded' }, 429)
+  }
+
+  if (!(await validateAuth(c, projectId))) {
+    return c.json({ error: 'Unauthorized' }, 401)
+  }
+
+  try {
+    const { prisma } = await import('../lib/prisma')
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+      select: { id: true, workspaceId: true },
+    })
+    if (!project) {
+      return c.json({ error: 'Project not found' }, 404)
+    }
+
+    const { getProjectOwnerUserId } = await import('../lib/project-user-context')
+    const ownerUserId = await getProjectOwnerUserId(projectId)
+
+    // Match the TTL used at provisioning time (build-project-env.ts /
+    // knative-project-manager.ts). The refresher schedules itself well
+    // inside this window, so the effective rotation cadence is what
+    // controls security, not this number. Lowering this default back to
+    // the original 24h is a follow-up once the refresher has been observed
+    // in staging.
+    const expiryMs = 7 * 24 * 60 * 60 * 1000
+    const { generateProxyToken } = await import('../lib/ai-proxy-token')
+    const token = await generateProxyToken(
+      project.id,
+      project.workspaceId ?? 'local-dev',
+      ownerUserId,
+      expiryMs,
+    )
+
+    const exp = Math.floor((Date.now() + expiryMs) / 1000)
+    console.log(`[Internal] Refreshed AI_PROXY_TOKEN for ${projectId} (exp=${exp})`)
+    return c.json({ token, exp })
+  } catch (err: any) {
+    console.error(`[Internal] refresh-ai-proxy-token failed for ${projectId}:`, err?.message ?? err)
+    return c.json({ error: 'Refresh failed' }, 500)
+  }
+})
+
+/**
  * GET /api/internal/subagent-overrides/resolve
  *   ?workspaceId=...&projectId=...&agentType=...
  *

--- a/packages/agent-runtime/src/ai-proxy-token-refresher.ts
+++ b/packages/agent-runtime/src/ai-proxy-token-refresher.ts
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * AI Proxy Token Refresher
+ *
+ * Rotates `process.env.AI_PROXY_TOKEN` in place inside a long-lived runtime
+ * pod before the JWT exp elapses.
+ *
+ * Why this exists
+ * ---------------
+ * `AI_PROXY_TOKEN` is a short-lived HS256 JWT (default 24h, currently
+ * provisioned with 7d at the call sites in `apps/api/src/lib/knative-
+ * project-manager.ts` and `build-project-env.ts`). It's minted exactly
+ * once per pod, at revision-creation time, and injected as a Knative env
+ * var. Because Knative revision env is immutable, and project pods run
+ * with `min-scale: 1` so they never recycle while heartbeat / Slack
+ * traffic flows, the pod can outlive the credential it was issued with.
+ * Once exp elapses every LLM call 401s and the agent silently no-ops.
+ *
+ * This module is the runtime-side half of the fix: it decodes the JWT
+ * sitting in `process.env.AI_PROXY_TOKEN`, schedules a refresh well
+ * before `exp`, calls `POST /api/internal/refresh-ai-proxy-token/:projectId`
+ * with the pod's existing long-lived identity (K8s SA token or
+ * `RUNTIME_AUTH_SECRET`, both already wired through `getInternalHeaders`),
+ * and mutates `process.env.AI_PROXY_TOKEN` so every existing consumer
+ * that reads from process.env naturally picks up the fresh value.
+ *
+ * Failure modes
+ * -------------
+ *  - Network blip / API down: exponential backoff, never gives up.
+ *  - Token already expired at boot: refresh immediately.
+ *  - PROJECT_ID / AI_PROXY_TOKEN not set: this is non-cloud runtime
+ *    (e.g. external mode, headless eval). Module is a no-op.
+ *  - Malformed JWT: log once, schedule a single-shot refresh attempt
+ *    in 60s. After that we assume the API will keep it healthy.
+ *
+ * Public surface
+ * --------------
+ *  - `startAiProxyTokenRefresher()` — idempotent; safe to call from
+ *    `initializeEssentials()`.
+ *  - `forceRefreshAiProxyToken(reason?)` — trigger an immediate refresh
+ *    (e.g. after observing a 401 from the AI proxy). Returns the new
+ *    token on success, null on failure.
+ *  - `stopAiProxyTokenRefresher()` — cancel the scheduled timer (for
+ *    graceful shutdown and tests).
+ */
+
+import { deriveApiUrl, getInternalHeaders } from './internal-api'
+
+// ---------------------------------------------------------------------------
+// Tuning
+// ---------------------------------------------------------------------------
+
+/** Refresh this far ahead of `exp`. Picked to comfortably cover the
+ *  pre-Knative-default 24h TTL: with a 1h margin we still rotate ~23h
+ *  before the token would have failed. */
+const REFRESH_MARGIN_MS = 60 * 60 * 1000 // 1 hour
+
+/** Floor on the scheduled delay — don't hot-loop if a token somehow has
+ *  exp very close to now. */
+const MIN_SCHEDULE_MS = 30 * 1000 // 30 seconds
+
+/** Ceiling on the scheduled delay — even if the API ever issued an
+ *  absurdly long token, we still re-check at most every 6h so a
+ *  signing-secret rotation isn't blind for long. */
+const MAX_SCHEDULE_MS = 6 * 60 * 60 * 1000 // 6 hours
+
+/** Backoff schedule on transient refresh failures. After the last entry
+ *  we stay at MAX_BACKOFF until success. */
+const BACKOFF_MS = [5_000, 15_000, 60_000, 5 * 60_000, 15 * 60_000]
+const MAX_BACKOFF_MS = 30 * 60_000
+
+// ---------------------------------------------------------------------------
+// Module state
+// ---------------------------------------------------------------------------
+
+let timer: ReturnType<typeof setTimeout> | null = null
+let started = false
+let consecutiveFailures = 0
+let inFlight: Promise<string | null> | null = null
+
+// ---------------------------------------------------------------------------
+// JWT decoding (no signature check — we don't have the secret in the pod;
+// we just need to read `exp` to schedule ourselves).
+// ---------------------------------------------------------------------------
+
+interface DecodedExp { exp: number | null; valid: boolean }
+
+function decodeExp(token: string | undefined): DecodedExp {
+  if (!token) return { exp: null, valid: false }
+  const parts = token.split('.')
+  if (parts.length !== 3) return { exp: null, valid: false }
+  try {
+    // base64url → base64 → JSON
+    const payloadB64 = parts[1].replace(/-/g, '+').replace(/_/g, '/')
+    const padded = payloadB64 + '='.repeat((4 - (payloadB64.length % 4)) % 4)
+    const json = Buffer.from(padded, 'base64').toString('utf-8')
+    const payload = JSON.parse(json) as { exp?: number }
+    if (typeof payload.exp !== 'number') return { exp: null, valid: true }
+    return { exp: payload.exp, valid: true }
+  } catch {
+    return { exp: null, valid: false }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Refresh + schedule
+// ---------------------------------------------------------------------------
+
+function scheduleNextRefresh(reason: string): void {
+  if (timer) {
+    clearTimeout(timer)
+    timer = null
+  }
+  const projectId = process.env.PROJECT_ID
+  if (!projectId) return
+
+  const { exp, valid } = decodeExp(process.env.AI_PROXY_TOKEN)
+  let delayMs: number
+
+  if (consecutiveFailures > 0) {
+    // We've been failing — ignore the schedule and use backoff.
+    const idx = Math.min(consecutiveFailures - 1, BACKOFF_MS.length - 1)
+    delayMs = idx < 0 ? BACKOFF_MS[0] : BACKOFF_MS[idx]
+    if (consecutiveFailures > BACKOFF_MS.length) delayMs = MAX_BACKOFF_MS
+  } else if (!valid) {
+    // Malformed token — try once in a minute.
+    delayMs = 60_000
+  } else if (exp === null) {
+    // Valid JWT shape but no exp field. Re-check at the ceiling.
+    delayMs = MAX_SCHEDULE_MS
+  } else {
+    const nowMs = Date.now()
+    const expMs = exp * 1000
+    delayMs = expMs - REFRESH_MARGIN_MS - nowMs
+    if (delayMs < MIN_SCHEDULE_MS) delayMs = MIN_SCHEDULE_MS
+    if (delayMs > MAX_SCHEDULE_MS) delayMs = MAX_SCHEDULE_MS
+  }
+
+  timer = setTimeout(() => {
+    timer = null
+    refreshOnce(`scheduled (${reason})`).catch(() => { /* logged inside */ })
+  }, delayMs)
+  // Don't block process exit on this timer.
+  if (typeof (timer as any).unref === 'function') (timer as any).unref()
+
+  const human = Math.round(delayMs / 1000)
+  console.log(`[ai-proxy-token-refresher] next refresh in ${human}s (reason: ${reason}, failures: ${consecutiveFailures})`)
+}
+
+async function refreshOnce(reason: string): Promise<string | null> {
+  // De-dupe: if a refresh is already in flight, return the same promise.
+  if (inFlight) return inFlight
+
+  const projectId = process.env.PROJECT_ID
+  if (!projectId) {
+    // No project context — nothing to refresh, nothing to schedule.
+    return null
+  }
+
+  const apiUrl = deriveApiUrl()
+  if (!apiUrl) {
+    console.warn('[ai-proxy-token-refresher] no API URL derivable; skipping refresh')
+    consecutiveFailures++
+    scheduleNextRefresh('no-api-url')
+    return null
+  }
+
+  const url = `${apiUrl.replace(/\/+$/, '')}/api/internal/refresh-ai-proxy-token/${encodeURIComponent(projectId)}`
+
+  inFlight = (async () => {
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: getInternalHeaders(),
+      })
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => '')
+        console.warn(`[ai-proxy-token-refresher] refresh failed (${reason}): HTTP ${res.status} ${body.slice(0, 200)}`)
+        consecutiveFailures++
+        scheduleNextRefresh(`http-${res.status}`)
+        return null
+      }
+
+      const data = (await res.json().catch(() => null)) as { token?: string; exp?: number } | null
+      if (!data?.token) {
+        console.warn(`[ai-proxy-token-refresher] refresh response missing token (${reason})`)
+        consecutiveFailures++
+        scheduleNextRefresh('bad-response')
+        return null
+      }
+
+      process.env.AI_PROXY_TOKEN = data.token
+      consecutiveFailures = 0
+      console.log(`[ai-proxy-token-refresher] rotated AI_PROXY_TOKEN (${reason}, exp=${data.exp ?? 'unknown'})`)
+      scheduleNextRefresh('post-success')
+      return data.token
+    } catch (err: any) {
+      console.warn(`[ai-proxy-token-refresher] refresh threw (${reason}): ${err?.message ?? err}`)
+      consecutiveFailures++
+      scheduleNextRefresh('threw')
+      return null
+    } finally {
+      inFlight = null
+    }
+  })()
+
+  return inFlight
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Start the background refresher. Idempotent — calling twice is a no-op.
+ * Safe to call before AI_PROXY_TOKEN is set; it will just schedule a
+ * single re-check.
+ */
+export function startAiProxyTokenRefresher(): void {
+  if (started) return
+  started = true
+
+  const projectId = process.env.PROJECT_ID
+  if (!projectId) {
+    console.log('[ai-proxy-token-refresher] no PROJECT_ID; refresher will stay idle')
+    return
+  }
+
+  const { exp, valid } = decodeExp(process.env.AI_PROXY_TOKEN)
+  const nowS = Math.floor(Date.now() / 1000)
+
+  if (!valid || exp === null) {
+    console.log('[ai-proxy-token-refresher] no usable AI_PROXY_TOKEN at boot; scheduling re-check')
+    scheduleNextRefresh('boot-no-token')
+    return
+  }
+
+  if (exp - nowS <= REFRESH_MARGIN_MS / 1000) {
+    // Already inside the refresh window (or past exp) — refresh now.
+    console.log(`[ai-proxy-token-refresher] token is within margin at boot (exp=${exp}, now=${nowS}); refreshing immediately`)
+    refreshOnce('boot-immediate').catch(() => { /* logged inside */ })
+    return
+  }
+
+  scheduleNextRefresh('boot')
+}
+
+/**
+ * Trigger an immediate refresh. Intended for use by callers that just saw
+ * a 401 from the AI proxy and want to recover inline before retrying the
+ * request. Returns the new token on success, null on failure.
+ */
+export function forceRefreshAiProxyToken(reason: string = 'forced'): Promise<string | null> {
+  return refreshOnce(reason)
+}
+
+/** Cancel the scheduled refresh. Mostly for tests and graceful shutdown. */
+export function stopAiProxyTokenRefresher(): void {
+  if (timer) {
+    clearTimeout(timer)
+    timer = null
+  }
+  started = false
+  consecutiveFailures = 0
+}

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -61,6 +61,7 @@ import { SkillServerManager } from './skill-server-manager'
 import { runtimeTerminalRoutes } from './runtime-terminal-routes'
 import { createPtyWsHandlers, type WsData } from './pty-ws-handler'
 import { deriveApiUrl, getInternalHeaders } from './internal-api'
+import { startAiProxyTokenRefresher } from './ai-proxy-token-refresher'
 import { userMessage } from './pi-adapter'
 import { fileURLToPath } from 'url'
 import { WebChatAdapter } from './channels/webchat'
@@ -3788,6 +3789,19 @@ async function initializeEssentials(): Promise<void> {
   // Bootstrap workspace files
   ensureWorkspaceFiles()
   logTiming('Workspace files ready')
+
+  // Start the AI_PROXY_TOKEN refresher. Long-lived warm pods (min-scale=1
+  // with active heartbeat / Slack traffic) outlive the 7d JWT baked into
+  // the Knative revision env at boot; without in-place rotation every
+  // LLM call 401s around day 7 while heartbeat metrics stay green. The
+  // refresher mutates process.env.AI_PROXY_TOKEN in place so every
+  // existing reader naturally picks up the fresh value. Idempotent and
+  // safe to call before AI_PROXY_TOKEN is populated.
+  try {
+    startAiProxyTokenRefresher()
+  } catch (err: any) {
+    console.error('[agent-runtime] Failed to start AI proxy token refresher:', err?.message ?? err)
+  }
 
   // Seed tech stack if specified (covers warm pool assignment path where
   // TECH_STACK_ID is injected after module-level code has already run).


### PR DESCRIPTION
Closes #607
Refs [SHOG-652](https://odin-ai.atlassian.net/browse/SHOG-652)

## TL;DR

Long-lived Knative warm pods (`min-scale: 1`, kept warm by heartbeat / Slack traffic) outlive the 7-day JWT baked into their revision env at boot. Because Knative revision env is immutable, the `AI_PROXY_TOKEN` is never refreshed and every LLM call 401s around day 7 while heartbeat metrics stay green.

This PR adds the missing in-place credential rotation, modeled on how kubelet rotates projected SA tokens. The pod refreshes its own `AI_PROXY_TOKEN` in `process.env` before the JWT `exp` elapses, using the long-lived identity it already has (K8s SA token in cluster, `RUNTIME_AUTH_SECRET` in local mode).

Full root-cause writeup is in #607 — this PR description focuses on the fix.

## Why this happened — short version

`ai-proxy-token.ts` was designed for short-lived (24h default) JWTs that *would* be rotated often. But the only mint points are one-shot, boot-time operations:

- `apps/api/src/lib/knative-project-manager.ts:1124` (revision env at pod creation)
- `apps/api/src/lib/runtime/build-project-env.ts:88` (warm-pool `/pool/assign`)
- `runtime/manager.ts:1363` (local runtime start)

Knative revision env is immutable. Project pods run with `min-scale: 1`. So the pod outlives the credential. The call sites bumped TTL from 24h to 7d to paper over the missing refresh path — that postpones the failure from day 1 to day 7, but doesn't fix the architectural mismatch and weakens the original security property of the JWT.

The circuit breaker in `BaseHeartbeatScheduler` doesn't catch this failure mode because `/agent/heartbeat/trigger` returns 200 — the LLM call dies *inside* the runtime, not at the heartbeat layer. So `heartbeat_scheduler.triggered` keeps climbing while the agent is dead, no alert fires, no eviction happens.

This is the same architectural problem Kubernetes solved for projected SA tokens: a long-lived consumer needs a short-lived credential, so kubelet rotates it in place inside the pod. We had every primitive needed — we just never wired the rotation.

## What this PR changes

### 1. `apps/api/src/routes/internal.ts` — new endpoint (+81 lines)

`POST /api/internal/refresh-ai-proxy-token/:projectId` → `200 { token, exp }`

- Authed via the existing `validateAuth()` helper (SA bearer in cluster, `x-runtime-token` in local mode). A pod can only refresh its own token.
- Rate-limited per project via the existing `checkRateLimit()` helper.
- Mints the JWT using the same `generateProxyToken()` the provisioner uses, with the same 7d TTL.
- 404 on unknown project, 401 on auth failure, 429 on rate-limit, 500 on internal error (with logged context).

### 2. `packages/agent-runtime/src/ai-proxy-token-refresher.ts` — new module (+265 lines)

- Decodes `process.env.AI_PROXY_TOKEN` payload (no signature check — we don't have the secret; we just need `exp` to schedule).
- Schedules a refresh at `exp − 1h` (`REFRESH_MARGIN_MS`), floor 30s (`MIN_SCHEDULE_MS`), ceiling 6h (`MAX_SCHEDULE_MS`).
- Calls the new API endpoint with the existing `getInternalHeaders()` (SA token / runtime token).
- On success: `process.env.AI_PROXY_TOKEN = newToken`, reschedule.
- On failure: exponential backoff (5s, 15s, 60s, 5m, 15m, then 30m forever). Never gives up.
- `forceRefreshAiProxyToken(reason)` exposed for inline 401-self-heal hooks.
- `stopAiProxyTokenRefresher()` for graceful shutdown and tests.
- In-flight de-dup so concurrent triggers don't pile up.
- Timer `.unref()`'d so it doesn't block process exit.

### 3. `packages/agent-runtime/src/server.ts` — wire-in (+14 lines)

- One import.
- One call in `initializeEssentials()`, right after `ensureWorkspaceFiles()`, guarded by try/catch so a refresher startup error never breaks pod boot.

## Why this is the *root* fix, not a patch

| Property | This PR |
|---|---|
| Aligns credential lifecycle with consumer lifecycle | ✅ |
| Touches the JWT shape, signing secret, or verifier | ❌ (preserved) |
| Touches existing `process.env.AI_PROXY_TOKEN` readers (gateway, gateway-tools, composio, …) | ❌ (zero churn — they pick up the fresh value automatically) |
| Adds a new identity primitive | ❌ (reuses SA token / `RUNTIME_AUTH_SECRET`) |
| Provides a 401-self-heal hook | ✅ (`forceRefreshAiProxyToken`) |
| Unlocks restoring the original 24h TTL | ✅ (follow-up) |

## Failure-mode coverage

| Scenario | Behavior |
|---|---|
| Token already expired at boot (e.g. slow provisioning) | Refresh fires immediately, not on schedule. |
| Token within the 1h refresh margin at boot | Refresh fires immediately. |
| Healthy steady state | Rotate at `exp − 1h`. With 7d TTL → ~once every ~6d23h. |
| Network blip / API hiccup | Backoff (5s → 30m) until success; existing token stays in place. |
| API returns malformed body | Logged, scheduled retry. |
| `PROJECT_ID` not set (external mode, headless eval) | No-op, no spam. |
| Malformed JWT in env | Logged once, single-shot retry in 60s. |
| Pod restart | Fresh token from `createKnativeService` + refresher restarts. No desync possible. |
| 401 from AI proxy at request time (future hook) | Caller can `await forceRefreshAiProxyToken()` then retry the request. |

## Verification

- `tsc -p apps/api/tsconfig.json --noEmit` → 0 errors in `routes/internal.ts`.
- `tsc -p packages/agent-runtime/tsconfig.json --noEmit` → 0 errors in `ai-proxy-token-refresher.ts` and in the lines added to `server.ts`.
- All remaining `tsc` errors in the repo are pre-existing and unrelated (server.ts:4925, prisma type mismatch in server.ts:6663, voice/email rootDir, tunnel.ts, etc.).

### How to verify on staging once merged

1. Deploy to staging.
2. For any existing project pod (no redeploy needed for the *next* deploy onwards; existing pods need a revision bump to pick up the runtime change):
   - Tail pod logs and look for `[ai-proxy-token-refresher] next refresh in <N>s (reason: boot, failures: 0)` shortly after start.
   - At `exp − 1h` (typically ~6 days later), look for `[ai-proxy-token-refresher] rotated AI_PROXY_TOKEN (scheduled (post-success), exp=…)`.
3. API side: `[Internal] Refreshed AI_PROXY_TOKEN for <projectId> (exp=…)` should appear in API logs at the same time.
4. Counter-check: `"[AI Proxy Token] Token expired"` log lines from `ai-proxy-token.ts:202` should stop occurring for projects on the new revision.
5. Synthetic check: trigger an immediate refresh on a staging pod by `curl -X POST` to the new endpoint from inside the pod and confirm `process.env.AI_PROXY_TOKEN` updates (visible in the next outbound LLM call's `Authorization` header).

## Deliberately out of scope (tracked in #607 as follow-ups)

- **Drop `AI_PROXY_TOKEN` TTL back to 24h.** One-line change in `knative-project-manager.ts:1124` and `build-project-env.ts:88`. Kept at 7d here so a refresher bug doesn't immediately recreate the original outage — with 7d TTL, the refresher gets ~7 attempts before any token would actually expire. Land after observing the refresher healthy in staging for a rotation cycle.
- **Wire `forceRefreshAiProxyToken()` into AI proxy 401 handling** so a stale token also recovers within a single request, not just within a refresh cycle.
- **Surface inner LLM-call failures from `/agent/heartbeat/trigger` to the API circuit breaker** so silent failures of this shape become observable regardless of root cause.

## Branch / target

- Source: `fix/cloud-agent-idle-shutdown-after-7-days`
- Target: `main`
- Commit: `fix(cloud-agent): rotate AI_PROXY_TOKEN in-place to prevent 7-day silent failure`

## Files changed

```
 apps/api/src/routes/internal.ts                       |  81 +++++++++
 packages/agent-runtime/src/ai-proxy-token-refresher.ts| 265 ++++++++++++++++++++++++++++
 packages/agent-runtime/src/server.ts                  |  14 ++
 3 files changed, 360 insertions(+)
```
