### PR TITLE
fix(mobile): sync persisted LLM model preference to runtime on project open

### DIFF
--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -463,12 +463,34 @@ export default observer(function ProjectLayout() {
     () => hasAdvancedModelAccess ? DEFAULT_MODEL_PRO : DEFAULT_MODEL_FREE
   )
 
+  // Tracks whether we've already synced the persisted preference to the
+  // runtime for this (project, model). Without this sync, Capabilities shows
+  // the AsyncStorage-restored model while Overview shows whatever the agent
+  // booted with — because the bootstrap previously only updated React state.
+  const modelPrefSyncedRef = useRef<string | null>(null)
   useEffect(() => {
+    let cancelled = false
     loadModelPreference(projectId).then((stored) => {
-      if (stored) setSelectedModel(stored)
-      else if (hasAdvancedModelAccess) setSelectedModel(DEFAULT_MODEL_PRO)
+      if (cancelled) return
+      const next = stored ?? (hasAdvancedModelAccess ? DEFAULT_MODEL_PRO : DEFAULT_MODEL_FREE)
+      setSelectedModel(next)
+      if (!agentUrl) return
+      const syncKey = `${projectId}:${next}`
+      if (modelPrefSyncedRef.current === syncKey) return
+      modelPrefSyncedRef.current = syncKey
+      const entry = MODEL_CATALOG[next as keyof typeof MODEL_CATALOG]
+      if (!entry) return
+      agentFetch(`${agentUrl}/agent/config`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: { provider: entry.provider, name: entry.id } }),
+      }).catch((err) => {
+        console.error('[ProjectLayout] Failed to sync persisted model to runtime:', err)
+        modelPrefSyncedRef.current = null
+      })
     })
-  }, [hasAdvancedModelAccess, projectId])
+    return () => { cancelled = true }
+  }, [hasAdvancedModelAccess, projectId, agentUrl])
 
   const handleModelChange = useCallback(async (modelId: string) => {
     setSelectedModel(modelId)


### PR DESCRIPTION
Closes #609. Linked Jira: [SHOG-655](https://odin-ai.atlassian.net/browse/SHOG-655).

## TL;DR

One-file fix (`apps/mobile/app/(app)/projects/[id]/_layout.tsx`, `+25 / -3`) that makes the **Overview** panel and the **Capabilities** picker agree on which LLM the agent is using — and makes the agent actually run turns on that model.

## The bug

On cold start, the project layout restores the per-project model preference from `AsyncStorage` and calls `setSelectedModel(stored)`. That updates React state for the Capabilities picker only — it **never PATCHes the agent runtime**, so:

| Surface | Reads from | Value after cold start | Status |
|---|---|---|---|
| Capabilities picker | React state (restored from AsyncStorage) | `claude-opus-4-7` | ✅ user's choice |
| Overview `Model:` row | `GET /agent/status` → `this.config.model` | `claude-sonnet-4-6` | ❌ stale runtime default |
| Gateway per-turn model | `session.modelOverride \|\| this.config.model.name` (`packages/agent-runtime/src/gateway.ts:1464`) | `claude-sonnet-4-6` | ❌ **wrong model used** |

The runtime truth never matched the picker because the bootstrap forgot to write it through.

## The fix

Make the bootstrap also push the restored preference to `PATCH /agent/config` once per `(projectId, modelId)`. The existing PATCH handler in `packages/agent-runtime/src/server.ts` already deep-merges `model: { provider, name }` into `config.json` and calls `agentGateway.reloadConfig()`, so subsequent turns automatically pick up the new model and `/agent/status` returns the same value Capabilities shows.

### Diff

```diff
-  useEffect(() => {
-    loadModelPreference(projectId).then((stored) => {
-      if (stored) setSelectedModel(stored)
-      else if (hasAdvancedModelAccess) setSelectedModel(DEFAULT_MODEL_PRO)
-    })
-  }, [hasAdvancedModelAccess, projectId])
+  const modelPrefSyncedRef = useRef<string | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    loadModelPreference(projectId).then((stored) => {
+      if (cancelled) return
+      const next = stored ?? (hasAdvancedModelAccess ? DEFAULT_MODEL_PRO : DEFAULT_MODEL_FREE)
+      setSelectedModel(next)
+      if (!agentUrl) return
+      const syncKey = `${projectId}:${next}`
+      if (modelPrefSyncedRef.current === syncKey) return
+      modelPrefSyncedRef.current = syncKey
+      const entry = MODEL_CATALOG[next as keyof typeof MODEL_CATALOG]
+      if (!entry) return
+      agentFetch(`${agentUrl}/agent/config`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: { provider: entry.provider, name: entry.id } }),
+      }).catch((err) => {
+        console.error('[ProjectLayout] Failed to sync persisted model to runtime:', err)
+        modelPrefSyncedRef.current = null
+      })
+    })
+    return () => { cancelled = true }
+  }, [hasAdvancedModelAccess, projectId, agentUrl])
```

## Why this design (not the alternatives)

During discovery I considered three approaches and dropped two:

1. **Add a model picker to the Overview tab.** Rejected — duplicates the Capabilities picker UI and introduces drift risk. The user explicitly asked to avoid new UI: "if capabilities tab already have a model picker… that model name should only be there in agent status."
2. **Make Overview read from the same React state as Capabilities.** Rejected — Overview's `/agent/status` is the only reliable source of what the runtime is actually using. If we hide the truth and only mirror React state, the runtime drift bug stays invisible while the agent silently runs on the wrong model.
3. **Sync React → runtime on bootstrap (this PR).** Accepted — one source of truth (`config.json`), Capabilities and Overview both reflect it, and the gateway actually uses it for turns.

## Guards in the implementation

- **One-shot per `(projectId, modelId)`** via `useRef`, so a user's mid-session selection in Capabilities is never clobbered by a late bootstrap PATCH.
- **Cancellation flag** on the async chain to avoid `setState` after unmount during fast project switching.
- **Re-runs on `agentUrl` change** — the layout commonly mounts before the agent process is reachable, so we wait for the URL to materialize.
- **Failure path resets the ref** so the next dependency change retries; we don't strand the UI on a flaky PATCH.
- **Catalog lookup guard** (`if (!entry) return`) — if AsyncStorage has a model id that no longer exists in the catalog, we skip the PATCH instead of writing garbage to `config.json`.

## Runtime path verified

Traced end-to-end so the user-selected model actually drives the agent (not just the UI):

1. **Write:** `PATCH /agent/config` (`packages/agent-runtime/src/server.ts:830`) deep-merges `model`, writes `config.json`, calls `agentGateway.reloadConfig()`.
2. **Reload:** `gateway.reloadConfig()` re-reads `this.config` from disk.
3. **Read on next turn:** `gateway.ts:1464` resolves `modelAlias = session.modelOverride || this.config.model.name`.
4. **Read on Overview poll:** `GET /agent/status` (`server.ts:807`) returns `model: this.config.model` (after a `reloadConfig`).

Result: the dropdown value, `config.json`, `/agent/status`, and the actual per-turn model are all the same string.

## Verification

- ✅ `bunx tsc --noEmit -p apps/mobile/tsconfig.json` — zero new errors (pre-existing tsconfig migration warning unchanged).
- ✅ Manual: open a project where Capabilities shows `Opus 4.7`, force-quit, reopen → Overview now shows `claude-opus-4-7 (anthropic)`; next chat turn runs on Opus.
- ✅ Mid-session re-selection in Capabilities still PATCHes (existing path untouched).
- ✅ Returning to an already-synced project does not re-PATCH (ref short-circuits).

## Test plan for reviewer

1. On `main`: pick Opus in Capabilities, kill app, reopen → Overview shows Sonnet (confirms bug).
2. Check out this branch, repeat → Overview shows Opus.
3. Send a chat message → confirm via runtime logs / cost line that the turn used Opus, not Sonnet.
4. Switch to a different model in Capabilities mid-session → Overview updates within the next status poll.
5. Open a fresh project that has no AsyncStorage value → defaults apply correctly (`DEFAULT_MODEL_PRO` if paid, `DEFAULT_MODEL_FREE` otherwise) **and** are pushed to the runtime.

## Risk

- **Surface:** single file, 28 lines touched. No schema, no API contract change, no migration.
- **Worst case regression:** PATCH fails silently → behavior identical to today's bug (strictly non-regressing).
- **Blast radius beyond this PR:** none. The runtime PATCH handler was already public and used by the in-session picker; this PR just calls it at one more well-defined moment.

## Out of scope (intentional)

- Adding a model selector to the Overview tab — explicitly deferred per design discussion.
- Clearing stale per-session `/model` slash-command overrides (`session.modelOverride`) when the default changes — separate semantic change, will file separately if needed.
- Pricing / token-cost surfacing inside the picker — already covered by the StatusPanel daily-cost estimate.

## Checklist

- [x] Linked to GitHub issue (#609) and Jira (SHOG-655)
- [x] One-file change, minimal surface
- [x] Typecheck clean
- [x] Manual cold-start verification on at least one paid-plan account
- [x] No new UI; existing picker is the single source of truth
- [x] Failure path is non-regressing