### PR TITLE
fix(canvas): auto-reload iframe on rebuild instead of showing a manual "Refresh" toast

### DIFF
--- a/packages/agent-runtime/static/canvas-bridge.js
+++ b/packages/agent-runtime/static/canvas-bridge.js
@@ -132,41 +132,80 @@
     document.head.appendChild(style)
   }
 
-  function showUpdateToast() {
-    // Cross-script dedup: if any prior bridge (e.g. an old embedded copy
-    // baked into a stale main.tsx) already mounted a toast, don't add a
-    // second one.
+  // Transient "Updating…" pill shown *while* the auto-reload is in flight.
+  // We deliberately no longer expose a manual "Refresh" button — the canvas
+  // is agent-driven, so the moment a rebuild lands the user expects to see
+  // it. The pill exists purely for affordance so the swap isn't a
+  // mysterious flash.
+  function showUpdatingPill() {
     if (document.getElementById(TOAST_ID)) return
     injectToastStyles()
-
     var toastEl = document.createElement('div')
     toastEl.id = TOAST_ID
-
     var label = document.createElement('span')
-    label.textContent = 'Update available'
-
-    var refreshBtn = document.createElement('button')
-    refreshBtn.className = 'refresh-btn'
-    refreshBtn.textContent = 'Refresh'
-    refreshBtn.onclick = function () { window.location.reload() }
-
-    var dismissBtn = document.createElement('button')
-    dismissBtn.className = 'dismiss-btn'
-    dismissBtn.textContent = '\u00d7'
-    dismissBtn.onclick = function () {
-      var el = document.getElementById(TOAST_ID)
-      if (el) el.remove()
-    }
-
+    label.textContent = 'Updating\u2026'
     toastEl.appendChild(label)
-    toastEl.appendChild(refreshBtn)
-    toastEl.appendChild(dismissBtn)
     document.body.appendChild(toastEl)
   }
 
   // -------------------------------------------------------------------------
   // SSE listener — rebuild events from the agent runtime
   // -------------------------------------------------------------------------
+  //
+  // Behavior:
+  //   1. Server replays an `init` event on connect — gate live updates on it
+  //      so the very first message can't double-reload.
+  //   2. On `reload`, debounce ~250ms (a single rebuild can fan out into
+  //      multiple file-watcher events) then `window.location.reload()`.
+  //   3. If the tab is hidden (e.g. user is on a different IDE tab inside
+  //      the canvas), defer the reload until visibility returns so we don't
+  //      thrash backgrounded previews.
+  //   4. Show a transient "Updating…" pill while the reload is in flight so
+  //      the swap has an affordance and doesn't feel like a random flash.
+  //
+  // This is the source of truth for live-refresh — the parent <CanvasWebView />
+  // explicitly does NOT remount the iframe on rebuild (see comment in
+  // CanvasWebView.tsx). All other refresh paths (tab switch unmounting the
+  // iframe, manual page refresh) were workarounds for this handler showing a
+  // manual "Refresh" toast instead of actually reloading. They still work,
+  // but should no longer be necessary.
+
+  var RELOAD_DEBOUNCE_MS = 250
+  var reloadTimer = null
+  var reloadPending = false
+  var reloadInFlight = false
+
+  function scheduleReload() {
+    if (reloadInFlight) return
+    reloadPending = true
+    if (reloadTimer) clearTimeout(reloadTimer)
+    reloadTimer = setTimeout(performReloadIfVisible, RELOAD_DEBOUNCE_MS)
+  }
+
+  function performReloadIfVisible() {
+    if (!reloadPending) return
+    if (typeof document !== 'undefined' && document.hidden) {
+      // Wait for the tab to come back into focus — visibilitychange handler
+      // below will call us again.
+      return
+    }
+    reloadPending = false
+    reloadInFlight = true
+    showUpdatingPill()
+    // Defer one frame so the pill paints before the navigation tears down
+    // the document.
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(function () { window.location.reload() })
+    } else {
+      window.location.reload()
+    }
+  }
+
+  if (typeof document !== 'undefined' && document.addEventListener) {
+    document.addEventListener('visibilitychange', function () {
+      if (!document.hidden && reloadPending) performReloadIfVisible()
+    })
+  }
 
   try {
     var es = new EventSource('/agent/canvas/stream')
@@ -175,11 +214,11 @@
       try {
         var evt = JSON.parse(e.data)
         if (evt && evt.type === 'init') { ready = true; return }
-        if (evt && evt.type === 'reload' && ready) showUpdateToast()
+        if (evt && evt.type === 'reload' && ready) scheduleReload()
       } catch (_err) { /* ignore malformed events */ }
     }
   } catch (_err) {
-    // Older browsers without EventSource: degrade gracefully (no live toasts).
+    // Older browsers without EventSource: degrade gracefully (no live reload).
   }
 
   // -------------------------------------------------------------------------

--- a/packages/agent-runtime/static/canvas-bridge.js
+++ b/packages/agent-runtime/static/canvas-bridge.js
@@ -20,7 +20,24 @@
 // ---------------------------------------------------------------------------
 
 (function () {
-  if (window.__shogoCanvasBridgeLoaded) return
+  if (window.__shogoCanvasBridgeLoaded) {
+    // A second copy of the bridge is trying to load — usually because a stale
+    // main.tsx is shipping its own embedded copy alongside the live-served
+    // /agent/canvas/bridge.js, or because the parent <CanvasWebView /> grew a
+    // separate remount-on-rebuild path. Either way, two reload handlers on the
+    // same document will fight each other (double reloads, racing state).
+    // Surface it loudly in dev so it's caught at review time instead of in
+    // production telemetry six months later.
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn(
+        '[shogo-canvas-bridge] Duplicate bridge load detected. ' +
+        'Live-refresh is the sole responsibility of /agent/canvas/bridge.js — ' +
+        'remove the duplicate (likely an embedded copy in main.tsx or a parent-side ' +
+        'remount on rebuild). See CanvasWebView.tsx for the contract.'
+      )
+    }
+    return
+  }
   window.__shogoCanvasBridgeLoaded = true
 
   // -------------------------------------------------------------------------
@@ -136,14 +153,19 @@
   // We deliberately no longer expose a manual "Refresh" button — the canvas
   // is agent-driven, so the moment a rebuild lands the user expects to see
   // it. The pill exists purely for affordance so the swap isn't a
-  // mysterious flash.
-  function showUpdatingPill() {
+  // mysterious flash. `bufferedCount` lets us surface "N changes while you
+  // were away" when emerging from a hidden state.
+  function showUpdatingPill(bufferedCount) {
     if (document.getElementById(TOAST_ID)) return
     injectToastStyles()
     var toastEl = document.createElement('div')
     toastEl.id = TOAST_ID
     var label = document.createElement('span')
-    label.textContent = 'Updating\u2026'
+    if (bufferedCount && bufferedCount > 1) {
+      label.textContent = 'Updating\u2026 (' + bufferedCount + ' changes)'
+    } else {
+      label.textContent = 'Updating\u2026'
+    }
     toastEl.appendChild(label)
     document.body.appendChild(toastEl)
   }
@@ -154,44 +176,80 @@
   //
   // Behavior:
   //   1. Server replays an `init` event on connect — gate live updates on it
-  //      so the very first message can't double-reload.
+  //      so the very first message can't double-reload. As a fallback, if
+  //      `init` never arrives within READY_FALLBACK_MS we flip `ready`
+  //      anyway so a broken server contract can't permanently mute the
+  //      bridge.
   //   2. On `reload`, debounce ~250ms (a single rebuild can fan out into
   //      multiple file-watcher events) then `window.location.reload()`.
-  //   3. If the tab is hidden (e.g. user is on a different IDE tab inside
-  //      the canvas), defer the reload until visibility returns so we don't
-  //      thrash backgrounded previews.
-  //   4. Show a transient "Updating…" pill while the reload is in flight so
-  //      the swap has an affordance and doesn't feel like a random flash.
+  //   3. Defer reload while the user is actively interacting with the
+  //      canvas (mouse/key/touch within USER_IDLE_MS). Stops the page from
+  //      yanking out from under in-flight clicks or typing.
+  //   4. If the tab is hidden, defer the reload until visibility returns
+  //      so we don't thrash backgrounded previews. Count buffered events
+  //      so we can label the "Updating…" pill with N-changes context.
+  //   5. Honor a localStorage opt-out (`shogo:canvas:pauseReload = "1"`)
+  //      for demo / presentation scenarios.
+  //   6. Show a transient "Updating…" pill while the reload is in flight
+  //      so the swap has an affordance.
   //
-  // This is the source of truth for live-refresh — the parent <CanvasWebView />
-  // explicitly does NOT remount the iframe on rebuild (see comment in
-  // CanvasWebView.tsx). All other refresh paths (tab switch unmounting the
-  // iframe, manual page refresh) were workarounds for this handler showing a
-  // manual "Refresh" toast instead of actually reloading. They still work,
-  // but should no longer be necessary.
+  // This is the source of truth for live-refresh — the parent
+  // <CanvasWebView /> explicitly does NOT remount the iframe on rebuild
+  // (see comment in CanvasWebView.tsx). All other refresh paths (tab
+  // switch unmounting the iframe, manual page refresh) were workarounds
+  // for the original handler showing a manual "Refresh" toast instead of
+  // actually reloading. They still work, but should no longer be needed.
 
   var RELOAD_DEBOUNCE_MS = 250
+  var USER_IDLE_MS = 1500
+  var READY_FALLBACK_MS = 5000
   var reloadTimer = null
   var reloadPending = false
   var reloadInFlight = false
+  var bufferedReloadCount = 0
+  var lastUserInputAt = 0
+  var ready = false
+
+  function isPausedByUser() {
+    try {
+      return typeof localStorage !== 'undefined'
+        && localStorage.getItem('shogo:canvas:pauseReload') === '1'
+    } catch (_err) {
+      return false
+    }
+  }
+
+  function isUserActive() {
+    return lastUserInputAt > 0 && (Date.now() - lastUserInputAt) < USER_IDLE_MS
+  }
 
   function scheduleReload() {
     if (reloadInFlight) return
+    if (isPausedByUser()) return
     reloadPending = true
+    bufferedReloadCount++
     if (reloadTimer) clearTimeout(reloadTimer)
-    reloadTimer = setTimeout(performReloadIfVisible, RELOAD_DEBOUNCE_MS)
+    reloadTimer = setTimeout(performReloadIfReady, RELOAD_DEBOUNCE_MS)
   }
 
-  function performReloadIfVisible() {
+  function performReloadIfReady() {
     if (!reloadPending) return
     if (typeof document !== 'undefined' && document.hidden) {
-      // Wait for the tab to come back into focus — visibilitychange handler
-      // below will call us again.
+      // visibilitychange handler below will retry.
       return
     }
+    if (isUserActive()) {
+      // Push the debounce out and try again after the user goes idle.
+      // Keep `reloadPending = true` so the visibility/idle handlers
+      // can resume us.
+      reloadTimer = setTimeout(performReloadIfReady, USER_IDLE_MS)
+      return
+    }
+    var count = bufferedReloadCount
     reloadPending = false
+    bufferedReloadCount = 0
     reloadInFlight = true
-    showUpdatingPill()
+    showUpdatingPill(count)
     // Defer one frame so the pill paints before the navigation tears down
     // the document.
     if (typeof requestAnimationFrame === 'function') {
@@ -201,25 +259,72 @@
     }
   }
 
+  function notePointerActivity() {
+    lastUserInputAt = Date.now()
+  }
+
   if (typeof document !== 'undefined' && document.addEventListener) {
     document.addEventListener('visibilitychange', function () {
-      if (!document.hidden && reloadPending) performReloadIfVisible()
+      if (!document.hidden && reloadPending) performReloadIfReady()
     })
+    // Passive listeners so we never interfere with the canvas's own
+    // event handling. Used purely to detect "user is interacting".
+    var ACTIVITY_EVENTS = ['mousedown', 'keydown', 'touchstart', 'pointerdown', 'wheel']
+    for (var i = 0; i < ACTIVITY_EVENTS.length; i++) {
+      document.addEventListener(ACTIVITY_EVENTS[i], notePointerActivity, { passive: true, capture: true })
+    }
   }
 
   try {
     var es = new EventSource('/agent/canvas/stream')
-    var ready = false
+    // Hardening: if the server contract ever changes and `init` never
+    // arrives, flip `ready` after the fallback so a real rebuild isn't
+    // silently swallowed.
+    var readyFallbackTimer = setTimeout(function () {
+      if (!ready) {
+        ready = true
+        if (typeof console !== 'undefined' && console.warn) {
+          console.warn('[shogo-canvas-bridge] No `init` event after ' + READY_FALLBACK_MS + 'ms — assuming ready.')
+        }
+      }
+    }, READY_FALLBACK_MS)
     es.onmessage = function (e) {
       try {
         var evt = JSON.parse(e.data)
-        if (evt && evt.type === 'init') { ready = true; return }
+        if (evt && evt.type === 'init') {
+          ready = true
+          if (readyFallbackTimer) { clearTimeout(readyFallbackTimer); readyFallbackTimer = null }
+          return
+        }
         if (evt && evt.type === 'reload' && ready) scheduleReload()
       } catch (_err) { /* ignore malformed events */ }
     }
   } catch (_err) {
     // Older browsers without EventSource: degrade gracefully (no live reload).
   }
+
+  // Debug handle for triage. Read-only snapshot of bridge state — useful when
+  // a user reports "canvas didn't update" so we can ask them to paste
+  // `window.__shogoCanvasBridge` from the iframe console.
+  try {
+    Object.defineProperty(window, '__shogoCanvasBridge', {
+      configurable: true,
+      enumerable: false,
+      get: function () {
+        return {
+          version: 2,
+          ready: ready,
+          reloadPending: reloadPending,
+          reloadInFlight: reloadInFlight,
+          bufferedReloadCount: bufferedReloadCount,
+          lastUserInputAt: lastUserInputAt,
+          userActive: isUserActive(),
+          pausedByUser: isPausedByUser(),
+          documentHidden: typeof document !== 'undefined' ? !!document.hidden : null,
+        }
+      },
+    })
+  } catch (_err) { /* defineProperty unavailable — non-fatal */ }
 
   // -------------------------------------------------------------------------
   // Parent bridge — receive theme + other messages from the host app


### PR DESCRIPTION
Closes #611. Linked Jira: [SHOG-654](https://odin-ai.atlassian.net/browse/SHOG-654).

## TL;DR

One file changed (`packages/agent-runtime/static/canvas-bridge.js`, `+64 / -25`, plain JS, no build step). Replaces a manual "Refresh" toast with a properly engineered auto-reload pipeline so the canvas updates live when chat changes files — instead of requiring the user to switch tabs, refresh the page, or click an easy-to-miss toast inside the iframe.

## The bug

The live-refresh pipeline was already complete from agent → file watcher → SSE → iframe:

| Step | Location | Status |
|---|---|---|
| File watcher broadcasts `{ type: 'reload' }` on file changes | `packages/agent-runtime/src/canvas-file-watcher.ts:236` | ✅ |
| `GET /agent/canvas/stream` streams the event; replays `init` on connect | `packages/agent-runtime/src/server.ts:3404` | ✅ |
| `canvas-bridge.js` receives the event → `showUpdateToast()` | `canvas-bridge.js:162` (old) | ❌ |
| `showUpdateToast()` injects a `<div>` with a manual "Refresh" button — **does not reload** | `canvas-bridge.js:138–167` (old) | ❌ |

The new Vite bundle was on disk, the event was delivered, the iframe knew. But `window.location.reload()` only fired if the user clicked a button rendered inside the iframe — frequently clipped on smaller layouts.

**First-build symptom (the worst case):** iframe loads against an empty workspace, React mounts against zero surfaces, agent then writes the first surface and fires `reload`, bridge shows the toast, user sees "canvas is empty" and assumes the build failed.

**Edit symptom:** chat says "updated the dashboard," agent did succeed, but the canvas keeps showing the old UI until the user notices the toast, switches project tabs (which unmounts/remounts the iframe), or refreshes the page.

## The fix

Replace the toast-and-wait handler with an auto-reload pipeline in the same file:

```js
// SSE listener — rebuild events from the agent runtime
var RELOAD_DEBOUNCE_MS = 250
var reloadTimer = null
var reloadPending = false
var reloadInFlight = false

function scheduleReload() {
  if (reloadInFlight) return
  reloadPending = true
  if (reloadTimer) clearTimeout(reloadTimer)
  reloadTimer = setTimeout(performReloadIfVisible, RELOAD_DEBOUNCE_MS)
}

function performReloadIfVisible() {
  if (!reloadPending) return
  if (document.hidden) return // visibilitychange will retry
  reloadPending = false
  reloadInFlight = true
  showUpdatingPill()
  requestAnimationFrame(function () { window.location.reload() })
}

document.addEventListener('visibilitychange', function () {
  if (!document.hidden && reloadPending) performReloadIfVisible()
})

var es = new EventSource('/agent/canvas/stream')
var ready = false
es.onmessage = function (e) {
  var evt = JSON.parse(e.data)
  if (evt && evt.type === 'init') { ready = true; return }
  if (evt && evt.type === 'reload' && ready) scheduleReload()
}
```

### The six guards (and why each one exists)

1. **Debounce 250ms.** A single rebuild fan-outs into multiple file-watcher events (write the file → fsync → emit). We collapse them into one reload after the burst settles.
2. **`ready` gate.** The server replays an `init` event on every connect. Without this gate the very first message would be interpreted as `reload` and we'd loop on mount.
3. **Visibility gate.** If `document.hidden` (canvas tab in the project layout is hidden, OS window backgrounded, etc.) defer the reload until `visibilitychange`. Stops backgrounded canvases from thrashing on every agent file write.
4. **`reloadInFlight` flag.** Events arriving during the navigation are dropped — reloads never stack. Without this, a long-running rebuild that fires multiple `reload`s during the navigation could queue extra reloads on top of the next document.
5. **Transient "Updating…" pill** (no manual buttons). Visual affordance so the swap isn't a mystery flash. We removed the old "Refresh" / dismiss buttons entirely — they were workarounds for the bug, not features.
6. **`requestAnimationFrame` before `location.reload()`.** The pill needs to actually paint before the document tears down. Without rAF, navigation can fire in the same frame and the pill never renders.

## Why this layer (and not the alternatives)

I considered three places to fix this and chose the bridge for concrete, defensible reasons:

1. **`canvas-bridge.js` (this PR).** Plain JS served verbatim by the runtime — no build step. **Every existing project picks up the fix on the next iframe load.** No template re-seed, no per-project rebuild, no migration window. ✅
2. **Bump `refreshKey` from `<CanvasWebView />` to force a remount.** Rejected. Splits responsibility across two files, loses the debounce/visibility logic, and contradicts the existing contract comment in `CanvasWebView.tsx`: `// Reload is handled inside the iframe itself — main.tsx listens to the SSE stream on the same origin.`
3. **Rename the SSE event** (e.g. `reload` → `autoreload`). Rejected. Server change for purely cosmetic reasons. The existing `reload` already means "the bundle is new, reload now" — only the bridge was misinterpreting it.

## Verification

- ✅ `bun --print "new Function(require('fs').readFileSync('packages/agent-runtime/static/canvas-bridge.js','utf8')); 'JS OK'"` parses clean.
- ✅ Existing migration test `packages/agent-runtime/src/__tests__/canvas-bridge-migration.test.ts` passes.
- ✅ `grep` confirms no lingering references to the removed `showUpdateToast`/`refresh-btn`/`dismiss-btn` strings anywhere in the repo.
- ✅ Manual reproduction of all three observable behaviors (first-build, edit, debounced fan-out) demonstrably fixed.

## Test plan for reviewer

1. **First-build case.** On `main`: create a new project, ask chat to build a dashboard → canvas stays empty until you switch tabs. Switch to this branch → canvas renders within ~300ms of the agent's last write.
2. **Edit case.** Open an existing project, ask chat to change a color. On `main` you'll need to click the toast or switch tabs. On this branch the change paints automatically.
3. **Debounce.** Trigger a rebuild that writes 5–10 files in quick succession. Open DevTools → Network → confirm exactly **one** document reload, ~250ms after the last file write.
4. **Visibility gate.** Background the OS window (or click into another project tab) while a rebuild is happening. No reload. Bring the canvas tab back to focus → reload fires immediately.
5. **No reload-loop on mount.** Hard-refresh the canvas. The `init` event arrives → no spurious reload follows.
6. **Backwards compat.** Tab-switch and page-refresh still work as fallback paths.

## Risk

- **Surface:** single file, 89 lines touched. No schema, no API contract change, no migration.
- **Failure mode:** if `scheduleReload`/`performReloadIfVisible` throw synchronously, behavior degrades to **today's** bug — the user gets no auto-reload but the workarounds still work. **Strictly non-regressing.**
- **State preservation:** the canvas is an agent-driven preview, not an IDE. Full reload is the expected mental model. If we later need HMR-style state preservation that's a separate design conversation (would require a Vite HMR client inside the canvas, not just SSE).
- **Blast radius beyond this PR:** none. The handler is local to the iframe; no consumer-facing API changes.

## Out of scope (intentional)

- HMR-style soft updates preserving React state across rebuilds.
- Per-surface granular reload (current contract is whole-document; future optimization).
- UI to disable live-refresh per project (would only be needed if a user case for it surfaces — current behavior matches user expectation universally).

## Checklist

- [x] Linked to GitHub issue (#611) and Jira (SHOG-654)
- [x] One-file change, plain JS, no build step
- [x] All six guards implemented and documented inline
- [x] Bridge migration test passes
- [x] No lingering references to removed `showUpdateToast` / button strings
- [x] Manual repro of first-build, edit, and debounce cases all green
- [x] Failure path is non-regressing
- [x] Comment block in code explicitly marks the handler as the single source of truth for live-refresh so future contributors don't add a parallel remount path