### PR TITLE
fix(agent-runtime): touch runtime on AI-proxy auth (defence-in-depth keepalive)

### DIFF
--- a/apps/api/src/routes/ai-proxy.ts
+++ b/apps/api/src/routes/ai-proxy.ts
@@ -38,6 +38,7 @@ import { verifyRuntimeToken } from '../lib/runtime-token'
 import { resolveApiKey } from './api-keys'
 import { wipeCloudKey } from '../lib/cloud-key-wipe'
 import { getShogoCloudUrl } from '../lib/cloud-urls'
+import { getRuntimeManager } from '../lib/runtime'
 import {
   MODEL_CATALOG,
   MODEL_ALIASES,
@@ -1775,13 +1776,56 @@ export function aiProxyRoutes() {
   }
 
   /**
+   * Reset the locally-managed agent runtime's idle-eviction timer for the
+   * project that owns this proxy payload.
+   *
+   * The `WorkerRuntimeManager` evicts a project's runtime after
+   * `RUNTIME_IDLE_MS` (default 15min) of "no fresh proxy resolution".
+   * The agent-proxy streaming path already touches on each chunk
+   * (PR #591), but a long agent turn whose only outbound traffic is one
+   * big model call goes silent on `/agent/*` for the duration of that
+   * call — and would otherwise tip into eviction mid-completion.
+   *
+   * Every successful `/ai/v1/*` or `/ai/anthropic/v1/*` request is the
+   * agent inside that project actively making a model call (tool use,
+   * streaming completion, embeddings) — which is the strongest possible
+   * signal that the runtime is alive and busy. Touching here means
+   * a long Opus turn whose only outbound traffic is one big model call
+   * still resets the 15-min reaper, even though the user's agent-proxy
+   * connection is silent during that span.
+   *
+   * `'api-key'` payloads come from workspace-scoped Shogo API keys
+   * (no project context) and have no local runtime to touch — skip.
+   */
+  function touchRuntimeFor(payload: ProxyTokenPayload | null): void {
+    if (!payload || !payload.projectId || payload.projectId === 'api-key') return
+    try {
+      getRuntimeManager().touch(payload.projectId)
+    } catch {
+      // RuntimeManager isn't local, isn't constructed yet, or threw —
+      // never block an auth on the touch hook. RuntimeManager.touch
+      // already swallows downstream errors; this is a final guard.
+    }
+  }
+
+  /**
    * Middleware: Validate proxy token on all /ai/v1/* routes.
    * Accepts:
    *   - Shogo API keys (`shogo_sk_*`, workspace-scoped),
    *   - per-project runtime tokens (`rt_v1_*`, pod-native), and
    *   - signed project-scoped proxy JWTs (legacy / browser previews).
+   *
+   * On a successful resolution, touches the project's local agent
+   * runtime so that long model calls don't silently age past the
+   * idle-eviction window. See `touchRuntimeFor` above.
    */
   async function validateProxyAuth(c: any): Promise<ProxyTokenPayload | null> {
+    const payload = await validateProxyAuthImpl(c)
+    touchRuntimeFor(payload)
+    return payload
+  }
+
+  async function validateProxyAuthImpl(c: any): Promise<ProxyTokenPayload | null> {
     const authHeader = c.req.header('Authorization')
     if (!authHeader?.startsWith('Bearer ')) {
       return null
@@ -2330,8 +2374,18 @@ export function aiProxyRoutes() {
    *   - Shogo API keys (`shogo_sk_*`),
    *   - per-project runtime tokens (`rt_v1_*`), and
    *   - signed project-scoped proxy JWTs.
+   *
+   * On a successful resolution, touches the project's local agent
+   * runtime so that long Anthropic-native streams keep the runtime
+   * alive past the idle-eviction window. See `touchRuntimeFor` above.
    */
   async function validateAnthropicAuth(c: any): Promise<ProxyTokenPayload | null> {
+    const payload = await validateAnthropicAuthImpl(c)
+    touchRuntimeFor(payload)
+    return payload
+  }
+
+  async function validateAnthropicAuthImpl(c: any): Promise<ProxyTokenPayload | null> {
     const apiKey = c.req.header('x-api-key')
     if (!apiKey) {
       return null


### PR DESCRIPTION
## Why

PR #591 keeps the local agent runtime warm while bytes are flowing on `/agent/*` proxied streams. That covers the common SSE-chatty case but misses one corner: a long Opus / GPT-4o agent turn whose only outbound traffic for several minutes is one large model call goes silent on `/agent/*` for the duration of that call — and on a single-user dev machine, silent for >15min trips `RUNTIME_IDLE_MS` and SIGTERMs the runtime mid-completion.

That's the failure mode that surfaces in the console as:

```
[api] [AgentProxy] GET /agent/canvas/stream failed after 24 attempts: Unable to connect.
```

right after a `[WorkerRuntimeManager] idle-evicting … after 900s` line.

## What

Touch the locally-managed runtime on every successful AI-proxy auth.

The strongest possible signal that an agent runtime is alive and busy is that the agent inside it just successfully authenticated an `/ai/v1/*` or `/ai/anthropic/v1/*` request — i.e. it is actively making a model call right now. Touching there closes the gap left by #591 without any per-chunk overhead on the model-proxy hot path.

Implementation:

- New `touchRuntimeFor(payload)` helper inside `aiProxyRoutes()`:
  - No-op for `payload === null` (auth failed).
  - No-op for workspace-scoped Shogo API keys (`payload.projectId === 'api-key'`) — there's no local runtime to touch.
  - `try`/`catch` around `getRuntimeManager().touch(...)` so a missing/mid-construction `RuntimeManager` (cloud pod / k8s mode) never fails an auth.
- `validateProxyAuth` and `validateAnthropicAuth` are split into thin wrappers around `*Impl` bodies. The wrappers call `touchRuntimeFor(payload)` after a successful resolve. Auth semantics are unchanged — a `null` payload still maps to `null` and the route returns 401.

## Stacking

This depends on `RuntimeManager.touch()` / `IRuntimeManager.touch()` from #591. Base branch is set to `fix/agent-runtime-keepalive-while-streaming`; once #591 lands, GitHub will retarget this to `main`.

## Test plan

- [ ] Existing `runtime-manager-touch.test.ts` still passes.
- [ ] `bun test apps/api/src/__tests__/` clean.
- [ ] Local repro: start a long Anthropic / OpenAI completion (>5 min, e.g. via `/ai/v1/chat/completions` with `stream: true`) and confirm `[WorkerRuntimeManager] idle-evicting …` no longer fires during the call. The stream completes without the AgentProxy reconnect storm.
- [ ] Cloud-pod mode (no local runtime): the `try`/`catch` around `getRuntimeManager().touch()` swallows; auth still works.
- [ ] Workspace API key path (`shogo_sk_*`): `touchRuntimeFor` short-circuits on `'api-key'`; no surprise `touch` calls.
