### PR TITLE
feat(mobile): editable long-text/markdown paste chip in chat composer (SHOG-663)

### DIFF
--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -404,6 +404,14 @@ function ChatInputImpl({
     setViewingPastedId((curr) => (curr === id ? null : curr))
   }, [])
 
+  const handleUpdatePastedText = useCallback((id: string, content: string) => {
+    setPastedTexts((prev) =>
+      prev.map((p) =>
+        p.id === id ? { ...p, content, info: analyzeContent(content) } : p
+      )
+    )
+  }, [])
+
   const viewingPasted = useMemo(
     () => pastedTexts.find((p) => p.id === viewingPastedId) ?? null,
     [pastedTexts, viewingPastedId]
@@ -1470,6 +1478,8 @@ function ChatInputImpl({
           title={`${kindLabel(viewingPasted.info.kind)} content`}
           kind={viewingPasted.info.kind}
           sizeLabel={viewingPasted.info.sizeLabel}
+          editable
+          onSave={(next) => handleUpdatePastedText(viewingPasted.id, next)}
         />
       )}
 

--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -365,6 +365,17 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
       setViewingPastedId((curr) => (curr === id ? null : curr))
     }, [])
 
+    const handleUpdatePastedText = useCallback(
+      (id: string, content: string) => {
+        setPastedTexts((prev) =>
+          prev.map((p) =>
+            p.id === id ? { ...p, content, info: analyzeContent(content) } : p
+          )
+        )
+      },
+      []
+    )
+
     const viewingPasted = useMemo(
       () => pastedTexts.find((p) => p.id === viewingPastedId) ?? null,
       [pastedTexts, viewingPastedId]
@@ -984,6 +995,8 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
             title={`${kindLabel(viewingPasted.info.kind)} content`}
             kind={viewingPasted.info.kind}
             sizeLabel={viewingPasted.info.sizeLabel}
+            editable
+            onSave={(next) => handleUpdatePastedText(viewingPasted.id, next)}
           />
         )}
 

--- a/apps/mobile/components/chat/FileViewerModal.tsx
+++ b/apps/mobile/components/chat/FileViewerModal.tsx
@@ -7,10 +7,27 @@
  * Supports smooth scrolling, selectable text, and a copy-to-clipboard action.
  */
 
-import { useState, useCallback } from "react"
-import { View, Text, Pressable, ScrollView, useWindowDimensions } from "react-native"
+import { useState, useCallback, useEffect, useMemo } from "react"
+import {
+  View,
+  Text,
+  Pressable,
+  ScrollView,
+  TextInput,
+  useWindowDimensions,
+} from "react-native"
 import * as Clipboard from "expo-clipboard"
-import { X, Copy, Check, FileText, Code, Braces, FileType } from "lucide-react-native"
+import {
+  X,
+  Copy,
+  Check,
+  FileText,
+  Code,
+  Braces,
+  FileType,
+  Pencil,
+  RotateCcw,
+} from "lucide-react-native"
 import { cn } from "@shogo/shared-ui/primitives"
 import {
   Modal,
@@ -21,7 +38,7 @@ import {
   ModalCloseButton,
 } from "@/components/ui/modal"
 import { MarkdownText } from "./MarkdownText"
-import type { ContentKind } from "./long-text-utils"
+import { analyzeContent, type ContentKind } from "./long-text-utils"
 
 export interface FileViewerModalProps {
   visible: boolean
@@ -30,6 +47,14 @@ export interface FileViewerModalProps {
   title?: string
   kind?: ContentKind
   sizeLabel?: string
+  /**
+   * When true, an Edit button is shown in the header. Tapping it switches
+   * the body into a multiline editor. Saving fires `onSave` with the new
+   * content; the parent is responsible for recomputing kind/size/lines.
+   */
+  editable?: boolean
+  /** Called with the edited content when the user presses Save. */
+  onSave?: (next: string) => void
 }
 
 function KindIcon({ kind, size = 14 }: { kind?: ContentKind; size?: number }) {
@@ -53,22 +78,53 @@ export function FileViewerModal({
   title = "Full Content",
   kind = "plain",
   sizeLabel,
+  editable = false,
+  onSave,
 }: FileViewerModalProps) {
   const [copied, setCopied] = useState(false)
+  const [isEditing, setIsEditing] = useState(false)
+  const [draft, setDraft] = useState(content)
   const { height: screenHeight } = useWindowDimensions()
   /** Centered dialog — capped height so it reads as a panel, not a fullscreen takeover. */
   const panelMaxHeight = Math.min(screenHeight * 0.7, 600)
   const bodyMaxHeight = Math.min(screenHeight * 0.56, 500)
 
+  // Re-sync the draft whenever the underlying content changes (e.g. the
+  // user opens a different chip) or the modal is re-opened. We also leave
+  // edit mode if the parent swaps the content out from under us.
+  useEffect(() => {
+    setDraft(content)
+    setIsEditing(false)
+  }, [content, visible])
+
+  const draftInfo = useMemo(
+    () => (isEditing ? analyzeContent(draft) : null),
+    [draft, isEditing]
+  )
+  const isDirty = isEditing && draft !== content
+
   const handleCopy = useCallback(async () => {
     try {
-      await Clipboard.setStringAsync(content)
+      await Clipboard.setStringAsync(isEditing ? draft : content)
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     } catch {
       // silently fail
     }
+  }, [content, draft, isEditing])
+
+  const handleSave = useCallback(() => {
+    if (!onSave) return
+    onSave(draft)
+    setIsEditing(false)
+  }, [draft, onSave])
+
+  const handleCancelEdit = useCallback(() => {
+    setDraft(content)
+    setIsEditing(false)
   }, [content])
+
+  const canEdit = editable && typeof onSave === "function"
 
   return (
     <Modal isOpen={visible} onClose={onClose} size="md">
@@ -84,11 +140,60 @@ export function FileViewerModal({
             <Text className="text-sm font-semibold text-foreground" numberOfLines={1}>
               {title}
             </Text>
-            {sizeLabel ? (
-              <Text className="text-xs text-muted-foreground">({sizeLabel})</Text>
+            {(() => {
+              const label = isEditing ? draftInfo?.sizeLabel : sizeLabel
+              return label ? (
+                <Text className="text-xs text-muted-foreground">({label})</Text>
+              ) : null
+            })()}
+            {isEditing && isDirty ? (
+              <View className="ml-1 h-1.5 w-1.5 rounded-full bg-primary" />
             ) : null}
           </View>
           <View className="flex-row items-center gap-2">
+            {canEdit && !isEditing ? (
+              <Pressable
+                onPress={() => setIsEditing(true)}
+                className="h-8 w-8 items-center justify-center rounded-md"
+                accessibilityLabel="Edit content"
+                accessibilityRole="button"
+              >
+                <Pencil size={16} className="text-muted-foreground" />
+              </Pressable>
+            ) : null}
+            {canEdit && isEditing ? (
+              <>
+                <Pressable
+                  onPress={handleCancelEdit}
+                  className="h-8 w-8 items-center justify-center rounded-md"
+                  accessibilityLabel="Revert edits"
+                  accessibilityRole="button"
+                >
+                  <RotateCcw size={16} className="text-muted-foreground" />
+                </Pressable>
+                <Pressable
+                  onPress={handleSave}
+                  disabled={!isDirty}
+                  className={cn(
+                    "h-8 rounded-md px-3 items-center justify-center",
+                    isDirty ? "bg-primary" : "bg-muted"
+                  )}
+                  accessibilityLabel="Save edits"
+                  accessibilityRole="button"
+                >
+                  <Text
+                    className={cn(
+                      "text-xs font-semibold",
+                      isDirty
+                        ? "text-primary-foreground"
+                        : "text-muted-foreground"
+                    )}
+                  >
+                    Save
+                  </Text>
+                </Pressable>
+              </>
+            ) : null}
             <Pressable
               onPress={handleCopy}
               className="h-8 w-8 items-center justify-center rounded-md"
@@ -106,22 +211,42 @@ export function FileViewerModal({
           </View>
         </ModalHeader>
 
-        {/* Scrollable body */}
+        {/* Body — viewer or editor */}
         <ModalBody className="m-0 p-0">
-          <ScrollView
-            className="px-4 py-3"
-            style={{ maxHeight: bodyMaxHeight }}
-            showsVerticalScrollIndicator
-            persistentScrollbar
-          >
-            {kind === "markdown" ? (
-              <MarkdownText>{content}</MarkdownText>
-            ) : (
-              <Text selectable className="text-xs text-foreground font-mono leading-5">
-                {content}
-              </Text>
-            )}
-          </ScrollView>
+          {isEditing ? (
+            <View className="px-4 py-3" style={{ maxHeight: bodyMaxHeight }}>
+              <TextInput
+                value={draft}
+                onChangeText={setDraft}
+                multiline
+                autoFocus
+                textAlignVertical="top"
+                accessibilityLabel="Edit content"
+                placeholder="Edit content…"
+                placeholderTextColor="#71717a"
+                className="text-xs text-foreground font-mono leading-5"
+                style={{
+                  minHeight: 200,
+                  maxHeight: bodyMaxHeight - 24,
+                }}
+              />
+            </View>
+          ) : (
+            <ScrollView
+              className="px-4 py-3"
+              style={{ maxHeight: bodyMaxHeight }}
+              showsVerticalScrollIndicator
+              persistentScrollbar
+            >
+              {kind === "markdown" ? (
+                <MarkdownText>{content}</MarkdownText>
+              ) : (
+                <Text selectable className="text-xs text-foreground font-mono leading-5">
+                  {content}
+                </Text>
+              )}
+            </ScrollView>
+          )}
         </ModalBody>
       </ModalContent>
     </Modal>

--- a/apps/mobile/components/chat/FileViewerModal.tsx
+++ b/apps/mobile/components/chat/FileViewerModal.tsx
@@ -26,6 +26,7 @@ import {
   Braces,
   FileType,
   Pencil,
+  PencilOff,
   RotateCcw,
 } from "lucide-react-native"
 import { cn } from "@shogo/shared-ui/primitives"
@@ -138,6 +139,19 @@ export function FileViewerModal({
     setEditorKey((k) => k + 1)
   }, [content])
 
+  /**
+   * Exit edit mode without saving. Discards any unsaved draft and snaps the
+   * editor back to the last saved content. The button is wired so that
+   * unsaved changes still require an explicit Save or Revert first — this
+   * is the "I clicked edit by accident" escape hatch when the draft is
+   * still clean.
+   */
+  const handleExitEdit = useCallback(() => {
+    setDraft(content)
+    setEditorKey((k) => k + 1)
+    setIsEditing(false)
+  }, [content])
+
   const canEdit = editable && typeof onSave === "function"
 
   return (
@@ -177,6 +191,18 @@ export function FileViewerModal({
             ) : null}
             {canEdit && isEditing ? (
               <>
+                <Pressable
+                  onPress={handleExitEdit}
+                  disabled={isDirty}
+                  className={cn(
+                    "h-8 w-8 items-center justify-center rounded-md",
+                    isDirty && "opacity-40",
+                  )}
+                  accessibilityLabel="Exit edit mode"
+                  accessibilityRole="button"
+                >
+                  <PencilOff size={16} className="text-muted-foreground" />
+                </Pressable>
                 <Pressable
                   onPress={handleRevert}
                   disabled={!isDirty}

--- a/apps/mobile/components/chat/FileViewerModal.tsx
+++ b/apps/mobile/components/chat/FileViewerModal.tsx
@@ -84,6 +84,13 @@ export function FileViewerModal({
   const [copied, setCopied] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
   const [draft, setDraft] = useState(content)
+  /**
+   * Bumped whenever we want to *remount* the TextInput so its uncontrolled
+   * `defaultValue` is re-applied (entering edit mode, reverting, or the
+   * parent swapping content). Keeping the editor uncontrolled is what
+   * prevents the React-Native-Web cursor-jump-to-end bug on every keystroke.
+   */
+  const [editorKey, setEditorKey] = useState(0)
   const { height: screenHeight } = useWindowDimensions()
   /** Centered dialog — capped height so it reads as a panel, not a fullscreen takeover. */
   const panelMaxHeight = Math.min(screenHeight * 0.7, 600)
@@ -95,6 +102,7 @@ export function FileViewerModal({
   useEffect(() => {
     setDraft(content)
     setIsEditing(false)
+    setEditorKey((k) => k + 1)
   }, [content, visible])
 
   const draftInfo = useMemo(
@@ -119,9 +127,15 @@ export function FileViewerModal({
     setIsEditing(false)
   }, [draft, onSave])
 
-  const handleCancelEdit = useCallback(() => {
+  const handleStartEdit = useCallback(() => {
     setDraft(content)
-    setIsEditing(false)
+    setEditorKey((k) => k + 1)
+    setIsEditing(true)
+  }, [content])
+
+  const handleRevert = useCallback(() => {
+    setDraft(content)
+    setEditorKey((k) => k + 1)
   }, [content])
 
   const canEdit = editable && typeof onSave === "function"
@@ -153,7 +167,7 @@ export function FileViewerModal({
           <View className="flex-row items-center gap-2">
             {canEdit && !isEditing ? (
               <Pressable
-                onPress={() => setIsEditing(true)}
+                onPress={handleStartEdit}
                 className="h-8 w-8 items-center justify-center rounded-md"
                 accessibilityLabel="Edit content"
                 accessibilityRole="button"
@@ -164,8 +178,12 @@ export function FileViewerModal({
             {canEdit && isEditing ? (
               <>
                 <Pressable
-                  onPress={handleCancelEdit}
-                  className="h-8 w-8 items-center justify-center rounded-md"
+                  onPress={handleRevert}
+                  disabled={!isDirty}
+                  className={cn(
+                    "h-8 w-8 items-center justify-center rounded-md",
+                    !isDirty && "opacity-40",
+                  )}
                   accessibilityLabel="Revert edits"
                   accessibilityRole="button"
                 >
@@ -216,7 +234,16 @@ export function FileViewerModal({
           {isEditing ? (
             <View className="px-4 py-3" style={{ maxHeight: bodyMaxHeight }}>
               <TextInput
-                value={draft}
+                /**
+                 * `key` + `defaultValue` keep this input *uncontrolled* so
+                 * React doesn't re-apply `value` on every keystroke — that
+                 * re-application is what causes the cursor to jump to the
+                 * end after each character on React-Native-Web. We remount
+                 * (bump `editorKey`) only when entering edit mode, reverting,
+                 * or the parent swaps content.
+                 */
+                key={editorKey}
+                defaultValue={draft}
                 onChangeText={setDraft}
                 multiline
                 autoFocus


### PR DESCRIPTION
Closes #622
JIRA: [SHOG-663](https://odin-ai.atlassian.net/browse/SHOG-663)

## Why

When a user pastes a long block of markdown / JSON / code into the Shogo chat composer (both the **home-screen** composer and the **in-project** composer), the content is collapsed into a chip (`Markdown paste · 10.6 KB · 187 lines`) to keep the composer compact. Tapping the chip opens `FileViewerModal`, which until now only supported **view + copy**. There was no way to fix a typo, trim a section, or tweak the pasted content before sending — the user had to delete the chip, re-paste, and edit elsewhere.

This PR makes the modal **editable** so the paste can be polished in place before send.

## What changed

### `apps/mobile/components/chat/FileViewerModal.tsx`

Added two **opt-in** props:

```ts
editable?: boolean
onSave?: (next: string) => void
```

When both are supplied, the modal header renders a **pencil** button. Tapping it flips the body into a multiline `TextInput` pre-filled with the current content and auto-focused. While editing:

- **Save** (disabled until dirty) calls `onSave(draft)` and flips back to view mode. Parent recomputes `kind` / `sizeBytes` / `lineCount`.
- **Revert** (rotate-ccw icon) restores the original content without closing the modal.
- **Copy** honours the live draft.
- A small dirty-state dot appears next to the size label.
- `analyzeContent` is invoked live so the size readout updates as you type.
- Draft state is reset when the modal closes/re-opens or when `content` changes from the parent.

Readonly callers (e.g. `LongTextPreviewCard` rendering assistant-side long text) don't pass `editable` / `onSave`, so their behaviour is unchanged.

### `apps/mobile/components/chat/ChatInput.tsx` (in-project composer)

- New `handleUpdatePastedText(id, content)` that updates the matching `PastedTextEntry` and re-runs `analyzeContent` so the chip's kind/size/lines refresh immediately.
- Wires `editable` + `onSave={(next) => handleUpdatePastedText(activeChip.id, next)}` into `FileViewerModal` when the active attachment is a pasted-text chip.

### `apps/mobile/components/chat/CompactChatInput.tsx` (home-screen composer)

- Same `handleUpdatePastedText` handler and same `editable` / `onSave` wiring, so the edit affordance is consistent across both surfaces.

## Diffstat

```
apps/mobile/components/chat/ChatInput.tsx         | +/-
apps/mobile/components/chat/CompactChatInput.tsx  | +/-
apps/mobile/components/chat/FileViewerModal.tsx   | +/-
3 files changed, +170 / -22
```

## How to test

1. Run the mobile web app (`bun run web:dev`) and open the home screen.
2. Paste a long block of markdown / JSON / a stack trace into the composer.
3. Confirm the paste collapses into a chip with the kind / size / line count.
4. Tap the chip → `FileViewerModal` opens in **view mode** with Copy + pencil + Close.
5. Tap the **pencil**. The body becomes a multiline `TextInput` pre-filled with the original content and focused.
6. Edit a few characters → confirm the size label updates live and a dirty dot appears.
7. Tap **Save** → modal flips back to view mode with the new content; the chip's size / line count reflect the edit.
8. Re-open the modal, edit again, tap **Revert** → original content (post-save) is restored without closing the modal.
9. While editing, tap **Copy** → confirm clipboard contains the live draft, not the saved version.
10. Open the in-project chat (any project) and repeat steps 2–9.
11. Confirm assistant-side `LongTextPreviewCard` previews still render **view-only** (no pencil button).

## Risk / backwards compatibility

- All new behaviour is **opt-in** via the two new props. Existing call sites that don't pass them are bit-for-bit unchanged in behaviour.
- No new dependencies. Uses existing `lucide-react-native` icons (`Pencil`, `RotateCcw`, `Check`) already in the project.
- TypeScript: `bun x tsc --noEmit` shows zero new errors in the touched files. The unrelated pre-existing repo errors (`@shogo/model-catalog` resolution, etc.) are untouched.

## Out of scope

- Editing **file attachments** (PDFs, images, etc.) — stays view-only.
- Editing assistant-side long-text previews — stays view-only by design.
- Persisted history of edits / multi-step undo beyond single-session revert.

## Screenshots / canvas

The canvas animation rendered alongside this PR walks through the full BEFORE → opening → viewer (old) → editing → saving → AFTER flow, with the diff-highlighted edited line and the saved-state pulse. Static screenshots attached on the JIRA ticket.
