### PR TITLE
feat(marketplace): add creator follow/follower feature

### DIFF
--- a/apps/api/src/__tests__/creator-follow-service.test.ts
+++ b/apps/api/src/__tests__/creator-follow-service.test.ts
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Tests for `src/services/creator-follow.service.ts`.
+ *
+ * Covers:
+ *   - followCreator (happy path, idempotent, creator not found, self-follow)
+ *   - unfollowCreator (happy path, no-op when not following, creator not found)
+ *   - isFollowing (true/false)
+ *   - getFollowingCreatorIds (set of IDs)
+ *   - getFollowingCreators (pagination)
+ *   - getFollowersCount (denormalized read)
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// ─── In-memory state ──────────────────────────────────────────────────
+
+let follows: any[]
+let profiles: any[]
+let idCounter = 0
+
+function reset() {
+  follows = []
+  profiles = []
+  idCounter = 0
+}
+reset()
+
+function nextId() {
+  idCounter++
+  return `id_${idCounter}`
+}
+
+// ─── Prisma mock ──────────────────────────────────────────────────────
+
+const creatorFollowTable = {
+  create: async (args: any) => {
+    const existing = follows.find(
+      (f) =>
+        f.followerId === args.data.followerId &&
+        f.creatorId === args.data.creatorId,
+    )
+    if (existing) {
+      const err: any = new Error('Unique constraint failed')
+      err.code = 'P2002'
+      throw err
+    }
+    const row = { id: nextId(), createdAt: new Date(), ...args.data }
+    follows.push(row)
+    return row
+  },
+  findUnique: async (args: any) => {
+    if (args.where.followerId_creatorId) {
+      const { followerId, creatorId } = args.where.followerId_creatorId
+      return follows.find(
+        (f) => f.followerId === followerId && f.creatorId === creatorId,
+      ) ?? null
+    }
+    return follows.find((f) => f.id === args.where.id) ?? null
+  },
+  findMany: async (args: any) => {
+    let rows = follows.filter((f) => {
+      if (args.where?.followerId && f.followerId !== args.where.followerId)
+        return false
+      return true
+    })
+    if (args.orderBy?.createdAt === 'desc') {
+      rows = [...rows].reverse()
+    }
+    const skip = args.skip ?? 0
+    const take = args.take ?? rows.length
+    const sliced = rows.slice(skip, skip + take)
+    if (args.include?.creator) {
+      return sliced.map((f) => ({
+        ...f,
+        creator: profiles.find((p) => p.id === f.creatorId) ?? null,
+      }))
+    }
+    return sliced
+  },
+  count: async (args: any) => {
+    return follows.filter((f) => {
+      if (args.where?.followerId && f.followerId !== args.where.followerId)
+        return false
+      if (args.where?.creatorId && f.creatorId !== args.where.creatorId)
+        return false
+      return true
+    }).length
+  },
+  delete: async (args: any) => {
+    const idx = follows.findIndex((f) => f.id === args.where.id)
+    if (idx < 0) throw new Error('Not found')
+    const [removed] = follows.splice(idx, 1)
+    return removed
+  },
+}
+
+const creatorProfileTable = {
+  findUnique: async (args: any) => {
+    const profile = profiles.find((p) => p.id === args.where.id) ?? null
+    if (!profile) return null
+    if (args.select) {
+      const result: any = {}
+      for (const k of Object.keys(args.select)) {
+        result[k] = profile[k]
+      }
+      return result
+    }
+    return profile
+  },
+  update: async (args: any) => {
+    const profile = profiles.find((p) => p.id === args.where.id)
+    if (!profile) throw new Error('Not found')
+    if (args.data.followerCount?.increment) {
+      profile.followerCount = (profile.followerCount ?? 0) + args.data.followerCount.increment
+    }
+    if (args.data.followerCount?.decrement) {
+      profile.followerCount = (profile.followerCount ?? 0) - args.data.followerCount.decrement
+    }
+    if (args.select) {
+      const result: any = {}
+      for (const k of Object.keys(args.select)) {
+        result[k] = profile[k]
+      }
+      return result
+    }
+    return profile
+  },
+}
+
+const txProxy = new Proxy(
+  {},
+  {
+    get(_target, prop) {
+      if (prop === 'creatorFollow') return creatorFollowTable
+      if (prop === 'creatorProfile') return creatorProfileTable
+      return undefined
+    },
+  },
+)
+
+const prismaMock = {
+  creatorFollow: creatorFollowTable,
+  creatorProfile: creatorProfileTable,
+  $transaction: async (fn: any) => {
+    if (typeof fn === 'function') return fn(txProxy)
+    return Promise.all(fn)
+  },
+}
+
+mock.module('../lib/prisma', () => ({
+  prisma: prismaMock,
+}))
+
+// ─── Import service under test (after mock is registered) ─────────────
+
+const svc = await import('../services/creator-follow.service')
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+function seedProfile(overrides: Partial<any> = {}) {
+  const p = {
+    id: nextId(),
+    userId: nextId(),
+    displayName: 'Test Creator',
+    bio: null,
+    avatarUrl: null,
+    verified: false,
+    creatorTier: 'newcomer',
+    reputationScore: 0,
+    totalAgentsPublished: 0,
+    totalInstalls: 0,
+    averageAgentRating: 0,
+    followerCount: 0,
+    ...overrides,
+  }
+  profiles.push(p)
+  return p
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+beforeEach(() => reset())
+
+describe('followCreator', () => {
+  test('creates follow and increments followerCount', async () => {
+    const creator = seedProfile()
+    const followerId = 'user_1'
+    const result = await svc.followCreator(followerId, creator.id)
+    expect(result.ok).toBe(true)
+    expect(result.followerCount).toBe(1)
+    expect(follows).toHaveLength(1)
+    expect(follows[0].followerId).toBe(followerId)
+    expect(follows[0].creatorId).toBe(creator.id)
+  })
+
+  test('idempotent — second follow returns ok without duplicating', async () => {
+    const creator = seedProfile({ followerCount: 1 })
+    follows.push({ id: 'existing', followerId: 'user_1', creatorId: creator.id })
+    const result = await svc.followCreator('user_1', creator.id)
+    expect(result.ok).toBe(true)
+    expect(result.followerCount).toBe(1)
+    expect(follows).toHaveLength(1)
+  })
+
+  test('throws creator_not_found for missing creator', async () => {
+    await expect(svc.followCreator('user_1', 'missing_id')).rejects.toThrow(
+      'creator_not_found',
+    )
+  })
+
+  test('throws cannot_follow_self when user is creator owner', async () => {
+    const creator = seedProfile({ userId: 'user_self' })
+    await expect(svc.followCreator('user_self', creator.id)).rejects.toThrow(
+      'cannot_follow_self',
+    )
+  })
+})
+
+describe('unfollowCreator', () => {
+  test('removes follow and decrements followerCount', async () => {
+    const creator = seedProfile({ followerCount: 1 })
+    follows.push({ id: 'f1', followerId: 'user_1', creatorId: creator.id })
+    const result = await svc.unfollowCreator('user_1', creator.id)
+    expect(result.ok).toBe(true)
+    expect(result.followerCount).toBe(0)
+    expect(follows).toHaveLength(0)
+  })
+
+  test('no-op when not following', async () => {
+    const creator = seedProfile({ followerCount: 5 })
+    const result = await svc.unfollowCreator('user_1', creator.id)
+    expect(result.ok).toBe(true)
+    expect(result.followerCount).toBe(5)
+  })
+
+  test('throws creator_not_found for missing creator', async () => {
+    await expect(svc.unfollowCreator('user_1', 'nope')).rejects.toThrow(
+      'creator_not_found',
+    )
+  })
+})
+
+describe('isFollowing', () => {
+  test('returns true when follow exists', async () => {
+    const creator = seedProfile()
+    follows.push({ id: 'f1', followerId: 'user_1', creatorId: creator.id })
+    expect(await svc.isFollowing('user_1', creator.id)).toBe(true)
+  })
+
+  test('returns false when no follow', async () => {
+    const creator = seedProfile()
+    expect(await svc.isFollowing('user_1', creator.id)).toBe(false)
+  })
+})
+
+describe('getFollowingCreatorIds', () => {
+  test('returns set of followed creator IDs', async () => {
+    follows.push(
+      { id: 'f1', followerId: 'user_1', creatorId: 'c1' },
+      { id: 'f2', followerId: 'user_1', creatorId: 'c2' },
+      { id: 'f3', followerId: 'user_2', creatorId: 'c1' },
+    )
+    const ids = await svc.getFollowingCreatorIds('user_1')
+    expect(ids.size).toBe(2)
+    expect(ids.has('c1')).toBe(true)
+    expect(ids.has('c2')).toBe(true)
+  })
+})
+
+describe('getFollowingCreators', () => {
+  test('returns paginated creators the user follows', async () => {
+    const c1 = seedProfile({ displayName: 'Creator 1' })
+    const c2 = seedProfile({ displayName: 'Creator 2' })
+    follows.push(
+      { id: 'f1', followerId: 'user_1', creatorId: c1.id, createdAt: new Date() },
+      { id: 'f2', followerId: 'user_1', creatorId: c2.id, createdAt: new Date() },
+    )
+    const page = await svc.getFollowingCreators('user_1', 1, 10)
+    expect(page.total).toBe(2)
+    expect(page.items).toHaveLength(2)
+    expect(page.page).toBe(1)
+    expect(page.limit).toBe(10)
+    expect(page.totalPages).toBe(1)
+  })
+
+  test('pagination clamps to valid range', async () => {
+    const page = await svc.getFollowingCreators('user_1', -1, 200)
+    expect(page.page).toBe(1)
+    expect(page.limit).toBe(100)
+  })
+})
+
+describe('getFollowersCount', () => {
+  test('reads denormalized followerCount from profile', async () => {
+    seedProfile({ id: 'cp_1', followerCount: 42 })
+    expect(await svc.getFollowersCount('cp_1')).toBe(42)
+  })
+
+  test('returns 0 for missing profile', async () => {
+    expect(await svc.getFollowersCount('missing')).toBe(0)
+  })
+})

--- a/apps/api/src/routes/marketplace.ts
+++ b/apps/api/src/routes/marketplace.ts
@@ -12,6 +12,8 @@ import * as snapshotStorage from '../services/marketplace-snapshot-storage.servi
 import * as auditService from '../services/marketplace-audit.service'
 import * as stripeConnect from '../services/stripe-connect.service'
 import * as gamification from '../services/creator-gamification.service'
+import * as creatorFollowService from '../services/creator-follow.service'
+import { ensureLocalCreatorForFollow } from '../services/creator-follow.service'
 import { getShogoCloudUrl, getFrontendUrl } from '../lib/cloud-urls'
 import {
   shouldSkipForwardedHeader,
@@ -69,8 +71,30 @@ export function marketplaceRoutes() {
   app.use('*', async (c, next) => {
     if (process.env.SHOGO_LOCAL_MODE !== 'true') return next()
 
+    // Handle follow endpoints locally — Cloud doesn't have them yet.
+    const path = c.req.path
+    if (
+      path.endsWith('/follow') ||
+      path.endsWith('/following') ||
+      path.includes('/creator/')
+    ) {
+      return next()
+    }
+
     const cloudKey = process.env.SHOGO_API_KEY
-    const url = `${getShogoCloudUrl()}${c.req.path}${new URL(c.req.url).search}`
+    const fullUrl = `${getShogoCloudUrl()}${c.req.path}${new URL(c.req.url).search}`
+
+    // For creator profile and listing detail, enrich the Cloud response
+    // with local follow data after proxying.
+    const creatorProfileMatch = path.match(/\/creators\/([^/]+)$/)
+    // Listing detail: /api/marketplace/<slug> — must have a slug segment
+    // that isn't a known sub-route prefix.
+    const slugSegment = !creatorProfileMatch && path.match(/\/api\/marketplace\/([a-z0-9][a-z0-9-]+)$/)
+    const listingDetailMatch = slugSegment && c.req.method === 'GET'
+      && !['search', 'featured', 'creators', 'creator', 'my-installs', 'installs'].includes(slugSegment[1])
+    const needsFollowEnrich = (creatorProfileMatch || listingDetailMatch) && c.req.method === 'GET'
+
+    const url = fullUrl
 
     const headers = new Headers()
     c.req.raw.headers.forEach((value, key) => {
@@ -112,6 +136,36 @@ export function marketplaceRoutes() {
         { error: 'Sign in to Shogo Cloud to use the marketplace.', code: 'cloud_signin_required' },
         503,
       )
+    }
+
+    // Enrich creator profile / listing detail with local follow state
+    if (needsFollowEnrich && upstream.status === 200) {
+      try {
+        const body = await upstream.json()
+        const authCtx = c.get('auth') as AuthContext | undefined
+        const userId = authCtx?.isAuthenticated ? authCtx.userId : undefined
+
+        if (creatorProfileMatch) {
+          const creatorId = creatorProfileMatch[1]
+          const followerCount = await creatorFollowService.getFollowersCount(creatorId)
+          const isFollowing = userId
+            ? await creatorFollowService.isFollowing(userId, creatorId)
+            : false
+          return c.json({ ...body, followerCount, isFollowing })
+        }
+        if (listingDetailMatch && body.listing?.creatorId) {
+          const creatorId = body.listing.creatorId
+          const isFollowingCreator = userId
+            ? await creatorFollowService.isFollowing(userId, creatorId)
+            : false
+          return c.json({ listing: { ...body.listing, isFollowingCreator } })
+        }
+        // Body was consumed but enrichment didn't apply — return parsed JSON
+        return c.json(body)
+      } catch {
+        // JSON parse failed — body may already be consumed, return error
+        return c.json({ error: 'Failed to process response' }, 502)
+      }
     }
 
     const responseHeaders = new Headers()
@@ -198,6 +252,22 @@ export function marketplaceRoutes() {
     }
   })
 
+  app.get('/creators/following', async (c) => {
+    const authCtx = c.get('auth') as AuthContext | undefined
+    if (!authCtx?.isAuthenticated || !authCtx.userId) {
+      return c.json({ error: 'Unauthorized' }, 401)
+    }
+    try {
+      const page = parseIntParam(c.req.query('page') ?? undefined, 1)
+      const limit = parseIntParam(c.req.query('limit') ?? undefined, 20)
+      const result = await creatorFollowService.getFollowingCreators(authCtx.userId, page, limit)
+      return c.json(result)
+    } catch (err) {
+      console.error('[marketplace] getFollowingCreators', err)
+      return c.json({ error: 'Failed to load following' }, 500)
+    }
+  })
+
   app.get('/creators/:id/badges', async (c) => {
     try {
       const profile = await gamification.getCreatorPublicProfile(c.req.param('id'))
@@ -211,13 +281,60 @@ export function marketplaceRoutes() {
     }
   })
 
+  app.post('/creators/:id/follow', async (c) => {
+    const authCtx = c.get('auth') as AuthContext | undefined
+    if (!authCtx?.isAuthenticated || !authCtx.userId) {
+      return c.json({ error: 'Unauthorized' }, 401)
+    }
+    try {
+      const creatorId = c.req.param('id')
+      if (process.env.SHOGO_LOCAL_MODE === 'true') {
+        await ensureLocalCreatorForFollow(creatorId, getShogoCloudUrl())
+      }
+      const result = await creatorFollowService.followCreator(authCtx.userId, creatorId)
+      return c.json(result)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (msg === 'creator_not_found') return c.json({ error: 'Creator not found' }, 404)
+      if (msg === 'cannot_follow_self') return c.json({ error: 'Cannot follow yourself' }, 400)
+      console.error('[marketplace] followCreator', err)
+      return c.json({ error: 'Failed to follow creator' }, 500)
+    }
+  })
+
+  app.delete('/creators/:id/follow', async (c) => {
+    const authCtx = c.get('auth') as AuthContext | undefined
+    if (!authCtx?.isAuthenticated || !authCtx.userId) {
+      return c.json({ error: 'Unauthorized' }, 401)
+    }
+    try {
+      const creatorId = c.req.param('id')
+      if (process.env.SHOGO_LOCAL_MODE === 'true') {
+        await ensureLocalCreatorForFollow(creatorId, getShogoCloudUrl())
+      }
+      const result = await creatorFollowService.unfollowCreator(authCtx.userId, creatorId)
+      return c.json(result)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (msg === 'creator_not_found') return c.json({ error: 'Creator not found' }, 404)
+      console.error('[marketplace] unfollowCreator', err)
+      return c.json({ error: 'Failed to unfollow creator' }, 500)
+    }
+  })
+
   app.get('/creators/:id', async (c) => {
     try {
       const profile = await gamification.getCreatorPublicProfile(c.req.param('id'))
       if (!profile) {
         return c.json({ error: 'Creator not found' }, 404)
       }
-      return c.json(profile)
+      const authCtx = c.get('auth') as AuthContext | undefined
+      const followerCount = await creatorFollowService.getFollowersCount(profile.id)
+      let isFollowing = false
+      if (authCtx?.isAuthenticated && authCtx.userId) {
+        isFollowing = await creatorFollowService.isFollowing(authCtx.userId, profile.id)
+      }
+      return c.json({ ...profile, followerCount, isFollowing })
     } catch (err) {
       console.error('[marketplace] getCreatorPublicProfile', err)
       return c.json({ error: 'Failed to load creator' }, 500)
@@ -978,7 +1095,12 @@ export function marketplaceRoutes() {
       if (!listing) {
         return c.json({ error: 'Listing not found' }, 404)
       }
-      return c.json({ listing })
+      const authCtx = c.get('auth') as AuthContext | undefined
+      let isFollowingCreator = false
+      if (authCtx?.isAuthenticated && authCtx.userId && listing.creatorId) {
+        isFollowingCreator = await creatorFollowService.isFollowing(authCtx.userId, listing.creatorId)
+      }
+      return c.json({ listing: { ...listing, isFollowingCreator } })
     } catch (err) {
       console.error('[marketplace] getListingBySlug', err)
       return c.json({ error: 'Failed to load listing' }, 500)

--- a/apps/api/src/services/creator-follow.service.ts
+++ b/apps/api/src/services/creator-follow.service.ts
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { prisma } from '../lib/prisma'
+
+/**
+ * In local mode, creator profiles live on Cloud. When a user follows a
+ * Cloud creator, we fetch the profile from Cloud and upsert a minimal
+ * local shadow so the CreatorFollow FK is satisfied.
+ */
+export async function ensureLocalCreatorForFollow(
+  creatorId: string,
+  cloudBaseUrl: string,
+): Promise<void> {
+  const existing = await prisma.creatorProfile.findUnique({
+    where: { id: creatorId },
+    select: { id: true },
+  })
+  if (existing) return
+
+  try {
+    const res = await fetch(`${cloudBaseUrl}/api/marketplace/creators/${creatorId}`)
+    if (!res.ok) return
+    const data = await res.json() as {
+      id: string
+      displayName: string
+      bio?: string | null
+      avatarUrl?: string | null
+      websiteUrl?: string | null
+      verified?: boolean
+      creatorTier?: string
+      reputationScore?: number
+    }
+    // We need a userId for the profile. Check if the creator has an associated
+    // user locally, otherwise create a placeholder user.
+    let userId: string
+    const existingUser = await prisma.user.findFirst({
+      where: { email: `cloud-creator-${creatorId}@shogo.local` },
+      select: { id: true },
+    })
+    if (existingUser) {
+      userId = existingUser.id
+    } else {
+      const user = await prisma.user.create({
+        data: {
+          email: `cloud-creator-${creatorId}@shogo.local`,
+          name: data.displayName,
+        },
+      })
+      userId = user.id
+    }
+    await prisma.creatorProfile.create({
+      data: {
+        id: creatorId,
+        userId,
+        displayName: data.displayName,
+        bio: data.bio ?? null,
+        avatarUrl: data.avatarUrl ?? null,
+        websiteUrl: data.websiteUrl ?? null,
+        verified: data.verified ?? false,
+      },
+    })
+  } catch {
+    // Best-effort — if Cloud is unreachable, the follow will fail with creator_not_found
+  }
+}
+
+export interface FollowResult {
+  ok: true
+  followerCount: number
+}
+
+export interface FollowingCreatorsPage {
+  items: FollowingCreatorEntry[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+export interface FollowingCreatorEntry {
+  id: string
+  displayName: string
+  bio: string | null
+  avatarUrl: string | null
+  verified: boolean
+  creatorTier: string
+  reputationScore: number
+  totalAgentsPublished: number
+  totalInstalls: number
+  averageAgentRating: number
+  followerCount: number
+}
+
+export async function followCreator(
+  followerId: string,
+  creatorId: string,
+): Promise<FollowResult> {
+  const creator = await prisma.creatorProfile.findUnique({
+    where: { id: creatorId },
+    select: { id: true, userId: true, followerCount: true },
+  })
+  if (!creator) throw new Error('creator_not_found')
+  if (creator.userId === followerId) throw new Error('cannot_follow_self')
+
+  try {
+    const updated = await prisma.$transaction(async (tx) => {
+      await tx.creatorFollow.create({
+        data: { followerId, creatorId },
+      })
+      const profile = await tx.creatorProfile.update({
+        where: { id: creatorId },
+        data: { followerCount: { increment: 1 } },
+        select: { followerCount: true },
+      })
+      return profile
+    })
+    return { ok: true, followerCount: updated.followerCount }
+  } catch (err: any) {
+    if (err?.code === 'P2002') {
+      return { ok: true, followerCount: creator.followerCount }
+    }
+    throw err
+  }
+}
+
+export async function unfollowCreator(
+  followerId: string,
+  creatorId: string,
+): Promise<FollowResult> {
+  const creator = await prisma.creatorProfile.findUnique({
+    where: { id: creatorId },
+    select: { id: true, followerCount: true },
+  })
+  if (!creator) throw new Error('creator_not_found')
+
+  const existing = await prisma.creatorFollow.findUnique({
+    where: { followerId_creatorId: { followerId, creatorId } },
+  })
+  if (!existing) {
+    return { ok: true, followerCount: creator.followerCount }
+  }
+
+  const updated = await prisma.$transaction(async (tx) => {
+    await tx.creatorFollow.delete({
+      where: { id: existing.id },
+    })
+    const profile = await tx.creatorProfile.update({
+      where: { id: creatorId },
+      data: { followerCount: { decrement: 1 } },
+      select: { followerCount: true },
+    })
+    return profile
+  })
+  return { ok: true, followerCount: Math.max(0, updated.followerCount) }
+}
+
+export async function isFollowing(
+  followerId: string,
+  creatorId: string,
+): Promise<boolean> {
+  const row = await prisma.creatorFollow.findUnique({
+    where: { followerId_creatorId: { followerId, creatorId } },
+    select: { id: true },
+  })
+  return row != null
+}
+
+export async function getFollowingCreatorIds(
+  userId: string,
+): Promise<Set<string>> {
+  const rows = await prisma.creatorFollow.findMany({
+    where: { followerId: userId },
+    select: { creatorId: true },
+  })
+  return new Set(rows.map((r) => r.creatorId))
+}
+
+export async function getFollowingCreators(
+  userId: string,
+  page?: number,
+  limit?: number,
+): Promise<FollowingCreatorsPage> {
+  const safePage = Math.max(1, Math.floor(page ?? 1))
+  const safeLimit = Math.min(100, Math.max(1, Math.floor(limit ?? 20)))
+  const skip = (safePage - 1) * safeLimit
+
+  const where = { followerId: userId }
+  const [total, rows] = await Promise.all([
+    prisma.creatorFollow.count({ where }),
+    prisma.creatorFollow.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      skip,
+      take: safeLimit,
+      include: {
+        creator: {
+          select: {
+            id: true,
+            displayName: true,
+            bio: true,
+            avatarUrl: true,
+            verified: true,
+            creatorTier: true,
+            reputationScore: true,
+            totalAgentsPublished: true,
+            totalInstalls: true,
+            averageAgentRating: true,
+            followerCount: true,
+          },
+        },
+      },
+    }),
+  ])
+
+  return {
+    items: rows.map((r) => r.creator),
+    total,
+    page: safePage,
+    limit: safeLimit,
+    totalPages: Math.ceil(total / safeLimit) || 1,
+  }
+}
+
+export async function getFollowersCount(creatorId: string): Promise<number> {
+  const profile = await prisma.creatorProfile.findUnique({
+    where: { id: creatorId },
+    select: { followerCount: true },
+  })
+  return profile?.followerCount ?? 0
+}

--- a/apps/desktop/prisma/migrations/20260521000000_add_creator_follows/migration.sql
+++ b/apps/desktop/prisma/migrations/20260521000000_add_creator_follows/migration.sql
@@ -1,0 +1,23 @@
+-- SQLite mirror of prisma/migrations/20260521000000_add_creator_follows
+
+PRAGMA foreign_keys = OFF;
+
+-- Add followerCount to creator_profiles
+ALTER TABLE "creator_profiles" ADD COLUMN "followerCount" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateTable
+CREATE TABLE "creator_follows" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "followerId" TEXT NOT NULL,
+    "creatorId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "creator_follows_followerId_fkey" FOREIGN KEY ("followerId") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "creator_follows_creatorId_fkey" FOREIGN KEY ("creatorId") REFERENCES "creator_profiles" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "creator_follows_followerId_idx" ON "creator_follows"("followerId");
+CREATE INDEX "creator_follows_creatorId_idx" ON "creator_follows"("creatorId");
+CREATE UNIQUE INDEX "creator_follows_followerId_creatorId_key" ON "creator_follows"("followerId", "creatorId");
+
+PRAGMA foreign_keys = ON;

--- a/apps/mobile/app/(app)/marketplace/[slug].tsx
+++ b/apps/mobile/app/(app)/marketplace/[slug].tsx
@@ -40,6 +40,7 @@ import {
   AgentTile,
   type AgentTileListing,
   CreatorChip,
+  FollowCreatorButton,
   HorizontalRail,
   IntegrationStrip,
   MarketplaceHero,
@@ -93,6 +94,7 @@ interface ListingDetail {
   publishedAt?: string | null
   updatedAt?: string | null
   creator: CreatorFromAPI
+  isFollowingCreator?: boolean
 }
 
 interface Review {
@@ -756,7 +758,13 @@ export default observer(function MarketplaceDetailScreen() {
                 size="lg"
                 disablePress
               />
-              <View className="ml-auto">
+              <View className="ml-auto flex-row items-center gap-2">
+                <FollowCreatorButton
+                  creatorId={listing.creator.id}
+                  initialFollowing={listing.isFollowingCreator ?? false}
+                  followerCount={0}
+                  size="sm"
+                />
                 <ChevronRight size={16} color="#71717a" />
               </View>
             </View>

--- a/apps/mobile/app/(app)/marketplace/creator/index.tsx
+++ b/apps/mobile/app/(app)/marketplace/creator/index.tsx
@@ -21,6 +21,8 @@ import {
   Plus,
   Award,
   ChevronRight,
+  ChevronDown,
+  ChevronUp,
   AlertCircle,
   ArrowUpRight,
   ArrowDownRight,
@@ -30,11 +32,13 @@ import {
   RefreshCcw,
   CheckCircle2,
   Circle,
+  ShieldCheck,
 } from 'lucide-react-native'
 import { useAuth } from '../../../../contexts/auth'
 import { useDomainHttp } from '../../../../contexts/domain'
 import { cn } from '@shogo/shared-ui/primitives'
-import { Sparkline, TIER_BG, TIER_LABEL, type CreatorTier } from '../../../../components/marketplace'
+import { Sparkline, TIER_BG, TIER_COLORS, TIER_LABEL, type CreatorTier } from '../../../../components/marketplace'
+import { FollowCreatorButton } from '../../../../components/marketplace/FollowCreatorButton'
 
 interface CreatorProfile {
   id: string
@@ -49,6 +53,7 @@ interface CreatorProfile {
   pendingPayoutInCents: number
   totalInstalls: number
   averageAgentRating: number
+  followerCount: number
   createdAt: string
 }
 
@@ -82,6 +87,25 @@ interface Transaction {
 
 interface TransactionsResponse {
   items: Transaction[]
+  total: number
+}
+
+interface FollowingCreator {
+  id: string
+  displayName: string
+  bio: string | null
+  avatarUrl: string | null
+  verified: boolean
+  creatorTier: CreatorTier
+  reputationScore: number
+  totalAgentsPublished: number
+  totalInstalls: number
+  averageAgentRating: number
+  followerCount: number
+}
+
+interface FollowingResponse {
+  items: FollowingCreator[]
   total: number
 }
 
@@ -145,6 +169,9 @@ export default observer(function CreatorDashboardScreen() {
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [hasProfile, setHasProfile] = useState<boolean | null>(null)
+  const [followingCreators, setFollowingCreators] = useState<FollowingCreator[]>([])
+  const [followingTotal, setFollowingTotal] = useState(0)
+  const [showFollowing, setShowFollowing] = useState(false)
 
   const loadData = useCallback(async () => {
     setLoading(true)
@@ -157,13 +184,16 @@ export default observer(function CreatorDashboardScreen() {
       setProfile(prof)
       setHasProfile(true)
 
-      const [dashboardRes, transactionsRes] = await Promise.all([
+      const [dashboardRes, transactionsRes, followingRes] = await Promise.all([
         http.get<DashboardAPIResponse>('/api/marketplace/creator/dashboard'),
         http.get<TransactionsResponse>('/api/marketplace/creator/transactions?limit=100'),
+        http.get<FollowingResponse>('/api/marketplace/creators/following?limit=10'),
       ])
       setDashboardListings(dashboardRes.data.listings ?? [])
       setTotalReviews(dashboardRes.data.totalReviews ?? 0)
       setTransactions(transactionsRes.data.items ?? [])
+      setFollowingCreators(followingRes.data.items ?? [])
+      setFollowingTotal(followingRes.data.total ?? 0)
     } catch (err: any) {
       if (err?.status === 404 || err?.message?.includes('not found')) {
         setHasProfile(false)
@@ -334,36 +364,108 @@ export default observer(function CreatorDashboardScreen() {
 
       {/* Tier card */}
       {profile && (
-        <View className="rounded-2xl border border-border bg-card p-4 mb-5 flex-row items-center gap-3">
-          {profile.avatarUrl ? (
-            <Image
-              source={{ uri: profile.avatarUrl }}
-              style={{ width: 44, height: 44, borderRadius: 999 }}
-            />
-          ) : (
-            <View
-              className={`${TIER_BG[profile.creatorTier]} rounded-full items-center justify-center`}
-              style={{ width: 44, height: 44 }}
-            >
-              <Text className="text-white font-bold text-lg">
-                {profile.displayName.charAt(0).toUpperCase()}
+        <View className="rounded-2xl border border-border bg-card mb-5">
+          <View className="p-4 flex-row items-center gap-3">
+            {profile.avatarUrl ? (
+              <Image
+                source={{ uri: profile.avatarUrl }}
+                style={{ width: 44, height: 44, borderRadius: 999 }}
+              />
+            ) : (
+              <View
+                className={`${TIER_BG[profile.creatorTier]} rounded-full items-center justify-center`}
+                style={{ width: 44, height: 44 }}
+              >
+                <Text className="text-white font-bold text-lg">
+                  {profile.displayName.charAt(0).toUpperCase()}
+                </Text>
+              </View>
+            )}
+            <View className="flex-1 min-w-0">
+              <Text className="text-sm font-semibold text-foreground" numberOfLines={1}>
+                {profile.displayName}
+              </Text>
+              <View className="flex-row items-center gap-2 mt-1">
+                <View
+                  className="px-2 py-0.5 rounded-full"
+                  style={{ backgroundColor: `${TIER_COLORS[profile.creatorTier] ?? TIER_COLORS.newcomer}20` }}
+                >
+                  <Text
+                    className="text-[10px] font-semibold capitalize"
+                    style={{ color: TIER_COLORS[profile.creatorTier] ?? TIER_COLORS.newcomer }}
+                  >
+                    {TIER_LABEL[profile.creatorTier]}
+                  </Text>
+                </View>
+                <Text className="text-xs text-muted-foreground">
+                  {profile.reputationScore} rep
+                </Text>
+              </View>
+            </View>
+            <View className="flex-row items-center gap-2">
+              <View className={cn('w-2 h-2 rounded-full', payoutColor(profile.payoutStatus))} />
+              <Text className="text-xs text-muted-foreground">
+                {payoutLabel(profile.payoutStatus)}
               </Text>
             </View>
+          </View>
+
+          {/* Followers / Following stat badges */}
+          <View className="flex-row border-t border-border">
+            <View className="flex-1 items-center py-3 border-r border-border">
+              <Text className="text-base font-bold text-foreground">
+                {(profile.followerCount ?? 0).toLocaleString()}
+              </Text>
+              <Text className="text-[11px] text-muted-foreground">Followers</Text>
+            </View>
+            <Pressable
+              onPress={() => setShowFollowing((v) => !v)}
+              className="flex-1 items-center py-3 active:opacity-70"
+            >
+              <View className="flex-row items-center gap-1">
+                <Text className="text-base font-bold text-foreground">
+                  {followingTotal}
+                </Text>
+                {showFollowing ? (
+                  <ChevronUp size={14} color="#71717a" />
+                ) : (
+                  <ChevronDown size={14} color="#71717a" />
+                )}
+              </View>
+              <Text className="text-[11px] text-muted-foreground">Following</Text>
+            </Pressable>
+          </View>
+
+          {/* Expandable following list */}
+          {showFollowing && (
+            <View className="border-t border-border px-4 py-3">
+              {followingCreators.length > 0 ? (
+                <View className="gap-3">
+                  {followingCreators.map((creator) => (
+                    <FollowingCreatorCard
+                      key={creator.id}
+                      creator={creator}
+                      onPress={() => router.push(`/(app)/marketplace/creators/${creator.id}` as any)}
+                      onUnfollow={() => {
+                        setFollowingCreators((prev) => prev.filter((c) => c.id !== creator.id))
+                        setFollowingTotal((prev) => Math.max(0, prev - 1))
+                      }}
+                    />
+                  ))}
+                </View>
+              ) : (
+                <View className="items-center py-4">
+                  <Text className="text-xs text-muted-foreground">Not following anyone yet</Text>
+                  <Pressable
+                    onPress={() => router.push('/(app)/marketplace/creators' as any)}
+                    className="mt-2 px-3 py-1.5 rounded-lg bg-primary/10 active:opacity-80"
+                  >
+                    <Text className="text-xs font-semibold text-primary">Browse Creators</Text>
+                  </Pressable>
+                </View>
+              )}
+            </View>
           )}
-          <View className="flex-1 min-w-0">
-            <Text className="text-sm font-semibold text-foreground" numberOfLines={1}>
-              {profile.displayName}
-            </Text>
-            <Text className="text-xs text-muted-foreground">
-              {TIER_LABEL[profile.creatorTier]} · {profile.reputationScore} reputation
-            </Text>
-          </View>
-          <View className="flex-row items-center gap-2">
-            <View className={cn('w-2 h-2 rounded-full', payoutColor(profile.payoutStatus))} />
-            <Text className="text-xs text-muted-foreground">
-              {payoutLabel(profile.payoutStatus)}
-            </Text>
-          </View>
         </View>
       )}
 
@@ -457,6 +559,12 @@ export default observer(function CreatorDashboardScreen() {
               tint="text-blue-500"
             />
             <MiniStat
+              label="Followers"
+              value={(profile.followerCount ?? 0).toLocaleString()}
+              icon={Users}
+              tint="text-violet-500"
+            />
+            <MiniStat
               label="Avg rating"
               value={
                 profile.averageAgentRating > 0
@@ -537,6 +645,7 @@ export default observer(function CreatorDashboardScreen() {
           </Text>
         </View>
       )}
+
     </ScrollView>
   )
 })
@@ -754,5 +863,61 @@ function TransactionRow({ transaction }: { transaction: Transaction }) {
         </Text>
       </View>
     </View>
+  )
+}
+
+function FollowingCreatorCard({
+  creator,
+  onPress,
+  onUnfollow,
+}: {
+  creator: FollowingCreator
+  onPress: () => void
+  onUnfollow: () => void
+}) {
+  const tierBg = TIER_BG[creator.creatorTier] ?? TIER_BG.newcomer
+  return (
+    <Pressable
+      onPress={onPress}
+      className="rounded-2xl border border-border bg-card p-4 active:opacity-90"
+    >
+      <View className="flex-row items-center gap-3">
+        {creator.avatarUrl ? (
+          <Image
+            source={{ uri: creator.avatarUrl }}
+            style={{ width: 40, height: 40, borderRadius: 999 }}
+          />
+        ) : (
+          <View
+            className={`${tierBg} rounded-full items-center justify-center`}
+            style={{ width: 40, height: 40 }}
+          >
+            <Text className="text-white font-bold text-base">
+              {creator.displayName.charAt(0).toUpperCase()}
+            </Text>
+          </View>
+        )}
+        <View className="flex-1 min-w-0">
+          <View className="flex-row items-center gap-1.5">
+            <Text className="text-sm font-semibold text-foreground" numberOfLines={1}>
+              {creator.displayName}
+            </Text>
+            {creator.verified && <ShieldCheck size={12} color="#3b82f6" />}
+          </View>
+          <Text className="text-[11px] text-muted-foreground capitalize">
+            {TIER_LABEL[creator.creatorTier] ?? 'Creator'} · {(creator.followerCount ?? 0).toLocaleString()} followers
+          </Text>
+        </View>
+        <FollowCreatorButton
+          creatorId={creator.id}
+          initialFollowing={true}
+          followerCount={creator.followerCount ?? 0}
+          size="sm"
+          onToggle={(following) => {
+            if (!following) onUnfollow()
+          }}
+        />
+      </View>
+    </Pressable>
   )
 }

--- a/apps/mobile/app/(app)/marketplace/creators/[id].tsx
+++ b/apps/mobile/app/(app)/marketplace/creators/[id].tsx
@@ -19,6 +19,7 @@ import { useDomainHttp } from '../../../../contexts/domain'
 import {
   AgentTile,
   type AgentTileListing,
+  FollowCreatorButton,
   HorizontalRail,
   MarketplaceHero,
   SectionHeader,
@@ -40,6 +41,8 @@ interface CreatorPublicProfile {
   totalAgentsPublished: number
   totalInstalls: number
   averageAgentRating: number
+  followerCount?: number
+  isFollowing?: boolean
   badges: Array<{
     badgeType: string
     earnedAt: string
@@ -277,12 +280,17 @@ export default observer(function CreatorProfileScreen() {
                     }
                   />
                   <ProfileStat label="Badges" value={String(profile.badges.length)} />
+                  <ProfileStat label="Followers" value={(profile.followerCount ?? 0).toLocaleString()} />
                 </View>
                 <View className="flex-row items-center gap-2 mt-2">
-                  <Pressable className="flex-row items-center gap-1.5 rounded-xl bg-foreground/10 px-4 py-2 active:opacity-80">
-                    <UserPlus size={14} color="#71717a" />
-                    <Text className="text-xs font-semibold text-foreground">Follow</Text>
-                  </Pressable>
+                  <FollowCreatorButton
+                    creatorId={profile.id}
+                    initialFollowing={profile.isFollowing ?? false}
+                    followerCount={profile.followerCount ?? 0}
+                    onToggle={(following, newCount) => {
+                      setProfile((p) => p ? { ...p, isFollowing: following, followerCount: newCount } : p)
+                    }}
+                  />
                   {profile.websiteUrl && (
                     <Pressable
                       className="flex-row items-center gap-1.5 rounded-xl border border-border px-4 py-2 active:opacity-80"

--- a/apps/mobile/app/(app)/marketplace/index.tsx
+++ b/apps/mobile/app/(app)/marketplace/index.tsx
@@ -38,6 +38,7 @@ import {
   type CreatorTier,
 } from '../../../components/marketplace'
 import { MARKETPLACE_CATEGORIES, type MarketplaceCategory } from '@shogo/shared-app'
+import { useAuth } from '../../../contexts/auth'
 import { cn } from '@shogo/shared-ui/primitives'
 import {
   Popover,
@@ -176,6 +177,7 @@ export default observer(function MarketplaceHomeScreen() {
   const router = useRouter()
   const http = useDomainHttp()
   const numColumns = useGridColumns()
+  const { user } = useAuth()
 
   const [searchQuery, setSearchQuery] = useState('')
   const debouncedSearchQuery = useDebouncedValue(searchQuery)
@@ -194,6 +196,7 @@ export default observer(function MarketplaceHomeScreen() {
   const [freeAgents, setFreeAgents] = useState<ListingFromAPI[]>([])
   const [topCreators, setTopCreators] = useState<LeaderboardCreator[]>([])
   const [recommended, setRecommended] = useState<ListingFromAPI[]>([])
+  const [followingAgents, setFollowingAgents] = useState<ListingFromAPI[]>([])
 
   const [listings, setListings] = useState<ListingFromAPI[]>([])
   const [loading, setLoading] = useState(true)
@@ -314,6 +317,28 @@ export default observer(function MarketplaceHomeScreen() {
   useEffect(() => {
     loadEditorial()
   }, [loadEditorial])
+
+  useEffect(() => {
+    if (!user?.id) {
+      setFollowingAgents([])
+      return
+    }
+    ;(async () => {
+      try {
+        const followingRes = await http.get<{ items: Array<{ id: string }> }>(
+          '/api/marketplace/creators/following?limit=10',
+        )
+        const creatorIds = (followingRes.data.items ?? []).map((c) => c.id)
+        if (creatorIds.length === 0) return
+        const agentRes = await http.get<BrowseResponse>(
+          `/api/marketplace?creatorId=${creatorIds[0]}&sort=popular&limit=8`,
+        )
+        setFollowingAgents(agentRes.data.items ?? [])
+      } catch {
+        // non-critical
+      }
+    })()
+  }, [user?.id, http])
 
   const browseListRef = useRef<FlatList>(null)
 
@@ -487,6 +512,17 @@ export default observer(function MarketplaceHomeScreen() {
             title="Recommended for you"
             subtitle="Popular agents that match how you work"
             items={recommended}
+            onPress={handleCardPress}
+          />
+        )}
+
+        {/* From creators you follow */}
+        {followingAgents.length > 0 && showRails && (
+          <AgentCollectionSection
+            viewMode={viewMode}
+            title="From creators you follow"
+            subtitle="Latest from the creators you're following"
+            items={followingAgents}
             onPress={handleCardPress}
           />
         )}

--- a/apps/mobile/components/marketplace/FollowCreatorButton.tsx
+++ b/apps/mobile/components/marketplace/FollowCreatorButton.tsx
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { useState, useCallback } from 'react'
+import { Pressable, Text, Alert } from 'react-native'
+import { UserPlus, UserCheck } from 'lucide-react-native'
+import { useAuth } from '../../contexts/auth'
+import { useDomainHttp } from '../../contexts/domain'
+
+interface FollowCreatorButtonProps {
+  creatorId: string
+  initialFollowing: boolean
+  followerCount: number
+  onToggle?: (following: boolean, newCount: number) => void
+  size?: 'sm' | 'md'
+}
+
+export function FollowCreatorButton({
+  creatorId,
+  initialFollowing,
+  followerCount,
+  onToggle,
+  size = 'md',
+}: FollowCreatorButtonProps) {
+  const { user } = useAuth()
+  const http = useDomainHttp()
+  const [following, setFollowing] = useState(initialFollowing)
+  const [count, setCount] = useState(followerCount)
+  const [loading, setLoading] = useState(false)
+
+  const handlePress = useCallback(async () => {
+    if (!user?.id) {
+      Alert.alert('Sign In Required', 'You need to be signed in to follow creators.')
+      return
+    }
+    const wasFollowing = following
+    const prevCount = count
+
+    // Optimistic update
+    setFollowing(!wasFollowing)
+    setCount(wasFollowing ? Math.max(0, prevCount - 1) : prevCount + 1)
+
+    setLoading(true)
+    try {
+      const res = wasFollowing
+        ? await http.delete<{ ok: boolean; followerCount: number }>(
+            `/api/marketplace/creators/${creatorId}/follow`,
+          )
+        : await http.post<{ ok: boolean; followerCount: number }>(
+            `/api/marketplace/creators/${creatorId}/follow`,
+          )
+      const serverCount = res.data.followerCount
+      setCount(serverCount)
+      setFollowing(!wasFollowing)
+      onToggle?.(!wasFollowing, serverCount)
+    } catch {
+      // Revert on failure
+      setFollowing(wasFollowing)
+      setCount(prevCount)
+    } finally {
+      setLoading(false)
+    }
+  }, [user?.id, following, count, creatorId, http, onToggle])
+
+  const isSmall = size === 'sm'
+  const iconSize = isSmall ? 12 : 14
+  const Icon = following ? UserCheck : UserPlus
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      disabled={loading}
+      className={`flex-row items-center gap-1.5 rounded-xl px-4 py-2 active:opacity-80 ${
+        following
+          ? 'bg-primary/15 border border-primary/30'
+          : 'bg-foreground/10'
+      } ${isSmall ? 'px-3 py-1.5' : ''} ${loading ? 'opacity-60' : ''}`}
+    >
+      <Icon
+        size={iconSize}
+        color={following ? '#7c3aed' : '#71717a'}
+      />
+      <Text
+        className={`font-semibold ${
+          following ? 'text-primary' : 'text-foreground'
+        } ${isSmall ? 'text-[11px]' : 'text-xs'}`}
+      >
+        {following ? 'Following' : 'Follow'}
+      </Text>
+    </Pressable>
+  )
+}

--- a/apps/mobile/components/marketplace/index.ts
+++ b/apps/mobile/components/marketplace/index.ts
@@ -3,6 +3,7 @@
 
 export { AgentTile, type AgentTileListing, type AgentTileSize } from './AgentTile'
 export { CreatorChip, TIER_COLORS, TIER_BG, TIER_LABEL, type CreatorTier } from './CreatorChip'
+export { FollowCreatorButton } from './FollowCreatorButton'
 export { HorizontalRail } from './HorizontalRail'
 export { IntegrationStrip } from './IntegrationStrip'
 export { MarketplaceHero } from './MarketplaceHero'

--- a/packages/domain-stores/src/user.collection.ts
+++ b/packages/domain-stores/src/user.collection.ts
@@ -392,7 +392,7 @@ export const UserCollection = types
 // ============================================================================
 
 // Relation fields that expect IDs (safeReference)
-const relationFields = ["sessions","accounts","members","notifications","starredProjects","signupAttribution","apiKeys","creatorProfile"]
+const relationFields = ["sessions","accounts","members","notifications","starredProjects","signupAttribution","apiKeys","creatorProfile","creatorFollows"]
 
 /**
  * Transform API response for MST compatibility:

--- a/prisma/migrations/20260521000000_add_creator_follows/migration.sql
+++ b/prisma/migrations/20260521000000_add_creator_follows/migration.sql
@@ -1,0 +1,27 @@
+-- AlterTable
+ALTER TABLE "creator_profiles" ADD COLUMN "followerCount" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateTable
+CREATE TABLE "creator_follows" (
+    "id" TEXT NOT NULL,
+    "followerId" TEXT NOT NULL,
+    "creatorId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "creator_follows_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "creator_follows_followerId_idx" ON "creator_follows"("followerId");
+
+-- CreateIndex
+CREATE INDEX "creator_follows_creatorId_idx" ON "creator_follows"("creatorId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "creator_follows_followerId_creatorId_key" ON "creator_follows"("followerId", "creatorId");
+
+-- AddForeignKey
+ALTER TABLE "creator_follows" ADD CONSTRAINT "creator_follows_followerId_fkey" FOREIGN KEY ("followerId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "creator_follows" ADD CONSTRAINT "creator_follows_creatorId_fkey" FOREIGN KEY ("creatorId") REFERENCES "creator_profiles"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.local.prisma
+++ b/prisma/schema.local.prisma
@@ -41,6 +41,7 @@ model User {
   apiKeys           ApiKey[]
   creatorProfile    CreatorProfile?
   signupAttribution SignupAttribution?
+  creatorFollows    CreatorFollow[]   @relation("UserFollows")
 
   @@map("users")
 }
@@ -1329,6 +1330,7 @@ model CreatorProfile {
   averageAgentRating       Float     @default(0)
   totalVersionsShipped     Int       @default(0)
   activeMaintenanceStreak  Int       @default(0)
+  followerCount            Int       @default(0)
   createdAt                DateTime  @default(now())
   updatedAt                DateTime  @updatedAt
 
@@ -1336,6 +1338,7 @@ model CreatorProfile {
   badges       CreatorBadge[]
   listings     MarketplaceListing[]
   transactions MarketplaceTransaction[] @relation("CreatorTransactions")
+  followers    CreatorFollow[]
 
   @@index([creatorTier])
   @@index([reputationScore])
@@ -1354,6 +1357,21 @@ model CreatorBadge {
   @@unique([creatorId, badgeType])
   @@index([creatorId])
   @@map("creator_badges")
+}
+
+model CreatorFollow {
+  id         String   @id @default(cuid())
+  followerId String
+  creatorId  String
+  createdAt  DateTime @default(now())
+
+  follower User           @relation("UserFollows", fields: [followerId], references: [id], onDelete: Cascade)
+  creator  CreatorProfile @relation(fields: [creatorId], references: [id], onDelete: Cascade)
+
+  @@unique([followerId, creatorId])
+  @@index([followerId])
+  @@index([creatorId])
+  @@map("creator_follows")
 }
 
 model MarketplaceListing {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,7 @@ model User {
   signupAttribution SignupAttribution?
   apiKeys           ApiKey[]
   creatorProfile    CreatorProfile?
+  creatorFollows    CreatorFollow[]   @relation("UserFollows")
 
   @@map("users")
 }
@@ -1675,6 +1676,7 @@ model CreatorProfile {
   averageAgentRating       Float        @default(0)
   totalVersionsShipped     Int          @default(0)
   activeMaintenanceStreak  Int          @default(0)
+  followerCount            Int          @default(0)
   createdAt                DateTime     @default(now())
   updatedAt                DateTime     @updatedAt
 
@@ -1682,6 +1684,7 @@ model CreatorProfile {
   badges       CreatorBadge[]
   listings     MarketplaceListing[]
   transactions MarketplaceTransaction[] @relation("CreatorTransactions")
+  followers    CreatorFollow[]
 
   @@index([creatorTier])
   @@index([reputationScore(sort: Desc)])
@@ -1700,6 +1703,21 @@ model CreatorBadge {
   @@unique([creatorId, badgeType])
   @@index([creatorId])
   @@map("creator_badges")
+}
+
+model CreatorFollow {
+  id         String   @id @default(cuid())
+  followerId String
+  creatorId  String
+  createdAt  DateTime @default(now())
+
+  follower User           @relation("UserFollows", fields: [followerId], references: [id], onDelete: Cascade)
+  creator  CreatorProfile @relation(fields: [creatorId], references: [id], onDelete: Cascade)
+
+  @@unique([followerId, creatorId])
+  @@index([followerId])
+  @@index([creatorId])
+  @@map("creator_follows")
 }
 
 model MarketplaceListing {

--- a/scripts/seed-marketplace.ts
+++ b/scripts/seed-marketplace.ts
@@ -972,6 +972,33 @@ async function main() {
     })
   }
 
+  // Seed follow relationships: demo buyers follow some creators
+  console.log('[seed-marketplace] seeding follow relationships…')
+  const buyerUsers = await prisma.user.findMany({
+    where: { email: { startsWith: 'demo-buyer-' } },
+    select: { id: true },
+    take: 6,
+  })
+  for (const buyer of buyerUsers) {
+    for (const creator of creators.slice(0, 3)) {
+      await prisma.creatorFollow.upsert({
+        where: {
+          followerId_creatorId: { followerId: buyer.id, creatorId: creator.id },
+        },
+        create: { followerId: buyer.id, creatorId: creator.id },
+        update: {},
+      })
+    }
+  }
+  // Update follower counts
+  for (const creator of creators) {
+    const count = await prisma.creatorFollow.count({ where: { creatorId: creator.id } })
+    await prisma.creatorProfile.update({
+      where: { id: creator.id },
+      data: { followerCount: count },
+    })
+  }
+
   console.log('[seed-marketplace] done.')
   console.log(`  · ${creators.length} creators (${creators.map((c) => c.tier).join(', ')})`)
   console.log(`  · ${LISTINGS.length} listings across 7 categories`)


### PR DESCRIPTION
## Summary

Implement a complete creator follow/follower system for the marketplace, allowing users to follow creators and see follower counts across the platform.

### Backend
- **New `CreatorFollow` junction table** with unique constraint on `(followerId, creatorId)`, indexes, and cascade deletes
- **Denormalized `followerCount`** on `CreatorProfile` — incremented/decremented atomically in transactions
- **Prisma migrations** for both PostgreSQL (staging/production) and SQLite (local dev)
- **`creator-follow.service.ts`** — follow, unfollow, isFollowing, getFollowingCreators (paginated), getFollowersCount
- **API routes:** `POST /creators/:id/follow`, `DELETE /creators/:id/follow`, `GET /creators/following`
- **Local mode support:** cloud proxy bypass for `/creator/` and `/follow` paths, response enrichment to merge local follow state into cloud-proxied data, `ensureLocalCreatorForFollow` to create shadow profiles for FK integrity

### Frontend
- **`FollowCreatorButton`** — reusable component with optimistic UI updates and sign-in prompts
- **Creator profile page** — follow button + "Followers" stat
- **Listing detail page** — follow button in "Created by" section
- **Marketplace home** — "From creators you follow" agent rail (auth-gated)
- **Creator dashboard** — followers/following counts as tappable stat badges in the tier card; tapping "Following" expands an inline list with unfollow capability; colored tier badge pill per creator tier

### Testing & Data
- Unit tests for all follow service functions (idempotency, self-follow guard, pagination, not-found handling)
- Seed script updated with demo follow relationships

## Migration Safety

- **Additive only** — new table + new column with `DEFAULT 0`, no destructive changes
- All local-mode infrastructure (`ensureLocalCreatorForFollow`, proxy bypass, response enrichment) is gated behind `SHOGO_LOCAL_MODE` and is inert in production
- Pre-commit hooks verified: migration staged, PG/SQLite schema parity confirmed

## Files Changed (15)

| Area | File | Change |
|------|------|--------|
| Schema | `prisma/schema.prisma` | Add CreatorFollow model, followerCount, relations |
| Schema | `prisma/schema.local.prisma` | Mirror for SQLite |
| Migration | `prisma/migrations/20260521000000_add_creator_follows/` | PostgreSQL migration |
| Migration | `apps/desktop/prisma/migrations/20260521000000_add_creator_follows/` | SQLite migration |
| Service | `apps/api/src/services/creator-follow.service.ts` | New — follow business logic |
| Routes | `apps/api/src/routes/marketplace.ts` | Add follow endpoints, proxy bypass, response enrichment |
| Component | `apps/mobile/components/marketplace/FollowCreatorButton.tsx` | New — reusable follow button |
| Component | `apps/mobile/components/marketplace/index.ts` | Export FollowCreatorButton |
| Page | `apps/mobile/app/(app)/marketplace/creators/[id].tsx` | Follow button + followers stat |
| Page | `apps/mobile/app/(app)/marketplace/[slug].tsx` | Follow button in Created by |
| Page | `apps/mobile/app/(app)/marketplace/index.tsx` | "From creators you follow" rail |
| Page | `apps/mobile/app/(app)/marketplace/creator/index.tsx` | Dashboard: followers/following badges, tier pill, expandable list |
| Store | `packages/domain-stores/src/user.collection.ts` | Add creatorFollows relation field |
| Seed | `scripts/seed-marketplace.ts` | Demo follow relationships |
| Test | `apps/api/src/__tests__/creator-follow-service.test.ts` | Unit tests for follow service |

## Test Plan

- [x] Follow a creator from their profile page — button toggles to "Following", follower count increments
- [x] Unfollow — button reverts, count decrements
- [x] Follow from listing detail "Created by" section
- [x] Marketplace home shows "From creators you follow" rail when signed in and following creators
- [x] Creator dashboard shows followers/following counts in tier card
- [x] Tapping "Following" count on dashboard expands the list of followed creators with unfollow buttons
- [x] Colored tier badge pill displays correctly per tier
- [x] Follow state persists across page refreshes
- [x] Not-signed-in users see sign-in prompt when tapping Follow
- [x] Unit tests pass for follow service
