### PR TITLE
fix(composio): OAuth redirect honors originating client (no more localhost → desktop app hijack)

### DIFF
--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -78,11 +78,28 @@ function extractRedirectFromCallbackUrl(callbackUrl: string): string | null {
   }
 }
 
+/**
+ * Construct the cloud-proxy callback URL for Composio.
+ *
+ * If the originating client passed a `redirectParam` (i.e. it told us
+ * "send me back here when OAuth completes") we forward it. If it did
+ * not, we deliberately omit the `redirect` query entirely — the cloud
+ * callback handler then falls through to the popup-close-and-poll
+ * branch ("You can close this window."), which is safe for every
+ * client.
+ *
+ * We used to default to `shogo://integrations-callback` here, which
+ * forced the OS protocol handler to launch the registered desktop app
+ * regardless of where the user actually came from — a localhost
+ * browser tab that initiated the connect would mysteriously open the
+ * desktop app on completion. Letting the no-redirect branch handle
+ * the fallback keeps every client in its own window/tab.
+ */
 function buildCloudCallbackUrl(redirectParam?: string | null): string {
   const cloudUrl = getShogoCloudUrl()
   const base = `${cloudUrl}/api/integrations/callback`
-  const redirect = redirectParam || 'shogo://integrations-callback'
-  return `${base}?redirect=${encodeURIComponent(redirect)}`
+  if (!redirectParam) return base
+  return `${base}?redirect=${encodeURIComponent(redirectParam)}`
 }
 
 // =============================================================================

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -140,7 +140,7 @@ import { type PlanData } from "./PlanCard"
 import { usePlanStreamSafe } from "./PlanStreamContext"
 import { AgentClient } from "@shogo-ai/sdk/agent"
 import { agentFetch } from "../../lib/agent-fetch"
-import { openAuthFlow, preCreateAuthWindow, isMobileWeb } from "@shogo/ui-kit/platform"
+import { openAuthFlow, preCreateAuthWindow } from "@shogo/ui-kit/platform"
 import { PermissionApprovalDialog } from "../security/PermissionApprovalDialog"
 import { buildStopRequest } from "../../lib/chat-stop"
 import { configureSubagentStop } from "../../lib/subagent-stop"
@@ -4461,7 +4461,12 @@ export const ChatPanel = observer(function ChatPanel({
                           let redirect: string | undefined
                           if (isNative) {
                             redirect = ExpoLinking.createURL('integrations-callback')
-                          } else if (isMobileWeb()) {
+                          } else {
+                            // Web (desktop browser, mobile web, Electron):
+                            // always pass our own URL so the OAuth callback
+                            // returns here instead of OS-routing through a
+                            // `shogo://` protocol handler. See
+                            // ConnectToolWidget.tsx for the full rationale.
                             const returnUrl = new URL(window.location.href)
                             returnUrl.searchParams.set('fromOAuth', '1')
                             redirect = returnUrl.toString()

--- a/apps/mobile/components/chat/turns/ConnectToolWidget.tsx
+++ b/apps/mobile/components/chat/turns/ConnectToolWidget.tsx
@@ -17,7 +17,7 @@ import { useState, useEffect, useCallback, useRef } from "react"
 import { View, Text, Pressable, Platform } from "react-native"
 import * as ExpoLinking from "expo-linking"
 import { cn } from "@shogo/shared-ui/primitives"
-import { openAuthFlow, preCreateAuthWindow, isMobileWeb } from "@shogo/ui-kit/platform"
+import { openAuthFlow, preCreateAuthWindow } from "@shogo/ui-kit/platform"
 import {
   CheckCircle2,
   Loader2,
@@ -203,8 +203,15 @@ export function ConnectToolWidget({
             redirect = ExpoLinking.createURL(
               `integrations-callback?projectId=${encodeURIComponent(projectId)}`,
             )
-          } else if (isMobileWeb()) {
-            // Mobile web: tell the server callback to redirect back to our page
+          } else {
+            // Web (desktop browser, mobile web, Electron-bundled UI): pass
+            // our own URL so the server's callback returns to *this* tab/
+            // window. Without this every web client falls through to whatever
+            // server-side default exists, which historically pointed at
+            // `shogo://integrations-callback` and OS-routed to the registered
+            // desktop-app protocol handler — sending users away from the
+            // browser tab they initiated from (e.g. localhost web → desktop
+            // app launch).
             const returnUrl = new URL(window.location.href)
             returnUrl.searchParams.set("fromOAuth", "1")
             redirect = returnUrl.toString()

--- a/apps/mobile/components/project/IntegrationsCard.tsx
+++ b/apps/mobile/components/project/IntegrationsCard.tsx
@@ -34,7 +34,7 @@ import {
   Plug,
 } from 'lucide-react-native'
 import { cn } from '@shogo/shared-ui/primitives'
-import { openAuthFlow, preCreateAuthWindow, isMobileWeb } from '@shogo/ui-kit/platform'
+import { openAuthFlow, preCreateAuthWindow } from '@shogo/ui-kit/platform'
 import { API_URL, api } from '../../lib/api'
 
 const LOG_PREFIX = '[IntegrationsCard]'
@@ -327,7 +327,10 @@ export function IntegrationsCard({
           redirect = ExpoLinking.createURL(
             `integrations-callback?projectId=${encodeURIComponent(projectId)}`,
           )
-        } else if (isMobileWeb()) {
+        } else {
+          // Web (desktop browser, mobile web, Electron): always pass our own
+          // URL so the OAuth callback returns here. See ConnectToolWidget.tsx
+          // for the rationale on why every web client must opt in.
           const returnUrl = new URL(window.location.href)
           returnUrl.searchParams.set('fromOAuth', '1')
           redirect = returnUrl.toString()

--- a/apps/mobile/components/project/panels/ServicesPanel.tsx
+++ b/apps/mobile/components/project/panels/ServicesPanel.tsx
@@ -19,7 +19,7 @@ import {
   X,
 } from 'lucide-react-native'
 import { cn } from '@shogo/shared-ui/primitives'
-import { openAuthFlow, preCreateAuthWindow, isMobileWeb } from '@shogo/ui-kit/platform'
+import { openAuthFlow, preCreateAuthWindow } from '@shogo/ui-kit/platform'
 import { API_URL, api } from '../../../lib/api'
 
 const LOG_PREFIX = '[ServicesPanel]'
@@ -104,7 +104,10 @@ export function ServicesPanel({ projectId, agentUrl, visible }: ServicesPanelPro
       let redirect: string | undefined
       if (isNative) {
         redirect = ExpoLinking.createURL('integrations-callback')
-      } else if (isMobileWeb()) {
+      } else {
+        // Web (desktop browser, mobile web, Electron): always pass our own
+        // URL so the OAuth callback returns here. See ConnectToolWidget.tsx
+        // for the rationale on why every web client must opt in.
         const returnUrl = new URL(window.location.href)
         returnUrl.searchParams.set('fromOAuth', '1')
         redirect = returnUrl.toString()

--- a/apps/mobile/components/project/panels/ToolsPanel.tsx
+++ b/apps/mobile/components/project/panels/ToolsPanel.tsx
@@ -28,7 +28,7 @@ import {
   Globe,
 } from 'lucide-react-native'
 import { cn } from '@shogo/shared-ui/primitives'
-import { openAuthFlow, preCreateAuthWindow, isMobileWeb } from '@shogo/ui-kit/platform'
+import { openAuthFlow, preCreateAuthWindow } from '@shogo/ui-kit/platform'
 import { API_URL, api } from '../../../lib/api'
 
 const LOG_PREFIX = '[ToolsPanel]'
@@ -231,7 +231,12 @@ export function ToolsPanel({ projectId, agentUrl, visible }: ToolsPanelProps) {
         let redirect: string | undefined
         if (isNative) {
           redirect = ExpoLinking.createURL('integrations-callback')
-        } else if (isMobileWeb()) {
+        } else {
+          // Web (desktop browser, mobile web, Electron): always return to the
+          // initiating tab/window. See ConnectToolWidget.tsx for the full
+          // rationale — every web client must pass an explicit redirect so
+          // the callback never falls back to a `shogo://` deep link that
+          // would launch the desktop app from a localhost browser session.
           const returnUrl = new URL(window.location.href)
           returnUrl.searchParams.set('fromOAuth', '1')
           redirect = returnUrl.toString()
@@ -277,7 +282,10 @@ export function ToolsPanel({ projectId, agentUrl, visible }: ToolsPanelProps) {
       let redirect: string | undefined
       if (isNative) {
         redirect = ExpoLinking.createURL('integrations-callback')
-      } else if (isMobileWeb()) {
+      } else {
+        // Web (desktop browser, mobile web, Electron): always pass our own
+        // URL — see the connect-flow above and ConnectToolWidget.tsx for
+        // why every web client must opt in explicitly.
         const returnUrl = new URL(window.location.href)
         returnUrl.searchParams.set('fromOAuth', '1')
         redirect = returnUrl.toString()

--- a/apps/mobile/components/settings/IntegrationsTab.tsx
+++ b/apps/mobile/components/settings/IntegrationsTab.tsx
@@ -40,7 +40,7 @@ import {
 import { useActiveWorkspace } from '../../hooks/useActiveWorkspace'
 import { useDomainHttp } from '../../contexts/domain'
 import { api, API_URL } from '../../lib/api'
-import { openAuthFlow, preCreateAuthWindow, isMobileWeb } from '@shogo/ui-kit/platform'
+import { openAuthFlow, preCreateAuthWindow } from '@shogo/ui-kit/platform'
 import {
   Card,
   CardContent,
@@ -195,7 +195,10 @@ export function IntegrationsTab() {
         let redirect: string | undefined
         if (isNative) {
           redirect = ExpoLinking.createURL('integrations-callback')
-        } else if (isMobileWeb()) {
+        } else {
+          // Web (desktop browser, mobile web, Electron): always pass our own
+          // URL so the OAuth callback returns here. See ConnectToolWidget.tsx
+          // for the rationale on why every web client must opt in.
           const returnUrl = new URL(window.location.href)
           returnUrl.searchParams.set('fromOAuth', '1')
           redirect = returnUrl.toString()

--- a/packages/agent-runtime/src/composio.ts
+++ b/packages/agent-runtime/src/composio.ts
@@ -587,8 +587,21 @@ async function initiateComposioAuth(
     const callbackBase = isCloudProxy
       ? (process.env.SHOGO_CLOUD_URL || 'https://studio.shogo.ai').replace(/\/$/, '')
       : (process.env.BETTER_AUTH_URL || process.env.API_URL || 'http://localhost:8002')
+    // No `redirect` param: the agent-runtime initiates this from the
+    // server side and has no first-class knowledge of which UI client
+    // (localhost browser, native, Electron) is actually waiting for the
+    // connection. The post-callback page falls through to the
+    // "you can close this window" branch and the UI then polls
+    // `/api/integrations/status/:toolkit` to discover completion. Any
+    // UI client that wants an explicit return navigation re-initiates
+    // through `POST /api/integrations/connect` with its own `callbackUrl`.
+    //
+    // We used to hardcode `redirect=shogo://integrations-callback` here,
+    // which OS-routed the user to the registered desktop-app protocol
+    // handler regardless of where they actually came from — sending
+    // localhost-web users into the desktop app on completion.
     const connection = await session.authorize(toolkitSlug, {
-      callbackUrl: `${callbackBase}/api/integrations/callback?toolkit=${encodeURIComponent(toolkitSlug)}&redirect=${encodeURIComponent('shogo://integrations-callback')}`,
+      callbackUrl: `${callbackBase}/api/integrations/callback?toolkit=${encodeURIComponent(toolkitSlug)}`,
     })
 
     const redirectUrl = (connection as any)?.redirectUrl || (connection as any)?.redirect_url


### PR DESCRIPTION
## Why

Adding a Composio integration from a **localhost browser tab** was incorrectly launching the **desktop app** on completion. The "Redirecting back to Shogo…" page was firing `window.location.href = "shogo://integrations-callback"`, the OS protocol handler picked that up, and the user got bounced into whichever app had registered `shogo://` (i.e. the desktop install) instead of staying in their browser.

The plumbing to return users to the right client *already exists* — it's the `redirect` query param on `/api/integrations/callback`. The bug is that two server-side defaults and a UI gate together made "no client opinion → deep-link to desktop" the de facto behavior for every non-mobile-web client.

## What

Three changes that together remove every code path through which a non-desktop client can land on `shogo://`:

### 1. UI clients always opt in (six files)

`ConnectToolWidget`, `ToolsPanel` (×2 sites), `ServicesPanel`, `IntegrationsCard`, `IntegrationsTab`, and `ChatPanel` all gated the "pass our own URL as redirect" behavior behind `isMobileWeb()`. So desktop browsers, localhost web, and the Electron-bundled web UI all fell through with `redirect = undefined` and inherited the server-side default (which was `shogo://`).

Drop the gate — every web platform now passes `window.location.href + "?fromOAuth=1"` as redirect. The server callback's existing http(s) origin allowlist (`BETTER_AUTH_URL` / `API_URL` / `APP_URL` / `EXPO_PUBLIC_API_URL` + request host) accepts these and 302s back. Electron UIs running at `shogo://app/…` still match the **native-redirect** branch and stay in the same window via the in-process protocol handler.

`isMobileWeb` is no longer imported in any of the touched files.

### 2. `buildCloudCallbackUrl` stops defaulting to `shogo://`

```ts
// before
const redirect = redirectParam || 'shogo://integrations-callback'
return `${base}?redirect=${encodeURIComponent(redirect)}`

// after
if (!redirectParam) return base
return `${base}?redirect=${encodeURIComponent(redirectParam)}`
```

If no client redirect was supplied, omit the `redirect` query entirely. The cloud callback HTML then falls through to the "You can close this window." branch and the UI polls `/api/integrations/status/:toolkit`. Safe for every client.

### 3. Agent-runtime drops its hardcoded `shogo://`

`packages/agent-runtime/src/composio.ts` was building auth URLs with `redirect=shogo://integrations-callback` baked in. The agent has no first-class knowledge of which UI client is waiting; the universally-safe fallback is the same close-and-poll behavior. Removed.

## What is not changed

- `apps/api/src/server.ts` callback handler is untouched — its `shogo://` / `exp://` / http(s) branching was already correct, and it's the consumer of (not the source of) the bad defaults this PR removes.
- The native (`shogo://integrations-callback?projectId=…`) and Expo (`exp://…`) redirects from native clients still go through unchanged.
- The Electron web UI still works: `Platform.OS === 'web'` so it now passes `window.location.href` (`shogo://app/…`), which the server callback classifies as a native redirect and JS-redirects to. Inside Electron's renderer, that's intercepted by the registered protocol handler and serves the static Expo export at the same origin — same window, no OS handoff.
- The e2e staging test `e2e/staging/composio-cloud-proxy.test.ts` still passes `redirect=shogo://integrations-callback` itself, intentionally — it simulates a desktop client. That's still a valid (and now opt-in) request shape.

## Test plan

- [ ] **Localhost web (the reported bug)**: connect any Composio toolkit from `http://localhost:PORT/...`. After authorizing on Composio, the callback page 302s back to the same tab with `?fromOAuth=1`. The desktop app must **not** launch.
- [ ] **Desktop app (Electron)**: connect a toolkit. After OAuth, the popup either closes-and-polls (if `Platform.OS === 'web'` and origin is `shogo://app`, the http(s) allowlist rejects → close-window branch) or JS-redirects via the in-process `shogo://` handler back to the same window.
- [ ] **Native iOS / Android**: connect a toolkit. After OAuth, `openAuthSessionAsync` intercepts the `exp://` or `shogo://` JS redirect and returns control to the app — unchanged.
- [ ] **Mobile Safari / mobile Chrome web**: connect a toolkit. After OAuth, 302 back to the same tab with `?fromOAuth=1` — unchanged.
- [ ] **Cloud-proxy local mode** (`SHOGO_API_KEY` set, callback rewritten to cloud): if cloud's allowlist doesn't include localhost, callback shows "You can close this window." and UI polls. Acceptable — beats opening the wrong app.
- [ ] **Agent-initiated install** via chat `tool_install`: the agent's auth URL no longer contains a hardcoded `shogo://`; the UI re-initiates via `POST /integrations/connect` with its own client-correct redirect (existing behavior in `ConnectToolWidget`).

## Out of scope

A nice follow-up is hardening: capture `Origin` / `Referer` on `POST /integrations/connect`, store it on the in-flight connection, and use it as the server-side fallback so even clients that forget to pass `redirect` still get sent back correctly. Saves us if a future call site re-introduces this bug.
