### PR TITLE
fix(k8s): wire per-region Cloudflare DNS env vars on prod API ksvcs

### DIFF
--- a/k8s/overlays/production-eu/api-service.yaml
+++ b/k8s/overlays/production-eu/api-service.yaml
@@ -109,6 +109,24 @@ spec:
               value: "shogo.ai"
             - name: PREVIEW_ENVIRONMENT
               value: "production"
+            # Per-preview Cloudflare DNS: upserts a proxied A record for
+            # every preview--<projectId>.shogo.ai hostname pointing at
+            # this cluster's Kourier LB. Without these three vars,
+            # `apps/api/src/lib/cloudflare-dns.ts` is a no-op and EU
+            # previews fall back to the flat `*.shogo.ai` wildcard,
+            # which routes to US Kourier and returns 404 / CF 522.
+            # See docs/cloudflare-dns-per-preview.md and the
+            # 2026-05-21 incident.
+            - name: CF_ZONE_ID
+              value: "c2d56140e7de85a4ac5ab5bea8e7434f"
+            - name: KOURIER_LB_IP
+              value: "79.76.126.115"
+            - name: CF_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflare-dns
+                  key: CF_API_TOKEN
+                  optional: true
             - name: S3_WORKSPACES_BUCKET
               value: "shogo-workspaces-production"
             - name: S3_REGION

--- a/k8s/overlays/production-india/api-service.yaml
+++ b/k8s/overlays/production-india/api-service.yaml
@@ -109,6 +109,24 @@ spec:
               value: "shogo.ai"
             - name: PREVIEW_ENVIRONMENT
               value: "production"
+            # Per-preview Cloudflare DNS: upserts a proxied A record for
+            # every preview--<projectId>.shogo.ai hostname pointing at
+            # this cluster's Kourier LB. Without these three vars,
+            # `apps/api/src/lib/cloudflare-dns.ts` is a no-op and India
+            # previews fall back to the flat `*.shogo.ai` wildcard,
+            # which routes to US Kourier and returns 404 / CF 522.
+            # See docs/cloudflare-dns-per-preview.md and the
+            # 2026-05-21 incident.
+            - name: CF_ZONE_ID
+              value: "c2d56140e7de85a4ac5ab5bea8e7434f"
+            - name: KOURIER_LB_IP
+              value: "161.118.170.159"
+            - name: CF_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflare-dns
+                  key: CF_API_TOKEN
+                  optional: true
             - name: S3_WORKSPACES_BUCKET
               value: "shogo-workspaces-production"
             - name: S3_REGION

--- a/k8s/overlays/production-us/api-service.yaml
+++ b/k8s/overlays/production-us/api-service.yaml
@@ -109,6 +109,23 @@ spec:
               value: "shogo.ai"
             - name: PREVIEW_ENVIRONMENT
               value: "production"
+            # Per-preview Cloudflare DNS: upserts a proxied A record for
+            # every preview--<projectId>.shogo.ai hostname pointing at
+            # this cluster's Kourier LB. US currently works via the flat
+            # `*.shogo.ai` wildcard (which also points at this LB), but
+            # wiring per-preview records here keeps all three regions
+            # consistent and avoids surprises if we ever repoint the
+            # wildcard. See docs/cloudflare-dns-per-preview.md.
+            - name: CF_ZONE_ID
+              value: "c2d56140e7de85a4ac5ab5bea8e7434f"
+            - name: KOURIER_LB_IP
+              value: "152.70.192.220"
+            - name: CF_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflare-dns
+                  key: CF_API_TOKEN
+                  optional: true
             - name: S3_WORKSPACES_BUCKET
               value: "shogo-workspaces-production"
             - name: S3_REGION


### PR DESCRIPTION
## Summary

- Adds `CF_API_TOKEN` / `CF_ZONE_ID` / `KOURIER_LB_IP` to **all three** production overlays (`production-india`, `production-eu`, `production-us`) so `apps/api/src/lib/cloudflare-dns.ts` actually runs in each region.
- Without this, India/EU preview hostnames (`preview--<projectId>.shogo.ai`) silently fall back to the flat `*.shogo.ai` CF wildcard, which resolves to US Kourier — where no `DomainMapping` exists for the hostname → user sees an envoy 404 inside the preview iframe (or CF error 522 "Connection timed out" from far PoPs).
- US is wired for consistency; behavior there is unchanged because the wildcard already points at the US LB.

## Incident

- 2026-05-21 ~17:30 UTC, production-india.
- New project `14d48b2b-c440-4bfb-a977-4697db588e61` was correctly assigned `warm-pool-87dab032` and its `DomainMapping preview--…shogo.ai → warm-pool-87dab032` reached `Ready=True`, but the user saw "connection timed out" in the project view.
- Forced-resolve confirmed:
  - `--resolve …:443:161.118.170.159` (India LB) → **200 OK**
  - `--resolve …:443:152.70.192.220` (US LB) → **404 from envoy**
  - CF wildcard `*.shogo.ai` content: `152.70.192.220, proxied=true` ← root cause
- No `[cloudflare-dns]` log lines have ever been emitted by any production region; \`kubectl get ksvc api -o jsonpath\` confirmed all three CF env vars were missing on all three production API ksvcs even though the `cloudflare-dns` secret has existed in every cluster for 27 days. Step 3 of `docs/cloudflare-dns-per-preview.md` simply never ran.

## Rollout note

The `cloudflare-dns` secret already exists in `shogo-production-system` on US, EU, and India. Once this lands and the API ksvc rolls a new revision, the next preview claim in each region will log `[cloudflare-dns] Created preview--<id>.shogo.ai -> <region LB IP> (proxied)`. Existing in-flight India/EU previews that pre-date the deploy will be back-filled automatically on the next claim (helper is idempotent), or can be touched manually.

The single live India preview that was broken at the time of the incident has already been unblocked by manually creating the CF record (will be cleaned up by the normal `deletePreviewDnsRecord` path when the pod is evicted).

## Follow-up

A separate PR will replace the hardcoded `KOURIER_LB_IP` with self-discovery from `Service kourier/kourier-system` at API startup, so future new regions only need `CF_API_TOKEN` + `CF_ZONE_ID` wired and can never repeat this footgun.

## Test plan

- [ ] Confirm staging deploy still healthy (env vars are unused there — secret won't exist → helper is a no-op).
- [ ] After merge + deploy to India: create a fresh test project, watch api logs for `[cloudflare-dns] Created preview--<id>.shogo.ai -> 161.118.170.159 (proxied)`.
- [ ] `dig +short preview--<id>.shogo.ai` returns CF edge IPs (sanity), then `curl --resolve …:443:161.118.170.159` returns 200 *and* the wildcard-resolved curl also returns 200 (no longer routed to US).
- [ ] Repeat for EU.
- [ ] US: confirm no regression (wildcard target unchanged; helper just creates an extra record at the same IP).

Made with [Cursor](https://cursor.com)