### PR TITLE
feat(cloudflare-dns): auto-discover Kourier LB IP at API startup

### DIFF
--- a/apps/api/src/__tests__/cloudflare-dns.test.ts
+++ b/apps/api/src/__tests__/cloudflare-dns.test.ts
@@ -16,6 +16,7 @@
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import {
   _resetCloudflareDnsConfigForTest,
+  _setKourierDiscovererForTest,
   deletePreviewDnsRecord,
   getCloudflareDnsConfig,
   upsertPreviewDnsRecord,
@@ -32,6 +33,9 @@ beforeEach(() => {
     delete process.env[k]
   }
   _resetCloudflareDnsConfigForTest()
+  // Default: discovery returns null (no LB ingress) so tests that don't
+  // explicitly set KOURIER_LB_IP don't accidentally hit the real K8s API.
+  _setKourierDiscovererForTest(async () => null)
 })
 
 afterEach(() => {
@@ -40,6 +44,7 @@ afterEach(() => {
     else process.env[k] = SAVED[k]
   }
   _resetCloudflareDnsConfigForTest()
+  _setKourierDiscovererForTest(null)
 })
 
 // ─── fake fetch helpers ───────────────────────────────────────────────────
@@ -83,27 +88,28 @@ function setEnv(over: Partial<Record<(typeof ENV_KEYS)[number], string>> = {}) {
 // ─── getCloudflareDnsConfig ───────────────────────────────────────────────
 
 describe('getCloudflareDnsConfig', () => {
-  test('returns null when CF_API_TOKEN is missing', () => {
+  test('returns null when CF_API_TOKEN is missing', async () => {
     process.env.CF_ZONE_ID = 'z'
     process.env.KOURIER_LB_IP = '1.1.1.1'
-    expect(getCloudflareDnsConfig()).toBeNull()
+    expect(await getCloudflareDnsConfig()).toBeNull()
   })
 
-  test('returns null when CF_ZONE_ID is missing', () => {
+  test('returns null when CF_ZONE_ID is missing', async () => {
     process.env.CF_API_TOKEN = 't'
     process.env.KOURIER_LB_IP = '1.1.1.1'
-    expect(getCloudflareDnsConfig()).toBeNull()
+    expect(await getCloudflareDnsConfig()).toBeNull()
   })
 
-  test('returns null when KOURIER_LB_IP is missing', () => {
+  test('returns null when KOURIER_LB_IP is missing AND discovery returns null', async () => {
     process.env.CF_API_TOKEN = 't'
     process.env.CF_ZONE_ID = 'z'
-    expect(getCloudflareDnsConfig()).toBeNull()
+    // Default discoverer (set in beforeEach) returns null.
+    expect(await getCloudflareDnsConfig()).toBeNull()
   })
 
-  test('returns config when all three env vars are set', () => {
+  test('returns config when all three env vars are set', async () => {
     setEnv()
-    const cfg = getCloudflareDnsConfig()
+    const cfg = await getCloudflareDnsConfig()
     expect(cfg).toEqual({
       apiToken: 'cf-token',
       zoneId: 'zone-abc',
@@ -112,38 +118,169 @@ describe('getCloudflareDnsConfig', () => {
     })
   })
 
-  test('honors CF_DNS_COMMENT override', () => {
+  test('honors CF_DNS_COMMENT override', async () => {
     setEnv({ CF_DNS_COMMENT: 'staging-env' })
-    expect(getCloudflareDnsConfig()?.comment).toBe('staging-env')
+    expect((await getCloudflareDnsConfig())?.comment).toBe('staging-env')
   })
 
-  test('caches the result — flipping env after the first call does NOT change the answer', () => {
+  test('caches the result — flipping env after the first call does NOT change the answer', async () => {
     setEnv()
-    const first = getCloudflareDnsConfig()
+    const first = await getCloudflareDnsConfig()
     expect(first).not.toBeNull()
     delete process.env.CF_API_TOKEN
     // Cache lives until _resetCloudflareDnsConfigForTest fires (or process restart).
-    expect(getCloudflareDnsConfig()).toBe(first as any)
+    expect(await getCloudflareDnsConfig()).toBe(first as any)
   })
 
-  test('_resetCloudflareDnsConfigForTest re-reads env on next call', () => {
+  test('_resetCloudflareDnsConfigForTest re-reads env on next call', async () => {
     setEnv()
-    expect(getCloudflareDnsConfig()).not.toBeNull()
+    expect(await getCloudflareDnsConfig()).not.toBeNull()
     delete process.env.CF_API_TOKEN
     _resetCloudflareDnsConfigForTest()
-    expect(getCloudflareDnsConfig()).toBeNull()
+    expect(await getCloudflareDnsConfig()).toBeNull()
   })
 
-  test('caches null too — once disabled, stays disabled until reset', () => {
+  test('caches null too — once disabled, stays disabled until reset', async () => {
     // No env set → null.
-    expect(getCloudflareDnsConfig()).toBeNull()
+    expect(await getCloudflareDnsConfig()).toBeNull()
     // Set env directly (NOT via setEnv — that helper resets the cache).
     process.env.CF_API_TOKEN = 'cf-token'
     process.env.CF_ZONE_ID = 'zone-abc'
     process.env.KOURIER_LB_IP = '10.0.0.1'
-    expect(getCloudflareDnsConfig()).toBeNull() // cache still says null
+    expect(await getCloudflareDnsConfig()).toBeNull() // cache still says null
     _resetCloudflareDnsConfigForTest()
-    expect(getCloudflareDnsConfig()).not.toBeNull()
+    expect(await getCloudflareDnsConfig()).not.toBeNull()
+  })
+})
+
+// ─── Kourier LB IP discovery fallback ─────────────────────────────────────
+
+describe('getCloudflareDnsConfig — Kourier LB discovery', () => {
+  test('uses discoverer when CF env present but KOURIER_LB_IP env missing', async () => {
+    process.env.CF_API_TOKEN = 'cf-token'
+    process.env.CF_ZONE_ID = 'zone-abc'
+    delete process.env.KOURIER_LB_IP
+    _setKourierDiscovererForTest(async () => '203.0.113.42')
+    _resetCloudflareDnsConfigForTest()
+
+    const cfg = await getCloudflareDnsConfig()
+    expect(cfg).toEqual({
+      apiToken: 'cf-token',
+      zoneId: 'zone-abc',
+      lbIp: '203.0.113.42',
+      comment: 'shogo-preview (managed by api)',
+    })
+  })
+
+  test('prefers env over discovery — env is the operator escape hatch', async () => {
+    process.env.CF_API_TOKEN = 'cf-token'
+    process.env.CF_ZONE_ID = 'zone-abc'
+    process.env.KOURIER_LB_IP = '10.0.0.1'
+    let discovererCalled = false
+    _setKourierDiscovererForTest(async () => {
+      discovererCalled = true
+      return '203.0.113.42'
+    })
+    _resetCloudflareDnsConfigForTest()
+
+    const cfg = await getCloudflareDnsConfig()
+    expect(cfg?.lbIp).toBe('10.0.0.1')
+    expect(discovererCalled).toBe(false)
+  })
+
+  test('disables helper when discovery throws (e.g. RBAC denial)', async () => {
+    process.env.CF_API_TOKEN = 'cf-token'
+    process.env.CF_ZONE_ID = 'zone-abc'
+    delete process.env.KOURIER_LB_IP
+    const errSpy = spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      _setKourierDiscovererForTest(async () => {
+        throw new Error('Forbidden: services "kourier" is forbidden')
+      })
+      _resetCloudflareDnsConfigForTest()
+
+      expect(await getCloudflareDnsConfig()).toBeNull()
+      const joined = errSpy.mock.calls.map((c) => c.join(' ')).join('\n')
+      expect(joined).toContain('Kourier LB discovery failed')
+      expect(joined).toContain('Forbidden')
+    } finally {
+      errSpy.mockRestore()
+    }
+  })
+
+  test('disables helper when service exists but has no LB ingress yet', async () => {
+    process.env.CF_API_TOKEN = 'cf-token'
+    process.env.CF_ZONE_ID = 'zone-abc'
+    delete process.env.KOURIER_LB_IP
+    const errSpy = spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      _setKourierDiscovererForTest(async () => null)
+      _resetCloudflareDnsConfigForTest()
+
+      expect(await getCloudflareDnsConfig()).toBeNull()
+      const joined = errSpy.mock.calls.map((c) => c.join(' ')).join('\n')
+      expect(joined).toContain('no loadBalancer.ingress')
+    } finally {
+      errSpy.mockRestore()
+    }
+  })
+
+  test('only invokes discoverer once across many config calls (caches resolved IP)', async () => {
+    process.env.CF_API_TOKEN = 'cf-token'
+    process.env.CF_ZONE_ID = 'zone-abc'
+    delete process.env.KOURIER_LB_IP
+    let calls = 0
+    _setKourierDiscovererForTest(async () => {
+      calls++
+      return '203.0.113.7'
+    })
+    _resetCloudflareDnsConfigForTest()
+
+    for (let i = 0; i < 5; i++) {
+      const cfg = await getCloudflareDnsConfig()
+      expect(cfg?.lbIp).toBe('203.0.113.7')
+    }
+    expect(calls).toBe(1)
+  })
+
+  test('concurrent first-call requests share a single in-flight discovery', async () => {
+    process.env.CF_API_TOKEN = 'cf-token'
+    process.env.CF_ZONE_ID = 'zone-abc'
+    delete process.env.KOURIER_LB_IP
+    let calls = 0
+    _setKourierDiscovererForTest(async () => {
+      calls++
+      await new Promise((r) => setTimeout(r, 5))
+      return '198.51.100.10'
+    })
+    _resetCloudflareDnsConfigForTest()
+
+    const [a, b, c] = await Promise.all([
+      getCloudflareDnsConfig(),
+      getCloudflareDnsConfig(),
+      getCloudflareDnsConfig(),
+    ])
+    expect(a?.lbIp).toBe('198.51.100.10')
+    expect(b?.lbIp).toBe('198.51.100.10')
+    expect(c?.lbIp).toBe('198.51.100.10')
+    // Only one in-flight discovery despite three concurrent callers — this
+    // is the property that makes the lazy-async pattern safe under burst
+    // load (e.g. many warm pods being claimed in parallel at pod startup).
+    expect(calls).toBe(1)
+  })
+
+  test('skips discovery entirely when CF env is missing — no kourier service read', async () => {
+    delete process.env.CF_API_TOKEN
+    delete process.env.CF_ZONE_ID
+    let called = false
+    _setKourierDiscovererForTest(async () => {
+      called = true
+      return '1.1.1.1'
+    })
+    _resetCloudflareDnsConfigForTest()
+
+    expect(await getCloudflareDnsConfig()).toBeNull()
+    expect(called).toBe(false)
   })
 })
 
@@ -164,7 +301,7 @@ describe('upsertPreviewDnsRecord', () => {
       if (call.method === 'GET') return { result: [] }
       return { result: { id: 'new-rec' } }
     })
-    const cfg = getCloudflareDnsConfig()!
+    const cfg = (await getCloudflareDnsConfig())!
     cfg.fetch = fetchImpl
 
     await upsertPreviewDnsRecord('preview--p1.shogo.ai')
@@ -195,7 +332,7 @@ describe('upsertPreviewDnsRecord', () => {
   test('uses the configured comment when set', async () => {
     setEnv({ CF_DNS_COMMENT: 'staging' })
     const { fetchImpl, calls } = makeFakeFetch(() => ({ result: [] }))
-    const cfg = getCloudflareDnsConfig()!
+    const cfg = (await getCloudflareDnsConfig())!
     cfg.fetch = fetchImpl
 
     await upsertPreviewDnsRecord('preview--p1.shogo.ai')
@@ -215,7 +352,7 @@ describe('upsertPreviewDnsRecord', () => {
         },
       ],
     }))
-    const cfg = getCloudflareDnsConfig()!
+    const cfg = (await getCloudflareDnsConfig())!
     cfg.fetch = fetchImpl
 
     await upsertPreviewDnsRecord('preview--p1.shogo.ai')
@@ -242,7 +379,7 @@ describe('upsertPreviewDnsRecord', () => {
       }
       return { result: { id: 'rec-1' } }
     })
-    const cfg = getCloudflareDnsConfig()!
+    const cfg = (await getCloudflareDnsConfig())!
     cfg.fetch = fetchImpl
 
     await upsertPreviewDnsRecord('preview--p1.shogo.ai')
@@ -271,7 +408,7 @@ describe('upsertPreviewDnsRecord', () => {
       }
       return { result: { id: 'rec-1' } }
     })
-    const cfg = getCloudflareDnsConfig()!
+    const cfg = (await getCloudflareDnsConfig())!
     cfg.fetch = fetchImpl
 
     await upsertPreviewDnsRecord('preview--p1.shogo.ai')
@@ -287,7 +424,7 @@ describe('upsertPreviewDnsRecord', () => {
         ok: false,
         errors: [{ code: 9109, message: 'Invalid token' }],
       }))
-      const cfg = getCloudflareDnsConfig()!
+      const cfg = (await getCloudflareDnsConfig())!
       cfg.fetch = fetchImpl
 
       await expect(upsertPreviewDnsRecord('preview--p1.shogo.ai')).resolves.toBeUndefined()
@@ -309,7 +446,7 @@ describe('upsertPreviewDnsRecord', () => {
         if (call.method === 'GET') return { result: [] }
         return { ok: false, errors: [{ code: 81057, message: 'Record already exists' }] }
       })
-      const cfg = getCloudflareDnsConfig()!
+      const cfg = (await getCloudflareDnsConfig())!
       cfg.fetch = fetchImpl
 
       await expect(upsertPreviewDnsRecord('preview--p2.shogo.ai')).resolves.toBeUndefined()
@@ -334,7 +471,7 @@ describe('upsertPreviewDnsRecord', () => {
         }
         return { ok: false, errors: [{ code: 81000, message: 'patch denied' }] }
       })
-      const cfg = getCloudflareDnsConfig()!
+      const cfg = (await getCloudflareDnsConfig())!
       cfg.fetch = fetchImpl
 
       await expect(upsertPreviewDnsRecord('preview--p3.shogo.ai')).resolves.toBeUndefined()
@@ -352,7 +489,7 @@ describe('upsertPreviewDnsRecord', () => {
       const thrower = mock(async () => {
         throw new Error('ECONNREFUSED')
       }) as unknown as typeof globalThis.fetch
-      const cfg = getCloudflareDnsConfig()!
+      const cfg = (await getCloudflareDnsConfig())!
       cfg.fetch = thrower
 
       await expect(upsertPreviewDnsRecord('preview--p4.shogo.ai')).resolves.toBeUndefined()
@@ -367,7 +504,7 @@ describe('upsertPreviewDnsRecord', () => {
   test('URL-encodes the hostname in the list query', async () => {
     setEnv()
     const { fetchImpl, calls } = makeFakeFetch(() => ({ result: [] }))
-    const cfg = getCloudflareDnsConfig()!
+    const cfg = (await getCloudflareDnsConfig())!
     cfg.fetch = fetchImpl
 
     await upsertPreviewDnsRecord('weird host.shogo.ai')
@@ -388,7 +525,7 @@ describe('deletePreviewDnsRecord', () => {
   test('no-op when the record does not exist (no DELETE issued)', async () => {
     setEnv()
     const { fetchImpl, calls } = makeFakeFetch(() => ({ result: [] }))
-    const cfg = getCloudflareDnsConfig()!
+    const cfg = (await getCloudflareDnsConfig())!
     cfg.fetch = fetchImpl
 
     await deletePreviewDnsRecord('preview--p1.shogo.ai')
@@ -414,7 +551,7 @@ describe('deletePreviewDnsRecord', () => {
       }
       return { result: { id: 'rec-42' } }
     })
-    const cfg = getCloudflareDnsConfig()!
+    const cfg = (await getCloudflareDnsConfig())!
     cfg.fetch = fetchImpl
 
     await deletePreviewDnsRecord('preview--p1.shogo.ai')
@@ -435,7 +572,7 @@ describe('deletePreviewDnsRecord', () => {
         ok: false,
         errors: [{ code: 7003, message: 'No such zone' }],
       }))
-      const cfg = getCloudflareDnsConfig()!
+      const cfg = (await getCloudflareDnsConfig())!
       cfg.fetch = fetchImpl
 
       await expect(deletePreviewDnsRecord('h.shogo.ai')).resolves.toBeUndefined()
@@ -461,7 +598,7 @@ describe('deletePreviewDnsRecord', () => {
         }
         return { ok: false, errors: [{ code: 81044, message: 'Record locked' }] }
       })
-      const cfg = getCloudflareDnsConfig()!
+      const cfg = (await getCloudflareDnsConfig())!
       cfg.fetch = fetchImpl
 
       await expect(deletePreviewDnsRecord('h.shogo.ai')).resolves.toBeUndefined()
@@ -479,7 +616,7 @@ describe('deletePreviewDnsRecord', () => {
       const thrower = mock(async () => {
         throw new Error('socket hang up')
       }) as unknown as typeof globalThis.fetch
-      const cfg = getCloudflareDnsConfig()!
+      const cfg = (await getCloudflareDnsConfig())!
       cfg.fetch = thrower
 
       await expect(deletePreviewDnsRecord('preview--zz.shogo.ai')).resolves.toBeUndefined()

--- a/apps/api/src/lib/__tests__/cloudflare-dns.test.ts
+++ b/apps/api/src/lib/__tests__/cloudflare-dns.test.ts
@@ -16,6 +16,7 @@ import {
   deletePreviewDnsRecord,
   getCloudflareDnsConfig,
   _resetCloudflareDnsConfigForTest,
+  _setKourierDiscovererForTest,
 } from '../cloudflare-dns'
 
 interface FetchCall {
@@ -57,23 +58,38 @@ function clearEnv() {
   delete process.env.KOURIER_LB_IP
   delete process.env.CF_DNS_COMMENT
   _resetCloudflareDnsConfigForTest()
+  // Avoid accidentally falling through to the real K8s-based discoverer
+  // in tests that only set CF_API_TOKEN + CF_ZONE_ID.
+  _setKourierDiscovererForTest(async () => null)
 }
 
 describe('cloudflare-dns configuration', () => {
   beforeEach(() => clearEnv())
   afterEach(() => clearEnv())
 
-  test('returns null when any var is missing', () => {
-    expect(getCloudflareDnsConfig()).toBeNull()
+  test('returns null when any var is missing', async () => {
+    expect(await getCloudflareDnsConfig()).toBeNull()
     process.env.CF_API_TOKEN = 't'
     _resetCloudflareDnsConfigForTest()
-    expect(getCloudflareDnsConfig()).toBeNull()
+    expect(await getCloudflareDnsConfig()).toBeNull()
     process.env.CF_ZONE_ID = 'z'
     _resetCloudflareDnsConfigForTest()
-    expect(getCloudflareDnsConfig()).toBeNull()
+    // CF env now satisfied but discoverer (stubbed in clearEnv) returns null,
+    // so helper stays disabled.
+    expect(await getCloudflareDnsConfig()).toBeNull()
     process.env.KOURIER_LB_IP = '1.1.1.1'
     _resetCloudflareDnsConfigForTest()
-    expect(getCloudflareDnsConfig()).not.toBeNull()
+    expect(await getCloudflareDnsConfig()).not.toBeNull()
+  })
+
+  test('falls back to Kourier service discovery when KOURIER_LB_IP is missing', async () => {
+    process.env.CF_API_TOKEN = 't'
+    process.env.CF_ZONE_ID = 'z'
+    delete process.env.KOURIER_LB_IP
+    _setKourierDiscovererForTest(async () => '198.51.100.7')
+    _resetCloudflareDnsConfigForTest()
+    const cfg = await getCloudflareDnsConfig()
+    expect(cfg?.lbIp).toBe('198.51.100.7')
   })
 
   test('upsert is a no-op without config', async () => {

--- a/apps/api/src/lib/__tests__/kourier-lb-discovery.test.ts
+++ b/apps/api/src/lib/__tests__/kourier-lb-discovery.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Unit tests for `kourier-lb-discovery.ts`.
+ *
+ * The module reads `Service kourier/kourier-system` and returns the first
+ * `.status.loadBalancer.ingress[].ip`. We test the behavior contract via
+ * a mocked @kubernetes/client-node so we never need a real cluster.
+ *
+ * The cached CoreV1Api inside the module is intentionally reset between
+ * tests via the exported `_resetKourierLbDiscoveryForTest` helper so that
+ * each test sees a fresh client instance built from the current mock.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+interface FakeReadResponse {
+  status?: {
+    loadBalancer?: {
+      ingress?: Array<{ ip?: string; hostname?: string }>
+    }
+  }
+}
+
+let readImpl: (args: { name: string; namespace: string }) => Promise<FakeReadResponse>
+
+mock.module('@kubernetes/client-node', () => {
+  class KubeConfig {
+    loadFromOptions() {}
+    loadFromDefault() {}
+    makeApiClient() {
+      return {
+        readNamespacedService: (args: { name: string; namespace: string }) => readImpl(args),
+      }
+    }
+  }
+  class CoreV1Api {}
+  return { KubeConfig, CoreV1Api }
+})
+
+import {
+  _resetKourierLbDiscoveryForTest,
+  discoverKourierLbIp,
+} from '../kourier-lb-discovery'
+
+beforeEach(() => {
+  readImpl = async () => ({})
+  _resetKourierLbDiscoveryForTest()
+})
+
+afterEach(() => {
+  _resetKourierLbDiscoveryForTest()
+})
+
+describe('discoverKourierLbIp', () => {
+  test('returns the first ingress IP when present', async () => {
+    readImpl = async (args) => {
+      expect(args.namespace).toBe('kourier-system')
+      expect(args.name).toBe('kourier')
+      return { status: { loadBalancer: { ingress: [{ ip: '203.0.113.10' }] } } }
+    }
+    expect(await discoverKourierLbIp()).toBe('203.0.113.10')
+  })
+
+  test('skips ingress entries without ip, falling through to the next entry', async () => {
+    readImpl = async () => ({
+      status: { loadBalancer: { ingress: [{}, { ip: '198.51.100.42' }] } },
+    })
+    expect(await discoverKourierLbIp()).toBe('198.51.100.42')
+  })
+
+  test('returns null when service has no loadBalancer ingress yet', async () => {
+    readImpl = async () => ({ status: { loadBalancer: { ingress: [] } } })
+    expect(await discoverKourierLbIp()).toBeNull()
+  })
+
+  test('returns null when service has no status at all', async () => {
+    readImpl = async () => ({})
+    expect(await discoverKourierLbIp()).toBeNull()
+  })
+
+  test('throws on hostname-only ingress so caller does not produce a malformed A record', async () => {
+    readImpl = async () => ({
+      status: { loadBalancer: { ingress: [{ hostname: 'a1b2.elb.amazonaws.com' }] } },
+    })
+    await expect(discoverKourierLbIp()).rejects.toThrow(/hostname-only/)
+  })
+
+  test('propagates K8s API errors (e.g. RBAC denial) so the caller can disable the helper', async () => {
+    readImpl = async () => {
+      const err: any = new Error('Forbidden: services "kourier" is forbidden')
+      err.statusCode = 403
+      throw err
+    }
+    await expect(discoverKourierLbIp()).rejects.toThrow(/Forbidden/)
+  })
+
+  test('respects KOURIER_NAMESPACE / KOURIER_SERVICE_NAME env overrides via module re-import', async () => {
+    // We can't easily re-evaluate the module-level env reads in the same
+    // process, so this just documents the contract — the env vars are
+    // read once at module load. Operators wanting a custom namespace
+    // should set these before the api process starts.
+    expect(typeof discoverKourierLbIp).toBe('function')
+  })
+})

--- a/apps/api/src/lib/cloudflare-dns.ts
+++ b/apps/api/src/lib/cloudflare-dns.ts
@@ -12,14 +12,23 @@
  * per-preview records at the moment a DomainMapping is created, and
  * remove them when the DomainMapping is deleted.
  *
- * Only active when all three env vars are set:
+ * Active when both of these are set:
  *   CF_API_TOKEN   — Zone.DNS:Edit scope on the zone
  *   CF_ZONE_ID     — Cloudflare zone id for the preview base domain
- *   KOURIER_LB_IP  — this cluster's externally-routable Kourier IP
  *
- * If any is missing the helper is a no-op, which means local dev and
- * single-region deployments keep working unchanged.
+ * The cluster's Kourier LB IP is resolved in this order:
+ *   1. `KOURIER_LB_IP` env var, if set (operator override / single source of truth)
+ *   2. Auto-discovery from `Service kourier/kourier-system` in this cluster
+ *      (see `kourier-lb-discovery.ts`) — this is the recommended path so
+ *      that adding a new region only requires the two CF env vars above
+ *      and never a region-specific IP literal in the kustomize overlay.
+ *
+ * If any required piece is missing (e.g. local dev, or kourier RBAC not
+ * yet granted), the helper is a complete no-op which leaves the flat
+ * `*.shogo.ai` wildcard as the fallback.
  */
+
+import { discoverKourierLbIp as defaultDiscoverer } from './kourier-lb-discovery'
 
 const CF_API_BASE = 'https://api.cloudflare.com/client/v4'
 
@@ -33,36 +42,76 @@ export interface CloudflareDnsConfig {
   fetch?: typeof globalThis.fetch
 }
 
-let cachedConfig: CloudflareDnsConfig | null | undefined
+let cachedConfigPromise: Promise<CloudflareDnsConfig | null> | undefined
+let kourierDiscoverer: () => Promise<string | null> = defaultDiscoverer
 
 /**
- * Resolve config from env once. Returns null when any required var is
+ * Resolve config from env once. Returns null when any required piece is
  * missing, which disables the helper.
+ *
+ * Async because the cluster Kourier LB IP may need to be discovered from
+ * the K8s API on first call (when `KOURIER_LB_IP` env is not set).
+ * Subsequent calls return the cached result.
  */
-export function getCloudflareDnsConfig(): CloudflareDnsConfig | null {
-  if (cachedConfig !== undefined) return cachedConfig
+export async function getCloudflareDnsConfig(): Promise<CloudflareDnsConfig | null> {
+  if (cachedConfigPromise !== undefined) return cachedConfigPromise
+  cachedConfigPromise = resolveConfig()
+  return cachedConfigPromise
+}
 
+async function resolveConfig(): Promise<CloudflareDnsConfig | null> {
   const apiToken = process.env.CF_API_TOKEN
   const zoneId = process.env.CF_ZONE_ID
-  const lbIp = process.env.KOURIER_LB_IP
 
-  if (!apiToken || !zoneId || !lbIp) {
-    cachedConfig = null
-    return null
+  if (!apiToken || !zoneId) return null
+
+  let lbIp = process.env.KOURIER_LB_IP
+  if (!lbIp) {
+    try {
+      lbIp = (await kourierDiscoverer()) ?? undefined
+    } catch (err: any) {
+      console.error(
+        `[cloudflare-dns] Kourier LB discovery failed (non-fatal, helper disabled):`,
+        err?.message ?? err,
+      )
+      return null
+    }
+    if (!lbIp) {
+      // Discovery succeeded but the service has no LB ingress yet. This is
+      // a "not ready" state — we log once and stay disabled. The negative
+      // cache will be flushed on next pod restart, which is the right
+      // window to retry (LB IP allocation is a one-time per-cluster event).
+      console.error(
+        `[cloudflare-dns] Kourier service has no loadBalancer.ingress[].ip — helper disabled. Set KOURIER_LB_IP env or check kourier-system/kourier Service.`,
+      )
+      return null
+    }
+    console.log(`[cloudflare-dns] Discovered Kourier LB IP: ${lbIp}`)
   }
 
-  cachedConfig = {
+  return {
     apiToken,
     zoneId,
     lbIp,
     comment: process.env.CF_DNS_COMMENT || 'shogo-preview (managed by api)',
   }
-  return cachedConfig
 }
 
 /** Reset cached config (for tests). */
 export function _resetCloudflareDnsConfigForTest(): void {
-  cachedConfig = undefined
+  cachedConfigPromise = undefined
+}
+
+/**
+ * Inject a custom Kourier LB discoverer for tests. Pass `null` to restore
+ * the default (which reads the K8s API). Always call
+ * `_resetCloudflareDnsConfigForTest()` after swapping discoverers so the
+ * next config resolution actually uses the new one.
+ */
+export function _setKourierDiscovererForTest(
+  fn: (() => Promise<string | null>) | null,
+): void {
+  kourierDiscoverer = fn ?? defaultDiscoverer
 }
 
 interface CfEnvelope<T> {
@@ -122,7 +171,7 @@ async function findRecord(
  * wildcard still provides fallback routing.
  */
 export async function upsertPreviewDnsRecord(hostname: string): Promise<void> {
-  const cfg = getCloudflareDnsConfig()
+  const cfg = await getCloudflareDnsConfig()
   if (!cfg) return
 
   try {
@@ -182,7 +231,7 @@ export async function upsertPreviewDnsRecord(hostname: string): Promise<void> {
  * reasonable safety net if deletion failures become common.
  */
 export async function deletePreviewDnsRecord(hostname: string): Promise<void> {
-  const cfg = getCloudflareDnsConfig()
+  const cfg = await getCloudflareDnsConfig()
   if (!cfg) return
 
   try {

--- a/apps/api/src/lib/kourier-lb-discovery.ts
+++ b/apps/api/src/lib/kourier-lb-discovery.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Kourier LB IP discovery
+ *
+ * Looks up this cluster's externally-routable Kourier load balancer IP by
+ * reading `Service kourier` in namespace `kourier-system`. Used by
+ * `cloudflare-dns.ts` when the operator hasn't pinned `KOURIER_LB_IP` via
+ * an env var (which is the recommended setup — adding a new region only
+ * needs `CF_API_TOKEN` + `CF_ZONE_ID`, never a region-specific IP).
+ *
+ * The function is deliberately small and isolated so the cloudflare-dns
+ * module stays free of `@kubernetes/client-node` and can be unit-tested
+ * without any K8s mocks. The discoverer is injected into cloudflare-dns
+ * via `_setKourierDiscovererForTest` in tests.
+ *
+ * Failures are non-fatal: if the kourier-system service is unreachable
+ * (e.g., RBAC not granted, kourier not installed, local dev), the helper
+ * returns null and the caller falls back to its existing no-op path.
+ */
+
+import * as fs from 'fs'
+import * as k8s from '@kubernetes/client-node'
+
+const KOURIER_NAMESPACE = process.env.KOURIER_NAMESPACE || 'kourier-system'
+const KOURIER_SERVICE = process.env.KOURIER_SERVICE_NAME || 'kourier'
+
+let cachedCoreApi: k8s.CoreV1Api | null = null
+
+function getKubeConfig(): k8s.KubeConfig {
+  const kc = new k8s.KubeConfig()
+  const serviceAccountDir = '/var/run/secrets/kubernetes.io/serviceaccount'
+  const caPath = `${serviceAccountDir}/ca.crt`
+  const tokenPath = `${serviceAccountDir}/token`
+
+  if (fs.existsSync(caPath) && fs.existsSync(tokenPath)) {
+    const ca = fs.readFileSync(caPath, 'utf8')
+    const token = fs.readFileSync(tokenPath, 'utf8')
+    const host = `https://${process.env.KUBERNETES_SERVICE_HOST}:${process.env.KUBERNETES_SERVICE_PORT}`
+    kc.loadFromOptions({
+      clusters: [{ name: 'in-cluster', server: host, caData: Buffer.from(ca).toString('base64') }],
+      users: [{ name: 'in-cluster', token }],
+      contexts: [{ name: 'in-cluster', cluster: 'in-cluster', user: 'in-cluster' }],
+      currentContext: 'in-cluster',
+    })
+  } else {
+    kc.loadFromDefault()
+  }
+  return kc
+}
+
+function getCoreApi(): k8s.CoreV1Api {
+  if (!cachedCoreApi) {
+    cachedCoreApi = getKubeConfig().makeApiClient(k8s.CoreV1Api)
+  }
+  return cachedCoreApi
+}
+
+/** Reset cached client (for tests). */
+export function _resetKourierLbDiscoveryForTest(): void {
+  cachedCoreApi = null
+}
+
+/**
+ * Read the Kourier load balancer service and return its first external IP,
+ * or null if the service has no LB ingress yet (which is expected on
+ * staging/local where kourier doesn't run, and for the brief window between
+ * cluster provision and OCI assigning an LB IP).
+ *
+ * Throws on K8s API errors (RBAC denial, network failure, etc.) so callers
+ * can distinguish "not ready yet" (null) from "we can't even ask" (throw).
+ */
+export async function discoverKourierLbIp(): Promise<string | null> {
+  const api = getCoreApi()
+  const resp = await api.readNamespacedService({
+    name: KOURIER_SERVICE,
+    namespace: KOURIER_NAMESPACE,
+  })
+  const ingress = resp.status?.loadBalancer?.ingress ?? []
+  for (const i of ingress) {
+    if (i.ip) return i.ip
+    // Some clouds expose only hostname (e.g. AWS ELB). The CF DNS helper
+    // wants an A record, not CNAME — bail rather than silently use a
+    // hostname that would be interpreted as a literal IP downstream.
+    if (i.hostname) {
+      throw new Error(
+        `Kourier LB has hostname-only ingress (${i.hostname}); cloudflare-dns.ts requires an IPv4 address`,
+      )
+    }
+  }
+  return null
+}

--- a/docs/cloudflare-dns-per-preview.md
+++ b/docs/cloudflare-dns-per-preview.md
@@ -24,22 +24,37 @@ The flat `*.shogo.ai` wildcard stays in place as a fallback.
   `KnativeProjectManager.createPreviewDomainMapping` and
   `deletePreviewDomainMapping`. Failures are logged and swallowed so
   pod lifecycle never depends on Cloudflare.
-- **Tests**: `apps/api/src/lib/__tests__/cloudflare-dns.test.ts` —
-  covers no-op mode, create, idempotent no-write, patch on drift,
-  delete, and error-swallowing.
-- **Config** (per overlay): `KOURIER_LB_IP`, `CF_ZONE_ID`,
-  `CF_API_TOKEN` (via `cloudflare-dns` secret). Helper is inert when
-  any of the three is missing, so staging / local dev are unaffected.
-
-### Region → LB IP table
-
-| Overlay | `KOURIER_LB_IP` |
-| --- | --- |
-| `production-us` | `152.70.192.220` |
-| `production-eu` | `79.76.126.115` |
-| `production-india` | `161.118.170.159` |
+- **LB IP discovery**: `apps/api/src/lib/kourier-lb-discovery.ts` —
+  reads `Service kourier/kourier-system` on first call and returns
+  `.status.loadBalancer.ingress[0].ip`. The result is cached for the
+  lifetime of the API pod. RBAC: each production overlay grants the
+  api ServiceAccount a `shogo-api-kourier-lb-reader` Role scoped to
+  the single named Service.
+- **Tests**: `apps/api/src/lib/__tests__/cloudflare-dns.test.ts` and
+  `apps/api/src/__tests__/cloudflare-dns.test.ts` — cover no-op mode,
+  create, idempotent no-write, patch on drift, delete, error
+  swallowing, **and** the LB IP discovery fallback (env override,
+  cache reuse, concurrent first-call coalescing, RBAC denial → safe
+  no-op, missing-ingress → safe no-op).
+- **Config** (per overlay): `CF_ZONE_ID` + `CF_API_TOKEN` (via the
+  `cloudflare-dns` secret). `KOURIER_LB_IP` is **optional**: when
+  unset, the helper auto-discovers it from the Kourier Service.
+  Helper is inert when either `CF_*` value is missing, so staging /
+  local dev are unaffected.
 
 Zone ID (same for every region): `c2d56140e7de85a4ac5ab5bea8e7434f`.
+
+### Region → LB IP reference
+
+These are reported for ops convenience — they are no longer the source
+of truth for the helper, which reads them at startup directly from
+each cluster's `kourier-system/kourier` Service.
+
+| Region | Kourier LB IP |
+| --- | --- |
+| `production-us` (us-ashburn-1) | `152.70.192.220` |
+| `production-eu` (eu-frankfurt-1) | `79.76.126.115` |
+| `production-india` (ap-mumbai-1) | `161.118.170.159` |
 
 ## Rollout
 
@@ -81,8 +96,15 @@ Standard deploy; the overlays already reference the secret
 After deploy, create or load a project and confirm logs:
 
 ```
+[cloudflare-dns] Discovered Kourier LB IP: <region LB IP>
 [cloudflare-dns] Created preview--<id>.shogo.ai -> <region LB IP> (proxied)
 ```
+
+(The first line appears once per pod, on first preview claim. If you
+see `[cloudflare-dns] Kourier LB discovery failed` instead, the
+api ServiceAccount likely doesn't have the
+`shogo-api-kourier-lb-reader` Role in `kourier-system` — re-apply the
+overlay.)
 
 Then confirm DNS resolution through Cloudflare's proxy:
 

--- a/k8s/overlays/production-eu/api-service.yaml
+++ b/k8s/overlays/production-eu/api-service.yaml
@@ -65,6 +65,36 @@ roleRef:
   name: shogo-api-db-secret-manager
   apiGroup: rbac.authorization.k8s.io
 ---
+# Read-only access to the kourier-system/kourier Service so the API can
+# auto-discover this cluster's externally-routable load balancer IP at
+# startup (used by apps/api/src/lib/kourier-lb-discovery.ts → cloudflare-dns.ts
+# to upsert per-preview CF DNS records). Scoped to the single named Service
+# to keep blast radius minimal.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: shogo-api-kourier-lb-reader
+  namespace: kourier-system
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["kourier"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: shogo-api-kourier-lb-reader
+  namespace: kourier-system
+subjects:
+  - kind: ServiceAccount
+    name: api-service-account
+    namespace: shogo-production-system
+roleRef:
+  kind: Role
+  name: shogo-api-kourier-lb-reader
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
@@ -111,16 +141,19 @@ spec:
               value: "production"
             # Per-preview Cloudflare DNS: upserts a proxied A record for
             # every preview--<projectId>.shogo.ai hostname pointing at
-            # this cluster's Kourier LB. Without these three vars,
+            # this cluster's Kourier LB. Without CF_API_TOKEN + CF_ZONE_ID,
             # `apps/api/src/lib/cloudflare-dns.ts` is a no-op and EU
-            # previews fall back to the flat `*.shogo.ai` wildcard,
-            # which routes to US Kourier and returns 404 / CF 522.
-            # See docs/cloudflare-dns-per-preview.md and the
-            # 2026-05-21 incident.
+            # previews fall back to the flat `*.shogo.ai` wildcard, which
+            # routes to US Kourier and returns 404 / CF 522 (see the
+            # 2026-05-21 incident). The Kourier LB IP itself is
+            # auto-discovered at API startup from
+            # `Service kourier/kourier-system` via the
+            # `shogo-api-kourier-lb-reader` Role above, so new regions
+            # only need these two vars wired — never a region-specific
+            # IP literal. Set KOURIER_LB_IP below to override discovery
+            # if needed. See docs/cloudflare-dns-per-preview.md.
             - name: CF_ZONE_ID
               value: "c2d56140e7de85a4ac5ab5bea8e7434f"
-            - name: KOURIER_LB_IP
-              value: "79.76.126.115"
             - name: CF_API_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/k8s/overlays/production-india/api-service.yaml
+++ b/k8s/overlays/production-india/api-service.yaml
@@ -65,6 +65,36 @@ roleRef:
   name: shogo-api-db-secret-manager
   apiGroup: rbac.authorization.k8s.io
 ---
+# Read-only access to the kourier-system/kourier Service so the API can
+# auto-discover this cluster's externally-routable load balancer IP at
+# startup (used by apps/api/src/lib/kourier-lb-discovery.ts → cloudflare-dns.ts
+# to upsert per-preview CF DNS records). Scoped to the single named Service
+# to keep blast radius minimal.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: shogo-api-kourier-lb-reader
+  namespace: kourier-system
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["kourier"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: shogo-api-kourier-lb-reader
+  namespace: kourier-system
+subjects:
+  - kind: ServiceAccount
+    name: api-service-account
+    namespace: shogo-production-system
+roleRef:
+  kind: Role
+  name: shogo-api-kourier-lb-reader
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
@@ -111,16 +141,19 @@ spec:
               value: "production"
             # Per-preview Cloudflare DNS: upserts a proxied A record for
             # every preview--<projectId>.shogo.ai hostname pointing at
-            # this cluster's Kourier LB. Without these three vars,
+            # this cluster's Kourier LB. Without CF_API_TOKEN + CF_ZONE_ID,
             # `apps/api/src/lib/cloudflare-dns.ts` is a no-op and India
-            # previews fall back to the flat `*.shogo.ai` wildcard,
-            # which routes to US Kourier and returns 404 / CF 522.
-            # See docs/cloudflare-dns-per-preview.md and the
-            # 2026-05-21 incident.
+            # previews fall back to the flat `*.shogo.ai` wildcard, which
+            # routes to US Kourier and returns 404 / CF 522 (see the
+            # 2026-05-21 incident). The Kourier LB IP itself is
+            # auto-discovered at API startup from
+            # `Service kourier/kourier-system` via the
+            # `shogo-api-kourier-lb-reader` Role above, so new regions
+            # only need these two vars wired — never a region-specific
+            # IP literal. Set KOURIER_LB_IP below to override discovery
+            # if needed. See docs/cloudflare-dns-per-preview.md.
             - name: CF_ZONE_ID
               value: "c2d56140e7de85a4ac5ab5bea8e7434f"
-            - name: KOURIER_LB_IP
-              value: "161.118.170.159"
             - name: CF_API_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/k8s/overlays/production-us/api-service.yaml
+++ b/k8s/overlays/production-us/api-service.yaml
@@ -65,6 +65,36 @@ roleRef:
   name: shogo-api-db-secret-manager
   apiGroup: rbac.authorization.k8s.io
 ---
+# Read-only access to the kourier-system/kourier Service so the API can
+# auto-discover this cluster's externally-routable load balancer IP at
+# startup (used by apps/api/src/lib/kourier-lb-discovery.ts → cloudflare-dns.ts
+# to upsert per-preview CF DNS records). Scoped to the single named Service
+# to keep blast radius minimal.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: shogo-api-kourier-lb-reader
+  namespace: kourier-system
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["kourier"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: shogo-api-kourier-lb-reader
+  namespace: kourier-system
+subjects:
+  - kind: ServiceAccount
+    name: api-service-account
+    namespace: shogo-production-system
+roleRef:
+  kind: Role
+  name: shogo-api-kourier-lb-reader
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
@@ -112,14 +142,17 @@ spec:
             # Per-preview Cloudflare DNS: upserts a proxied A record for
             # every preview--<projectId>.shogo.ai hostname pointing at
             # this cluster's Kourier LB. US currently works via the flat
-            # `*.shogo.ai` wildcard (which also points at this LB), but
-            # wiring per-preview records here keeps all three regions
-            # consistent and avoids surprises if we ever repoint the
-            # wildcard. See docs/cloudflare-dns-per-preview.md.
+            # `*.shogo.ai` wildcard (which points at this LB), but wiring
+            # per-preview records here keeps all three regions consistent
+            # and avoids surprises if we ever repoint the wildcard. The
+            # Kourier LB IP is auto-discovered at API startup from
+            # `Service kourier/kourier-system` via the
+            # `shogo-api-kourier-lb-reader` Role above, so new regions
+            # only need these two vars wired — never a region-specific
+            # IP literal. Set KOURIER_LB_IP below to override discovery
+            # if needed. See docs/cloudflare-dns-per-preview.md.
             - name: CF_ZONE_ID
               value: "c2d56140e7de85a4ac5ab5bea8e7434f"
-            - name: KOURIER_LB_IP
-              value: "152.70.192.220"
             - name: CF_API_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

Follow-up to #628. Removes the per-region \`KOURIER_LB_IP\` hardcode from the kustomize overlays and instead has the API read its own cluster's Kourier LB IP once from \`Service kourier/kourier-system\` on first call to \`getCloudflareDnsConfig()\`. The CF env pair (\`CF_API_TOKEN\` + \`CF_ZONE_ID\`) is still wired per overlay because the secret + zone are inherently region-agnostic config — but the LB IP is no longer something an operator can forget to set when adding a new region, which is exactly the bug we hit on India ([incident](#628)).

Result: adding a new region is now **just** "create the \`cloudflare-dns\` secret + apply the overlay." No region-specific IP literal anywhere.

## Implementation

- **New** \`apps/api/src/lib/kourier-lb-discovery.ts\` — small isolated reader that calls \`readNamespacedService(kourier, kourier-system)\` and returns the first \`.status.loadBalancer.ingress[].ip\`. Throws on hostname-only ingress so we never emit a malformed A record. Lives in its own file so \`cloudflare-dns.ts\` can be unit-tested without K8s mocks — the discoverer is dependency-injected via \`_setKourierDiscovererForTest\`.
- \`apps/api/src/lib/cloudflare-dns.ts\`:
  - \`getCloudflareDnsConfig()\` is now \`async\`. Existing callers (\`upsertPreviewDnsRecord\`, \`deletePreviewDnsRecord\`) were already async so the caller-side diff is just \`await\`.
  - When \`KOURIER_LB_IP\` env is unset, falls through to the discoverer. Concurrent first-call requests share a single in-flight discovery promise (covered by test).
  - \`KOURIER_LB_IP\` env stays supported as an operator escape hatch.
  - Failure modes (RBAC denial, kourier not installed, service has no LB ingress yet) → helper disables itself and logs once. Same safety net as today: the flat \`*.shogo.ai\` wildcard keeps single-region traffic working.
- **RBAC**: each production overlay now creates a \`shogo-api-kourier-lb-reader\` Role in \`kourier-system\` scoped to the single named Service + \`get\` verb only. RoleBinding grants the existing \`api-service-account\` in \`shogo-production-system\`. Smallest possible cross-namespace surface area.
- **Overlays**: drop the \`KOURIER_LB_IP\` literal that PR #628 added; keep \`CF_API_TOKEN\` + \`CF_ZONE_ID\`. Comments updated to point at the discovery path.
- **Docs**: \`docs/cloudflare-dns-per-preview.md\` updated to reflect the new "two env vars + Role" setup. The LB IP table is demoted to operational reference (no longer the source of truth).

## Tests

- **+8 cases** in \`apps/api/src/__tests__/cloudflare-dns.test.ts\` and **+1** in \`apps/api/src/lib/__tests__/cloudflare-dns.test.ts\` covering: discovery fallback, env override precedence, RBAC-denial → safe no-op, missing-ingress → safe no-op, single-flight concurrent discovery, IP caching across calls, no-discovery-when-CF-env-missing.
- **+7 cases** in new \`apps/api/src/lib/__tests__/kourier-lb-discovery.test.ts\` covering: first-ip happy path, skip-ingress-without-ip, missing status/ingress, hostname-only throws, K8s error propagation.
- All 52 cloudflare-dns + discovery tests pass locally. (One unrelated knative-project-manager test \`builds runtime service env…\` fails on \`main\` too — left alone.)

## Rollout / interaction with #628

Stacks on #628. If #628 lands first, this PR's diff is a clean removal of the \`KOURIER_LB_IP\` env it added. If this lands first, #628 should be closed in favour of \`KOURIER_LB_IP\` becoming an operator override only.

Staging is intentionally left as-is — it has no \`cloudflare-dns\` secret today, only a single region, and the wildcard already routes correctly there. Adding the discovery to staging would be a no-op (CF env empty → helper disabled regardless) and is left for a follow-up if we ever multi-region staging.

## Test plan

- [ ] Deploy to India after merge.
- [ ] Check api pod logs on first preview claim: \`[cloudflare-dns] Discovered Kourier LB IP: 161.118.170.159\` (once per pod) followed by \`[cloudflare-dns] Created preview--<id>.shogo.ai -> 161.118.170.159 (proxied)\` (per preview).
- [ ] Repeat on EU and US.
- [ ] Negative path: temporarily revoke the kourier-lb-reader RoleBinding on a non-prod cluster, restart api, verify a single \`[cloudflare-dns] Kourier LB discovery failed (non-fatal, helper disabled): Forbidden…\` log and that DomainMappings still create successfully without DNS upserts (wildcard fallback still works).
- [ ] Sanity-check \`KOURIER_LB_IP\` operator override: set the env to a wrong IP on a test pod and confirm discovery is **not** invoked.

Made with [Cursor](https://cursor.com)