### PR TITLE
feat(replication): single-writer region for in-process crons + CI guard

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -139,4 +139,22 @@ if printf '%s\n' "$staged_files" | grep -qxE "${LOCAL_SCHEMA}" \
   fi
 fi
 
+# Multi-region cron-lock + unique-key classification guard. Runs when any
+# of the inputs change: prisma/schema.prisma (new @unique adds a row that
+# must be classified), apps/api/src/lib/global-job-lock.ts (KNOWN_JOB_IDS
+# is the source of truth for "which crons are wrapped"), apps/api/src/jobs/
+# (new cron files), apps/api/src/server.ts (cron startup wiring), or the
+# storage/analytics-digest files directly invoked from server.ts. Catches
+# the 2026-05-21 analytics_digests poison-pill class at commit time.
+if printf '%s\n' "$staged_files" | grep -qE "^(${CLOUD_SCHEMA}|apps/api/src/lib/global-job-lock\.ts|apps/api/src/jobs/|apps/api/src/server\.ts|apps/api/src/services/storage\.service\.ts|apps/api/src/lib/analytics-digest-collector\.ts|scripts/check-multiregion-cron-locks\.ts)"; then
+  echo "[pre-commit] Cron or schema unique-key change detected — checking multi-region lock + classification..."
+  if command -v bun >/dev/null 2>&1; then
+    if ! bun scripts/check-multiregion-cron-locks.ts --quiet; then
+      rc=1
+    fi
+  else
+    echo "[pre-commit] WARN: bun not on PATH — skipping multi-region check."
+  fi
+fi
+
 exit $rc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,35 @@ jobs:
       - name: Check replication publication is self-maintaining
         run: bun run check:publication
 
+      - name: Check multi-region cron locks + unique-key classification
+        # Guards against the 2026-05-21 analytics_digests poison-pill class
+        # of failure: an in-process cron upserting on a non-PK unique index
+        # in every API replica in every region, where logical replication's
+        # `last_update_wins` cannot resolve the conflict and the apply
+        # worker halts until manual intervention.
+        #
+        # The check has two halves:
+        #   1. Every cron entry point in apps/api/src/jobs/ (and the two
+        #      directly-invoked-from-server.ts ones — recalculateAllStorageUsage,
+        #      generateDigest) must EITHER wrap its body in
+        #      `withGlobalJobLock('<name>', ...)` AND register `<name>` in
+        #      KNOWN_JOB_IDS in apps/api/src/lib/global-job-lock.ts, OR be
+        #      listed in INTENTIONALLY_REGIONAL with a regionKeyColumn that
+        #      the schema actually proves out.
+        #   2. Every @unique / @@unique in prisma/schema.prisma must be
+        #      classified in ACCEPTED_UNIQUE_KEYS with one of
+        #      random_secret | external_global_id | request_scoped |
+        #      single_tenant_upsert | cron_locked | cron_regional, plus a
+        #      one-line justification.
+        #
+        # Both halves cross-reference: a cron_locked classification has to
+        # point at a real KNOWN_JOB_IDS entry, a cron_regional at a real
+        # INTENTIONALLY_REGIONAL entry, and stale allowlist entries fail
+        # the check loudly so a model rename can't silently bypass the
+        # guard. The friction is intentional — this is the human review
+        # gate that would have caught the storage_usage shape at PR time.
+        run: bun run check:multiregion
+
       - name: Replay desktop SQLite migrations against an empty DB
         # Guards against the "shipped a migration without its prerequisite"
         # failure mode — e.g. an ALTER TABLE whose CREATE TABLE was never

--- a/apps/api/src/jobs/grant-monthly-refill.ts
+++ b/apps/api/src/jobs/grant-monthly-refill.ts
@@ -20,6 +20,7 @@
 
 import { prisma } from '../lib/prisma'
 import { applyGrantMonthlyAllocation } from '../services/billing.service'
+import { withGlobalJobLock } from '../lib/global-job-lock'
 
 function startOfMonthUtc(d: Date): Date {
   return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1, 0, 0, 0, 0))
@@ -31,75 +32,105 @@ export interface GrantMonthlyRefillSummary {
   skipped: number
   failed: number
   period: Date
+  /**
+   * True when the global advisory lock was held by a peer region and
+   * this region skipped the cycle entirely. The rest of the counters
+   * are zeroed in that case.
+   */
+  lockSkipped?: boolean
 }
 
+/**
+ * Multi-region safety: wrapped in `withGlobalJobLock('grant-monthly-refill')`
+ * so that across all API replicas in US/EU/India exactly one writer
+ * runs per tick. Without this, every region's daily tick concurrently
+ * upserts on `usage_wallets.workspaceId` (a non-PK unique index),
+ * which logical replication's `last_update_wins` cannot resolve and
+ * which would poison the apply worker until manually unwedged — same
+ * failure class as the 2026-05-21 `analytics_digests` incident. See
+ * `apps/api/src/lib/global-job-lock.ts` for the lock contract.
+ */
 export async function runGrantMonthlyRefill(
   options: { now?: Date } = {},
 ): Promise<GrantMonthlyRefillSummary> {
   const now = options.now ?? new Date()
   const period = startOfMonthUtc(now)
 
-  // Find workspaces that have at least one currently-active grant that
-  // contributes to the monthly allotment — either a monthly USD amount
-  // or a `planId` that confers per-seat included USD — and no active
-  // paid subscription. Seat-only grants (`freeSeats > 0`, no USD, no
-  // planId) are excluded because their only effect is reducing the
-  // Stripe seat quantity, which is irrelevant when there's no Stripe
-  // subscription.
-  const grants = await prisma.workspaceGrant.findMany({
-    where: {
-      startsAt: { lte: now },
-      workspace: {
-        subscriptions: {
-          none: { status: { in: ['active', 'trialing'] } },
+  const lockResult = await withGlobalJobLock('grant-monthly-refill', async () => {
+    // Find workspaces that have at least one currently-active grant that
+    // contributes to the monthly allotment — either a monthly USD amount
+    // or a `planId` that confers per-seat included USD — and no active
+    // paid subscription. Seat-only grants (`freeSeats > 0`, no USD, no
+    // planId) are excluded because their only effect is reducing the
+    // Stripe seat quantity, which is irrelevant when there's no Stripe
+    // subscription.
+    const grants = await prisma.workspaceGrant.findMany({
+      where: {
+        startsAt: { lte: now },
+        workspace: {
+          subscriptions: {
+            none: { status: { in: ['active', 'trialing'] } },
+          },
         },
+        AND: [
+          { OR: [{ monthlyIncludedUsd: { gt: 0 } }, { planId: { not: null } }] },
+          { OR: [{ expiresAt: null }, { expiresAt: { gt: now } }] },
+        ],
       },
-      AND: [
-        { OR: [{ monthlyIncludedUsd: { gt: 0 } }, { planId: { not: null } }] },
-        { OR: [{ expiresAt: null }, { expiresAt: { gt: now } }] },
-      ],
-    },
-    select: { workspaceId: true },
-  })
-  const workspaceIds = Array.from(new Set(grants.map((g) => g.workspaceId)))
+      select: { workspaceId: true },
+    })
+    const workspaceIds = Array.from(new Set(grants.map((g) => g.workspaceId)))
 
-  const summary: GrantMonthlyRefillSummary = {
-    candidates: workspaceIds.length,
+    const summary: GrantMonthlyRefillSummary = {
+      candidates: workspaceIds.length,
+      refilled: 0,
+      skipped: 0,
+      failed: 0,
+      period,
+    }
+
+    for (const workspaceId of workspaceIds) {
+      try {
+        const wallet = await prisma.usageWallet.findUnique({
+          where: { workspaceId },
+          select: { lastMonthlyReset: true },
+        })
+        // No wallet yet -> `allocateFreeWallet` will seed it with the grant
+        // amount the first time the workspace consumes anything; nothing to
+        // do here.
+        if (!wallet) {
+          summary.skipped += 1
+          continue
+        }
+        if (wallet.lastMonthlyReset >= period) {
+          summary.skipped += 1
+          continue
+        }
+        await applyGrantMonthlyAllocation(workspaceId, now)
+        summary.refilled += 1
+      } catch (err) {
+        summary.failed += 1
+        console.error('[GrantRefill] unexpected error:', { workspaceId, err })
+      }
+    }
+
+    if (summary.candidates > 0) {
+      console.log('[GrantRefill] cycle complete', summary)
+    }
+    return summary
+  })
+
+  if (lockResult.acquired) {
+    return lockResult.result
+  }
+  return {
+    candidates: 0,
     refilled: 0,
     skipped: 0,
     failed: 0,
     period,
+    lockSkipped: true,
   }
-
-  for (const workspaceId of workspaceIds) {
-    try {
-      const wallet = await prisma.usageWallet.findUnique({
-        where: { workspaceId },
-        select: { lastMonthlyReset: true },
-      })
-      // No wallet yet -> `allocateFreeWallet` will seed it with the grant
-      // amount the first time the workspace consumes anything; nothing to
-      // do here.
-      if (!wallet) {
-        summary.skipped += 1
-        continue
-      }
-      if (wallet.lastMonthlyReset >= period) {
-        summary.skipped += 1
-        continue
-      }
-      await applyGrantMonthlyAllocation(workspaceId, now)
-      summary.refilled += 1
-    } catch (err) {
-      summary.failed += 1
-      console.error('[GrantRefill] unexpected error:', { workspaceId, err })
-    }
-  }
-
-  if (summary.candidates > 0) {
-    console.log('[GrantRefill] cycle complete', summary)
-  }
-  return summary
 }
 
 /**

--- a/apps/api/src/jobs/voice-monthly-rebill.ts
+++ b/apps/api/src/jobs/voice-monthly-rebill.ts
@@ -20,6 +20,7 @@ import {
   resolvePlanIdForWorkspace,
   calculateVoiceNumberCost,
 } from '../lib/voice-cost'
+import { withGlobalJobLock } from '../lib/global-job-lock'
 
 function startOfMonthUtc(d: Date): Date {
   return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1, 0, 0, 0, 0))
@@ -31,88 +32,119 @@ export interface VoiceMonthlyRebillSummary {
   skipped: number
   failed: number
   period: Date
+  /**
+   * True when the global advisory lock was held by a peer region and
+   * this region skipped the cycle entirely. The rest of the counters
+   * are zeroed in that case.
+   */
+  lockSkipped?: boolean
 }
 
+/**
+ * Multi-region safety: wrapped in `withGlobalJobLock('voice-monthly-rebill')`
+ * so that across all API replicas in US/EU/India exactly one writer
+ * runs per tick. Without this, every region's daily tick concurrently
+ * updates `voice_project_configs.monthlyRateDebitedFor` AND issues
+ * `consumeUsage` writes per provisioned number. The watermark is the
+ * only thing that prevents double-billing — if two regions race the
+ * SELECT, both see the old watermark, both debit, then the watermark
+ * UPDATE is idempotent and the customer is charged twice. See
+ * `apps/api/src/lib/global-job-lock.ts` for the lock contract.
+ */
 export async function runVoiceMonthlyRebill(
   options: { now?: Date } = {},
 ): Promise<VoiceMonthlyRebillSummary> {
   const now = options.now ?? new Date()
   const period = startOfMonthUtc(now)
 
-  const configs = await prisma.voiceProjectConfig.findMany({
-    where: {
-      twilioPhoneSid: { not: null },
-      OR: [
-        { monthlyRateDebitedFor: null },
-        { monthlyRateDebitedFor: { lt: period } },
-      ],
-    },
-    select: {
-      projectId: true,
-      workspaceId: true,
-      twilioPhoneSid: true,
-      twilioPhoneNumber: true,
-    },
+  const lockResult = await withGlobalJobLock('voice-monthly-rebill', async () => {
+    const configs = await prisma.voiceProjectConfig.findMany({
+      where: {
+        twilioPhoneSid: { not: null },
+        OR: [
+          { monthlyRateDebitedFor: null },
+          { monthlyRateDebitedFor: { lt: period } },
+        ],
+      },
+      select: {
+        projectId: true,
+        workspaceId: true,
+        twilioPhoneSid: true,
+        twilioPhoneNumber: true,
+      },
+    })
+
+    const summary: VoiceMonthlyRebillSummary = {
+      processed: configs.length,
+      debited: 0,
+      skipped: 0,
+      failed: 0,
+      period,
+    }
+
+    for (const cfg of configs) {
+      try {
+        const planId = await resolvePlanIdForWorkspace(cfg.workspaceId)
+        const { rawUsd, billedUsd } = calculateVoiceNumberCost(planId, 'monthly')
+        const result = await consumeUsage({
+          workspaceId: cfg.workspaceId,
+          projectId: cfg.projectId,
+          memberId: 'voice-rebill',
+          actionType: 'voice_number_monthly',
+          rawUsd,
+          billedUsd,
+          actionMetadata: {
+            projectId: cfg.projectId,
+            twilioPhoneSid: cfg.twilioPhoneSid,
+            twilioPhoneNumber: cfg.twilioPhoneNumber,
+            rawUsd,
+            billedUsd,
+            periodStart: period.toISOString(),
+          },
+        })
+
+        if (!result.success) {
+          console.warn(
+            '[VoiceRebill] debit failed, leaving watermark for retry',
+            {
+              projectId: cfg.projectId,
+              reason: result.error,
+            },
+          )
+          summary.failed += 1
+          continue
+        }
+
+        // Advance the watermark so the next run is a no-op for this
+        // config until the next month boundary.
+        await prisma.voiceProjectConfig.update({
+          where: { projectId: cfg.projectId },
+          data: { monthlyRateDebitedFor: period },
+        })
+        summary.debited += 1
+      } catch (err) {
+        summary.failed += 1
+        console.error('[VoiceRebill] unexpected error:', err)
+      }
+    }
+
+    if (summary.processed > 0) {
+      console.log('[VoiceRebill] cycle complete', summary)
+    }
+    return summary
   })
 
-  const summary: VoiceMonthlyRebillSummary = {
-    processed: configs.length,
+  if (lockResult.acquired) {
+    return lockResult.result
+  }
+  return {
+    processed: 0,
     debited: 0,
     skipped: 0,
     failed: 0,
     period,
+    lockSkipped: true,
   }
-
-  for (const cfg of configs) {
-    try {
-      const planId = await resolvePlanIdForWorkspace(cfg.workspaceId)
-      const { rawUsd, billedUsd } = calculateVoiceNumberCost(planId, 'monthly')
-      const result = await consumeUsage({
-        workspaceId: cfg.workspaceId,
-        projectId: cfg.projectId,
-        memberId: 'voice-rebill',
-        actionType: 'voice_number_monthly',
-        rawUsd,
-        billedUsd,
-        actionMetadata: {
-          projectId: cfg.projectId,
-          twilioPhoneSid: cfg.twilioPhoneSid,
-          twilioPhoneNumber: cfg.twilioPhoneNumber,
-          rawUsd,
-          billedUsd,
-          periodStart: period.toISOString(),
-        },
-      })
-
-      if (!result.success) {
-        console.warn(
-          '[VoiceRebill] debit failed, leaving watermark for retry',
-          {
-            projectId: cfg.projectId,
-            reason: result.error,
-          },
-        )
-        summary.failed += 1
-        continue
-      }
-
-      // Advance the watermark so the next run is a no-op for this
-      // config until the next month boundary.
-      await prisma.voiceProjectConfig.update({
-        where: { projectId: cfg.projectId },
-        data: { monthlyRateDebitedFor: period },
-      })
-      summary.debited += 1
-    } catch (err) {
-      summary.failed += 1
-      console.error('[VoiceRebill] unexpected error:', err)
-    }
-  }
-
-  if (summary.processed > 0) {
-    console.log('[VoiceRebill] cycle complete', summary)
-  }
-  return summary
 }
 
 /**

--- a/apps/api/src/lib/__tests__/analytics-digest-collector.test.ts
+++ b/apps/api/src/lib/__tests__/analytics-digest-collector.test.ts
@@ -165,7 +165,15 @@ describe('generateDigest', () => {
     const digest = await generateDigest(fakePrisma)
     expect(upsertCalls).toHaveLength(1)
     const u = upsertCalls[0]
-    expect(u.where.date_period.period).toBe('24h')
+    // The unique key was widened from `(date, period)` to
+    // `(date, period, region)` in the 2026-05-21 migration that fixed
+    // the cross-region poison-pill on analytics_digests; the Prisma
+    // compound-key name moved from `date_period` to
+    // `date_period_region` to match. `region` defaults to `'unknown'`
+    // when REGION_ID is unset (local/dev runs, including this test).
+    expect(u.where.date_period_region.period).toBe('24h')
+    expect(u.where.date_period_region.region).toBe('unknown')
+    expect(u.create.region).toBe('unknown')
     expect(u.create.totalSpendUsd).toBe(2)
     expect(u.create.totalToolCalls).toBe(3)
     expect(u.create.totalMessages).toBe(4)

--- a/apps/api/src/lib/__tests__/global-job-lock.test.ts
+++ b/apps/api/src/lib/__tests__/global-job-lock.test.ts
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * `withGlobalJobLock` is the single-writer-region wrapper for
+ * globally-aggregating in-process crons (see
+ * `apps/api/src/lib/global-job-lock.ts` for the contract). This test
+ * exercises the three properties the wrapper exists to guarantee:
+ *
+ *   1. Concurrency: when two callers race the same `jobName`, exactly
+ *      one runs the body and the other returns `{ skipped: true,
+ *      reason: 'lock_not_acquired' }`. This is the structural fix for
+ *      the 2026-05-21 analytics_digests poison-pill class — without
+ *      the lock both regions would INSERT rows with conflicting
+ *      secondary unique keys.
+ *
+ *   2. Failure release: a body that throws still releases the lock,
+ *      so the next tick (whether in the same region or another) is
+ *      not permanently locked out.
+ *
+ *   3. SHA-256 → bigint job-id derivation is deterministic across
+ *      process restarts. This is what makes the lock work across pods
+ *      in different K8s clusters; if the key derivation drifted, US's
+ *      lock-id wouldn't match EU's and both would succeed.
+ *
+ * The concurrency / release halves talk to a real Postgres advisory
+ * lock — there's no in-memory shim that meaningfully exercises
+ * `pg_try_advisory_lock` race semantics. We follow the same
+ * pg-reachability gate that `heartbeat-scheduler.test.ts` uses so devs
+ * without a local pg can still run the unit suite.
+ */
+
+import { describe, test, expect, beforeAll } from 'bun:test'
+import { Socket } from 'node:net'
+
+const TEST_DB_URL =
+  process.env.DATABASE_URL || 'postgres://shogo:shogo_dev@127.0.0.1:5432/shogo'
+
+async function isPostgresReady(): Promise<boolean> {
+  try {
+    const url = new URL(TEST_DB_URL)
+    const host = url.hostname
+    const port = parseInt(url.port || '5432', 10)
+    return await new Promise<boolean>((resolve) => {
+      const sock = new Socket()
+      const done = (ok: boolean) => {
+        sock.destroy()
+        resolve(ok)
+      }
+      sock.setTimeout(500)
+      sock.once('connect', () => done(true))
+      sock.once('error', () => done(false))
+      sock.once('timeout', () => done(false))
+      sock.connect(port, host)
+    })
+  } catch {
+    return false
+  }
+}
+
+const POSTGRES_READY = await isPostgresReady()
+
+// Pure helper — no network. Safe to import unconditionally.
+const { jobNameToLockId, withGlobalJobLock } = await import(
+  '../global-job-lock'
+)
+
+describe('jobNameToLockId', () => {
+  test('is deterministic for the same input', () => {
+    expect(jobNameToLockId('storage-recalculate-all')).toBe(
+      jobNameToLockId('storage-recalculate-all'),
+    )
+  })
+
+  test('differs between distinct job names', () => {
+    // Different job names must produce different lock keys; otherwise
+    // two unrelated crons would serialise on the same advisory lock.
+    expect(jobNameToLockId('storage-recalculate-all')).not.toBe(
+      jobNameToLockId('grant-monthly-refill'),
+    )
+    expect(jobNameToLockId('grant-monthly-refill')).not.toBe(
+      jobNameToLockId('voice-monthly-rebill'),
+    )
+  })
+
+  test('result fits in a signed 64-bit integer (postgres bigint range)', () => {
+    const key = jobNameToLockId('storage-recalculate-all')
+    const TWO_63 = 1n << 63n
+    expect(typeof key).toBe('bigint')
+    expect(key >= -TWO_63).toBe(true)
+    expect(key < TWO_63).toBe(true)
+  })
+})
+
+describe('withGlobalJobLock — local-mode shortcut', () => {
+  test('SHOGO_LOCAL_MODE=true runs the body unconditionally without touching pg', async () => {
+    const prev = process.env.SHOGO_LOCAL_MODE
+    process.env.SHOGO_LOCAL_MODE = 'true'
+    try {
+      let bodyRan = 0
+      const res = await withGlobalJobLock(
+        'local-mode-test',
+        async () => {
+          bodyRan++
+          return 'ok'
+        },
+        // Deliberately bogus connection string to prove the helper
+        // never tries to use it in local mode.
+        { connectionString: 'postgres://unreachable.invalid:9999/x' },
+      )
+      expect(bodyRan).toBe(1)
+      expect(res.acquired).toBe(true)
+      if (res.acquired) {
+        expect(res.result).toBe('ok')
+      }
+    } finally {
+      if (prev === undefined) delete process.env.SHOGO_LOCAL_MODE
+      else process.env.SHOGO_LOCAL_MODE = prev
+    }
+  })
+
+  test('missing/non-pg DATABASE_URL also runs the body unconditionally', async () => {
+    let bodyRan = 0
+    const res = await withGlobalJobLock(
+      'sqlite-mode-test',
+      async () => {
+        bodyRan++
+      },
+      { connectionString: 'file:./shogo.db' },
+    )
+    expect(bodyRan).toBe(1)
+    expect(res.acquired).toBe(true)
+  })
+})
+
+// Use a unique job name per test run so reruns can't collide with a
+// stale lock if a previous run was killed mid-body. The lock helper
+// already names them stably for production crons, but this test wants
+// fresh keys.
+function uniqueJobName(label: string): string {
+  return `__test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+describe.skipIf(!POSTGRES_READY)(
+  'withGlobalJobLock — pg-backed concurrency',
+  () => {
+    let connectionString: string
+
+    beforeAll(() => {
+      connectionString = TEST_DB_URL
+      // Make sure local-mode shortcut isn't enabled when we explicitly
+      // want the pg path.
+      delete process.env.SHOGO_LOCAL_MODE
+    })
+
+    test('two concurrent callers: exactly one runs the body, the other reports lock_not_acquired', async () => {
+      const job = uniqueJobName('concurrency')
+
+      let bodyEntries = 0
+      let bodyExits = 0
+      let releaseBody!: () => void
+      const bodyGate = new Promise<void>((resolve) => {
+        releaseBody = resolve
+      })
+
+      // Caller A: enters the body, waits on bodyGate before returning.
+      // While it's inside, caller B will race for the same lock.
+      const pA = withGlobalJobLock(
+        job,
+        async () => {
+          bodyEntries++
+          await bodyGate
+          bodyExits++
+          return 'A'
+        },
+        { connectionString },
+      )
+
+      // Wait until A is definitely inside the body (its lock query has
+      // returned `locked: true`) before kicking off B. A few ms is
+      // enough; the body's await blocks until we resolve `bodyGate`.
+      await new Promise((r) => setTimeout(r, 75))
+      expect(bodyEntries).toBe(1)
+      expect(bodyExits).toBe(0)
+
+      const pB = withGlobalJobLock(
+        job,
+        async () => {
+          bodyEntries++ // must not fire
+          return 'B'
+        },
+        { connectionString },
+      )
+
+      const resB = await pB
+      expect(resB.acquired).toBe(false)
+      if (!resB.acquired) {
+        expect(resB.skipped).toBe(true)
+        expect(resB.reason).toBe('lock_not_acquired')
+      }
+      // A is still holding the lock — its body hasn't returned yet.
+      expect(bodyEntries).toBe(1)
+      expect(bodyExits).toBe(0)
+
+      releaseBody()
+      const resA = await pA
+      expect(resA.acquired).toBe(true)
+      if (resA.acquired) {
+        expect(resA.result).toBe('A')
+      }
+      expect(bodyExits).toBe(1)
+
+      // After A releases, a third call must succeed cleanly — proving
+      // the lock was returned, not leaked.
+      let cRan = 0
+      const resC = await withGlobalJobLock(
+        job,
+        async () => {
+          cRan++
+        },
+        { connectionString },
+      )
+      expect(cRan).toBe(1)
+      expect(resC.acquired).toBe(true)
+    }, 30_000)
+
+    test('body throws → lock is released (next call succeeds)', async () => {
+      const job = uniqueJobName('release-on-throw')
+
+      await expect(
+        withGlobalJobLock(
+          job,
+          async () => {
+            throw new Error('boom')
+          },
+          { connectionString },
+        ),
+      ).rejects.toThrow('boom')
+
+      let nextRan = 0
+      const next = await withGlobalJobLock(
+        job,
+        async () => {
+          nextRan++
+          return 'recovered'
+        },
+        { connectionString },
+      )
+      expect(nextRan).toBe(1)
+      expect(next.acquired).toBe(true)
+      if (next.acquired) {
+        expect(next.result).toBe('recovered')
+      }
+    }, 15_000)
+
+    test('different job names do not serialise against each other', async () => {
+      const jobA = uniqueJobName('isolation-a')
+      const jobB = uniqueJobName('isolation-b')
+
+      let releaseA!: () => void
+      const gateA = new Promise<void>((r) => {
+        releaseA = r
+      })
+
+      const pA = withGlobalJobLock(
+        jobA,
+        async () => {
+          await gateA
+          return 'A'
+        },
+        { connectionString },
+      )
+
+      // Even with A's body still pending, B with a different jobName
+      // must acquire and run immediately.
+      const resB = await withGlobalJobLock(
+        jobB,
+        async () => 'B',
+        { connectionString },
+      )
+      expect(resB.acquired).toBe(true)
+
+      releaseA()
+      const resA = await pA
+      expect(resA.acquired).toBe(true)
+    }, 15_000)
+
+    test('onSkipped callback is invoked instead of the default log when provided', async () => {
+      const job = uniqueJobName('on-skipped')
+
+      let releaseHolder!: () => void
+      const gate = new Promise<void>((r) => {
+        releaseHolder = r
+      })
+
+      const pHolder = withGlobalJobLock(
+        job,
+        async () => {
+          await gate
+          return 'held'
+        },
+        { connectionString },
+      )
+
+      await new Promise((r) => setTimeout(r, 50))
+
+      let skippedJob: string | null = null
+      const resSkipped = await withGlobalJobLock(
+        job,
+        async () => 'never',
+        {
+          connectionString,
+          onSkipped: (name) => {
+            skippedJob = name
+          },
+        },
+      )
+      expect(resSkipped.acquired).toBe(false)
+      expect(skippedJob).toBe(job)
+
+      releaseHolder()
+      await pHolder
+    }, 15_000)
+  },
+)

--- a/apps/api/src/lib/global-job-lock.ts
+++ b/apps/api/src/lib/global-job-lock.ts
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Postgres advisory-lock wrapper for globally-aggregating in-process crons.
+ *
+ * Background
+ * ----------
+ * Shogo runs three OCI regions (US/EU/India) against a single logical-
+ * replicated Postgres database (CNPG, PG 18, `INSERT_EXISTS_ACTION =
+ * last_update_wins`). `last_update_wins` only resolves PRIMARY-KEY
+ * collisions on apply; a conflict on any other UNIQUE INDEX halts the
+ * apply worker until a human deletes the loser row. The 2026-05-21
+ * `analytics_digests` incident was the first symptom — and the audit
+ * trail in this repo identified `storage_usage` and `usage_wallets` as
+ * latent versions of the same class.
+ *
+ * Every API replica in every region boots the same `setInterval`-based
+ * cron schedulers (see `apps/api/src/server.ts` lines 6975-7157). For a
+ * cron whose unique-key columns don't already include a writer-identity
+ * column (`region`, `instanceId`, `writerId`, …), two regions hitting
+ * the same tick produce two row inserts with different PKs but the same
+ * secondary unique key. They both INSERT locally, replicate to the peer,
+ * and poison the apply worker on conflict.
+ *
+ * Fix shape
+ * ---------
+ * Wrap the body of every "globally-aggregating" cron in
+ * `withGlobalJobLock(jobName, body)`. Exactly one region wins
+ * `pg_try_advisory_lock(<jobId>)` per tick; the others return
+ * `{ skipped: true }`. If the holder's API pod dies mid-body the TCP
+ * connection drops and Postgres releases the session-level lock, so
+ * the next tick in any region can pick the job back up — failover is
+ * automatic, no environment variable or external coordinator needed.
+ *
+ * `analytics_digests` is INTENTIONALLY NOT wrapped — it's the one cron
+ * we want to evolve into a genuine per-region aggregation (separate
+ * funnel numbers for US/EU/India). The CI guard at
+ * `scripts/check-multiregion-cron-locks.ts` knows about this exemption
+ * via an explicit `INTENTIONALLY_REGIONAL` allowlist entry.
+ *
+ * Implementation notes
+ * --------------------
+ * - The lock is held on a DEDICATED `pg.Client` connection (not on the
+ *   shared Prisma pool). This way the body can issue its own
+ *   `prisma.*` calls against the pool in parallel without re-entering
+ *   the lock connection, and the body's duration doesn't tie up a pool
+ *   slot or hold an XID open. (`pg_try_advisory_xact_lock` inside a
+ *   `prisma.$transaction` was the original sketch — rejected because
+ *   `recalculateAllStorageUsage` iterates every workspace, calls S3 per
+ *   project, and can run for minutes; that's too long to hold an
+ *   open transaction.)
+ * - Lock keys are SHA-256(jobName) truncated to 64 bits and interpreted
+ *   as a signed `BIGINT` (pg's `pg_try_advisory_lock(bigint)`
+ *   signature). Stable across language/process restarts; the
+ *   `KNOWN_JOB_IDS` map below is the CI guard's source of truth for
+ *   "which crons must be wrapped".
+ * - Local-mode (SQLite, `SHOGO_LOCAL_MODE === 'true'`) bypasses the
+ *   lock and runs the body directly — there's only one writer in local
+ *   mode by definition.
+ */
+
+import { createHash } from 'node:crypto'
+
+/**
+ * Registry of every cron currently wrapped in `withGlobalJobLock`.
+ * The CI guard (`scripts/check-multiregion-cron-locks.ts`) reads this
+ * map as the source of truth for which jobs are expected to use the
+ * wrapper. Adding a new entry here without also wrapping the cron, or
+ * vice versa, fails CI.
+ *
+ * `jobName` is the string passed to `withGlobalJobLock(jobName, ...)`.
+ * The `bigint` is the SHA-256-derived lock key, exposed so operators
+ * can correlate `pg_locks` rows back to job names if they ever need to
+ * debug a stuck lock.
+ */
+export const KNOWN_JOB_IDS: Record<string, bigint> = Object.freeze({
+  'storage-recalculate-all': jobNameToLockId('storage-recalculate-all'),
+  'grant-monthly-refill': jobNameToLockId('grant-monthly-refill'),
+  'voice-monthly-rebill': jobNameToLockId('voice-monthly-rebill'),
+}) as Record<string, bigint>
+
+export type GlobalJobLockResult<T> =
+  | { acquired: true; result: T }
+  | { acquired: false; skipped: true; reason: 'lock_not_acquired' }
+  | { acquired: false; skipped: true; reason: 'local_mode' }
+
+export interface WithGlobalJobLockOptions {
+  /**
+   * Optional override of the Postgres connection string. Defaults to
+   * `process.env.DATABASE_URL`. Exposed for tests.
+   */
+  connectionString?: string
+  /**
+   * Called when the lock could not be acquired and the body was skipped.
+   * Defaults to a `console.log` with the job name.
+   */
+  onSkipped?: (jobName: string) => void
+}
+
+/**
+ * Acquire `pg_advisory_lock(<jobId>)` on a dedicated connection, run
+ * `body`, then release. Returns `{ skipped: true }` (does not throw)
+ * when the lock is already held in another region — callers should log
+ * and move on, NOT retry inside the same tick.
+ *
+ * Exceptions thrown by `body` propagate to the caller AFTER the lock is
+ * released; the connection is always closed in `finally`.
+ */
+export async function withGlobalJobLock<T>(
+  jobName: string,
+  body: () => Promise<T>,
+  opts: WithGlobalJobLockOptions = {},
+): Promise<GlobalJobLockResult<T>> {
+  const connectionString = opts.connectionString ?? process.env.DATABASE_URL
+
+  // Local SQLite mode and missing DB — no replication, no peers to
+  // race against; run the body unconditionally so dev/test paths still
+  // exercise the cron logic.
+  if (
+    process.env.SHOGO_LOCAL_MODE === 'true' ||
+    !connectionString ||
+    !connectionString.startsWith('postgres')
+  ) {
+    const result = await body()
+    return { acquired: true, result }
+  }
+
+  const key = KNOWN_JOB_IDS[jobName] ?? jobNameToLockId(jobName)
+
+  // Import `pg` lazily so the lock helper can be imported in SQLite-
+  // only test contexts without pulling the driver eagerly.
+  const { Client } = await import('pg')
+  const client = new Client({ connectionString })
+  await client.connect()
+  try {
+    // Disable statement_timeout for the lock session — the body can run
+    // for many minutes (S3 listing, per-workspace recalculation). Some
+    // deployments set a global default that would otherwise cancel the
+    // session mid-body and release the lock prematurely.
+    await client.query('SET LOCAL statement_timeout = 0').catch(() => {
+      // `SET LOCAL` requires an active transaction; fall back to
+      // session-scoped SET, which is what we actually want here.
+      return client.query('SET statement_timeout = 0')
+    })
+
+    // `pg` parameterises bigint as a string; pg-side it's cast back to
+    // `bigint` by the function signature `pg_try_advisory_lock(bigint)`.
+    const acquired = await client.query<{ locked: boolean }>(
+      'SELECT pg_try_advisory_lock($1::bigint) AS locked',
+      [key.toString()],
+    )
+    if (!acquired.rows[0]?.locked) {
+      const onSkipped =
+        opts.onSkipped ??
+        ((name: string) =>
+          console.log(
+            `[GlobalJobLock] ${name} skipped — lock held by another region (key=${key})`,
+          ))
+      onSkipped(jobName)
+      return { acquired: false, skipped: true, reason: 'lock_not_acquired' }
+    }
+
+    try {
+      const result = await body()
+      return { acquired: true, result }
+    } finally {
+      // Best-effort release; the session-end below will release anyway
+      // if this somehow fails.
+      try {
+        await client.query('SELECT pg_advisory_unlock($1::bigint)', [
+          key.toString(),
+        ])
+      } catch (err) {
+        console.error(
+          `[GlobalJobLock] ${jobName}: pg_advisory_unlock failed (non-fatal — session-end will release):`,
+          err,
+        )
+      }
+    }
+  } finally {
+    try {
+      await client.end()
+    } catch {
+      // Connection might already be closed (pod shutdown race); ignore.
+    }
+  }
+}
+
+/**
+ * Map a job name to a stable 64-bit signed integer suitable for
+ * `pg_try_advisory_lock(bigint)`. Deterministic across deploys and
+ * processes; SHA-256 ensures collision resistance even as we add more
+ * cron names.
+ *
+ * Postgres `bigint` is signed (range -2^63 .. 2^63 - 1). We take the
+ * first 8 bytes of the digest and interpret them as a signed BE
+ * integer; `BigInt.asIntN(64, x)` masks to that range.
+ */
+export function jobNameToLockId(jobName: string): bigint {
+  const digest = createHash('sha256').update(jobName, 'utf-8').digest()
+  // Read big-endian 64-bit unsigned, then reinterpret as signed.
+  const unsigned = digest.readBigUInt64BE(0)
+  return BigInt.asIntN(64, unsigned)
+}

--- a/apps/api/src/services/storage.service.ts
+++ b/apps/api/src/services/storage.service.ts
@@ -10,6 +10,7 @@
 import { prisma } from '../lib/prisma'
 import { listAllObjectsInS3 } from '../lib/s3'
 import { INSTANCE_SIZES, type InstanceSizeName } from '../config/instance-sizes'
+import { withGlobalJobLock } from '../lib/global-job-lock'
 
 const S3_WORKSPACES_BUCKET = process.env.S3_WORKSPACES_BUCKET || 'shogo-workspaces'
 
@@ -140,21 +141,32 @@ export async function isOverStorageLimit(workspaceId: string): Promise<boolean> 
 /**
  * Recalculate storage for all workspaces. Intended to be called
  * periodically (e.g., every 6 hours) from a cron/timer.
+ *
+ * Multi-region safety: wrapped in `withGlobalJobLock('storage-recalculate-all')`
+ * so that across all API replicas in US/EU/India exactly one writer
+ * runs per tick. Without this, every region's 6h tick concurrently
+ * upserts on `storage_usage.workspaceId` (a non-PK unique index),
+ * which logical replication's `last_update_wins` cannot resolve and
+ * which would poison the apply worker until manually unwedged — same
+ * failure class as the 2026-05-21 `analytics_digests` incident. See
+ * `apps/api/src/lib/global-job-lock.ts` for the lock contract.
  */
 export async function recalculateAllStorageUsage() {
-  const workspaces = await prisma.workspace.findMany({
-    select: { id: true },
-  })
+  await withGlobalJobLock('storage-recalculate-all', async () => {
+    const workspaces = await prisma.workspace.findMany({
+      select: { id: true },
+    })
 
-  console.log(`[Storage] Recalculating storage for ${workspaces.length} workspaces`)
+    console.log(`[Storage] Recalculating storage for ${workspaces.length} workspaces`)
 
-  for (const ws of workspaces) {
-    try {
-      await calculateWorkspaceStorageUsage(ws.id)
-    } catch (err: any) {
-      console.error(`[Storage] Failed to recalculate for workspace ${ws.id}:`, err.message)
+    for (const ws of workspaces) {
+      try {
+        await calculateWorkspaceStorageUsage(ws.id)
+      } catch (err: any) {
+        console.error(`[Storage] Failed to recalculate for workspace ${ws.id}:`, err.message)
+      }
     }
-  }
 
-  console.log(`[Storage] Recalculation complete`)
+    console.log(`[Storage] Recalculation complete`)
+  })
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "check:publication": "bun scripts/check-publication-drift.ts",
     "check:migrations": "bun scripts/check-migrations.ts",
     "check:desktop-schema-drift": "bun scripts/check-desktop-schema-drift.ts",
+    "check:multiregion": "bun scripts/check-multiregion-cron-locks.ts",
     "db:reset": "npx prisma migrate reset",
     "seed:marketplace": "bun scripts/seed-marketplace.ts",
     "docker:prod": "docker-compose up",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1380,6 +1380,30 @@ model AnalyticsDigest {
   // row has a region tag. The analytics-digest collector defaults missing
   // `REGION_ID` env to `'unknown'` (single, distinct sentinel) so local
   // dev/test runs still satisfy the constraint.
+  //
+  // INTENTIONALLY REGIONAL — DO NOT wrap `generateDigest` in
+  // `withGlobalJobLock`. Every other globally-aggregating cron uses
+  // the lock pattern in `apps/api/src/lib/global-job-lock.ts`, but
+  // this one is the seed for genuine per-region analytics (a dashboard
+  // showing separate funnel numbers for US/EU/India). The
+  // `INTENTIONALLY_REGIONAL` allowlist in
+  // `scripts/check-multiregion-cron-locks.ts` records this exemption
+  // explicitly so the CI guard doesn't flag it as a missing wrapper,
+  // and conversely so the wrapper can't be added without also
+  // updating the allowlist (one human review).
+  //
+  // TODO(analytics-regional): today's `getUserFunnel` /
+  // `getUserActivityTable` / `getTemplateEngagement` /
+  // `getChatConversations` / `getSourceBreakdown` queries are global
+  // aggregates over the (logically-replicated) full row set — every
+  // region computes the same numbers. To make this column carry real
+  // meaning, add `signupRegion` / `writeRegion` columns to source
+  // tables (`users`, `chat_messages`, `usage_events`, `projects`),
+  // backfill historical rows to `'unknown'`, and add `region`
+  // parameters to the analytics-service queries. Until then the
+  // contents are global-tagged-with-region and the row-per-region
+  // shape is correct only as a defense-in-depth backstop against the
+  // replication poison-pill class.
   region String
 
   funnelSignups        Int    @default(0)

--- a/scripts/__tests__/check-multiregion-cron-locks.test.ts
+++ b/scripts/__tests__/check-multiregion-cron-locks.test.ts
@@ -1,0 +1,524 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Regression coverage for `scripts/check-multiregion-cron-locks.ts`.
+ *
+ * The CI guard exists to catch the 2026-05-21 analytics_digests
+ * poison-pill class at PR time — an in-process cron upserting on a
+ * non-PK unique index in every region. The script's failure modes are
+ * exactly what we want to lock down here:
+ *
+ *   1. Happy path: with the current repo state (3 locked crons, 1
+ *      intentionally regional, all schema uniques classified) the
+ *      check exits 0.
+ *
+ *   2. Cron-wrapper completeness: a cron that calls neither
+ *      `withGlobalJobLock` nor appears in `INTENTIONALLY_REGIONAL`
+ *      must fail with an actionable message.
+ *
+ *   3. INTENTIONALLY_REGIONAL claims a column that isn't in any
+ *      @unique on the named model → must fail. Without this, an
+ *      author could "fix" the analytics_digest poison-pill by writing
+ *      the allowlist entry and dropping the @@unique in the same PR
+ *      and the check would still pass.
+ *
+ *   4. Schema-uniques registry completeness: a new @unique in the
+ *      schema that isn't in `ACCEPTED_UNIQUE_KEYS` must fail. This is
+ *      the half that would have caught storage_usage at PR time.
+ *
+ *   5. Cross-registry consistency: a `cron_locked` allowlist entry
+ *      that names a writer not in `KNOWN_JOB_IDS` must fail (catches
+ *      a typo / rename that would silently bypass the guard).
+ *
+ *   6. Stale allowlist entries (a `cron_locked` entry whose model was
+ *      deleted from the schema) must fail.
+ *
+ * The script is pure — no network, no fs writes — so we test it by
+ * importing the per-check functions directly with synthetic
+ * fixtures, plus one end-to-end run via `bun` against the real repo
+ * to lock the happy-path result.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
+
+import {
+  ACCEPTED_UNIQUE_KEYS,
+  INTENTIONALLY_REGIONAL,
+  parseSchema,
+  enumerateCronEntries,
+  findOutermostLockCall,
+  readKnownJobIds,
+  checkCronWrappers,
+  checkIntentionallyRegionalSchema,
+  checkUniqueRegistry,
+} from '../check-multiregion-cron-locks'
+
+import * as ts from 'typescript'
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const REPO_ROOT = resolve(import.meta.dir, '../..')
+
+// ===========================================================================
+// End-to-end happy-path: the real repo currently passes.
+// ===========================================================================
+
+describe('check-multiregion-cron-locks (e2e, current repo state)', () => {
+  test('exits 0 against the real repo', () => {
+    const proc = spawnSync(
+      'bun',
+      ['scripts/check-multiregion-cron-locks.ts', '--quiet'],
+      { cwd: REPO_ROOT, encoding: 'utf-8' },
+    )
+    if (proc.status !== 0) {
+      // Surface the failure body so the assertion error is debuggable.
+      throw new Error(
+        `expected exit 0, got ${proc.status}\nstdout:\n${proc.stdout}\nstderr:\n${proc.stderr}`,
+      )
+    }
+    expect(proc.status).toBe(0)
+  })
+
+  test('discovers exactly the 4 known cron entry points', () => {
+    const entries = enumerateCronEntries()
+    const names = new Set(entries.map((e) => e.fn))
+    expect(names.has('runGrantMonthlyRefill')).toBe(true)
+    expect(names.has('runVoiceMonthlyRebill')).toBe(true)
+    expect(names.has('recalculateAllStorageUsage')).toBe(true)
+    expect(names.has('generateDigest')).toBe(true)
+  })
+
+  test('readKnownJobIds reads exactly the registered names from global-job-lock.ts', () => {
+    const ids = readKnownJobIds()
+    expect(ids.has('storage-recalculate-all')).toBe(true)
+    expect(ids.has('grant-monthly-refill')).toBe(true)
+    expect(ids.has('voice-monthly-rebill')).toBe(true)
+    // `analytics-digest` is INTENTIONALLY NOT here — that cron is
+    // exempt via INTENTIONALLY_REGIONAL.
+    expect(ids.has('analytics-digest')).toBe(false)
+    expect(ids.has('generateDigest')).toBe(false)
+  })
+
+  test('every wrapped cron resolves to a known job id (cross-registry)', () => {
+    const ids = readKnownJobIds()
+    const entries = enumerateCronEntries()
+    const regional = new Set(INTENTIONALLY_REGIONAL.map((r) => r.fn))
+    for (const entry of entries) {
+      if (regional.has(entry.fn)) continue
+      const arg = findOutermostLockCall(entry.node)
+      expect(arg).not.toBeNull()
+      if (arg) expect(ids.has(arg)).toBe(true)
+    }
+  })
+})
+
+// ===========================================================================
+// findOutermostLockCall — AST extraction
+// ===========================================================================
+
+function parseFn(src: string): ts.FunctionDeclaration {
+  const sf = ts.createSourceFile(
+    'fixture.ts',
+    src,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  )
+  for (const stmt of sf.statements) {
+    if (ts.isFunctionDeclaration(stmt) && stmt.name) return stmt
+  }
+  throw new Error('no function in fixture')
+}
+
+describe('findOutermostLockCall', () => {
+  test('detects `const r = await withGlobalJobLock("foo", ...)` at top level', () => {
+    const fn = parseFn(`
+      export async function runFoo() {
+        const r = await withGlobalJobLock('foo', async () => 1)
+        return r
+      }
+    `)
+    expect(findOutermostLockCall(fn)).toBe('foo')
+  })
+
+  test('detects bare `await withGlobalJobLock("foo", ...)` at top level', () => {
+    const fn = parseFn(`
+      export async function runFoo() {
+        await withGlobalJobLock('foo', async () => { /* body */ })
+      }
+    `)
+    expect(findOutermostLockCall(fn)).toBe('foo')
+  })
+
+  test('detects `return await withGlobalJobLock("foo", ...)`', () => {
+    const fn = parseFn(`
+      export async function runFoo() {
+        return await withGlobalJobLock('foo', async () => 1)
+      }
+    `)
+    expect(findOutermostLockCall(fn)).toBe('foo')
+  })
+
+  test('returns null when the call is nested inside an if-block (rejects evasion)', () => {
+    const fn = parseFn(`
+      export async function runFoo() {
+        if (process.env.MAYBE === '1') {
+          await withGlobalJobLock('foo', async () => { /* body */ })
+        }
+      }
+    `)
+    expect(findOutermostLockCall(fn)).toBeNull()
+  })
+
+  test('returns null when the call is inside a try/catch (rejects evasion)', () => {
+    const fn = parseFn(`
+      export async function runFoo() {
+        try {
+          await withGlobalJobLock('foo', async () => { /* body */ })
+        } catch (e) { /* swallow */ }
+      }
+    `)
+    expect(findOutermostLockCall(fn)).toBeNull()
+  })
+
+  test('returns null when the cron body has no lock call at all', () => {
+    const fn = parseFn(`
+      export async function runFoo() {
+        await prisma.thing.upsert({ where: { id: 1 }, create: {}, update: {} })
+      }
+    `)
+    expect(findOutermostLockCall(fn)).toBeNull()
+  })
+
+  test('returns null when wrapping function is a different name (e.g. typo)', () => {
+    const fn = parseFn(`
+      export async function runFoo() {
+        await withGlobalJoblock('foo', async () => { /* body */ })
+      }
+    `)
+    expect(findOutermostLockCall(fn)).toBeNull()
+  })
+})
+
+// ===========================================================================
+// checkCronWrappers — fixtures
+// ===========================================================================
+
+function mkCronEntry(src: string, fn: string, file = 'fixture.ts') {
+  const sf = ts.createSourceFile(
+    file,
+    src,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  )
+  for (const stmt of sf.statements) {
+    if (
+      ts.isFunctionDeclaration(stmt) &&
+      stmt.name?.text === fn &&
+      stmt.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      return {
+        fn,
+        file,
+        line: 1,
+        node: stmt as any,
+      }
+    }
+  }
+  throw new Error(`no exported function ${fn} found`)
+}
+
+describe('checkCronWrappers', () => {
+  test('flags a cron that has no withGlobalJobLock call', () => {
+    const entry = mkCronEntry(
+      `export async function runRogue() { await prisma.foo.upsert({} as any) }`,
+      'runRogue',
+    )
+    const v = checkCronWrappers([entry], new Set())
+    expect(v.length).toBeGreaterThan(0)
+    expect(v[0].message).toContain('not wrapped in `withGlobalJobLock')
+  })
+
+  test('flags a cron whose lock name is missing from KNOWN_JOB_IDS', () => {
+    const entry = mkCronEntry(
+      `export async function runWithMystery() { await withGlobalJobLock('unregistered-job', async () => {}) }`,
+      'runWithMystery',
+    )
+    const v = checkCronWrappers([entry], new Set(['some-other-job']))
+    expect(v.length).toBeGreaterThan(0)
+    expect(v[0].message).toContain("'unregistered-job'")
+    expect(v[0].message).toContain('KNOWN_JOB_IDS')
+  })
+
+  test('passes (no per-cron violations) when the lock name matches a KNOWN_JOB_IDS entry', () => {
+    const entry = mkCronEntry(
+      `export async function runOK() { const r = await withGlobalJobLock('happy-job', async () => 1); return r }`,
+      'runOK',
+    )
+    const v = checkCronWrappers([entry], new Set(['happy-job']))
+    // The reverse-direction "stale INTENTIONALLY_REGIONAL" check will
+    // fire for `generateDigest` because this fixture doesn't include
+    // it. Filter those out and assert the per-cron half is clean.
+    const perCronViolations = v.filter(
+      (x) => !x.message.includes('does not match any discovered cron entry'),
+    )
+    expect(perCronViolations).toEqual([])
+  })
+
+  test('passes when the cron is exempt via INTENTIONALLY_REGIONAL (file matches)', () => {
+    // We can't mutate the real INTENTIONALLY_REGIONAL list, so we
+    // verify the behaviour via the live `generateDigest` entry: the
+    // real entry exempts it, so an entry referencing the real file
+    // path with no lock call must pass.
+    const live = enumerateCronEntries().find(
+      (e) => e.fn === 'generateDigest',
+    )
+    expect(live).toBeDefined()
+    const v = checkCronWrappers([live!], new Set())
+    expect(v).toEqual([])
+  })
+})
+
+// ===========================================================================
+// checkIntentionallyRegionalSchema — fixtures
+// ===========================================================================
+
+describe('checkIntentionallyRegionalSchema (live INTENTIONALLY_REGIONAL)', () => {
+  test('passes against the real schema today', () => {
+    const models = parseSchema(`${REPO_ROOT}/prisma/schema.prisma`)
+    // Build modelToTable from the same source.
+    const modelToTable = new Map<string, string>()
+    const src = require('node:fs').readFileSync(
+      `${REPO_ROOT}/prisma/schema.prisma`,
+      'utf-8',
+    ) as string
+    const re = /^\s*model\s+(\w+)\s*\{([\s\S]*?)^\s*\}/gm
+    let m: RegExpExecArray | null
+    while ((m = re.exec(src))) {
+      const name = m[1]
+      const mapMatch = /@@map\(\s*"([^"]+)"\s*\)/.exec(m[2])
+      modelToTable.set(name, mapMatch ? mapMatch[1] : name)
+    }
+    const v = checkIntentionallyRegionalSchema(models, modelToTable)
+    expect(v).toEqual([])
+  })
+
+  test('fixture: a regional entry whose regionKeyColumn is not in any @@unique fails', () => {
+    // Build a tiny synthetic schema that *contains* a model with the
+    // column but NO @@unique on it; the check must detect the missing
+    // enforcement.
+    const tmp = mkdtempSync(join(tmpdir(), 'check-mr-'))
+    try {
+      const schemaPath = join(tmp, 'schema.prisma')
+      writeFileSync(
+        schemaPath,
+        `
+model AnalyticsDigest {
+  id     String @id @default(uuid())
+  date   DateTime
+  period String
+  region String
+
+  @@map("analytics_digests")
+}
+`,
+      )
+      const models = parseSchema(schemaPath)
+      const modelToTable = new Map<string, string>([
+        ['AnalyticsDigest', 'analytics_digests'],
+      ])
+      // Reuse the live INTENTIONALLY_REGIONAL entry which names
+      // `analytics_digests.region` — and check that against a schema
+      // where region exists but is NOT in @@unique. Must fail.
+      const v = checkIntentionallyRegionalSchema(models, modelToTable)
+      const regionMsg = v.find((x) => x.message.includes('NOT part of any @unique'))
+      expect(regionMsg).toBeDefined()
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('fixture: a regional entry whose regionKeyColumn references a missing column fails', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'check-mr-'))
+    try {
+      const schemaPath = join(tmp, 'schema.prisma')
+      writeFileSync(
+        schemaPath,
+        `
+model AnalyticsDigest {
+  id   String @id @default(uuid())
+  date DateTime
+  @@map("analytics_digests")
+}
+`,
+      )
+      const models = parseSchema(schemaPath)
+      const modelToTable = new Map<string, string>([
+        ['AnalyticsDigest', 'analytics_digests'],
+      ])
+      const v = checkIntentionallyRegionalSchema(models, modelToTable)
+      const missingCol = v.find((x) =>
+        x.message.includes('is not declared on'),
+      )
+      expect(missingCol).toBeDefined()
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})
+
+// ===========================================================================
+// checkUniqueRegistry — fixtures
+// ===========================================================================
+
+describe('checkUniqueRegistry', () => {
+  test('flags a new unique not in ACCEPTED_UNIQUE_KEYS', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'check-mr-'))
+    try {
+      const schemaPath = join(tmp, 'schema.prisma')
+      writeFileSync(
+        schemaPath,
+        `
+model NewThing {
+  id    String @id @default(uuid())
+  email String @unique
+  @@map("new_things")
+}
+`,
+      )
+      const models = parseSchema(schemaPath)
+      const v = checkUniqueRegistry(models, new Set())
+      const unclassified = v.find((x) =>
+        x.message.includes('`NewThing.email`'),
+      )
+      expect(unclassified).toBeDefined()
+      expect(unclassified!.message).toContain('not classified')
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('flags a cron_locked rule whose writer is not in KNOWN_JOB_IDS', () => {
+    // Synthesise a schema that matches one of the real rules so we can
+    // exercise the cross-registry path without inventing a new model.
+    // The live rule for `StorageUsage.workspaceId` is cron_locked
+    // pointing at `storage-recalculate-all`. We pass an empty
+    // knownJobIds and expect the cross-check to fire.
+    const tmp = mkdtempSync(join(tmpdir(), 'check-mr-'))
+    try {
+      const schemaPath = join(tmp, 'schema.prisma')
+      writeFileSync(
+        schemaPath,
+        `
+model StorageUsage {
+  id          String @id @default(uuid())
+  workspaceId String @unique
+  @@map("storage_usage")
+}
+`,
+      )
+      const models = parseSchema(schemaPath)
+      const v = checkUniqueRegistry(models, new Set())
+      const missingWriter = v.find((x) =>
+        x.message.includes('not in KNOWN_JOB_IDS'),
+      )
+      expect(missingWriter).toBeDefined()
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('flags a stale ACCEPTED_UNIQUE_KEYS entry that no longer matches any schema unique', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'check-mr-'))
+    try {
+      const schemaPath = join(tmp, 'schema.prisma')
+      // Schema with ZERO uniques at all -> every ACCEPTED entry is stale.
+      writeFileSync(schemaPath, `model OnlyId { id String @id @default(uuid()) }`)
+      const models = parseSchema(schemaPath)
+      const v = checkUniqueRegistry(models, new Set())
+      const stale = v.find((x) => x.message.includes('does not match'))
+      expect(stale).toBeDefined()
+      // sanity: should report many stale entries when comparing live
+      // ACCEPTED list against an empty schema.
+      const staleCount = v.filter((x) =>
+        x.message.includes('does not match any @unique'),
+      ).length
+      expect(staleCount).toBe(ACCEPTED_UNIQUE_KEYS.length)
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})
+
+// ===========================================================================
+// Schema parser — small sanity tests so a parser regression surfaces here
+// rather than as a cascade of misleading allowlist failures.
+// ===========================================================================
+
+describe('parseSchema', () => {
+  test('captures @unique on individual fields', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'check-mr-'))
+    try {
+      const p = join(tmp, 'schema.prisma')
+      writeFileSync(
+        p,
+        `model A {
+  id    String @id @default(uuid())
+  email String @unique
+}`,
+      )
+      const models = parseSchema(p)
+      const a = models.get('A')!
+      expect(a.uniques.map((u) => u.key)).toEqual(['A.email'])
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('captures @@unique([a, b]) and sorts columns alphabetically', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'check-mr-'))
+    try {
+      const p = join(tmp, 'schema.prisma')
+      writeFileSync(
+        p,
+        `model B {
+  id String @id @default(uuid())
+  x  String
+  y  String
+  @@unique([y, x])
+}`,
+      )
+      const models = parseSchema(p)
+      const b = models.get('B')!
+      expect(b.uniques).toHaveLength(1)
+      expect(b.uniques[0].key).toBe('B.(x,y)')
+      expect(b.uniques[0].columns).toEqual(['x', 'y'])
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('ignores @unique-looking text inside comments', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'check-mr-'))
+    try {
+      const p = join(tmp, 'schema.prisma')
+      writeFileSync(
+        p,
+        `model C {
+  id  String @id @default(uuid())
+  // NOTE: previously had @unique here; removed.
+  foo String
+}`,
+      )
+      const models = parseSchema(p)
+      const c = models.get('C')!
+      expect(c.uniques).toEqual([])
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})

--- a/scripts/check-multiregion-cron-locks.ts
+++ b/scripts/check-multiregion-cron-locks.ts
@@ -1,0 +1,957 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Guard against the multi-region replication poison-pill failure mode
+ * that bit `analytics_digests` on 2026-05-21 (and that the audit
+ * identified as latent in `storage_usage`, `usage_wallets`, and a
+ * handful of request-scoped tables).
+ *
+ * Failure mode
+ * ------------
+ * Shogo runs three OCI regions (US/EU/India) against a single logical-
+ * replicated Postgres database (CNPG, PG 18,
+ * `INSERT_EXISTS_ACTION=last_update_wins`). `last_update_wins` only
+ * resolves PRIMARY-KEY collisions on apply; a conflict on any other
+ * UNIQUE INDEX halts the apply worker until a human deletes the loser
+ * row. Every API replica in every region boots the same
+ * `setInterval`-based cron schedulers in `apps/api/src/server.ts`, so a
+ * cron that upserts on a non-PK unique index produces two inserts with
+ * different PKs but the same secondary unique key — the textbook
+ * poison-pill shape.
+ *
+ * Two complementary checks
+ * ------------------------
+ *
+ * 1. Cron-wrapper completeness.
+ *    Every cron entry point (top-level exported `run*` in
+ *    `apps/api/src/jobs/` or function invoked from a `start*Cron` /
+ *    `start*Collector` `setInterval` / `setTimeout` block in
+ *    `apps/api/src/server.ts`) must EITHER:
+ *      (a) call `withGlobalJobLock(<jobName>, async () => { ... })`
+ *          as the outermost await-target in its body, AND have an
+ *          entry in `apps/api/src/lib/global-job-lock.ts`'s
+ *          `KNOWN_JOB_IDS` map under the same `jobName`, OR
+ *      (b) be listed in this script's `INTENTIONALLY_REGIONAL`
+ *          allowlist with a justification + a `regionKeyColumn` that
+ *          actually exists in `prisma/schema.prisma` AND is part of a
+ *          `@@unique` on the same model.
+ *
+ *    The allowlist friction is intentional — it forces a human to
+ *    write down WHY a cron is allowed to run in every region, and the
+ *    `regionKeyColumn` proves the schema actually enforces the
+ *    region-discriminated unique key the allowlist claims.
+ *
+ * 2. Schema-level uniques registry.
+ *    Every `@unique` / `@@unique` in `prisma/schema.prisma` must be
+ *    categorised in `ACCEPTED_UNIQUE_KEYS` below. New uniques fail
+ *    the check until a human classifies them as one of:
+ *      - `random_secret`         — random UUID/hash, collision
+ *                                   impossible (api_keys.keyHash,
+ *                                   sessions.token, invite_links.token)
+ *      - `external_global_id`    — provider-assigned global id with a
+ *                                   single ingest path (Stripe
+ *                                   subscription/customer/payment ids,
+ *                                   Twilio/ElevenLabs ids)
+ *      - `request_scoped`        — written by user/webhook request
+ *                                   handlers only; conflict possible
+ *                                   on cross-region retry but rare
+ *                                   enough to handle with idempotency
+ *                                   work rather than leader election
+ *                                   (acknowledged today, scheduled for
+ *                                   a follow-up PR)
+ *      - `single_tenant_upsert`  — per-workspace/per-project key
+ *                                   written via `prisma.X.upsert` keyed
+ *                                   on the same column from a single
+ *                                   user-pinned request path
+ *      - `cron_locked`           — written by an in-process cron that
+ *                                   IS wrapped in `withGlobalJobLock`;
+ *                                   must reference a `KNOWN_JOB_IDS`
+ *                                   entry
+ *      - `cron_regional`         — written by an in-process cron that
+ *                                   is intentionally regional; must
+ *                                   reference an `INTENTIONALLY_REGIONAL`
+ *                                   entry whose `regionKeyColumn` is
+ *                                   part of this unique key
+ *
+ * Usage
+ * -----
+ *   bun scripts/check-multiregion-cron-locks.ts
+ *   bun scripts/check-multiregion-cron-locks.ts --quiet
+ *
+ * Exit code 0 on pass, 1 on any violation.
+ */
+
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs'
+import { resolve, join, relative } from 'node:path'
+import ts from 'typescript'
+
+const REPO_ROOT = resolve(import.meta.dir, '..')
+const SCHEMA_PATH = join(REPO_ROOT, 'prisma/schema.prisma')
+const JOBS_DIR = join(REPO_ROOT, 'apps/api/src/jobs')
+const SERVER_PATH = join(REPO_ROOT, 'apps/api/src/server.ts')
+const STORAGE_SERVICE_PATH = join(
+  REPO_ROOT,
+  'apps/api/src/services/storage.service.ts',
+)
+const ANALYTICS_DIGEST_PATH = join(
+  REPO_ROOT,
+  'apps/api/src/lib/analytics-digest-collector.ts',
+)
+const GLOBAL_JOB_LOCK_PATH = join(
+  REPO_ROOT,
+  'apps/api/src/lib/global-job-lock.ts',
+)
+
+// ===========================================================================
+// Allowlists (human-curated; the whole point of this script is the friction
+// of adding to them).
+// ===========================================================================
+
+interface IntentionallyRegional {
+  /** Exported function name that contains the cron body. */
+  fn: string
+  /** Source file relative to repo root, for error messages. */
+  file: string
+  /** Why this cron is allowed to run in every region. */
+  reason: string
+  /**
+   * `<table>.<column>` reference; the column must exist in
+   * `prisma/schema.prisma` AND be part of a `@@unique` on the same
+   * model. Asserted in `checkIntentionallyRegionalSchema()`.
+   */
+  regionKeyColumn: string
+}
+
+const INTENTIONALLY_REGIONAL: IntentionallyRegional[] = [
+  {
+    fn: 'generateDigest',
+    file: 'apps/api/src/lib/analytics-digest-collector.ts',
+    reason:
+      'Seed for genuine per-region analytics: dashboard will eventually show separate funnel numbers for US/EU/India. Folding `region` into the unique key is the contract; do not wrap in withGlobalJobLock. See schema comment on AnalyticsDigest.region for the follow-up plan (source-table region tagging).',
+    regionKeyColumn: 'analytics_digests.region',
+  },
+]
+
+interface UniqueKeyRule {
+  /** `<model>.<col>` or `<model>.(col1,col2,…)` (composite). Sorted alpha for composites. */
+  key: string
+  category:
+    | 'random_secret'
+    | 'external_global_id'
+    | 'request_scoped'
+    | 'single_tenant_upsert'
+    | 'cron_locked'
+    | 'cron_regional'
+  /** One-line justification. */
+  reason: string
+  /**
+   * For `cron_locked`: which `KNOWN_JOB_IDS` entry writes this row.
+   * For `cron_regional`: which `INTENTIONALLY_REGIONAL.fn` writes it.
+   * Unused for other categories.
+   */
+  writer?: string
+}
+
+const ACCEPTED_UNIQUE_KEYS: UniqueKeyRule[] = [
+  // --- random secrets / cryptographically-unique tokens --------------------
+  {
+    key: 'User.email',
+    category: 'request_scoped',
+    reason:
+      'Better Auth signup writes from one geo-routed region per user; cross-region duplicate signup requires a race during failover. P2 — fix is idempotent signup hook, not leader election.',
+  },
+  {
+    key: 'Session.token',
+    category: 'random_secret',
+    reason: 'Random session token; collision astronomically improbable.',
+  },
+  {
+    key: 'Account.(accountId,providerId)',
+    category: 'request_scoped',
+    reason:
+      'OAuth link via Better Auth; rare cross-region race during failover.',
+  },
+  {
+    key: 'Workspace.slug',
+    category: 'request_scoped',
+    reason:
+      'Workspace slug from createPersonalWorkspace/createPaidWorkspace, single-source per workspace creation; suffix uses deterministic user prefix or nanoid.',
+  },
+  {
+    key: 'Project.publishedSubdomain',
+    category: 'request_scoped',
+    reason:
+      'Publish flow pre-checks then updates; cross-region race possible during failover, P2 follow-up.',
+  },
+  {
+    key: 'AgentConfig.projectId',
+    category: 'single_tenant_upsert',
+    reason:
+      'Per-project upsert keyed on `projectId`; PATCH heartbeat-settings request from one region.',
+  },
+  {
+    key: 'GitHubConnection.projectId',
+    category: 'single_tenant_upsert',
+    reason: 'github.service.ts:309 upserts on projectId from a user request.',
+  },
+  {
+    key: 'StarredProject.(projectId,userId)',
+    category: 'request_scoped',
+    reason:
+      'Mobile star-toggle; double-tap during failover is the race window. P2 — needs idempotent upsert in the route.',
+  },
+  {
+    key: 'BillingAccount.workspaceId',
+    category: 'single_tenant_upsert',
+    reason: 'billing.service.ts:900 upserts on workspaceId from Stripe flow.',
+  },
+  {
+    key: 'InviteLink.token',
+    category: 'random_secret',
+    reason: 'Random UUID; collision impossible in practice.',
+  },
+  {
+    key: 'Subscription.stripeSubscriptionId',
+    category: 'external_global_id',
+    reason:
+      'Stripe webhook is single-source per Stripe account; collision needs cross-region webhook redelivery.',
+  },
+  {
+    key: 'Subscription.workspaceId',
+    category: 'single_tenant_upsert',
+    reason: 'billing.service.ts:829 upserts on workspaceId; one webhook ingest.',
+  },
+  {
+    key: 'UsageWallet.workspaceId',
+    category: 'cron_locked',
+    reason:
+      'Written by runGrantMonthlyRefill (cron) and billing service flows; the cron is the symmetric writer and is lock-wrapped. Request-time create-after-find race is a P1 idempotency follow-up.',
+    writer: 'grant-monthly-refill',
+  },
+  {
+    key: 'InstanceSubscription.workspaceId',
+    category: 'single_tenant_upsert',
+    reason:
+      'instance.service.ts:68 upserts on workspaceId from Stripe webhook (single ingest).',
+  },
+  {
+    key: 'InstanceSubscription.stripeSubscriptionId',
+    category: 'external_global_id',
+    reason:
+      'Stripe-assigned; single webhook ingest. Same shape as Subscription.stripeSubscriptionId.',
+  },
+  {
+    key: 'StorageUsage.workspaceId',
+    category: 'cron_locked',
+    reason:
+      'Written by recalculateAllStorageUsage (boot + 6h cron) and only by that cron. Wrapped in withGlobalJobLock.',
+    writer: 'storage-recalculate-all',
+  },
+  {
+    key: 'TaskDependency.(blockingTaskId,dependentTaskId)',
+    category: 'request_scoped',
+    reason: 'No runtime writers in app code today (eval/test seed only).',
+  },
+  {
+    key: 'ComponentDefinition.implementationRef',
+    category: 'request_scoped',
+    reason: 'Seed/migration DDL only; no runtime writers.',
+  },
+  {
+    key: 'Registry.name',
+    category: 'request_scoped',
+    reason: 'Seed/migration DDL only; no runtime writers.',
+  },
+  {
+    key: 'LayoutTemplate.name',
+    category: 'request_scoped',
+    reason: 'Seed/migration DDL only; no runtime writers.',
+  },
+  {
+    key: 'AnalyticsDigest.(date,period,region)',
+    category: 'cron_regional',
+    reason:
+      'Intentionally regional: every region writes its own row tagged with `REGION_ID`. Folding `region` into the key prevents the cross-region INSERT collision; the per-region semantics are the seed for genuine regional analytics (see schema comment + INTENTIONALLY_REGIONAL entry).',
+    writer: 'generateDigest',
+  },
+  {
+    key: 'SignupAttribution.userId',
+    category: 'single_tenant_upsert',
+    reason: 'admin.ts:744 upserts on userId from a request.',
+  },
+  {
+    key: 'ApiKey.keyHash',
+    category: 'random_secret',
+    reason: 'Random key + hash; collision cryptographically impossible.',
+  },
+  {
+    key: 'Instance.(hostname,workspaceId)',
+    category: 'single_tenant_upsert',
+    reason:
+      'instances.ts:667 upserts on (workspaceId,hostname) from instance heartbeat; one writer per instance.',
+  },
+  {
+    key: 'PushSubscription.(instanceId,pushToken)',
+    category: 'single_tenant_upsert',
+    reason: 'remote-audit.ts:108 upserts on (instanceId,pushToken).',
+  },
+  {
+    key: 'CreatorProfile.userId',
+    category: 'request_scoped',
+    reason:
+      'marketplace.service.ts:241 creates; onboarding double-submit race possible. P2 follow-up.',
+  },
+  {
+    key: 'CreatorBadge.(badgeType,creatorId)',
+    category: 'request_scoped',
+    reason:
+      'creator-gamification.service.ts:189 creates; non-atomic check-then-create. P2 follow-up.',
+  },
+  {
+    key: 'MarketplaceListing.projectId',
+    category: 'request_scoped',
+    reason: 'marketplace.service.ts:270 creates per-project; rare race.',
+  },
+  {
+    key: 'MarketplaceListing.slug',
+    category: 'request_scoped',
+    reason:
+      'marketplace.service.ts:270 generates slug with nanoid suffix; collision astronomically improbable in practice.',
+  },
+  {
+    key: 'MarketplaceListingVersion.(listingId,version)',
+    category: 'request_scoped',
+    reason:
+      'marketplace.ts:667 creates on version push; local 409 on P2002, cross-region race during failover is the residual P2.',
+  },
+  {
+    key: 'MarketplaceReview.(listingId,userId)',
+    category: 'request_scoped',
+    reason: 'marketplace.service.ts:464 creates; double-submit race. P2 follow-up.',
+  },
+  {
+    key: 'VoiceProjectConfig.projectId',
+    category: 'single_tenant_upsert',
+    reason: 'voice.ts:1238 / :231 upsert on projectId from user requests.',
+  },
+  {
+    key: 'VoiceCallMeter.conversationId',
+    category: 'request_scoped',
+    reason:
+      'voice-meter.ts:146 EL/Twilio webhook dedupe; cross-region webhook redelivery race. P2 follow-up.',
+  },
+  {
+    key: 'VoiceCallMeter.callSid',
+    category: 'request_scoped',
+    reason: 'Same as conversationId — Twilio side of the same webhook dedupe.',
+  },
+  {
+    key: 'VoiceCallMeter.usageEventId',
+    category: 'random_secret',
+    reason: 'Internal usage-event id (UUID); collision impossible.',
+  },
+  {
+    key: 'ProjectAgent.(name,projectId)',
+    category: 'request_scoped',
+    reason:
+      'projectAgentSync.service.ts:384 creates on deploy sync; redeploy race. P2 follow-up.',
+  },
+  {
+    key: 'AgentCostMetric.agentRunId',
+    category: 'random_secret',
+    reason:
+      'agentRunId is a generated unique id per subagent run; fire-and-forget create. P2 idempotency if double-close becomes a problem.',
+  },
+  {
+    key: 'SubagentModelOverride.(agentType,projectId,workspaceId)',
+    category: 'single_tenant_upsert',
+    reason:
+      'cost-analytics.service.ts:1217 find-then-create/update keyed on the composite; admin request path.',
+  },
+]
+
+// ===========================================================================
+// Schema parser — just enough to enumerate model fields and @unique markers.
+// ===========================================================================
+
+interface SchemaUnique {
+  /** Canonical `<Model>.<col>` or `<Model>.(col1,col2,…)` key. */
+  key: string
+  model: string
+  /** Columns participating in the unique. Sorted alpha. */
+  columns: string[]
+}
+
+interface SchemaModel {
+  name: string
+  /** Field name -> raw type string. */
+  fields: Map<string, string>
+  uniques: SchemaUnique[]
+}
+
+function parseSchema(path: string): Map<string, SchemaModel> {
+  const src = readFileSync(path, 'utf-8')
+  const lines = src.split('\n')
+  const models = new Map<string, SchemaModel>()
+  let i = 0
+  while (i < lines.length) {
+    const line = lines[i]
+    const modelMatch = /^\s*model\s+(\w+)\s*\{/.exec(line)
+    if (!modelMatch) {
+      i++
+      continue
+    }
+    const name = modelMatch[1]
+    const fields = new Map<string, string>()
+    const uniques: SchemaUnique[] = []
+    i++
+    while (i < lines.length && !/^\s*\}/.test(lines[i])) {
+      // Strip comments before further inspection so a `// ... @unique ...`
+      // comment doesn't false-match.
+      const raw = lines[i]
+      const trimmed = raw.replace(/\/\/.*$/, '').trim()
+      i++
+      if (!trimmed) continue
+
+      // @@unique([a, b, c])
+      const blockMatch = /^@@unique\s*\(\s*\[\s*([^\]]+)\s*\]\s*\)/.exec(
+        trimmed,
+      )
+      if (blockMatch) {
+        const cols = blockMatch[1]
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+        const sorted = [...cols].sort()
+        const key =
+          sorted.length === 1
+            ? `${name}.${sorted[0]}`
+            : `${name}.(${sorted.join(',')})`
+        uniques.push({ key, model: name, columns: sorted })
+        continue
+      }
+
+      // Skip other @@ block attributes.
+      if (trimmed.startsWith('@@')) continue
+      // Skip relation-only field lines / etc.
+
+      // field def: `name  Type @attrs...`
+      const fieldMatch = /^(\w+)\s+(\S+)(.*)$/.exec(trimmed)
+      if (!fieldMatch) continue
+      const fieldName = fieldMatch[1]
+      const fieldType = fieldMatch[2]
+      const rest = fieldMatch[3]
+      fields.set(fieldName, fieldType)
+      // @unique on the field itself
+      if (/\B@unique\b/.test(rest)) {
+        const sorted = [fieldName]
+        uniques.push({
+          key: `${name}.${sorted[0]}`,
+          model: name,
+          columns: sorted,
+        })
+      }
+    }
+    models.set(name, { name, fields, uniques })
+  }
+  return models
+}
+
+// Map model name -> db table name. Falls back to the model name if no @@map.
+function buildModelToTable(path: string): Map<string, string> {
+  const src = readFileSync(path, 'utf-8')
+  const mapping = new Map<string, string>()
+  const modelRe = /^\s*model\s+(\w+)\s*\{([\s\S]*?)^\s*\}/gm
+  let m: RegExpExecArray | null
+  while ((m = modelRe.exec(src))) {
+    const name = m[1]
+    const body = m[2]
+    const mapMatch = /@@map\(\s*"([^"]+)"\s*\)/.exec(body)
+    mapping.set(name, mapMatch ? mapMatch[1] : name)
+  }
+  return mapping
+}
+
+// ===========================================================================
+// AST walkers
+// ===========================================================================
+
+function loadSourceFile(path: string): ts.SourceFile {
+  return ts.createSourceFile(
+    path,
+    readFileSync(path, 'utf-8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  )
+}
+
+interface CronEntry {
+  /** Exported function name (e.g. `runGrantMonthlyRefill`). */
+  fn: string
+  /** Repo-relative file path. */
+  file: string
+  /** Line number (1-based) of the function declaration, for error msgs. */
+  line: number
+  node: ts.FunctionDeclaration | ts.VariableDeclaration
+}
+
+/**
+ * Enumerate every exported async function declared in
+ * `apps/api/src/jobs/*.ts` whose name starts with `run` followed by
+ * an upper-case letter (the project's cron-entrypoint convention) and
+ * the two storage/analytics functions explicitly invoked from
+ * `server.ts`'s cron startup blocks.
+ */
+function enumerateCronEntries(): CronEntry[] {
+  const entries: CronEntry[] = []
+
+  // Jobs directory: every `export async function run<Foo>(...)`.
+  const jobFiles = walkDir(JOBS_DIR).filter(
+    (f) => f.endsWith('.ts') && !f.includes('__tests__'),
+  )
+  for (const file of jobFiles) {
+    const sf = loadSourceFile(file)
+    ts.forEachChild(sf, (node) => {
+      if (
+        ts.isFunctionDeclaration(node) &&
+        node.name &&
+        node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) &&
+        /^run[A-Z]/.test(node.name.text)
+      ) {
+        entries.push({
+          fn: node.name.text,
+          file: relative(REPO_ROOT, file),
+          line:
+            sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1,
+          node,
+        })
+      }
+    })
+  }
+
+  // Two additional cron bodies invoked directly from server.ts's
+  // setInterval startup (not in the jobs/ directory). These are wired
+  // into the registry by hand because they don't match the run<Foo>
+  // convention.
+  const extras: Array<{ fn: string; file: string }> = [
+    { fn: 'recalculateAllStorageUsage', file: STORAGE_SERVICE_PATH },
+    { fn: 'generateDigest', file: ANALYTICS_DIGEST_PATH },
+  ]
+  for (const extra of extras) {
+    if (!existsSync(extra.file)) continue
+    const sf = loadSourceFile(extra.file)
+    ts.forEachChild(sf, (node) => {
+      if (
+        ts.isFunctionDeclaration(node) &&
+        node.name?.text === extra.fn &&
+        node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+      ) {
+        entries.push({
+          fn: extra.fn,
+          file: relative(REPO_ROOT, extra.file),
+          line:
+            sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1,
+          node,
+        })
+      }
+    })
+  }
+
+  return entries
+}
+
+function walkDir(dir: string): string[] {
+  if (!existsSync(dir)) return []
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const st = statSync(full)
+    if (st.isDirectory()) out.push(...walkDir(full))
+    else out.push(full)
+  }
+  return out
+}
+
+/**
+ * Return the literal argument passed to `withGlobalJobLock(<lit>, ...)`
+ * anywhere inside `node`, or null if no such call is found.
+ *
+ * The plan requires the call to be the outermost await-target — i.e.
+ * the function body's top-level statements should contain (in order):
+ *   const r = await withGlobalJobLock('name', async () => {...})
+ *   ...handle r.acquired branch...
+ * We enforce that by walking only the top-level statements of the
+ * function block, not arbitrarily nested expressions. This rejects
+ * the failure mode where someone wraps `withGlobalJobLock` inside a
+ * conditional / try/catch / loop and silently bypasses it.
+ */
+function findOutermostLockCall(
+  fnNode: ts.FunctionDeclaration | ts.VariableDeclaration,
+): string | null {
+  let body: ts.Block | undefined
+  if (ts.isFunctionDeclaration(fnNode)) body = fnNode.body
+  else if (
+    ts.isVariableDeclaration(fnNode) &&
+    fnNode.initializer &&
+    (ts.isArrowFunction(fnNode.initializer) ||
+      ts.isFunctionExpression(fnNode.initializer))
+  ) {
+    const init = fnNode.initializer
+    if (ts.isBlock(init.body)) body = init.body
+  }
+  if (!body) return null
+
+  // Allow top-level let/const = await withGlobalJobLock(...) OR
+  // bare await withGlobalJobLock(...).
+  for (const stmt of body.statements) {
+    const call = extractAwaitedLockCall(stmt)
+    if (call) return call
+  }
+  return null
+}
+
+function extractAwaitedLockCall(stmt: ts.Statement): string | null {
+  // `const x = await withGlobalJobLock('foo', async () => {...})`
+  if (ts.isVariableStatement(stmt)) {
+    for (const decl of stmt.declarationList.declarations) {
+      if (!decl.initializer) continue
+      const inner = unwrapAwait(decl.initializer)
+      const arg = matchLockCall(inner)
+      if (arg) return arg
+    }
+    return null
+  }
+  // `await withGlobalJobLock('foo', async () => {...})`
+  if (ts.isExpressionStatement(stmt)) {
+    const inner = unwrapAwait(stmt.expression)
+    return matchLockCall(inner)
+  }
+  // `return await withGlobalJobLock(...)`
+  if (ts.isReturnStatement(stmt) && stmt.expression) {
+    const inner = unwrapAwait(stmt.expression)
+    return matchLockCall(inner)
+  }
+  return null
+}
+
+function unwrapAwait(expr: ts.Expression): ts.Expression {
+  return ts.isAwaitExpression(expr) ? expr.expression : expr
+}
+
+function matchLockCall(expr: ts.Expression): string | null {
+  if (!ts.isCallExpression(expr)) return null
+  const callee = expr.expression
+  let name: string | null = null
+  if (ts.isIdentifier(callee)) name = callee.text
+  if (name !== 'withGlobalJobLock') return null
+  const firstArg = expr.arguments[0]
+  if (firstArg && ts.isStringLiteral(firstArg)) return firstArg.text
+  return null
+}
+
+// ===========================================================================
+// `KNOWN_JOB_IDS` extractor — parse the lock helper file for the
+// registered job names so the guard's "wrapped" claim is cross-checked
+// against the helper itself.
+// ===========================================================================
+
+function readKnownJobIds(): Set<string> {
+  if (!existsSync(GLOBAL_JOB_LOCK_PATH)) return new Set()
+  const sf = loadSourceFile(GLOBAL_JOB_LOCK_PATH)
+  const found = new Set<string>()
+  function visit(node: ts.Node) {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === 'KNOWN_JOB_IDS' &&
+      node.initializer
+    ) {
+      // Object literal — possibly wrapped in `Object.freeze({...}) as ...`.
+      let init: ts.Expression = node.initializer
+      if (ts.isAsExpression(init)) init = init.expression
+      if (
+        ts.isCallExpression(init) &&
+        ts.isPropertyAccessExpression(init.expression) &&
+        init.expression.name.text === 'freeze'
+      ) {
+        init = init.arguments[0]
+      }
+      if (init && ts.isObjectLiteralExpression(init)) {
+        for (const prop of init.properties) {
+          if (
+            ts.isPropertyAssignment(prop) &&
+            ts.isStringLiteral(prop.name)
+          ) {
+            found.add(prop.name.text)
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sf)
+  return found
+}
+
+// ===========================================================================
+// Checks
+// ===========================================================================
+
+interface Violation {
+  where: string
+  message: string
+}
+
+function checkCronWrappers(
+  entries: CronEntry[],
+  knownJobIds: Set<string>,
+): Violation[] {
+  const violations: Violation[] = []
+  const regionalIndex = new Map<string, IntentionallyRegional>()
+  for (const r of INTENTIONALLY_REGIONAL) regionalIndex.set(r.fn, r)
+
+  for (const entry of entries) {
+    const exempt = regionalIndex.get(entry.fn)
+    if (exempt) {
+      if (exempt.file !== entry.file) {
+        violations.push({
+          where: `${entry.file}:${entry.line}`,
+          message: `INTENTIONALLY_REGIONAL entry for \`${entry.fn}\` claims file \`${exempt.file}\` but found in \`${entry.file}\`. Fix the allowlist or move the function.`,
+        })
+      }
+      continue
+    }
+
+    const lockArg = findOutermostLockCall(entry.node)
+    if (lockArg === null) {
+      violations.push({
+        where: `${entry.file}:${entry.line}`,
+        message:
+          `Cron \`${entry.fn}\` is not wrapped in \`withGlobalJobLock(...)\` at the outermost statement of its body.\n` +
+          `       Either wrap it (\`await withGlobalJobLock('<job-name>', async () => { ... })\` and register the name in KNOWN_JOB_IDS in apps/api/src/lib/global-job-lock.ts), ` +
+          `or add it to INTENTIONALLY_REGIONAL in scripts/check-multiregion-cron-locks.ts with a regionKeyColumn justification.\n` +
+          `       See the file header for the rationale and the 2026-05-21 analytics_digests incident.`,
+      })
+      continue
+    }
+    if (!knownJobIds.has(lockArg)) {
+      violations.push({
+        where: `${entry.file}:${entry.line}`,
+        message: `Cron \`${entry.fn}\` calls \`withGlobalJobLock('${lockArg}', ...)\` but '${lockArg}' is not in KNOWN_JOB_IDS in apps/api/src/lib/global-job-lock.ts. Add it there so the CI registry stays in sync.`,
+      })
+    }
+  }
+
+  // Reverse direction: every INTENTIONALLY_REGIONAL entry must
+  // actually reference a real cron in `entries` (no stale allowlist).
+  const entryNames = new Set(entries.map((e) => e.fn))
+  for (const r of INTENTIONALLY_REGIONAL) {
+    if (!entryNames.has(r.fn)) {
+      violations.push({
+        where: r.file,
+        message: `INTENTIONALLY_REGIONAL entry \`${r.fn}\` does not match any discovered cron entry. Either remove the allowlist entry or restore the cron.`,
+      })
+    }
+  }
+
+  return violations
+}
+
+function checkIntentionallyRegionalSchema(
+  models: Map<string, SchemaModel>,
+  modelToTable: Map<string, string>,
+): Violation[] {
+  const violations: Violation[] = []
+  const tableToModel = new Map<string, string>()
+  for (const [model, table] of modelToTable) tableToModel.set(table, model)
+
+  for (const r of INTENTIONALLY_REGIONAL) {
+    const [table, col] = r.regionKeyColumn.split('.')
+    if (!table || !col) {
+      violations.push({
+        where: r.file,
+        message: `INTENTIONALLY_REGIONAL.\`${r.fn}\`.regionKeyColumn=\`${r.regionKeyColumn}\` must be in \`<table>.<column>\` form.`,
+      })
+      continue
+    }
+    const modelName = tableToModel.get(table) ?? table
+    const model = models.get(modelName)
+    if (!model) {
+      violations.push({
+        where: r.file,
+        message: `INTENTIONALLY_REGIONAL.\`${r.fn}\`.regionKeyColumn=\`${r.regionKeyColumn}\` references unknown model/table.`,
+      })
+      continue
+    }
+    if (!model.fields.has(col)) {
+      violations.push({
+        where: r.file,
+        message: `INTENTIONALLY_REGIONAL.\`${r.fn}\`.regionKeyColumn=\`${r.regionKeyColumn}\`: column \`${col}\` is not declared on \`${modelName}\`.`,
+      })
+      continue
+    }
+    const partOfUnique = model.uniques.some((u) => u.columns.includes(col))
+    if (!partOfUnique) {
+      violations.push({
+        where: r.file,
+        message: `INTENTIONALLY_REGIONAL.\`${r.fn}\`.regionKeyColumn=\`${r.regionKeyColumn}\`: column \`${col}\` is declared on \`${modelName}\` but is NOT part of any @unique / @@unique on that model. Without that, "intentionally regional" is a lie — every region's write will still collide on whatever unique IS on the model.`,
+      })
+    }
+  }
+  return violations
+}
+
+function checkUniqueRegistry(
+  models: Map<string, SchemaModel>,
+  knownJobIds: Set<string>,
+): Violation[] {
+  const violations: Violation[] = []
+  const allowedByKey = new Map<string, UniqueKeyRule>()
+  for (const rule of ACCEPTED_UNIQUE_KEYS) allowedByKey.set(rule.key, rule)
+
+  const schemaUniqueKeys = new Set<string>()
+  for (const model of models.values()) {
+    for (const u of model.uniques) schemaUniqueKeys.add(u.key)
+  }
+
+  // Direction 1: every schema unique must be classified.
+  for (const key of schemaUniqueKeys) {
+    const rule = allowedByKey.get(key)
+    if (!rule) {
+      violations.push({
+        where: 'prisma/schema.prisma',
+        message:
+          `Unique constraint \`${key}\` is not classified in ACCEPTED_UNIQUE_KEYS in scripts/check-multiregion-cron-locks.ts.\n` +
+          `       Add an entry with one of: random_secret | external_global_id | request_scoped | single_tenant_upsert | cron_locked | cron_regional, plus a one-line justification.\n` +
+          `       This is the structural guard that would have caught the storage_usage poison-pill at PR time.`,
+      })
+      continue
+    }
+    if (rule.category === 'cron_locked') {
+      if (!rule.writer) {
+        violations.push({
+          where: 'scripts/check-multiregion-cron-locks.ts',
+          message: `ACCEPTED_UNIQUE_KEYS.\`${key}\` is category=cron_locked but missing a \`writer\` field referencing a KNOWN_JOB_IDS entry.`,
+        })
+      } else if (!knownJobIds.has(rule.writer)) {
+        violations.push({
+          where: 'scripts/check-multiregion-cron-locks.ts',
+          message: `ACCEPTED_UNIQUE_KEYS.\`${key}\`.writer=\`${rule.writer}\` is not in KNOWN_JOB_IDS in apps/api/src/lib/global-job-lock.ts. The classification claims a cron-lock writer that doesn't exist.`,
+        })
+      }
+    }
+    if (rule.category === 'cron_regional') {
+      if (!rule.writer) {
+        violations.push({
+          where: 'scripts/check-multiregion-cron-locks.ts',
+          message: `ACCEPTED_UNIQUE_KEYS.\`${key}\` is category=cron_regional but missing a \`writer\` field referencing an INTENTIONALLY_REGIONAL entry.`,
+        })
+      } else {
+        const regional = INTENTIONALLY_REGIONAL.find(
+          (r) => r.fn === rule.writer,
+        )
+        if (!regional) {
+          violations.push({
+            where: 'scripts/check-multiregion-cron-locks.ts',
+            message: `ACCEPTED_UNIQUE_KEYS.\`${key}\`.writer=\`${rule.writer}\` does not match any INTENTIONALLY_REGIONAL.fn entry.`,
+          })
+        }
+      }
+    }
+  }
+
+  // Direction 2: no stale allowlist entries (catches schema column
+  // renames that orphan an ACCEPTED_UNIQUE_KEYS entry).
+  for (const rule of ACCEPTED_UNIQUE_KEYS) {
+    if (!schemaUniqueKeys.has(rule.key)) {
+      violations.push({
+        where: 'scripts/check-multiregion-cron-locks.ts',
+        message: `ACCEPTED_UNIQUE_KEYS.\`${rule.key}\` does not match any @unique / @@unique in prisma/schema.prisma. Remove the stale allowlist entry.`,
+      })
+    }
+  }
+
+  return violations
+}
+
+// ===========================================================================
+// Entry point
+// ===========================================================================
+
+function main(argv: string[]): number {
+  const quiet = argv.includes('--quiet')
+
+  if (!existsSync(SCHEMA_PATH)) {
+    console.error(`[check-multiregion-cron-locks] schema not found at ${SCHEMA_PATH}`)
+    return 2
+  }
+  if (!existsSync(GLOBAL_JOB_LOCK_PATH)) {
+    console.error(
+      `[check-multiregion-cron-locks] global-job-lock.ts not found at ${GLOBAL_JOB_LOCK_PATH}`,
+    )
+    return 2
+  }
+  if (!existsSync(SERVER_PATH)) {
+    console.error(`[check-multiregion-cron-locks] server.ts not found at ${SERVER_PATH}`)
+    return 2
+  }
+
+  const models = parseSchema(SCHEMA_PATH)
+  const modelToTable = buildModelToTable(SCHEMA_PATH)
+  const knownJobIds = readKnownJobIds()
+  const cronEntries = enumerateCronEntries()
+
+  const violations: Violation[] = [
+    ...checkIntentionallyRegionalSchema(models, modelToTable),
+    ...checkCronWrappers(cronEntries, knownJobIds),
+    ...checkUniqueRegistry(models, knownJobIds),
+  ]
+
+  if (violations.length === 0) {
+    if (!quiet) {
+      console.log(
+        `[check-multiregion-cron-locks] OK — ${cronEntries.length} cron entries, ` +
+          `${knownJobIds.size} wrapped, ${INTENTIONALLY_REGIONAL.length} intentionally regional, ` +
+          `${ACCEPTED_UNIQUE_KEYS.length} classified unique constraints.`,
+      )
+    }
+    return 0
+  }
+
+  console.error('[check-multiregion-cron-locks] FAIL')
+  for (const v of violations) {
+    console.error(`  ${v.where}: ${v.message}`)
+  }
+  console.error(
+    '\nThis check exists because of the 2026-05-21 analytics_digests poison-pill\n' +
+      'incident. Background and rationale live in:\n' +
+      '  - prisma/migrations/20260521000000_add_region_to_analytics_digest/migration.sql\n' +
+      '  - apps/api/src/lib/global-job-lock.ts (header)\n' +
+      '  - this script (header).',
+  )
+  return 1
+}
+
+// Allow importing from tests without immediately running.
+const isMain = typeof require !== 'undefined'
+  ? require.main === module
+  : import.meta.main === true
+
+if (isMain) {
+  process.exit(main(process.argv.slice(2)))
+}
+
+export {
+  ACCEPTED_UNIQUE_KEYS,
+  INTENTIONALLY_REGIONAL,
+  parseSchema,
+  buildModelToTable,
+  enumerateCronEntries,
+  findOutermostLockCall,
+  readKnownJobIds,
+  checkCronWrappers,
+  checkIntentionallyRegionalSchema,
+  checkUniqueRegistry,
+  main,
+}


### PR DESCRIPTION
## Summary

The 2026-05-21 `analytics_digests` poison-pill incident was the first symptom of a structural class: any in-process cron that boots in every API replica in every region (US/EU/India) and upserts on a non-PK unique index will eventually produce two regional INSERTs that conflict on apply. CNPG/PG18 `INSERT_EXISTS_ACTION=last_update_wins` only resolves PK collisions; **secondary unique conflicts halt the apply worker until a human deletes the loser row**.

This PR closes the class for in-process crons (P0/P1 in the audit) and adds a CI guard so the next instance fails at PR time instead of incident time.

## What changed

**Single-writer wrapper** — `apps/api/src/lib/global-job-lock.ts`
- `withGlobalJobLock(name, body)` around `pg_advisory_lock` on a **dedicated `pg.Client`** (not the Prisma pool — long bodies like S3 listings would otherwise tie up the pool or hold an XID open).
- Pod death → TCP drop → PG auto-releases the lock, so failover between regions is automatic; no static `WRITER_REGION_ID` env required.
- 64-bit lock keys derived via SHA-256 on the job name (deterministic across replicas, collision-resistant for our small `KNOWN_JOB_IDS` registry).

**Wrapped the three globally-aggregating crons:**
- `storage.service.ts::recalculateAllStorageUsage` → `storage-recalculate-all`
- `jobs/grant-monthly-refill.ts::runGrantMonthlyRefill` → `grant-monthly-refill`
- `jobs/voice-monthly-rebill.ts::runVoiceMonthlyRebill` → `voice-monthly-rebill`

**`analytics-digest-collector.ts::generateDigest` is INTENTIONALLY left unwrapped** — it's the seed for genuine per-region analytics (eventual US/EU/India funnel split). The schema comment on `AnalyticsDigest.region` documents the contract; the CI guard's `INTENTIONALLY_REGIONAL` allowlist records the exemption explicitly so the wrapper can't be added (nor the allowlist entry removed) without a paired human review.

**CI guard** — `scripts/check-multiregion-cron-locks.ts`
- AST-based: every cron entry point (`run*` in `apps/api/src/jobs/` + the two server.ts-invoked ones) must either call `withGlobalJobLock` at the outermost statement of its body **or** be in `INTENTIONALLY_REGIONAL` with a `regionKeyColumn` that the schema proves is part of a `@@unique`.
- Every `@unique` / `@@unique` in `prisma/schema.prisma` must be classified in `ACCEPTED_UNIQUE_KEYS`:
  - `random_secret` | `external_global_id` | `request_scoped` | `single_tenant_upsert` | `cron_locked` | `cron_regional`
  - one-line justification required
- Cross-checks: `cron_locked` writers must exist in `KNOWN_JOB_IDS`; `cron_regional` writers must exist in `INTENTIONALLY_REGIONAL`; stale allowlist entries fail loudly.
- Wired into `package.json` (`check:multiregion`), `.github/workflows/ci.yml`, and `.githooks/pre-commit`.

## Tests
- 24-test suite for the CI guard: AST evasion rejection (lock nested in `if` / `try-catch` / typo'd name), each violation class, and the live happy-path e2e against the actual repo state.
- 10-test suite for the lock helper: deterministic SHA-256→bigint derivation, local-mode shortcut, 4 pg-backed concurrency tests (skip-when-pg-unreachable, matching `heartbeat-scheduler.test.ts`).
- Fixed pre-existing `analytics-digest-collector.test.ts` failure where it still referenced the pre-2026-05-21 `date_period` compound key instead of `date_period_region`.

## Out of scope (documented in plan + schema comments)
- Request-scoped P2 offenders (`starred_projects`, `voice_call_meters`, `marketplace_*`, `project_agents`, `agent_cost_metrics`, `creator_badges`) — need idempotent-upsert work, not leader election.
- Source-table region tagging + region-parameterizing analytics queries to make the regional digest contents genuinely regional (TODO is captured in the `AnalyticsDigest.region` schema comment).
- Desktop SQLite schema — single-process, no replication.

## Test plan
- [x] `bun test apps/api/src/lib/__tests__/analytics-digest-collector.test.ts` (17 pass)
- [x] `bun test apps/api/src/lib/__tests__/global-job-lock.test.ts` (PG-backed tests skip locally without DB)
- [x] `bun test scripts/__tests__/check-multiregion-cron-locks.test.ts`
- [x] `bun run check:multiregion` against current repo state
- [ ] CI green on PR
- [ ] Post-merge: confirm only one region runs each wrapped cron via the `[global-job-lock] acquired/skipped` log line during the next 03:00 UTC window

Made with [Cursor](https://cursor.com)