### PR TITLE
fix(mobile): remove unused Projects menu and keep inbox visible for long names

### DIFF
--- a/apps/mobile/app/(app)/projects/index.tsx
+++ b/apps/mobile/app/(app)/projects/index.tsx
@@ -736,14 +736,7 @@ export default observer(function AllProjectsPage() {
     [currentWorkspace?.id, store, router, toast],
   )
 
-  const handleMoreOptions = useCallback(() => {
-    Alert.alert('More options', undefined, [
-      { text: 'Import project', onPress: handleImportProject },
-      { text: 'New folder', onPress: () => setNewFolderModalVisible(true) },
-      { text: 'Select projects', onPress: handleToggleSelect },
-      { text: 'Cancel', style: 'cancel' },
-    ])
-  }, [handleToggleSelect, handleImportProject])
+
 
   // Build combined data for FlatList (folders first, then projects)
   type ListItem =
@@ -1293,11 +1286,8 @@ export default observer(function AllProjectsPage() {
   return (
     <View className="flex-1 bg-background">
       {/* Header */}
-      <View className="flex-row items-center justify-between px-4 pt-3 pb-1">
+      <View className="flex-row items-center px-4 pt-3 pb-1">
         <Text className="text-lg font-semibold text-foreground">Projects</Text>
-        <Pressable onPress={handleMoreOptions} className="p-1.5 rounded-md active:bg-muted">
-          <MoreHorizontal size={18} className="text-muted-foreground" />
-        </Pressable>
       </View>
 
       {/* Breadcrumb navigation */}

--- a/apps/mobile/components/layout/AppSidebar.tsx
+++ b/apps/mobile/components/layout/AppSidebar.tsx
@@ -502,6 +502,7 @@ function UserMenu({ user, onSignOut, onNavigate, isSuperAdmin, isWide = true, bo
       <Popover
         placement="top"
         size="xs"
+        className="flex-1 min-w-0 w-auto h-auto items-stretch"
         isOpen={isOpen}
         onOpen={() => setIsOpen(true)}
         onClose={() => setIsOpen(false)}
@@ -512,7 +513,7 @@ function UserMenu({ user, onSignOut, onNavigate, isSuperAdmin, isWide = true, bo
             accessibilityLabel={`${user?.name || 'User'} — open user menu`}
             accessibilityHint="Opens menu with profile, appearance, and sign out options"
             accessibilityState={{ expanded: isOpen }}
-            className="flex-row items-center gap-2 active:opacity-80"
+            className="flex-row items-center gap-2 active:opacity-80 flex-1 min-w-0"
           >
             <Avatar
               fallback={getInitials(user?.name)}
@@ -520,7 +521,11 @@ function UserMenu({ user, onSignOut, onNavigate, isSuperAdmin, isWide = true, bo
               size="sm"
             />
             {!collapsed && (
-              <Text className="text-sm text-foreground flex-1" numberOfLines={1}>
+              <Text
+                className="text-sm text-foreground flex-1 min-w-0"
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
                 {user?.name || 'User'}
               </Text>
             )}
@@ -551,7 +556,7 @@ function UserMenu({ user, onSignOut, onNavigate, isSuperAdmin, isWide = true, bo
         accessibilityLabel={`${user?.name || 'User'} — open user menu`}
         accessibilityHint="Opens menu with profile, appearance, and sign out options"
         accessibilityState={{ expanded: isOpen }}
-        className="flex-row items-center gap-2 active:opacity-80"
+        className="flex-row items-center gap-2 active:opacity-80 flex-1 min-w-0"
       >
         <Avatar
           fallback={getInitials(user?.name)}
@@ -559,7 +564,11 @@ function UserMenu({ user, onSignOut, onNavigate, isSuperAdmin, isWide = true, bo
           size="sm"
         />
         {!collapsed && (
-          <Text className="text-sm text-foreground flex-1" numberOfLines={1}>
+          <Text
+            className="text-sm text-foreground flex-1 min-w-0"
+            numberOfLines={1}
+            ellipsizeMode="tail"
+          >
             {user?.name || 'User'}
           </Text>
         )}
@@ -1477,20 +1486,22 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
             collapsed ? 'justify-center' : 'px-3'
           )}
         >
-          <UserMenu
-            user={user}
-            onSignOut={handleSignOut}
-            onNavigate={(href) => { router.push(href as any); onNavPress() }}
-            isSuperAdmin={isSuperAdmin}
-            isWide={isWide}
-            bottomInset={insets.bottom}
-            collapsed={collapsed}
-          />
+          <View className={cn('min-w-0', !collapsed && 'flex-1')}>
+            <UserMenu
+              user={user}
+              onSignOut={handleSignOut}
+              onNavigate={(href) => { router.push(href as any); onNavPress() }}
+              isSuperAdmin={isSuperAdmin}
+              isWide={isWide}
+              bottomInset={insets.bottom}
+              collapsed={collapsed}
+            />
+          </View>
 
           {!collapsed && (
             <Pressable
               onPress={() => setInboxOpen(true)}
-              className="relative p-1.5 rounded-md active:bg-muted"
+              className="relative shrink-0 p-1.5 rounded-md active:bg-muted"
             >
               <Inbox size={18} className="text-muted-foreground" />
               {pendingInvites.length > 0 && (


### PR DESCRIPTION
## Summary

- Remove the non-functional three-dot overflow menu from the All Projects page header (Import, New folder, and Select remain in the toolbar).
- Fix sidebar bottom row layout so long display names truncate with ellipsis and the inbox notification icon stays visible.
- 
<img width="1665" height="514" alt="image" src="https://github.com/user-attachments/assets/2c0804f8-e85b-4bed-ba3c-c960281a5f9e" />
<img width="715" height="347" alt="image" src="https://github.com/user-attachments/assets/b55928dd-c2c0-40d3-a910-ecc2a841295a" />


## Test plan

- [ ] Open All Projects and confirm the header no longer shows a three-dot menu; toolbar actions still work (Import, New folder, Select, grid/list toggle).
- [ ] Sign in with a very long display name and confirm the sidebar shows truncated name with ellipsis and the inbox icon remains visible on the right.
- [ ] Open inbox with pending invites and confirm badge/count still appears.
- [ ] Collapse/expand sidebar and confirm user row layout on collapsed state is unchanged.

Made with [Cursor](https://cursor.com)