### PR TITLE
test(mobile): add unit tests for chat tools types and long-text helpers

### DIFF
--- a/apps/mobile/components/chat/__tests__/long-text-utils.test.ts
+++ b/apps/mobile/components/chat/__tests__/long-text-utils.test.ts
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Unit tests for long-text detection, snippets, and paste extraction.
+ */
+import { describe, expect, test } from "bun:test"
+import {
+  analyzeContent,
+  buildPastedAttachments,
+  extractLongPaste,
+  kindLabel,
+  pastedEntryToAttachment,
+  textSnippet,
+  type PastedTextEntry,
+} from "../long-text-utils"
+
+describe("textSnippet", () => {
+  test("returns short text unchanged", () => {
+    expect(textSnippet("hello")).toBe("hello")
+  })
+
+  test("truncates at word boundary when possible", () => {
+    const text = "one two three four five six seven eight nine ten"
+    const snippet = textSnippet(text, 20)
+    expect(snippet.endsWith("…")).toBe(true)
+    expect(snippet.length).toBeLessThanOrEqual(21)
+    expect(snippet).not.toContain("nine")
+  })
+
+  test("hard-cuts when no space in first maxLen chars", () => {
+    const text = "x".repeat(50)
+    expect(textSnippet(text, 10)).toBe("x".repeat(10) + "…")
+  })
+})
+
+describe("kindLabel", () => {
+  test("maps content kinds to display labels", () => {
+    expect(kindLabel("json")).toBe("JSON")
+    expect(kindLabel("code")).toBe("Code")
+    expect(kindLabel("markdown")).toBe("Markdown")
+    expect(kindLabel("plain")).toBe("Text")
+  })
+})
+
+describe("analyzeContent", () => {
+  test("short plain text is not long", () => {
+    const info = analyzeContent("hello world")
+    expect(info.kind).toBe("plain")
+    expect(info.isLong).toBe(false)
+    expect(info.chars).toBe(11)
+    expect(info.lines).toBe(1)
+  })
+
+  test("detects code from import prefix", () => {
+    expect(analyzeContent("import { foo } from 'bar'\nexport const x = 1").kind).toBe("code")
+  })
+
+  test("detects markdown from heading", () => {
+    expect(analyzeContent("# Title\n\nSome body").kind).toBe("markdown")
+  })
+
+  test("detects JSON objects with lower long threshold", () => {
+    const json = JSON.stringify({ alpha: "x".repeat(3_000) })
+    const info = analyzeContent(json)
+    expect(info.kind).toBe("json")
+    expect(info.isLong).toBe(true)
+  })
+
+  test("marks plain text long by character count", () => {
+    const info = analyzeContent("a".repeat(5_001))
+    expect(info.isLong).toBe(true)
+    expect(info.sizeLabel).toMatch(/KB|B/)
+  })
+
+  test("marks text long by line count", () => {
+    const info = analyzeContent(Array.from({ length: 151 }, (_, i) => `line ${i}`).join("\n"))
+    expect(info.isLong).toBe(true)
+    expect(info.lines).toBeGreaterThan(150)
+  })
+})
+
+describe("extractLongPaste", () => {
+  test("returns null when text shrinks", () => {
+    expect(extractLongPaste("hello world", "hello")).toBeNull()
+  })
+
+  test("returns null for small insertions", () => {
+    expect(extractLongPaste("", "short paste")).toBeNull()
+  })
+
+  test("returns null when inserted chunk is large but not long-content", () => {
+    const prev = ""
+    const inserted = "a".repeat(2_500)
+    expect(extractLongPaste(prev, inserted)).toBeNull()
+  })
+
+  test("detects select-all paste of long content", () => {
+    const prev = "replace me"
+    const block = "z".repeat(5_100)
+    const next = block
+    const result = extractLongPaste(prev, next)
+    expect(result).not.toBeNull()
+    expect(result!.inserted).toBe(block)
+    expect(result!.restored).toBe("")
+    expect(result!.info.isLong).toBe(true)
+  })
+
+  test("detects append paste after existing prefix", () => {
+    const prev = "typing "
+    const block = "x".repeat(5_100)
+    const next = prev + block
+    const result = extractLongPaste(prev, next)
+    expect(result!.inserted).toBe(block)
+    expect(result!.restored).toBe("typing ")
+  })
+})
+
+describe("pasted attachments", () => {
+  const entry = (kind: PastedTextEntry["info"]["kind"], content: string): PastedTextEntry => ({
+    id: "1",
+    content,
+    info: { ...analyzeContent(content), kind },
+  })
+
+  test("pastedEntryToAttachment names and types by kind", () => {
+    const att = pastedEntryToAttachment(entry("json", '{"a":1}'))
+    expect(att.name).toBe("Pasted json.json")
+    expect(att.type).toBe("application/json")
+    expect(att.dataUrl.startsWith("data:")).toBe(true)
+  })
+
+  test("increments duplicate kind filenames", () => {
+    const first = pastedEntryToAttachment(entry("markdown", "# Hi"), 0)
+    const second = pastedEntryToAttachment(entry("markdown", "# Bye"), 1)
+    expect(first.name).toBe("Pasted markdown.md")
+    expect(second.name).toBe("Pasted markdown (2).md")
+  })
+
+  test("buildPastedAttachments numbers per kind independently", () => {
+    const attachments = buildPastedAttachments([
+      entry("json", '{"a":1}'),
+      entry("json", '{"b":2}'),
+      entry("plain", "hello"),
+    ])
+    expect(attachments.map((a) => a.name)).toEqual([
+      "Pasted json.json",
+      "Pasted json (2).json",
+      "Pasted text.txt",
+    ])
+  })
+})

--- a/apps/mobile/components/chat/tools/__tests__/types.test.ts
+++ b/apps/mobile/components/chat/tools/__tests__/types.test.ts
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Unit tests for chat tool type helpers (category, display name, key arg).
+ */
+import { describe, expect, test } from "bun:test"
+import {
+  GRADIENT_CONFIG,
+  formatToolName,
+  getGradientOpacity,
+  getToolCategory,
+  getToolKeyArg,
+  getToolNamespace,
+} from "../types"
+
+describe("getToolCategory", () => {
+  test("mcp prefix", () => {
+    expect(getToolCategory("mcp__shogo__query")).toBe("mcp")
+  })
+
+  test("file tools (PascalCase and snake_case)", () => {
+    for (const name of [
+      "Read",
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep",
+      "read_file",
+      "write_file",
+      "edit_file",
+      "glob",
+      "grep",
+      "search",
+    ]) {
+      expect(getToolCategory(name)).toBe("file")
+    }
+  })
+
+  test("skill tools", () => {
+    for (const name of ["Skill", "Task", "task", "skill"]) {
+      expect(getToolCategory(name)).toBe("skill")
+    }
+  })
+
+  test("bash tools", () => {
+    expect(getToolCategory("Bash")).toBe("bash")
+    expect(getToolCategory("exec")).toBe("bash")
+  })
+
+  test("unknown tools", () => {
+    expect(getToolCategory("WebSearch")).toBe("other")
+    expect(getToolCategory("custom_tool")).toBe("other")
+  })
+})
+
+describe("formatToolName", () => {
+  test("joins MCP namespace segments with dots", () => {
+    expect(formatToolName("mcp__shogo__store_query")).toBe("shogo.store_query")
+  })
+
+  test("single MCP segment after prefix", () => {
+    expect(formatToolName("mcp__toolname")).toBe("toolname")
+  })
+
+  test("non-MCP names unchanged", () => {
+    expect(formatToolName("Read")).toBe("Read")
+    expect(formatToolName("Bash")).toBe("Bash")
+  })
+})
+
+describe("getToolNamespace", () => {
+  test("returns first MCP segment", () => {
+    expect(getToolNamespace("mcp__shogo__store_query")).toBe("shogo")
+    expect(getToolNamespace("mcp__github__pr")).toBe("github")
+  })
+
+  test("returns null for non-MCP tools", () => {
+    expect(getToolNamespace("Read")).toBeNull()
+    expect(getToolNamespace("Bash")).toBeNull()
+  })
+
+  test("returns null when MCP name has no namespace segment", () => {
+    expect(getToolNamespace("mcp__")).toBeNull()
+  })
+})
+
+describe("getGradientOpacity", () => {
+  test("uses configured opacities by index", () => {
+    expect(getGradientOpacity(0)).toBe(1)
+    expect(getGradientOpacity(1)).toBe(0.85)
+    expect(getGradientOpacity(4)).toBe(0.4)
+  })
+
+  test("clamps to last opacity for large indices", () => {
+    expect(getGradientOpacity(99)).toBe(GRADIENT_CONFIG.opacities[GRADIENT_CONFIG.opacities.length - 1])
+  })
+})
+
+describe("getToolKeyArg", () => {
+  test("returns null when args missing", () => {
+    expect(getToolKeyArg("Read")).toBeNull()
+    expect(getToolKeyArg("Read", undefined)).toBeNull()
+  })
+
+  test("ask_user uses first question header", () => {
+    expect(
+      getToolKeyArg("ask_user", {
+        questions: [{ header: "Deploy?", question: "Q", options: [], multiSelect: false }],
+      }),
+    ).toBe("Deploy?")
+  })
+
+  test("ask_user without header falls through", () => {
+    expect(getToolKeyArg("ask_user", { questions: [{ question: "Q", options: [], multiSelect: false }] })).toBeNull()
+  })
+
+  test("file tools use basename from file_path or path", () => {
+    expect(getToolKeyArg("Read", { file_path: "/a/b/c.ts" })).toBe("c.ts")
+    expect(getToolKeyArg("write_file", { path: "src/index.ts" })).toBe("index.ts")
+    expect(getToolKeyArg("Edit", { path: "only-name" })).toBe("only-name")
+    expect(getToolKeyArg("Read", { file_path: "/a/b/" })).toBe("/a/b/")
+  })
+
+  test("grep/glob/search truncate long patterns", () => {
+    const long = "a".repeat(50)
+    expect(getToolKeyArg("Grep", { pattern: "short" })).toBe("short")
+    expect(getToolKeyArg("glob", { pattern: long })).toBe("a".repeat(27) + "...")
+  })
+
+  test("bash/exec use first line, truncated when long", () => {
+    expect(getToolKeyArg("Bash", { command: "bun test\nbun lint" })).toBe("bun test")
+    const longLine = "x".repeat(50)
+    expect(getToolKeyArg("exec", { command: longLine })).toBe("x".repeat(37) + "...")
+  })
+
+  test("browser navigate truncates URL; other actions return action", () => {
+    expect(getToolKeyArg("browser", { action: "click" })).toBe("click")
+    const longUrl = "https://" + "x".repeat(40)
+    expect(getToolKeyArg("browser", { action: "navigate", url: longUrl })).toBe(longUrl.slice(0, 27) + "...")
+    expect(getToolKeyArg("browser", { action: "navigate", url: "https://example.com" })).toBe(
+      "https://example.com",
+    )
+  })
+
+  test("Task and Skill", () => {
+    expect(getToolKeyArg("Task", { description: "a".repeat(40) })).toBe("a".repeat(27) + "...")
+    expect(getToolKeyArg("Task", { description: "short task" })).toBe("short task")
+    expect(getToolKeyArg("Task", {})).toBeNull()
+    expect(getToolKeyArg("Skill", { skill: "babysit" })).toBe("babysit")
+  })
+
+  test("grep and bash without matching args fall through", () => {
+    expect(getToolKeyArg("Grep", {})).toBeNull()
+    expect(getToolKeyArg("Bash", {})).toBeNull()
+  })
+
+  test("mcp__shogo__ schema, store, and view helpers", () => {
+    expect(getToolKeyArg("mcp__shogo__schema_create", { name: "User" })).toBe("User")
+    expect(getToolKeyArg("mcp__shogo__schema_list", { schemaName: "core" })).toBe("core")
+    expect(getToolKeyArg("mcp__shogo__store_query", { model: "User", schema: "app" })).toBe("app.User")
+    expect(getToolKeyArg("mcp__shogo__store_query", { model: "User" })).toBe("User")
+    expect(getToolKeyArg("mcp__shogo__view_render", { view: "dashboard" })).toBe("dashboard")
+    expect(getToolKeyArg("mcp__shogo__view_list", { name: "home" })).toBe("home")
+  })
+
+  test("mcp__obsidian prefers filename, query, directory", () => {
+    expect(getToolKeyArg("mcp__obsidian__search", { query: "notes" })).toBe("notes")
+    expect(getToolKeyArg("mcp__obsidian__open", { filename: "daily.md" })).toBe("daily.md")
+    expect(getToolKeyArg("mcp__obsidian__list", { directory: "vault/inbox" })).toBe("vault/inbox")
+  })
+
+  test("mcp__chrome-devtools__ actions", () => {
+    expect(getToolKeyArg("mcp__chrome-devtools__navigate_page", { url: "https://a.com" })).toBe(
+      "https://a.com",
+    )
+    expect(getToolKeyArg("mcp__chrome-devtools__click", { uid: "btn-1" })).toBe("btn-1")
+    expect(getToolKeyArg("mcp__chrome-devtools__evaluate_script", {})).toBe("script")
+    expect(getToolKeyArg("mcp__chrome-devtools__take_screenshot", { fullPage: true })).toBe("full page")
+    expect(getToolKeyArg("mcp__chrome-devtools__take_screenshot", {})).toBe("viewport")
+  })
+
+  test("fallback string keys with truncation", () => {
+    expect(getToolKeyArg("custom_tool", { name: "widget" })).toBe("widget")
+    const long = "z".repeat(40)
+    expect(getToolKeyArg("custom_tool", { url: long })).toBe("z".repeat(27) + "...")
+  })
+
+  test("returns null when no matching arg keys", () => {
+    expect(getToolKeyArg("Read", {})).toBeNull()
+    expect(getToolKeyArg("custom_tool", { count: 3 })).toBeNull()
+  })
+})

--- a/apps/mobile/components/chat/turns/__tests__/diff-utils.test.ts
+++ b/apps/mobile/components/chat/turns/__tests__/diff-utils.test.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Unit tests for LCS-based line diff used in edit file widgets.
+ */
+import { describe, expect, test } from "bun:test"
+import { computeLineDiff, type DiffLine } from "../diff-utils"
+
+function lines(diff: DiffLine[]): string[] {
+  return diff.map((d) => `${d.type}:${d.text}`)
+}
+
+describe("computeLineDiff", () => {
+  test("identical content yields only context lines", () => {
+    const diff = computeLineDiff("alpha\nbeta\ngamma", "alpha\nbeta\ngamma")
+    expect(diff).toEqual([
+      { type: "context", text: "alpha" },
+      { type: "context", text: "beta" },
+      { type: "context", text: "gamma" },
+    ])
+  })
+
+  test("empty old string treats split('') as one empty line then additions", () => {
+    expect(computeLineDiff("", "one\ntwo")).toEqual([
+      { type: "removed", text: "" },
+      { type: "added", text: "one" },
+      { type: "added", text: "two" },
+    ])
+  })
+
+  test("empty new string removes content and adds trailing empty line", () => {
+    expect(computeLineDiff("one\ntwo", "")).toEqual([
+      { type: "removed", text: "one" },
+      { type: "removed", text: "two" },
+      { type: "added", text: "" },
+    ])
+  })
+
+  test("both empty strings match on the single empty line", () => {
+    expect(computeLineDiff("", "")).toEqual([{ type: "context", text: "" }])
+  })
+
+  test("single line replacement", () => {
+    expect(computeLineDiff("old", "new")).toEqual([
+      { type: "removed", text: "old" },
+      { type: "added", text: "new" },
+    ])
+  })
+
+  test("insertion in the middle keeps surrounding context", () => {
+    const diff = computeLineDiff("a\nc", "a\nb\nc")
+    expect(lines(diff)).toEqual(["context:a", "added:b", "context:c"])
+  })
+
+  test("deletion in the middle", () => {
+    const diff = computeLineDiff("a\nb\nc", "a\nc")
+    expect(lines(diff)).toEqual(["context:a", "removed:b", "context:c"])
+  })
+
+  test("multiple scattered edits", () => {
+    const diff = computeLineDiff("keep\nold-one\nshared\nold-two\ntail", "keep\nnew-one\nshared\nnew-two\ntail")
+    expect(diff.filter((d) => d.type === "context").map((d) => d.text)).toEqual(["keep", "shared", "tail"])
+    expect(diff.filter((d) => d.type === "removed").map((d) => d.text)).toEqual(["old-one", "old-two"])
+    expect(diff.filter((d) => d.type === "added").map((d) => d.text)).toEqual(["new-one", "new-two"])
+  })
+
+  test("complete replacement has no context", () => {
+    expect(computeLineDiff("x\ny", "p\nq")).toEqual([
+      { type: "removed", text: "x" },
+      { type: "removed", text: "y" },
+      { type: "added", text: "p" },
+      { type: "added", text: "q" },
+    ])
+  })
+
+  test("append-only change at end", () => {
+    const diff = computeLineDiff("line1", "line1\nline2")
+    expect(lines(diff)).toEqual(["context:line1", "added:line2"])
+  })
+})

--- a/apps/mobile/components/chat/turns/__tests__/file-lang-map.test.ts
+++ b/apps/mobile/components/chat/turns/__tests__/file-lang-map.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Unit tests for file path → language helpers used in diff/file turn UI.
+ */
+import { describe, expect, test } from "bun:test"
+import { getBasename, getLanguageFromPath, getLanguageLabel } from "../file-lang-map"
+
+describe("getLanguageFromPath", () => {
+  test("maps common extensions", () => {
+    expect(getLanguageFromPath("src/App.tsx")).toBe("tsx")
+    expect(getLanguageFromPath("lib/util.ts")).toBe("typescript")
+    expect(getLanguageFromPath("main.py")).toBe("python")
+    expect(getLanguageFromPath("schema.prisma")).toBe("prisma")
+  })
+
+  test("dockerfile names", () => {
+    expect(getLanguageFromPath("Dockerfile")).toBe("dockerfile")
+    expect(getLanguageFromPath("docker/Dockerfile.prod")).toBe("dockerfile")
+  })
+
+  test("makefile names", () => {
+    expect(getLanguageFromPath("Makefile")).toBe("makefile")
+    expect(getLanguageFromPath("GNUmakefile")).toBe("makefile")
+  })
+
+  test("returns text for unknown or extensionless paths", () => {
+    expect(getLanguageFromPath("README")).toBe("text")
+    expect(getLanguageFromPath("LICENSE")).toBe("text")
+    expect(getLanguageFromPath("notes.xyz")).toBe("text")
+  })
+})
+
+describe("getLanguageLabel", () => {
+  test("returns friendly labels for known languages", () => {
+    expect(getLanguageLabel("App.tsx")).toBe("TSX")
+    expect(getLanguageLabel("main.py")).toBe("Python")
+    expect(getLanguageLabel("deploy.yml")).toBe("YAML")
+  })
+
+  test("capitalizes unknown language ids", () => {
+    expect(getLanguageLabel("README")).toBe("Text")
+  })
+})
+
+describe("getBasename", () => {
+  test("returns last path segment", () => {
+    expect(getBasename("src/components/App.tsx")).toBe("App.tsx")
+    expect(getBasename("package.json")).toBe("package.json")
+  })
+
+  test("returns original string when no slash", () => {
+    expect(getBasename("App.tsx")).toBe("App.tsx")
+  })
+})


### PR DESCRIPTION
## Summary

Adds unit tests for four small, pure chat helpers in `apps/mobile` (no component rendering, no Playwright):

1. **`components/chat/tools/types.ts`** — tool category, display name, namespace, gradient opacity, and key-arg extraction for the tool timeline UI.
2. **`components/chat/turns/file-lang-map.ts`** — file path → Monaco language id and human-readable label.
3. **`components/chat/turns/diff-utils.ts`** — LCS-based line diff (`computeLineDiff`) used by edit-file widgets.
4. **`components/chat/long-text-utils.ts`** — long-text detection, snippets, paste extraction, and pasted-text → attachment conversion for chat inputs.

## Tests

| Module | Test file | Count |
|--------|-----------|-------|
| `tools/types.ts` | `tools/__tests__/types.test.ts` | 27 |
| `turns/file-lang-map.ts` | `turns/__tests__/file-lang-map.test.ts` | 8 |
| `turns/diff-utils.ts` | `turns/__tests__/diff-utils.test.ts` | 10 |
| `long-text-utils.ts` | `__tests__/long-text-utils.test.ts` | 18 |
| **Total** | | **63** |

## Coverage (isolated runs)

- `types.ts`: **100% funcs / ~95%+ lines** (was ~35% line coverage on main)
- `file-lang-map.ts`, `diff-utils.ts`, `long-text-utils.ts`: full coverage of exported helpers

## Test plan

- [x] `bun test apps/mobile/components/chat/tools/__tests__/types.test.ts`
- [x] `bun test apps/mobile/components/chat/turns/__tests__/file-lang-map.test.ts`
- [x] `bun test apps/mobile/components/chat/turns/__tests__/diff-utils.test.ts`
- [x] `bun test apps/mobile/components/chat/__tests__/long-text-utils.test.ts`
- [x] All four together (63 pass)
- [ ] Full mobile `test:coverage` green after PTY mock PR merges (unrelated BottomPanel/WebSocket failures on main)
