### PR TITLE
fix(mobile): show Ctrl+K search shortcut on Windows

### DIFF
--- a/apps/mobile/components/layout/AppSidebar.tsx
+++ b/apps/mobile/components/layout/AppSidebar.tsx
@@ -38,6 +38,7 @@ import {
 import { usePostHogSafe } from '../../contexts/posthog'
 import { useTheme } from '../../contexts/theme'
 import { EVENTS, trackEvent } from '../../lib/analytics'
+import { formatModKey } from '../../lib/keyboard-shortcuts'
 import {
   Popover,
   PopoverBackdrop,
@@ -1329,7 +1330,7 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
             icon={Search}
             label="Search"
             collapsed={collapsed}
-            shortcut="⌘K"
+            shortcut={formatModKey('k')}
             onPress={handleSearchPress}
           />
           {localMode && (

--- a/apps/mobile/lib/__tests__/keyboard-shortcuts.test.ts
+++ b/apps/mobile/lib/__tests__/keyboard-shortcuts.test.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, test, expect } from 'bun:test'
+
+import { formatModKey, isMacKeyboardPlatform } from '../keyboard-shortcuts'
+
+describe('isMacKeyboardPlatform', () => {
+  test('detects macOS and iOS platform strings', () => {
+    expect(isMacKeyboardPlatform('MacIntel')).toBe(true)
+    expect(isMacKeyboardPlatform('iPhone')).toBe(true)
+    expect(isMacKeyboardPlatform('iPad')).toBe(true)
+  })
+
+  test('treats Windows and Linux as non-Mac', () => {
+    expect(isMacKeyboardPlatform('Win32')).toBe(false)
+    expect(isMacKeyboardPlatform('Linux x86_64')).toBe(false)
+  })
+})
+
+describe('formatModKey', () => {
+  test('uses ⌘ on Mac platforms', () => {
+    expect(formatModKey('k', 'MacIntel')).toBe('⌘K')
+  })
+
+  test('uses Ctrl+ on Windows and Linux', () => {
+    expect(formatModKey('k', 'Win32')).toBe('Ctrl+K')
+    expect(formatModKey('k', 'Linux x86_64')).toBe('Ctrl+K')
+  })
+
+  test('uppercases single-character keys', () => {
+    expect(formatModKey('p', 'Win32')).toBe('Ctrl+P')
+  })
+})

--- a/apps/mobile/lib/keyboard-shortcuts.ts
+++ b/apps/mobile/lib/keyboard-shortcuts.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Display labels for modifier-key shortcuts on web.
+ * Key handlers should continue to use `(e.metaKey || e.ctrlKey)` — this module
+ * only formats what users see in the UI.
+ */
+
+/** True when the browser reports a Mac / iOS platform string. */
+export function isMacKeyboardPlatform(platform: string = getNavigatorPlatform()): boolean {
+  return /Mac|iPhone|iPod|iPad/i.test(platform)
+}
+
+function getNavigatorPlatform(): string {
+  if (typeof navigator === 'undefined') return ''
+  return navigator.platform ?? ''
+}
+
+/**
+ * Human-readable shortcut for modifier + letter (e.g. ⌘K vs Ctrl+K).
+ *
+ * @param key - Single letter or key name; single chars are uppercased.
+ * @param platform - Optional override for tests (`navigator.platform` when omitted).
+ */
+export function formatModKey(key: string, platform?: string): string {
+  const label = key.length === 1 ? key.toUpperCase() : key
+  const resolvedPlatform = platform ?? getNavigatorPlatform()
+  return isMacKeyboardPlatform(resolvedPlatform) ? `⌘${label}` : `Ctrl+${label}`
+}


### PR DESCRIPTION
## Summary
- Add \ormatModKey\ helper in \pps/mobile/lib/keyboard-shortcuts.ts\ to format modifier-key labels from \
avigator.platform\
- Use it for the sidebar Search shortcut badge so macOS shows **⌘K** and Windows/Linux show **Ctrl+K**
- Keyboard behavior is unchanged: Command Palette still opens with \metaKey || ctrlKey\ + K

<img width="517" height="316" alt="image" src="https://github.com/user-attachments/assets/6decd040-314a-48cc-b851-3b98683e49f3" />


## Test plan
- [ ] On Windows web, confirm sidebar Search shows **Ctrl+K** and Ctrl+K opens the command palette
- [ ] On macOS web, confirm sidebar Search shows **⌘K** and ⌘K opens the command palette
- [ ] Run \un test apps/mobile/lib/__tests__/keyboard-shortcuts.test.ts\


Made with [Cursor](https://cursor.com)