### PR TITLE
fix(api/git-http): post-receive hook missed fast-exit pushes — checkpoints never created

### DIFF
--- a/apps/api/src/__tests__/git-http-route.test.ts
+++ b/apps/api/src/__tests__/git-http-route.test.ts
@@ -33,6 +33,7 @@ let spawnResponder: SpawnResponder = () => ({
   exitCode: 0,
 })
 
+let spawnFastExit = false
 function makeFakeChild(call: SpawnCall): any {
   const proc = new EventEmitter() as any
   proc.stdin = {
@@ -45,12 +46,21 @@ function makeFakeChild(call: SpawnCall): any {
   proc.exitCode = null
 
   const res = spawnResponder(call)
-  setTimeout(() => {
+  const emit = () => {
     proc.stdout.emit('data', Buffer.from(res.stdout))
     proc.exitCode = res.exitCode
     proc.stdout.emit('end')
     proc.emit('exit', res.exitCode)
-  }, 5)
+  }
+  if (spawnFastExit) {
+    // SHOG-664 regression mode: emit on the next microtask so the child's
+    // `exit` fires *before* any code after `await headerReady` in the route
+    // can attach its own `child.on('exit')` listener. This reproduces the
+    // production race where the post-receive hook was silently skipped.
+    queueMicrotask(emit)
+  } else {
+    setTimeout(emit, 5)
+  }
   return proc
 }
 
@@ -368,6 +378,55 @@ describe('git-http route — POST handlers + auth edges', () => {
     }
   })
 
+})
+
+describe('SHOG-664 regression — post-receive hook fires even on fast child exit', () => {
+  it('runs runPostReceiveHook (inserts ProjectCheckpoint) when child exits before late .on("exit") would attach', async () => {
+    // Reproduce the original race: the spawned `git http-backend` exits on
+    // the next microtask, which is *before* the route handler's late
+    // `child.on('exit')` listener (the one that triggered the post-receive
+    // hook) used to be attached. With the bug, the listener missed the
+    // event and no ProjectCheckpoint row was ever created → empty IDE tab.
+    spawnFastExit = true
+    spawnResponder = () => ({
+      stdout:
+        'Status: 200 OK\r\nContent-Type: application/x-git-receive-pack-result\r\n\r\nOK',
+      exitCode: 0,
+    })
+    const { mkdtempSync, rmSync, mkdirSync } = await import('node:fs')
+    const { tmpdir } = await import('node:os')
+    const { join } = await import('node:path')
+    const baseDir = mkdtempSync(join(tmpdir(), 'git-http-shog664-'))
+    try {
+      mkdirSync(join(baseDir, 'p_race'))
+      checkpointCreate.mockClear()
+      checkpointFindFirst.mockImplementation(async () => null)
+      const app = new Hono()
+      app.use('*', async (c, next) => {
+        c.set('auth', { userId: 'u_race', isAuthenticated: true } as any)
+        await next()
+      })
+      app.route('/api', gitHttpRoutes({ workspacesDir: baseDir }))
+      const res = await app.request('/api/projects/p_race/git/git-receive-pack', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-git-receive-pack-request' },
+        body: 'fake-receive-pack-data',
+      })
+      expect(res.status).toBe(200)
+      await res.text()
+      // Let the exitPromise's .then microtask + runPostReceiveHook's
+      // internal awaits flush.
+      await new Promise((r) => setTimeout(r, 20))
+      expect(checkpointCreate).toHaveBeenCalled()
+      const data = (checkpointCreate as any).mock.calls.at(-1)?.[0]?.data
+      expect(data.projectId).toBe('p_race')
+      expect(data.isAutomatic).toBe(true)
+      expect(data.createdBy).toBe('u_race')
+    } finally {
+      rmSync(baseDir, { recursive: true, force: true })
+      spawnFastExit = false
+    }
+  })
 })
 
 describe('runPostReceiveHook — defensive edges', () => {

--- a/apps/api/src/routes/git-http.ts
+++ b/apps/api/src/routes/git-http.ts
@@ -198,6 +198,18 @@ async function runGitHttpBackend(c: Context, opts: {
     stdio: ['pipe', 'pipe', 'pipe'],
   })
 
+  // Capture the child's exit code into a single eagerly-attached Promise.
+  // Late `.then()` consumers on an already-settled Promise still fire on a
+  // future microtask, which is what we need: for fast pushes the child can
+  // exit *before* downstream code (header-wait, post-receive hook) attaches
+  // its own `child.on('exit')` listener. Node's EventEmitter does NOT replay
+  // `exit`, so those late listeners silently never fire — that's the
+  // SHOG-664 bug (no ProjectCheckpoint row ever gets written; the IDE
+  // Checkpoints tab stays empty).
+  const exitPromise = new Promise<number | null>((resolveExit) => {
+    child.on('exit', (code) => resolveExit(code))
+  })
+
   // Body → stdin (only POST requests carry one).
   if (c.req.method !== 'GET') {
     const reader = c.req.raw.body?.getReader()
@@ -283,7 +295,7 @@ async function runGitHttpBackend(c: Context, opts: {
         resolve()
       }
     }, 5)
-    child.on('exit', (code) => {
+    exitPromise.then((code) => {
       if (!headersResolved) {
         clearInterval(interval)
         // exited before producing headers — surface 502 with stderr.
@@ -311,7 +323,11 @@ async function runGitHttpBackend(c: Context, opts: {
   // hook for receive-pack pushes. We do this outside the streaming
   // pipeline so it doesn't delay the response.
   if (isReceivePack) {
-    child.on('exit', (code) => {
+    // Use the eagerly-captured exitPromise (NOT a fresh `child.on('exit')`
+    // listener) so that fast pushes whose child has already exited still
+    // run the hook. This is SHOG-664: late EventEmitter listeners miss
+    // events that already fired, which silently dropped checkpoint rows.
+    exitPromise.then((code) => {
       if (code === 0) {
         runPostReceiveHook(projectId, workspacePath, userId).catch((err) => {
           console.warn(`[git-http] post-receive hook for ${projectId} failed:`, err?.message ?? err)


### PR DESCRIPTION
Fixes #637
Jira: [SHOG-664](https://odin-ai.atlassian.net/browse/SHOG-664)

## What

On cloud-sync projects, `ProjectCheckpoint` rows were never being inserted, so the IDE Checkpoints tab was permanently empty. This PR fixes the underlying EventEmitter race in `apps/api/src/routes/git-http.ts` and adds a regression test that pins the invariant end-to-end.

## Why — root cause

Two `child.on('exit')` listeners were attached to the spawned `git http-backend` at different points:

1. **Listener #1** — inside the `headerReady` Promise, handling the 502-on-no-output failure.
2. **Listener #2** — attached AFTER `await headerReady` resolves, running `runPostReceiveHook()` (which writes the `ProjectCheckpoint` row).

For fast pushes (small packs, no-op pushes, anything where `git http-backend` exits quickly) the child has already emitted `exit` by the time listener #2 attaches. Node's `EventEmitter` does NOT replay past events for late subscribers → listener #2 silently never fires → no DB row → empty Checkpoints tab.

Compounding factor: `apps/api/src/routes/project-chat.ts` correctly skips its own chat-turn auto-checkpoint when `SHOGO_CLOUD_SYNC=1` (the worker push path is supposed to own checkpoint creation, otherwise we'd duplicate rows on every turn). With the worker path dropping the event and the chat-turn path opted out, **no code path** writes a checkpoint row — that's why the symptom is total, not intermittent.

Full root-cause analysis lives in issue #637.

## How — the fix

This is a **root fix**, not a patch.

The defect is that the handler was using `child.on('exit')` — a fire-once-and-forget event broadcast — as if it were a value that any later code could observe. That assumption is wrong for *every* late consumer, not just the post-receive hook.

This PR converts the exit signal into a durable value:

```ts
const child = spawn('git', ['http-backend'], { env, stdio: ['pipe','pipe','pipe'] })

// Eager, single source of truth — attached BEFORE any await.
const exitPromise = new Promise<number | null>((resolveExit) => {
  child.on('exit', (code) => resolveExit(code))
})
```

Both existing consumers (header-wait path + post-receive hook) now read from `exitPromise.then(...)` instead of attaching their own listeners. `.then()` on an already-settled Promise still fires on a future microtask, so the exit is observed correctly regardless of timing. The same change also eliminates the latent race on the header-wait path (it was just invisible because headers usually arrive before exit).

Why this is root, not patch:
- No conditional / no `if (exitCode != null) handleInline else attachListener` special-case.
- Symmetric treatment of both consumers — no "the new one is treated specially."
- Any future N=3, N=4 consumer (metrics, audit, etc.) gets correct behavior for free.
- The bug class — "late-attached listener misses fire-once event" — is gone from this handler, not just this instance of it.

## Regression test

Added a test in `apps/api/src/__tests__/git-http-route.test.ts` that drives `POST /api/projects/:id/git/git-receive-pack` end-to-end with a fast-exiting fake child (new `spawnFastExit` flag in `makeFakeChild` emits `exit` on the next microtask, before listener #2 could ever attach). The test asserts `prisma.projectCheckpoint.create` is invoked with the expected `projectId`, `createdBy`, and `isAutomatic: true`.

Verified properly:
- Stash this PR's changes to `git-http.ts` (keeping the new test) → test **fails** (`checkpointCreate` never called).
- Unstash → test **passes**. Full suite: 19/19 in `git-http-route.test.ts`.

The test pins the *invariant* ("the post-receive hook fires regardless of when the child exited"), not the surface symptom — any refactor that reintroduces the EventEmitter race will fail this test.

## Files changed

- `apps/api/src/routes/git-http.ts` — eager `exitPromise`; both consumers switched over.
- `apps/api/src/__tests__/git-http-route.test.ts` — adds `spawnFastExit` mode + SHOG-664 regression test.

No schema changes, no API shape changes, no behavior change for projects without `SHOGO_CLOUD_SYNC=1`.

## Verification checklist

- [x] Unit suite green (19/19 in `git-http-route.test.ts`).
- [x] Regression test confirmed failing on `main` and passing on this branch.
- [x] No changes to `project-chat.ts` auto-checkpoint opt-out (intentional — worker path correctly owns checkpoints in cloud-sync mode).
- [x] Jira [SHOG-664](https://odin-ai.atlassian.net/browse/SHOG-664) updated with full root cause + this branch.
- [ ] Manual smoke (post-merge): run a small agent turn on a cloud-sync project, confirm a checkpoint row appears in the Checkpoints tab.

## Risk

Low. Two-line conceptual change in one route, scoped to the exit-signal plumbing. Behavior on the success path (full push, exit > 5 ms after handler completes) is unchanged because `exitPromise.then(...)` fires identically to the old `child.on('exit', ...)` in that case. The change only affects the previously-broken fast-exit path.