### PR TITLE
test(mobile): add unit tests for subagent stop and stream store

### DIFF
--- a/apps/mobile/lib/__tests__/subagent-stop.test.ts
+++ b/apps/mobile/lib/__tests__/subagent-stop.test.ts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Unit tests for subagent cancellation entrypoint.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { configureSubagentStop, stopSubagent } from "../subagent-stop"
+import { subagentStreamStore } from "../subagent-stream-store"
+
+const API_BASE = "https://api.example.com"
+
+describe("stopSubagent", () => {
+  beforeEach(() => {
+    subagentStreamStore.clear()
+    configureSubagentStop(null)
+  })
+
+  afterEach(() => {
+    subagentStreamStore.clear()
+    configureSubagentStop(null)
+  })
+
+  test("returns immediately when instanceId is empty", () => {
+    const fetchCalls: string[] = []
+    configureSubagentStop({
+      apiBaseUrl: API_BASE,
+      platform: "web",
+      projectId: "proj-1",
+      fetchFn: () => {
+        fetchCalls.push("called")
+        return Promise.resolve(new Response())
+      },
+    })
+    stopSubagent("")
+    expect(fetchCalls).toHaveLength(0)
+  })
+
+  test("does nothing when config is not set", () => {
+    const warnings: string[] = []
+    const originalWarn = console.warn
+    console.warn = (...args: unknown[]) => {
+      warnings.push(String(args[0]))
+    }
+    try {
+      stopSubagent("inst-1")
+    } finally {
+      console.warn = originalWarn
+    }
+    expect(warnings.some((w) => w.includes("[subagent-stop]"))).toBe(true)
+  })
+
+  test("POSTs to project chat subagent stop URL on web", async () => {
+    let capturedUrl = ""
+    configureSubagentStop({
+      apiBaseUrl: API_BASE,
+      platform: "web",
+      projectId: "proj-123",
+      fetchFn: (url, init) => {
+        capturedUrl = String(url)
+        expect(init?.method).toBe("POST")
+        return Promise.resolve(new Response(null, { status: 204 }))
+      },
+    })
+    await stopSubagent("inst-abc")
+    expect(capturedUrl).toBe(`${API_BASE}/api/projects/proj-123/chat/subagents/inst-abc/stop`)
+  })
+
+  test("uses local agent URL when configured", async () => {
+    let capturedUrl = ""
+    configureSubagentStop({
+      apiBaseUrl: API_BASE,
+      platform: "web",
+      localAgentUrl: "http://127.0.0.1:9000",
+      projectId: "proj-ignored",
+      fetchFn: (url) => {
+        capturedUrl = String(url)
+        return Promise.resolve(new Response())
+      },
+    })
+    await stopSubagent("inst-1")
+    expect(capturedUrl).toBe("http://127.0.0.1:9000/agent/subagents/inst-1/stop")
+  })
+
+  test("skips fetch when stop request cannot be built", () => {
+    let called = false
+    configureSubagentStop({
+      apiBaseUrl: API_BASE,
+      platform: "web",
+      fetchFn: () => {
+        called = true
+        return Promise.resolve(new Response())
+      },
+    })
+    stopSubagent("inst-1")
+    expect(called).toBe(false)
+  })
+
+  test("optimistically marks stream completed when toolId provided", async () => {
+    subagentStreamStore.init("tool-1", {
+      agentId: "a1",
+      agentType: "task",
+      description: "run",
+      status: "running",
+    })
+    configureSubagentStop({
+      apiBaseUrl: API_BASE,
+      platform: "web",
+      projectId: "proj-1",
+      fetchFn: () => Promise.resolve(new Response()),
+    })
+    await stopSubagent("inst-1", "tool-1")
+    expect(subagentStreamStore.get("tool-1")!.status).toBe("completed")
+  })
+
+  test("swallows fetch errors after logging", async () => {
+    const warnings: string[] = []
+    const originalWarn = console.warn
+    console.warn = (...args: unknown[]) => {
+      warnings.push(String(args[0]))
+    }
+    configureSubagentStop({
+      apiBaseUrl: API_BASE,
+      platform: "web",
+      projectId: "proj-1",
+      fetchFn: () => Promise.reject(new Error("network down")),
+    })
+    try {
+      await stopSubagent("inst-1")
+    } finally {
+      console.warn = originalWarn
+    }
+    expect(warnings.some((w) => w.includes("Failed to cancel subagent"))).toBe(true)
+  })
+})
+
+describe("configureSubagentStop", () => {
+  afterEach(() => configureSubagentStop(null))
+
+  test("allows replacing config", async () => {
+    let first = false
+    configureSubagentStop({
+      apiBaseUrl: API_BASE,
+      platform: "web",
+      projectId: "proj-1",
+      fetchFn: () => {
+        first = true
+        return Promise.resolve(new Response())
+      },
+    })
+    await stopSubagent("inst-1")
+    expect(first).toBe(true)
+
+    configureSubagentStop(null)
+    first = false
+    stopSubagent("inst-1")
+    expect(first).toBe(false)
+  })
+})

--- a/apps/mobile/lib/__tests__/subagent-stream-store.test.ts
+++ b/apps/mobile/lib/__tests__/subagent-stream-store.test.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Unit tests for the ephemeral subagent stream store.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { subagentStreamStore } from "../subagent-stream-store"
+
+const baseData = {
+  agentId: "agent-1",
+  agentType: "explore",
+  description: "Search codebase",
+  status: "running" as const,
+}
+
+describe("subagentStreamStore", () => {
+  beforeEach(() => {
+    subagentStreamStore.clear()
+    subagentStreamStore.onRequestTabSwitch(null)
+  })
+
+  afterEach(() => {
+    subagentStreamStore.clear()
+    subagentStreamStore.onRequestTabSwitch(null)
+  })
+
+  test("init creates entry with empty parts", () => {
+    subagentStreamStore.init("tool-1", baseData)
+    const entry = subagentStreamStore.get("tool-1")
+    expect(entry).toMatchObject(baseData)
+    expect(entry!.parts).toEqual([])
+  })
+
+  test("init merges into existing entry without wiping parts", () => {
+    subagentStreamStore.init("tool-1", baseData)
+    subagentStreamStore.appendPart("tool-1", { type: "text", text: "hi", id: "p1" })
+    subagentStreamStore.init("tool-1", {
+      ...baseData,
+      agentType: "",
+      description: "Updated",
+      status: "completed",
+    })
+    const entry = subagentStreamStore.get("tool-1")
+    expect(entry!.agentType).toBe("explore")
+    expect(entry!.description).toBe("Updated")
+    expect(entry!.status).toBe("completed")
+    expect(entry!.parts).toHaveLength(1)
+  })
+
+  test("setParts updates when length changes", () => {
+    subagentStreamStore.init("tool-1", baseData)
+    const parts = [{ type: "text" as const, text: "a", id: "p1" }]
+    subagentStreamStore.setParts("tool-1", parts)
+    expect(subagentStreamStore.get("tool-1")!.parts).toEqual(parts)
+  })
+
+  test("setParts is a no-op when length unchanged", () => {
+    subagentStreamStore.init("tool-1", baseData)
+    const parts = [{ type: "text" as const, text: "a", id: "p1" }]
+    subagentStreamStore.setParts("tool-1", parts)
+    const versionBefore = subagentStreamStore.getVersion()
+    subagentStreamStore.setParts("tool-1", [{ type: "text", text: "b", id: "p2" }])
+    expect(subagentStreamStore.getVersion()).toBe(versionBefore)
+    expect(subagentStreamStore.get("tool-1")!.parts[0].type).toBe("text")
+    if (subagentStreamStore.get("tool-1")!.parts[0].type === "text") {
+      expect(subagentStreamStore.get("tool-1")!.parts[0].text).toBe("a")
+    }
+  })
+
+  test("appendPart and updateStatus", () => {
+    subagentStreamStore.init("tool-1", baseData)
+    subagentStreamStore.appendPart("tool-1", { type: "text", text: "chunk", id: "p1" })
+    subagentStreamStore.updateStatus("tool-1", "error")
+    expect(subagentStreamStore.get("tool-1")!.parts).toHaveLength(1)
+    expect(subagentStreamStore.get("tool-1")!.status).toBe("error")
+  })
+
+  test("setInstanceId and setModel skip redundant writes", () => {
+    subagentStreamStore.init("tool-1", { ...baseData, instanceId: "inst-1", model: "gpt-4" })
+    const versionAfterInit = subagentStreamStore.getVersion()
+    subagentStreamStore.setInstanceId("tool-1", "inst-1")
+    subagentStreamStore.setModel("tool-1", "gpt-4")
+    expect(subagentStreamStore.getVersion()).toBe(versionAfterInit)
+    subagentStreamStore.setInstanceId("tool-1", "inst-2")
+    subagentStreamStore.setModel("tool-1", "claude")
+    expect(subagentStreamStore.get("tool-1")!.instanceId).toBe("inst-2")
+    expect(subagentStreamStore.get("tool-1")!.model).toBe("claude")
+  })
+
+  test("clear removes all entries", () => {
+    subagentStreamStore.init("tool-1", baseData)
+    subagentStreamStore.init("tool-2", { ...baseData, agentId: "agent-2" })
+    subagentStreamStore.clear()
+    expect(subagentStreamStore.get("tool-1")).toBeUndefined()
+    expect(subagentStreamStore.getAll().size).toBe(0)
+  })
+
+  test("subscribe notifies on mutations", () => {
+    let calls = 0
+    const unsub = subagentStreamStore.subscribe(() => {
+      calls++
+    })
+    subagentStreamStore.init("tool-1", baseData)
+    subagentStreamStore.updateStatus("tool-1", "completed")
+    unsub()
+    subagentStreamStore.init("tool-2", baseData)
+    expect(calls).toBe(2)
+  })
+
+  test("requestTabSwitch invokes registered handler", () => {
+    let received: string | undefined
+    subagentStreamStore.onRequestTabSwitch((toolId) => {
+      received = toolId
+    })
+    subagentStreamStore.requestTabSwitch("tool-9")
+    expect(received).toBe("tool-9")
+  })
+
+  test("unknown toolId operations are no-ops", () => {
+    const versionBefore = subagentStreamStore.getVersion()
+    subagentStreamStore.appendPart("missing", { type: "text", text: "x", id: "p1" })
+    subagentStreamStore.setParts("missing", [])
+    subagentStreamStore.updateStatus("missing", "completed")
+    expect(subagentStreamStore.getVersion()).toBe(versionBefore)
+  })
+})


### PR DESCRIPTION
## Summary

Add Bun unit tests for subagent cancellation and the ephemeral subagent stream store used by ChatPanel and the Agents tab.

## Modules

| Module | Test file | Tests |
|--------|-----------|-------|
| lib/subagent-stop.ts | __tests__/subagent-stop.test.ts | 8 |
| lib/subagent-stream-store.ts | __tests__/subagent-stream-store.test.ts | 10 |
| **Total** | | **18** |

## Coverage

- stopSubagent: empty id, missing config, web/local fetch URLs, optimistic toolId status, fetch errors
- subagentStreamStore: init/merge, parts, status, instanceId/model, clear, subscribe, tab switch

## Test plan

- [x] bun test apps/mobile/lib/__tests__/subagent-stop.test.ts
- [x] bun test apps/mobile/lib/__tests__/subagent-stream-store.test.ts
- [x] Both together (18 pass)
- [ ] Full mobile CI green after PTY mock PR merges (unrelated failures on main)

Made with [Cursor](https://cursor.com)