### PR TITLE
fix(dev): auto-resolve P3018 ledger drift on dev:all SQLite migrations

### DIFF
--- a/scripts/__tests__/dev-all-migrate.test.ts
+++ b/scripts/__tests__/dev-all-migrate.test.ts
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Regression coverage for `scripts/dev-all.ts`'s SQLite migration
+ * self-heal.
+ *
+ * Background: Prisma's "apply migration" is two operations — execute
+ * the SQL, then `UPDATE _prisma_migrations SET finished_at = ?`.
+ * SQLite commits the SQL first, so when `bun dev:all` is interrupted
+ * (Ctrl+C, watch-api crash, OS sleep) between those two steps, the
+ * schema moves forward but the ledger row stays incomplete. Next boot,
+ * `prisma migrate deploy` returns P3018 "duplicate column name: X" and
+ * `dev:all` aborts until a human runs `prisma migrate resolve --applied`.
+ *
+ * The auto-resolve recovers from THIS specific shape only:
+ *   - error is P3018 with "duplicate column name: …"
+ *   - the failing migration is purely ALTER TABLE ADD COLUMN statements
+ *   - every column it would add is already present in the DB
+ * Anything else falls through to the original abort.
+ *
+ * These tests pin both halves of the contract:
+ *   1. parseDuplicateColumnFailure correctly extracts the migration name
+ *      and column from real Prisma stderr, and refuses to match other
+ *      error shapes.
+ *   2. isMigrationFullyApplied returns true ONLY when the migration is
+ *      purely ADD COLUMN AND every target column is already physically
+ *      present in the DB. Mixed-shape migrations (CREATE TABLE,
+ *      DROP COLUMN, data UPDATE, etc.) must fail closed regardless of
+ *      column state.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  isMigrationFullyApplied,
+  parseDuplicateColumnFailure,
+} from "../dev-all";
+
+describe("parseDuplicateColumnFailure", () => {
+  test("extracts migration name + column from real P3018 stderr", () => {
+    const stderr = `Datasource "db": SQLite database "shogo.db" at "file:./shogo.db"
+
+Applying migration \`20260518000000_grant_plan_tier\`
+Error: P3018
+
+A migration failed to apply. New migrations cannot be applied before the error is recovered from. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve
+
+Migration name: 20260518000000_grant_plan_tier
+
+Database error code: 1
+
+Database error:
+duplicate column name: planId
+`;
+    expect(parseDuplicateColumnFailure(stderr)).toEqual({
+      migrationName: "20260518000000_grant_plan_tier",
+      duplicateColumn: "planId",
+    });
+  });
+
+  test("returns null for non-P3018 errors (e.g. engine connection failures)", () => {
+    const stderr = `Error: P1001
+Can't reach database server at \`localhost:5432\``;
+    expect(parseDuplicateColumnFailure(stderr)).toBeNull();
+  });
+
+  test("returns null for P3018 caused by a non-duplicate-column error (e.g. NOT NULL)", () => {
+    const stderr = `Error: P3018
+Migration name: 20260101000000_add_required_field
+
+Database error code: 1
+Database error:
+NOT NULL constraint failed: projects.requiredField`;
+    // The auto-resolve only covers the duplicate-column shape; other
+    // P3018 causes (NOT NULL, FK violation, syntax error) need a real
+    // human to look at the data.
+    expect(parseDuplicateColumnFailure(stderr)).toBeNull();
+  });
+
+  test("returns null when stderr is empty", () => {
+    expect(parseDuplicateColumnFailure("")).toBeNull();
+  });
+});
+
+describe("isMigrationFullyApplied", () => {
+  let workDir: string;
+  let dbPath: string;
+  let migrationsDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "dev-all-migrate-"));
+    dbPath = join(workDir, "test.db");
+    migrationsDir = "fixtures/migrations";
+    mkdirSync(join(workDir, migrationsDir), { recursive: true });
+
+    // Seed a minimal DB schema. The "good" migration's columns ARE
+    // present; the "missing" migration's columns are NOT present.
+    const db = new Database(dbPath);
+    db.run(`
+      CREATE TABLE workspace_grants (
+        id TEXT PRIMARY KEY,
+        planId TEXT
+      )
+    `);
+    db.run(`
+      CREATE TABLE projects (
+        id TEXT PRIMARY KEY,
+        publishStatus TEXT,
+        publishError TEXT,
+        publishStatusAt INTEGER
+      )
+    `);
+    db.close();
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  function writeMigration(name: string, sql: string): void {
+    const dir = join(workDir, migrationsDir, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "migration.sql"), sql);
+  }
+
+  test("true when every ADD COLUMN target already exists", async () => {
+    writeMigration(
+      "20260518000000_grant_plan_tier",
+      `ALTER TABLE "workspace_grants"
+  ADD COLUMN "planId" TEXT;
+`,
+    );
+    const ok = await isMigrationFullyApplied(
+      "20260518000000_grant_plan_tier",
+      { rootDir: workDir, dbPath, migrationsDir },
+    );
+    expect(ok).toBe(true);
+  });
+
+  test("true for multi-column ADD COLUMN migration when all columns present", async () => {
+    writeMigration(
+      "20260520000000_project_publish_status",
+      `ALTER TABLE "projects" ADD COLUMN "publishStatus" TEXT;
+ALTER TABLE "projects" ADD COLUMN "publishError" TEXT;
+ALTER TABLE "projects" ADD COLUMN "publishStatusAt" INTEGER;
+`,
+    );
+    const ok = await isMigrationFullyApplied(
+      "20260520000000_project_publish_status",
+      { rootDir: workDir, dbPath, migrationsDir },
+    );
+    expect(ok).toBe(true);
+  });
+
+  test("false when ANY ADD COLUMN target is still missing", async () => {
+    writeMigration(
+      "20260601000000_partial",
+      `ALTER TABLE "projects" ADD COLUMN "publishStatus" TEXT;
+ALTER TABLE "projects" ADD COLUMN "newColumnNotYetApplied" TEXT;
+`,
+    );
+    const ok = await isMigrationFullyApplied(
+      "20260601000000_partial",
+      { rootDir: workDir, dbPath, migrationsDir },
+    );
+    // Critical: even if SOME columns are present, we must NOT auto-resolve
+    // — the migration genuinely needs to run for the missing columns.
+    expect(ok).toBe(false);
+  });
+
+  test("false when migration contains a non-ADD-COLUMN statement", async () => {
+    // A migration that mixes ADD COLUMN with CREATE INDEX could have
+    // partial state we can't safely paper over by marking it applied —
+    // the index might be missing even if every column is there.
+    writeMigration(
+      "20260602000000_add_with_index",
+      `ALTER TABLE "workspace_grants" ADD COLUMN "planId" TEXT;
+CREATE INDEX "workspace_grants_planId_idx" ON "workspace_grants"("planId");
+`,
+    );
+    const ok = await isMigrationFullyApplied(
+      "20260602000000_add_with_index",
+      { rootDir: workDir, dbPath, migrationsDir },
+    );
+    expect(ok).toBe(false);
+  });
+
+  test("false for DROP COLUMN migrations even if the drop seemingly succeeded", async () => {
+    writeMigration(
+      "20260603000000_drop_legacy_field",
+      `ALTER TABLE "workspace_grants" DROP COLUMN "legacyField";`,
+    );
+    const ok = await isMigrationFullyApplied(
+      "20260603000000_drop_legacy_field",
+      { rootDir: workDir, dbPath, migrationsDir },
+    );
+    expect(ok).toBe(false);
+  });
+
+  test("false when the migration directory is missing", async () => {
+    const ok = await isMigrationFullyApplied("does_not_exist", {
+      rootDir: workDir,
+      dbPath,
+      migrationsDir,
+    });
+    expect(ok).toBe(false);
+  });
+
+  test("ignores SQL line comments — a `-- DROP TABLE` in a comment must not leak through as a non-ADD-COLUMN statement", async () => {
+    writeMigration(
+      "20260604000000_only_comment",
+      `-- DROP TABLE projects;
+-- This migration intentionally does nothing.
+ALTER TABLE "workspace_grants" ADD COLUMN "planId" TEXT;
+`,
+    );
+    const ok = await isMigrationFullyApplied(
+      "20260604000000_only_comment",
+      { rootDir: workDir, dbPath, migrationsDir },
+    );
+    expect(ok).toBe(true);
+  });
+
+  test("false for SQL injection-shaped identifiers — defence in depth around PRAGMA interpolation", async () => {
+    writeMigration(
+      "20260605000000_evil",
+      `ALTER TABLE "workspace_grants'); DROP TABLE projects; --" ADD COLUMN "planId" TEXT;`,
+    );
+    const ok = await isMigrationFullyApplied(
+      "20260605000000_evil",
+      { rootDir: workDir, dbPath, migrationsDir },
+    );
+    expect(ok).toBe(false);
+
+    // Sanity: the projects table still exists. (If we'd interpolated
+    // unsafely, PRAGMA would have errored — but the explicit identifier
+    // shape check is the actual guard.)
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      const row = db
+        .query("SELECT name FROM sqlite_master WHERE type='table' AND name='projects'")
+        .get() as { name: string } | undefined;
+      expect(row?.name).toBe("projects");
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/scripts/dev-all.ts
+++ b/scripts/dev-all.ts
@@ -155,10 +155,36 @@ async function killProcessOnPort(port: number) {
 
 // ---------------------------------------------------------------------------
 // 2. Run Prisma migrations for the local SQLite database
+//
+// Self-heal note: Prisma's migration apply is two operations — execute
+// the SQL, then `UPDATE _prisma_migrations SET finished_at = ?`. SQLite
+// commits the SQL first, so when `bun dev:all` is interrupted between
+// those two steps (Ctrl+C, watch-api crash mid-boot, OS sleep) the
+// schema moves forward but the ledger row stays incomplete. Next boot,
+// `prisma migrate deploy` re-runs the same SQL and SQLite returns
+// `duplicate column name: X` (P3018), aborting `dev:all` until the user
+// manually `prisma migrate resolve --applied`s every stuck row.
+//
+// We auto-recover from this specific shape — and only this shape — by
+// detecting the P3018 + duplicate-column error, confirming every
+// ALTER TABLE ADD COLUMN target in the migration.sql is already
+// physically present in the DB, marking the migration applied, and
+// retrying. Anything that doesn't fit (DROP COLUMN, data-migration SQL,
+// CREATE TABLE, etc.) falls through to the original abort so we never
+// silently paper over a real schema problem.
 // ---------------------------------------------------------------------------
 
-async function migrate() {
-  console.log("[dev:all] Running SQLite migrations…");
+const MIGRATIONS_DIR = "apps/desktop/prisma/migrations";
+const SHOGO_DB_PATH = "shogo.db";
+const MAX_AUTO_RESOLVE_RETRIES = 10;
+
+/**
+ * Run `prisma migrate deploy` once and capture stderr so we can match
+ * known recoverable failure shapes against it. stdout still streams
+ * inherit-style so the user sees normal progress output in the
+ * `dev:all` terminal.
+ */
+async function runMigrateDeploy(): Promise<{ code: number; stderr: string }> {
   const proc = spawn({
     cmd: [
       "bun",
@@ -171,15 +197,197 @@ async function migrate() {
     ],
     cwd: ROOT,
     stdout: "inherit",
+    stderr: "pipe",
+    env: { ...process.env },
+  });
+  const stderrText = await new Response(proc.stderr).text();
+  // Mirror captured stderr to our own stderr so the user sees the error
+  // in real time even when `migrate deploy` fails. (Inherit would have
+  // done this for us, but we need the captured copy to pattern-match
+  // against.)
+  if (stderrText) process.stderr.write(stderrText);
+  const code = await proc.exited;
+  return { code, stderr: stderrText };
+}
+
+interface RecoverableFailure {
+  migrationName: string;
+  duplicateColumn: string;
+}
+
+/**
+ * Pull the migration name + duplicate column out of the P3018 error.
+ * Returns null when the error is any other shape (real schema drift,
+ * Prisma engine crash, datasource error, etc.) so we abort instead.
+ */
+export function parseDuplicateColumnFailure(stderr: string): RecoverableFailure | null {
+  const isP3018 = stderr.includes("Error: P3018");
+  if (!isP3018) return null;
+  const nameMatch = stderr.match(/Migration name:\s+(\S+)/);
+  const colMatch = stderr.match(/duplicate column name:\s+(\S+)/);
+  if (!nameMatch || !colMatch) return null;
+  return {
+    migrationName: nameMatch[1]!,
+    duplicateColumn: colMatch[1]!,
+  };
+}
+
+/**
+ * Verify the failed migration is purely a sequence of `ALTER TABLE
+ * ADD COLUMN` statements AND every column it would add is already
+ * present in the live DB. Returns true iff it's safe to mark the
+ * migration applied without re-running its SQL.
+ */
+export async function isMigrationFullyApplied(
+  migrationName: string,
+  opts: { rootDir?: string; dbPath?: string; migrationsDir?: string } = {},
+): Promise<boolean> {
+  const { resolve } = await import("node:path");
+  const { readFileSync, existsSync } = await import("node:fs");
+
+  const rootDir = opts.rootDir ?? ROOT;
+  const migrationsDir = opts.migrationsDir ?? MIGRATIONS_DIR;
+  const dbPath = opts.dbPath ?? resolve(rootDir, SHOGO_DB_PATH);
+
+  const sqlPath = resolve(rootDir, migrationsDir, migrationName, "migration.sql");
+  if (!existsSync(sqlPath)) return false;
+  const sql = readFileSync(sqlPath, "utf8");
+
+  // Strip SQL line comments so a `-- DROP TABLE foo;` in a comment
+  // doesn't make the safety check fail open.
+  const stripped = sql.replace(/--[^\n]*\n/g, "\n");
+
+  // Tokenise statements. Migration.sql files don't contain BEGIN/COMMIT
+  // so a naive `;` split is enough for our purposes.
+  const stmts = stripped
+    .split(";")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  const addColumnRe =
+    /^ALTER\s+TABLE\s+"([^"]+)"\s+ADD\s+COLUMN\s+"([^"]+)"/i;
+
+  // Conservative: every non-empty statement must be ADD COLUMN. Anything
+  // else (DROP, CREATE, UPDATE, RENAME) means the migration could have
+  // side-effects we can't safely skip.
+  const additions: Array<{ table: string; column: string }> = [];
+  for (const stmt of stmts) {
+    const m = stmt.match(addColumnRe);
+    if (!m) {
+      console.log(
+        `[dev:all] auto-resolve: ${migrationName} contains a non-ADD-COLUMN ` +
+          `statement (${stmt.slice(0, 60)}…) — falling through to abort.`,
+      );
+      return false;
+    }
+    additions.push({ table: m[1]!, column: m[2]! });
+  }
+
+  // Validate identifier shape before interpolating into PRAGMA — bound
+  // parameters aren't allowed for PRAGMA arguments and we need defence
+  // in depth against a malformed migration.sql.
+  const safeIdent = /^[A-Za-z_][A-Za-z0-9_]*$/;
+  const { Database } = await import("bun:sqlite");
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    for (const { table, column } of additions) {
+      if (!safeIdent.test(table) || !safeIdent.test(column)) {
+        console.log(
+          `[dev:all] auto-resolve: ${migrationName} references a non-identifier-shaped ` +
+            `name (${table}.${column}) — falling through to abort.`,
+        );
+        return false;
+      }
+      const cols = db.query(`PRAGMA table_info('${table}')`).all() as Array<{
+        name: string;
+      }>;
+      if (!cols.some((c) => c.name === column)) {
+        console.log(
+          `[dev:all] auto-resolve: ${migrationName} would add ${table}.${column} ` +
+            `but it is NOT yet present — re-running the migration is required.`,
+        );
+        return false;
+      }
+    }
+    return true;
+  } finally {
+    db.close();
+  }
+}
+
+async function markMigrationApplied(migrationName: string): Promise<boolean> {
+  console.log(
+    `[dev:all] auto-resolve: marking ${migrationName} as applied (ledger drift recovery)…`,
+  );
+  const proc = spawn({
+    cmd: [
+      "bun",
+      "x",
+      "prisma",
+      "migrate",
+      "resolve",
+      "--applied",
+      migrationName,
+      "--config",
+      "prisma.config.local.ts",
+    ],
+    cwd: ROOT,
+    stdout: "inherit",
     stderr: "inherit",
     env: { ...process.env },
   });
   const code = await proc.exited;
-  if (code !== 0) {
-    console.error("[dev:all] Migration failed — aborting.");
-    process.exit(code);
+  return code === 0;
+}
+
+async function migrate() {
+  console.log("[dev:all] Running SQLite migrations…");
+  for (let attempt = 0; attempt <= MAX_AUTO_RESOLVE_RETRIES; attempt++) {
+    const { code, stderr } = await runMigrateDeploy();
+    if (code === 0) {
+      console.log("[dev:all] Migrations applied.");
+      return;
+    }
+
+    const failure = parseDuplicateColumnFailure(stderr);
+    if (!failure) {
+      console.error("[dev:all] Migration failed — aborting.");
+      process.exit(code);
+    }
+
+    if (attempt === MAX_AUTO_RESOLVE_RETRIES) {
+      console.error(
+        `[dev:all] auto-resolve gave up after ${MAX_AUTO_RESOLVE_RETRIES} ` +
+          `recoveries — aborting. Run \`prisma migrate status --config ` +
+          `prisma.config.local.ts\` to inspect the ledger manually.`,
+      );
+      process.exit(code);
+    }
+
+    console.log(
+      `[dev:all] Detected P3018 ledger drift on ${failure.migrationName} ` +
+        `(duplicate column ${failure.duplicateColumn}); attempting auto-resolve…`,
+    );
+
+    const safe = await isMigrationFullyApplied(failure.migrationName);
+    if (!safe) {
+      console.error("[dev:all] Migration failed — aborting.");
+      process.exit(code);
+    }
+
+    const resolved = await markMigrationApplied(failure.migrationName);
+    if (!resolved) {
+      console.error(
+        `[dev:all] auto-resolve: failed to mark ${failure.migrationName} ` +
+          `as applied — aborting.`,
+      );
+      process.exit(code);
+    }
+    // Loop back and retry `migrate deploy` — the next iteration either
+    // succeeds outright or surfaces the next stuck migration in the
+    // chain (which we attempt to recover up to MAX_AUTO_RESOLVE_RETRIES
+    // times before giving up).
   }
-  console.log("[dev:all] Migrations applied.");
 }
 
 // ---------------------------------------------------------------------------
@@ -349,11 +557,17 @@ async function startDevServers() {
 
 // ---------------------------------------------------------------------------
 // Main
+//
+// Gated by `import.meta.main` so `scripts/__tests__/dev-all.test.ts` can
+// import this file to exercise the migrate-recovery helpers without the
+// import-time side effects (port-kill, prisma generate, dev server boot).
 // ---------------------------------------------------------------------------
 
-await Promise.all([killProcessOnPort(API_PORT), killProcessOnPort(WEB_PORT)]);
-await migrate();
-await generatePrismaClients();
-await generateRoutes();
-await buildSdk();
-await startDevServers();
+if (import.meta.main) {
+  await Promise.all([killProcessOnPort(API_PORT), killProcessOnPort(WEB_PORT)]);
+  await migrate();
+  await generatePrismaClients();
+  await generateRoutes();
+  await buildSdk();
+  await startDevServers();
+}


### PR DESCRIPTION
## Why

Devs hit `prisma migrate deploy` failing with `P3018: duplicate column name` whenever a teammate adds a migration whose SQL ran against the local SQLite but whose `_prisma_migrations` ledger row never got the "finished" timestamp. Today this was reported again — twice in a single `bun dev:all` run — and required hand-rolled `bunx prisma migrate resolve --applied <name>` invocations for each stuck migration.

This PR ports the auto-resolver from [PR #618](https://github.com/shogo-labs/shogo-ai/pull/618) onto a fresh branch off `main`, since #618 was bundled with the now-merged keepalive work and never landed.

This is a **straight cherry-pick** of `eb3d0fca` from #618, with one trivial conflict resolution: today's `main` calls `await buildSdk()` between `generateRoutes()` and `startDevServers()` (added by #590), and the cherry-pick had to thread through that. Combined form:

```ts
if (import.meta.main) {
  await Promise.all([killProcessOnPort(API_PORT), killProcessOnPort(WEB_PORT)]);
  await migrate();
  await generatePrismaClients();
  await generateRoutes();
  await buildSdk();      // from main
  await startDevServers();
}
```

## What changes

`scripts/dev-all.ts`:

- New `migrate()` retry loop (up to `MAX_AUTO_RESOLVE_RETRIES = 10` per session). On `code !== 0`:
  1. `parseDuplicateColumnFailure(stderr)` — only matches the exact `Error: P3018` + `Migration name: ...` + `duplicate column name: ...` shape. Anything else returns `null` and we abort.
  2. `isMigrationFullyApplied(name)` — opens `shogo.db` read-only, parses the migration's SQL, and verifies that **every** statement is `ALTER TABLE ... ADD COLUMN` and **every** target column already exists per `PRAGMA table_info`. Conservative on purpose; see "Coverage" below.
  3. `markMigrationApplied(name)` — shells out to `bunx prisma migrate resolve --applied <name> --config prisma.config.local.ts`.
  4. Retry the deploy.

- `scripts/dev-all.ts`'s top-level execution is now gated by `if (import.meta.main)` so the test file can import the module without triggering port-kill / Prisma-generate / dev-server boot side effects.

- New unit tests at `scripts/__tests__/dev-all-migrate.test.ts` (12 cases, all green) covering:
  - P3018 parser (positive, NOT NULL fault, empty stderr, non-P3018 errors)
  - `isMigrationFullyApplied` (multi-column happy path, partial column missing, presence of CREATE INDEX/DROP COLUMN, missing migration directory, comment stripping, SQL-injection-shaped identifier defence in depth)

## Coverage (be aware)

This is the baseline auto-resolver. It will only auto-recover the **pure `ALTER TABLE ADD COLUMN`** migration class — historically the most common P3018 shape. It deliberately bails on anything that contains `CREATE TABLE`, `CREATE INDEX`, `DROP INDEX`, `RENAME COLUMN`, etc., because those statements have schema side-effects we can't safely skip without per-statement existence checks.

**Today's two reported failures both contain non-`ADD COLUMN` statements** and would still need manual `migrate resolve` even after this lands:

| Migration | Failure | Reason resolver bails |
|---|---|---|
| `20260521000000_add_creator_follows` | `duplicate column name: followerCount` | Contains `CREATE TABLE creator_follows` + 3 `CREATE INDEX` |
| `20260521192222_add_region_to_analytics_digest` | `no such index: ..._date_period_key` | Failure shape isn't `duplicate column name` and SQL contains `DROP INDEX` + `CREATE INDEX` |

A planned follow-up extends `parseFailure` to also recognize `no such index: ...` / `index ... already exists` / `table ... already exists`, and extends `isMigrationFullyApplied` with per-statement existence checks for `CREATE TABLE` (table + column set), `CREATE INDEX` / `CREATE UNIQUE INDEX` (index name + indexed columns), and `DROP INDEX` (index gone). That follow-up would have caught both failures cleanly.

## Test plan

- [x] `bun test scripts/__tests__/dev-all-migrate.test.ts` — 12/12 pass locally.
- [ ] CI runs the same on the PR.
- [ ] Manual repro on a fresh dev machine: simulate a P3018 ledger drift on a pure-`ADD COLUMN` migration and confirm `bun dev:all` recovers automatically with the `[dev:all] auto-resolve: marking ... as applied` log line.

## Cleanup after this lands

- Close PR #618 as superseded.
- Delete the `fix/dev-all-auto-resolve-stuck-sqlite-migrations` branch.
