### PR TITLE
fix(desktop): drop discard-data=on from memory-backend-ram QEMU arg

### DIFF
--- a/apps/desktop/src/vm/darwin-vm-manager.ts
+++ b/apps/desktop/src/vm/darwin-vm-manager.ts
@@ -224,10 +224,14 @@ export class DarwinVMManager implements VMManager {
     const { config, overlayPath, seedISOPath, qmpPort, hostFwds } = opts
 
     // Memory layout:
-    // - `memory-backend-ram,discard-data=on,prealloc=off`: lazy host
-    //   allocation (HVF demand-pages anyway, but the discard-data flag
-    //   tells QEMU to `MADV_FREE` the backing pages when the guest
-    //   signals it no longer needs them).
+    // - `memory-backend-ram,prealloc=off`: lazy host allocation (HVF
+    //   demand-pages anyway). NOTE: `discard-data=on` is *not* a valid
+    //   property of `memory-backend-ram` in modern QEMU (≥ ~9.x rejects
+    //   it outright; older builds silently ignored it). It only applies
+    //   to `memory-backend-file` / `memory-backend-memfd`. Including it
+    //   here causes QEMU to exit with `Invalid parameter 'discard-data'`
+    //   and breaks VM warm pool boot. Memory reclamation is handled by
+    //   the balloon below.
     // - `virtio-balloon-pci,free-page-reporting=on`: the Linux guest's
     //   page reporting subsystem asynchronously tells QEMU about runs of
     //   free pages, which QEMU `madvise(MADV_DONTNEED)`s back to macOS.
@@ -240,7 +244,7 @@ export class DarwinVMManager implements VMManager {
       '-accel', 'hvf',
       '-machine', 'virt,memory-backend=mem0',
       '-cpu', 'host',
-      '-object', `memory-backend-ram,id=mem0,size=${config.memoryMB}M,prealloc=off,discard-data=on`,
+      '-object', `memory-backend-ram,id=mem0,size=${config.memoryMB}M,prealloc=off`,
       '-m', `${config.memoryMB}M`,
       '-smp', String(config.cpus),
       '-kernel', path.join(this.vmImageDir, 'vmlinuz'),

--- a/apps/desktop/src/vm/win32-vm-manager.ts
+++ b/apps/desktop/src/vm/win32-vm-manager.ts
@@ -225,7 +225,13 @@ export class Win32VMManager implements VMManager {
       ...(firmwareDir ? ['-L', firmwareDir] : []),
       '-accel', 'whpx', '-accel', 'tcg',
       '-machine', 'q35,memory-backend=mem0', '-cpu', 'Broadwell-v4',
-      '-object', `memory-backend-ram,id=mem0,size=${config.memoryMB}M,prealloc=off,discard-data=on`,
+      // NOTE: `discard-data=on` is *not* a valid property of `memory-backend-ram` in
+      // modern QEMU (≥ ~9.x rejects it outright; older builds silently ignored it).
+      // It only applies to `memory-backend-file` / `memory-backend-memfd`. Including
+      // it here causes QEMU to exit with `Invalid parameter 'discard-data'` and
+      // breaks VM warm pool boot. Memory reclamation on Windows is handled by
+      // `virtio-balloon-pci,free-page-reporting=on` below.
+      '-object', `memory-backend-ram,id=mem0,size=${config.memoryMB}M,prealloc=off`,
       '-m', `${config.memoryMB}M`,
       '-smp', String(config.cpus),
       '-kernel', path.join(this.vmImageDir, 'vmlinuz'),

--- a/apps/desktop/test-vm-pool-idle-memory.ts
+++ b/apps/desktop/test-vm-pool-idle-memory.ts
@@ -15,7 +15,9 @@
  *
  * Fixes in this test:
  *   - virtio-balloon-pci,free-page-reporting=on on QEMU
- *   - memory-backend-ram,discard-data=on
+ *   - memory-backend-ram,prealloc=off (note: `discard-data=on` was tried
+ *     here historically but is rejected by modern QEMU — only valid on
+ *     memory-backend-file/memfd. Reclamation is balloon-driven.)
  *   - guest sysctls (vfs_cache_pressure=500, dirty_ratio=5) + zram
  *   - pool VMs balloon-inflated to `poolMemoryMB` (1.5 GB) on boot,
  *     deflated to `memoryMB` (4 GB) on /pool/assign


### PR DESCRIPTION
## Summary

- Modern QEMU (≥ ~9.x) rejects `discard-data=on` on `memory-backend-ram` with `Invalid parameter 'discard-data'`. This causes `qemu-system-x86_64` to exit immediately on every VM boot, the desktop's VM warm pool to disable itself after 3 consecutive failures, and the app to loop forever on **"Starting your project…"** because Shogo intentionally refuses to fall back to host execution. Older QEMU silently ignored the flag, so this regressed quietly as users upgraded QEMU on their machines.
- `discard-data` is only valid on `memory-backend-file` / `memory-backend-memfd` — never had any effect on plain RAM backends anyway. Memory reclamation for idle VMs is already covered by `virtio-balloon-pci,free-page-reporting=on` plus guest sysctls + zram (i.e. what `test-vm-pool-idle-memory.ts` actually exercises), so dropping the flag is a no-op for memory behavior.
- Drop the flag in both `win32-vm-manager.ts` and `darwin-vm-manager.ts`, add a comment in each so it doesn't get reintroduced, and update the test docstring that listed it as one of the active fixes.

### Repro (before this PR)

On Windows with QEMU 10.2.0 installed, `%APPDATA%\Shogo\logs\main.log` shows:

```
[ERROR] [API] [QEMU] C:\Program Files\qemu\qemu-system-x86_64.exe:
  -object memory-backend-ram,id=mem0,size=1536M,prealloc=off,discard-data=on:
  Invalid parameter 'discard-data'
[INFO]  [API] [QEMU] Process exited with code 1
[ERROR] [API] [VMWarmPool] Boot failed (1/3): Failed to connect to QEMU QMP
... x3 ...
[ERROR] [API] [Runtime] VM pool unavailable for sandbox/url:
  VM warm pool disabled after 3 consecutive boot failures.
```

…repeating every ~3s for the lifetime of the project page, while the mobile UI is stuck on `Starting your project…`.

### Workaround for users on existing builds

Until a new desktop version ships, users can set `vmIsolation.enabled: false` in `%APPDATA%\Shogo\config.json` (Windows) or `~/Library/Application Support/Shogo/config.json` (macOS) to fall back to host execution. The error log already explicitly suggests this.

## Test plan

- [ ] On Windows with QEMU ≥ 9.x installed, set `vmIsolation.enabled: true` in `config.json`, launch the desktop app, open a project, confirm the VM warm pool boots and `Starting your project…` resolves (no `Invalid parameter 'discard-data'` lines in `main.log`).
- [ ] On macOS, run `RUN_VM_E2E=1 bun apps/desktop/test-vm-pool-idle-memory.ts` and confirm idle RSS still settles below `IDLE_THRESHOLD_MB` (i.e. balloon-driven reclamation is sufficient on its own).
- [ ] `bun run typecheck` (or repo-equivalent) on `apps/desktop` is clean.
