### PR TITLE
fix(auth): preserve ?next= through Google OAuth + email-verify so desktop cloud-login completes

### DIFF
--- a/apps/mobile/app/(auth)/sign-in.tsx
+++ b/apps/mobile/app/(auth)/sign-in.tsx
@@ -40,6 +40,20 @@ export default function SignInScreen() {
     }
     return '/'
   }
+  /**
+   * Build an absolute Better Auth `callbackURL` (origin + relative `next`)
+   * for OAuth/email-verification round-trips. Without threading `next` into
+   * the OAuth `callbackURL`, post-auth users always land at `/`, silently
+   * dropping the desktop cloud-login bridge's `state` + `userCode` params
+   * and stranding the desktop app on "Waiting for browser…".
+   */
+  const resolveCallbackUrl = (): string => {
+    const path = resolveNext()
+    if (typeof window !== 'undefined' && window.location?.origin) {
+      return `${window.location.origin}${path}`
+    }
+    return path
+  }
 
   const handleSignIn = async (email: string, password: string) => {
     try {
@@ -64,11 +78,21 @@ export default function SignInScreen() {
 
   const handleSignUp = async (name: string, email: string, password: string) => {
     try {
-      const result = await signUp(name, email, password)
+      // Forward `next` through Better Auth's email-verification callback so
+      // a user signing up via the desktop cloud-login bridge still lands
+      // back on /auth/cli-link?state=… after clicking the verification
+      // email. Without this, the post-verify redirect goes to /sign-in
+      // (without `next`) and the device-code state is never approved.
+      const nextPath = resolveNext()
+      const verifyCallback =
+        typeof window !== 'undefined' && window.location?.origin && nextPath !== '/'
+          ? `${window.location.origin}/sign-in?next=${encodeURIComponent(nextPath)}`
+          : undefined
+      const result = await signUp(name, email, password, verifyCallback ? { callbackURL: verifyCallback } : undefined)
       trackSignUp('email')
       sendAttribution('email')
       if (result.requiresVerification) {
-        router.replace({ pathname: '/(auth)/verify-email', params: { email } })
+        router.replace({ pathname: '/(auth)/verify-email', params: { email, next: nextPath !== '/' ? nextPath : undefined } as any })
       } else {
         router.replace(resolveNext() as any)
       }
@@ -77,7 +101,10 @@ export default function SignInScreen() {
 
   const handleGoogleSignIn = () => {
     try { sessionStorage.setItem('oauth_pending', 'google') } catch {}
-    signInWithGoogle()
+    // Pass an absolute callbackURL built from `?next=…` so post-OAuth
+    // users return to e.g. /auth/cli-link?state=… instead of `/`.
+    const callbackURL = resolveCallbackUrl()
+    signInWithGoogle(callbackURL ? { callbackURL } : undefined)
   }
 
   // App Store Guideline 4.8 — Login Services. Apple requires that any iOS

--- a/apps/mobile/app/(auth)/verify-email.tsx
+++ b/apps/mobile/app/(auth)/verify-email.tsx
@@ -10,8 +10,17 @@ import { EmailVerificationScreen } from '@shogo/shared-ui/screens'
 
 export default function VerifyEmailScreen() {
   const router = useRouter()
-  const params = useLocalSearchParams<{ email: string }>()
+  const params = useLocalSearchParams<{ email: string; next?: string }>()
   const email = typeof params.email === 'string' ? params.email : ''
+  // Preserve the `next` redirect target across the verification round-trip
+  // so the desktop cloud-login bridge survives a sign-up + email-verify
+  // flow (otherwise the post-verify "Back to Sign In" button drops the
+  // user on a fresh /sign-in with no `next` and the device-code state
+  // never gets approved).
+  const nextPath =
+    typeof params.next === 'string' && params.next.startsWith('/') && !params.next.startsWith('//')
+      ? params.next
+      : undefined
   const { sendVerificationEmail } = useAuth()
   const { theme } = useTheme()
   const systemColorScheme = useColorScheme()
@@ -24,15 +33,25 @@ export default function VerifyEmailScreen() {
   const handleResend = useCallback(async () => {
     setIsResending(true)
     try {
-      await sendVerificationEmail(email)
+      // If we have a `next`, propagate it into the verification email's
+      // post-verify redirect so the loop closes cleanly.
+      const verifyCallback =
+        typeof window !== 'undefined' && window.location?.origin && nextPath
+          ? `${window.location.origin}/sign-in?next=${encodeURIComponent(nextPath)}`
+          : undefined
+      await sendVerificationEmail(email, verifyCallback)
     } finally {
       setIsResending(false)
     }
-  }, [email, sendVerificationEmail])
+  }, [email, nextPath, sendVerificationEmail])
 
   const handleBackToSignIn = useCallback(() => {
-    router.replace('/(auth)/sign-in')
-  }, [router])
+    if (nextPath) {
+      router.replace({ pathname: '/(auth)/sign-in', params: { next: nextPath } } as any)
+    } else {
+      router.replace('/(auth)/sign-in')
+    }
+  }, [router, nextPath])
 
   return (
     <SafeAreaView className="flex-1 bg-background">

--- a/packages/shared-app/src/auth/AuthProvider.tsx
+++ b/packages/shared-app/src/auth/AuthProvider.tsx
@@ -36,8 +36,27 @@ export interface AuthContextValue {
   isAuthenticated: boolean
   error: string | null
   signIn: (email: string, password: string) => Promise<void>
-  signUp: (name: string, email: string, password: string) => Promise<SignUpResult>
-  signInWithGoogle: () => void
+  signUp: (
+    name: string,
+    email: string,
+    password: string,
+    /**
+     * Optional Better Auth `callbackURL` used after the verification email
+     * link is clicked. If a caller (e.g. the desktop cloud-login bridge)
+     * needs the user to land somewhere other than `/sign-in` post-verify,
+     * they can pass an absolute URL here. Defaults to `${origin}/sign-in`.
+     */
+    opts?: { callbackURL?: string },
+  ) => Promise<SignUpResult>
+  /**
+   * Initiate Google OAuth. Optional `callbackURL` overrides the default
+   * post-OAuth landing page (Better Auth bounces the user there once the
+   * provider redirects back with a successful auth code). Used by the
+   * desktop cloud-login bridge to send the user back to
+   * `/auth/cli-link?state=...&userCode=...` so they can finish approving
+   * the device-code flow.
+   */
+  signInWithGoogle: (opts?: { callbackURL?: string }) => void
   /**
    * Sign in with Apple using a native Apple identity token.
    *
@@ -107,14 +126,21 @@ export function AuthProvider({ authClient, children }: AuthProviderProps) {
     }
   }, [authClient])
 
-  const handleSignUp = useCallback(async (name: string, email: string, password: string): Promise<SignUpResult> => {
+  const handleSignUp = useCallback(async (
+    name: string,
+    email: string,
+    password: string,
+    opts?: { callbackURL?: string },
+  ): Promise<SignUpResult> => {
     setIsLoading(true)
     setError(null)
     try {
       const origin = getFrontendOrigin()
+      const callbackURL =
+        opts?.callbackURL ?? (origin ? `${origin}/sign-in` : '/sign-in')
       const { data, error: err } = await authClient.signUp.email({
         name, email, password,
-        callbackURL: origin ? `${origin}/sign-in` : '/sign-in',
+        callbackURL,
       })
       if (err) throw new Error(err.message || 'Sign up failed')
       const hasSession = !!(data as any)?.session || !!(data as any)?.token
@@ -131,10 +157,18 @@ export function AuthProvider({ authClient, children }: AuthProviderProps) {
     }
   }, [authClient])
 
-  const handleSignInWithGoogle = useCallback(async () => {
+  const handleSignInWithGoogle = useCallback(async (opts?: { callbackURL?: string }) => {
     setError(null)
     const origin = getFrontendOrigin()
-    const callbackURL = origin ? `${origin}/` : '/'
+    // Better Auth bounces the user to `callbackURL` after the OAuth
+    // round-trip. If a caller passed one (e.g. the desktop cloud-login
+    // bridge needs the user back at `/auth/cli-link?state=…`), respect
+    // it; otherwise default to the app root. Without this override,
+    // post-OAuth users always land on `/`, which silently strips any
+    // `?next=…` the bridge had threaded through `/sign-in?next=…` —
+    // breaking the desktop "Connect Shogo Cloud" flow because the
+    // device-code state never got approved.
+    const callbackURL = opts?.callbackURL ?? (origin ? `${origin}/` : '/')
     try {
       const result = await (authClient as any).signIn.social({
         provider: 'google',


### PR DESCRIPTION
## Symptom

From Shogo Desktop's **Settings → General → Connect Shogo Cloud**:

1. Click "Sign in to Shogo Cloud". Browser opens to `studio.shogo.ai/auth/cli-link?state=…&userCode=…&deviceId=…&client=desktop`.
2. The `cli-link` bridge sees no auth session and bounces to `/sign-in?next=/auth/cli-link?state=…&userCode=…`.
3. User signs in with **Google** (or signs up with email + verifies).
4. Browser lands on `/` (the dashboard), **not** back on `/auth/cli-link?…`.
5. Device-code state is never approved, so the desktop polls forever and the General settings card stays on **"Waiting for browser…"** until the user gives up.

`%APPDATA%\Shogo\logs\main.log` shows the desktop side waiting:

```
[CloudLogin] Sign in to Shogo Cloud
[CloudLogin]   user code: FD72D1
[CloudLogin]   Open this URL in your browser to approve:
[CloudLogin]   https://studio.shogo.ai/auth/cli-link?state=…&userCode=FD72D1&deviceId=…&client=desktop
[CloudLogin] Waiting for approval…
```

…with no `Approved` follow-up.

## Root cause

`packages/shared-app/src/auth/AuthProvider.tsx` was hardcoding the Better Auth `callbackURL`:

- **Google OAuth** → `callbackURL: ${origin}/`. After the OAuth round-trip, Better Auth bounces the user to `/`, dropping the `?next=…` the cli-link bridge had carefully threaded through `/sign-in?next=…`. So users were correctly signed in but never returned to `/auth/cli-link?state=…` to approve the device code.
- **Sign-up + email verification** → `callbackURL: ${origin}/sign-in`. After clicking the verification link, users land on `/sign-in` with no `next`, then post-sign-in `resolveNext()` returns `/`. Same loss-of-`next` problem on the verify path.

Email/password sign-in was already correct because `handleSignIn` in `apps/mobile/app/(auth)/sign-in.tsx` calls `router.replace(resolveNext())` directly after success — that path stayed in-app and never went through Better Auth's `callbackURL`.

The standalone `packages/sdk` `ShogoAuth.signInWithProvider` was also already correct (defaults `callbackURL` to `window.location.href`, which preserves the full cli-link query string). Only the shared-app provider was buggy, but it's the one used by `apps/mobile` (= `studio.shogo.ai`).

## Fix

- **`AuthProvider.signInWithGoogle`** now accepts `{ callbackURL?: string }` and uses it instead of always going to `/`.
- **`AuthProvider.signUp`** accepts `{ callbackURL?: string }` for the email-verification callback so callers can keep `next` alive across the verify round-trip.
- **`apps/mobile/app/(auth)/sign-in.tsx`** builds an absolute callback URL from `?next=…` and threads it into both the Google handler and the sign-up handler. It also forwards `next` when navigating to `/(auth)/verify-email`.
- **`apps/mobile/app/(auth)/verify-email.tsx`** now accepts `?next=`, propagates it into `sendVerificationEmail`, and preserves it on the "Back to Sign In" button — closing the loop end-to-end.

## Test plan

- [ ] Web: open `https://studio.shogo.ai/auth/cli-link?state=test&userCode=ABC123&client=desktop` while signed out, click Google, complete OAuth, confirm the post-OAuth landing page is `/auth/cli-link?state=test&userCode=ABC123&client=desktop` (not `/`).
- [ ] Web: same flow but with email + password sign-up of a fresh account, click the verification email link, confirm post-verify landing is `/sign-in?next=/auth/cli-link?…`, then sign in and confirm final landing is `/auth/cli-link?…`.
- [ ] Web: existing email/password sign-in via `/sign-in?next=/foo` still resolves to `/foo` (regression check on the unchanged path).
- [ ] Desktop: open Settings → General → Connect Shogo Cloud, sign in via Google in the browser, confirm the desktop card transitions from **"Waiting for browser…"** → **"Connected to Shogo Cloud"** within ~2 polling intervals after the cli-link bridge auto-approves.
- [ ] Desktop: same as above but with a brand-new account that has to verify email. After clicking the email link, confirm the desktop card flips to connected.
