### PR TITLE
fix(local-projects): rebind folder when project.json references a deleted project

### DIFF
--- a/apps/api/src/__tests__/local-projects-routes.expanded.test.ts
+++ b/apps/api/src/__tests__/local-projects-routes.expanded.test.ts
@@ -351,27 +351,50 @@ describe('localProjectsRoutes from folders', () => {
     expect(JSON.stringify(projects.get('existing-project').settings)).toContain('workingMode')
   })
 
-  test('returns errors for missing paths and foreign project metadata', async () => {
+  test('rejects empty paths payload', async () => {
     const missing = await appWithAuth().request('http://api.test/from-folders', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ paths: [] }),
     })
     expect(missing.status).toBe(400)
+  })
 
+  test('rebinds a folder whose project.json references a deleted project', async () => {
+    // Reproduces the "delete project from dashboard, re-open same folder"
+    // scenario: .shogo/project.json still references the old projectId,
+    // but the DB row was hard-deleted. The route used to 409 with
+    // alreadyBoundElsewhere, which surfaced as a silent no-op in the
+    // desktop UI. It now treats the binding as stale and creates a
+    // fresh project, overwriting project.json with the new id.
+    const projectJsonPath = join(rootDir, '.shogo', 'project.json')
     mkdirSync(join(rootDir, '.shogo'), { recursive: true })
-    writeFileSync(join(rootDir, '.shogo', 'project.json'), JSON.stringify({
-      projectId: 'missing-project',
+    writeFileSync(projectJsonPath, JSON.stringify({
+      projectId: 'deleted-project-id',
       createdAt: new Date().toISOString(),
       schemaVersion: 1,
     }))
-    const foreign = await appWithAuth().request('http://api.test/from-folders', {
+
+    const res = await appWithAuth().request('http://api.test/from-folders', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ paths: [rootDir], acceptedGitRoot: false }),
     })
-    expect(foreign.status).toBe(409)
-    expect((await json(foreign)).error).toBe('alreadyBoundElsewhere')
+
+    expect([200, 201]).toContain(res.status)
+    const body = await json(res)
+    expect(body.error).toBeUndefined()
+    expect(body.project?.id).toBeDefined()
+    expect(body.project.id).not.toBe('deleted-project-id')
+    expect(body.rebound).toBeFalsy()
+
+    // project.json on disk was rewritten to point at the new project.
+    const rewritten = JSON.parse(readFileSync(projectJsonPath, 'utf-8'))
+    expect(rewritten.projectId).toBe(body.project.id)
+    expect(rewritten.projectId).not.toBe('deleted-project-id')
+
+    // And the new project is actually stored in the DB.
+    expect(projects.get(body.project.id)).toBeDefined()
   })
 })
 

--- a/apps/api/src/routes/local-projects.ts
+++ b/apps/api/src/routes/local-projects.ts
@@ -478,28 +478,34 @@ export function localProjectsRoutes(): Hono {
     const finalPrimary = validated[0]!
 
     // Identity check. If the folder already has a project.json, rebind
-    // to the existing row rather than creating a duplicate. Refuse if
-    // the recorded projectId doesn't exist in our DB (folder was bound
-    // on another machine — needs an explicit "import" flow we'll add
-    // later).
+    // to the existing row rather than creating a duplicate. When the
+    // recorded projectId is missing from the local DB the binding is
+    // stale — almost always because the user deleted the project from
+    // the dashboard, which removes the row but leaves the folder's
+    // `.shogo/project.json` untouched. Falling through to the fresh-
+    // create path below lets `writeProjectJson` overwrite the stale id
+    // with a new one, so re-opening a previously-deleted folder Just
+    // Works instead of silently 409'ing (the desktop hook surfaces 409s
+    // via `Alert.alert`, which is effectively invisible on web/Electron
+    // — the user sees "nothing happens"). The "folder bound on another
+    // machine" scenario isn't distinguishable from "deleted locally"
+    // without a hostname marker, and the practical recovery is the
+    // same: rebind to a fresh project on this install.
     const existing = readProjectJson(finalPrimary)
-    if (existing) {
-      const existingProject = await prisma.project.findUnique({
-        where: { id: existing.projectId },
-        include: { projectFolders: true },
-      })
-      if (!existingProject) {
-        return c.json(
-          {
-            error: 'alreadyBoundElsewhere',
-            message:
-              `This folder is already bound to project ${existing.projectId}, which doesn't exist in this Shogo install. ` +
-              `Delete ${finalPrimary}/.shogo/project.json to re-bind, or open the folder on the original device.`,
-            projectId: existing.projectId,
-          },
-          409,
-        )
-      }
+    const existingProject = existing
+      ? await prisma.project.findUnique({
+          where: { id: existing.projectId },
+          include: { projectFolders: true },
+        })
+      : null
+    if (existing && !existingProject) {
+      console.log(
+        `[local-projects] Stale project.json at ${finalPrimary} ` +
+          `(projectId=${existing.projectId} not found in DB). ` +
+          `Rebinding folder to a fresh project.`,
+      )
+    }
+    if (existing && existingProject) {
       // Rebind: refresh lastOpenedAt on the primary folder, sync linked
       // folders with the new selection, and backfill chat-only IDE
       // defaults for any project that was created before they were the


### PR DESCRIPTION
Fixes #651

## Problem

Re-opening a folder via **New → Open folder…** after its associated project has been deleted from the **All Projects** tab silently fails: the menu closes, no toast appears, and the user stays on the home screen.

## Root cause

`POST /api/local/projects/from-folders` in `apps/api/src/routes/local-projects.ts` reads the folder's `.shogo/project.json`, looks up the referenced project in the local DB, and — if the row is missing — bails with `409 alreadyBoundElsewhere` on the assumption that the folder was "bound on another machine".

That assumption is wrong in the common case. There is **no hostname / install marker** in `project.json`, so the route cannot actually distinguish "foreign machine" from "deleted on this machine". And because `DELETE /api/projects/:id` removes the project row but leaves the linked folder's `project.json` on disk, every project deletion guarantees the linked folder ends up in the "stale id" state.

The frontend hook `useOpenLocalFolder` catches the resulting `ShogoError` and calls `Alert.alert(...)`, which on the Electron renderer is effectively a no-op — hence the silent menu-close behaviour the user sees.

## Fix (root, not patch)

When `.shogo/project.json` references a projectId that's missing from the local DB, treat the binding as **stale** and fall through to the normal "create fresh project" path. `writeProjectJson` is `writeFileSync`, so the stale id is overwritten atomically by the same disk write that would have happened for a brand-new folder.

```diff
- if (!existingProject) {
-   return c.json({ error: 'alreadyBoundElsewhere', … }, 409)
- }
+ if (existing && !existingProject) {
+   console.log('[local-projects] Stale project.json at … Rebinding to fresh project.')
+   // fall through → create fresh project, writeProjectJson overwrites stale id
+ }
+ if (existing && existingProject) {
+   // rebind path (unchanged)
+ }
```

Concretely:

- The "rebind to existing project" branch is unchanged when the referenced project still exists.
- The "create fresh project" branch is unchanged for first-open of a folder with no `project.json`.
- The only thing removed is the wrong early-return 409.
- No frontend change is required — the existing success path in `useOpenLocalFolder` navigates to the new project.

## Why this is a root fix (and not a patch)

| Patch I deliberately did not write | Why it's worse |
| --- | --- |
| Catch the 409 in the hook and show a real toast | Makes the failure visible but doesn't fix it — folder still won't open. |
| Auto-call a "delete project.json" endpoint and retry | Two round-trips, race conditions, route still lies about `alreadyBoundElsewhere`. |
| Friendlier error message | Same broken behaviour, prettier wording. |
| Have `DELETE /projects/:id` also `rm` linked-folder `project.json` files | Silently mutates user filesystems on delete (worse problem) and doesn't heal any folder that's already broken today. |

The change is a **removal** of an incorrect guard, not an **addition** of a workaround around it. Every folder already in the broken state heals itself on the next open — zero migration, zero user action.

## Heals existing state

Any user who deleted a project before this PR landed has a folder on disk with a stale `project.json`. With this change, the next time they pick that folder from **Open folder…** it succeeds normally and rewrites the file. No cleanup script, no migration, no documentation footnote.

## Tests

Replaced the assertion in `apps/api/src/__tests__/local-projects-routes.expanded.test.ts` that previously expected `409 alreadyBoundElsewhere` for a missing project. The new test reproduces the user-reported scenario end to end:

1. Write `.shogo/project.json` referencing `deleted-project-id` (which is not in the DB).
2. `POST /from-folders` with that path.
3. Assert response is 2xx, response project id is not `deleted-project-id`, the new project exists in the project map, and `project.json` on disk has been rewritten to the new id.

```
bun test apps/api/src/__tests__/local-projects-routes.expanded.test.ts
✓ 20 pass · 0 fail · 72 expect() · 60ms
```

Existing tests covering the happy rebind path, fresh-create path, and Git-root handling are all green and unchanged.

## Affected files

- `apps/api/src/routes/local-projects.ts` — remove the wrong 409, add stale-binding log, restructure the existing-project branch.
- `apps/api/src/__tests__/local-projects-routes.expanded.test.ts` — split the combined test; new "rebinds a folder whose project.json references a deleted project" case.

## Manual verification

1. Open folder A via `New → Open folder…` → project created.
2. All Projects → delete project A → confirm.
3. `New → Open folder…` again → pick folder A.
4. **Before this PR:** menu closes, home screen, nothing happens.
5. **With this PR:** project opens normally, `cat A/.shogo/project.json` shows the new projectId.

## Risk

Low. The change narrows a 409 path to a success path; it cannot make a previously-working call fail. The "rebind to existing project" path is byte-for-byte unchanged for the case where the referenced project actually exists in the DB.
