### PR TITLE
fix(ide): swallow Monaco's harmless Canceled cancellation-token leaks so they stop firing the dev error overlay

### DIFF
--- a/apps/mobile/components/project/panels/ide/CodeEditor.tsx
+++ b/apps/mobile/components/project/panels/ide/CodeEditor.tsx
@@ -5,6 +5,17 @@ import type { EditorSettings } from "./types";
 import { setupAgentFix } from "./agentFixProvider";
 import { setMonacoRef } from "./monaco/workspaceModels";
 import { setupExtraLibs } from "./monaco/extraLibs";
+import { installMonacoCanceledErrorSuppressor } from "./monaco/suppressCanceled";
+
+// Several Monaco contributions cancel pending async work during disposal
+// (`setModel`, `restoreViewState`, Strict-Mode double-mount, etc.) and the
+// resulting `Canceled` cancellation token can escape Monaco's internal
+// error filter — surfacing as an "Uncaught Error: Canceled" overlay even
+// though nothing is actually broken. This installs window-level filters
+// that drop ONLY those errors (matched by `name === message === "Canceled"`),
+// leaving real bugs to propagate normally. See `monaco/suppressCanceled.ts`
+// for the upstream issue links.
+installMonacoCanceledErrorSuppressor();
 
 // Point `@monaco-editor/loader` at our self-hosted Monaco bundle (mirrored
 // from `node_modules/monaco-editor/min/vs` into `public/vs` by

--- a/apps/mobile/components/project/panels/ide/__tests__/suppressCanceled.test.ts
+++ b/apps/mobile/components/project/panels/ide/__tests__/suppressCanceled.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Sanity tests for the Monaco "Canceled" error suppressor.
+ *
+ * The suppressor exists to drop Monaco's harmless CancellationError leaks
+ * from `window.onerror` / `unhandledrejection` — see the file comment in
+ * `monaco/suppressCanceled.ts` for the upstream issue list. We pin the
+ * match predicate here so a future refactor doesn't accidentally
+ * broaden it to swallow real bugs.
+ */
+import { describe, expect, test } from "bun:test";
+import { __test } from "../monaco/suppressCanceled";
+
+const { isMonacoCanceled } = __test;
+
+describe("isMonacoCanceled", () => {
+  test("matches Error with name===message===\"Canceled\"", () => {
+    const err = new Error("Canceled");
+    err.name = "Canceled";
+    expect(isMonacoCanceled(err)).toBe(true);
+  });
+
+  test("matches plain object with name+message Canceled (PromiseRejectionEvent.reason shape)", () => {
+    expect(isMonacoCanceled({ name: "Canceled", message: "Canceled" })).toBe(true);
+  });
+
+  test("rejects regular Error with different name", () => {
+    const err = new TypeError("Canceled");
+    expect(isMonacoCanceled(err)).toBe(false);
+  });
+
+  test("rejects Error whose message isn't Canceled", () => {
+    const err = new Error("Network request canceled");
+    expect(isMonacoCanceled(err)).toBe(false);
+  });
+
+  test("rejects null / undefined / primitives", () => {
+    expect(isMonacoCanceled(null)).toBe(false);
+    expect(isMonacoCanceled(undefined)).toBe(false);
+    expect(isMonacoCanceled("Canceled")).toBe(false);
+    expect(isMonacoCanceled(0)).toBe(false);
+  });
+
+  test("rejects objects whose name matches but message doesn't", () => {
+    expect(isMonacoCanceled({ name: "Canceled", message: "something else" })).toBe(false);
+    expect(isMonacoCanceled({ name: "Other", message: "Canceled" })).toBe(false);
+  });
+});

--- a/apps/mobile/components/project/panels/ide/monaco/suppressCanceled.ts
+++ b/apps/mobile/components/project/panels/ide/monaco/suppressCanceled.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Suppress Monaco's harmless "Canceled" errors from the browser-level error
+ * surface (uncaught error overlay, unhandledrejection listeners, Sentry).
+ *
+ * Why this is needed:
+ *   Several Monaco contributions cancel in-flight async work via
+ *   `CancellationTokenSource` when their host (editor / model / contribution)
+ *   is disposed — e.g. during `editor.setModel`, `editor.restoreViewState`,
+ *   or rapid mount/unmount cycles. Monaco's internal event delivery catches
+ *   listener errors and routes them through `onUnexpectedError`, which is
+ *   supposed to swallow cancellations. In practice the filter misses in
+ *   a few well-known cases:
+ *
+ *     - microsoft/monaco-editor#5135 — `setModel` during a command action
+ *     - microsoft/monaco-editor#4904 — `restoreViewState` on React remount
+ *     - microsoft/monaco-editor#4312 — Linked-editing contribution
+ *     - microsoft/monaco-editor#4389 — burst-paste under Cmd+V
+ *     - suren-atoyan/monaco-react#575 — Strict-Mode double-effect mount
+ *
+ *   The result is an "Uncaught Error: Canceled" overlay during normal
+ *   navigation (e.g. creating a new project — the IDE panel mounts under
+ *   `display: none`, Monaco initializes, `<Editor>` calls `setModel`, and
+ *   a disposing contribution's cancel cascade throws). It's cosmetic — no
+ *   feature is broken — but it crosses the React error boundary and looks
+ *   like a real crash in dev.
+ *
+ * What this does:
+ *   Install one `error` and one `unhandledrejection` listener at the
+ *   capture phase that call `preventDefault()` ONLY when the payload
+ *   matches Monaco's cancellation signature (name === "Canceled" and
+ *   message === "Canceled"). Anything else passes through untouched, so
+ *   real bugs still surface normally.
+ *
+ *   Idempotent — a module-level flag guards against repeat installs across
+ *   the Workbench mount / split-editor remounts / Fast Refresh.
+ */
+
+const CANCELED = 'Canceled'
+
+function isMonacoCanceled(value: unknown): boolean {
+  if (!value) return false
+  if (value instanceof Error) {
+    return value.name === CANCELED && value.message === CANCELED
+  }
+  if (typeof value === 'object') {
+    const v = value as { name?: unknown; message?: unknown }
+    return v.name === CANCELED && v.message === CANCELED
+  }
+  return false
+}
+
+let installed = false
+
+export function installMonacoCanceledErrorSuppressor(): void {
+  if (installed) return
+  if (typeof window === 'undefined') return
+  installed = true
+
+  window.addEventListener(
+    'error',
+    (event) => {
+      if (isMonacoCanceled(event.error)) {
+        event.preventDefault()
+        event.stopImmediatePropagation()
+      }
+    },
+    true,
+  )
+
+  window.addEventListener(
+    'unhandledrejection',
+    (event) => {
+      if (isMonacoCanceled(event.reason)) {
+        event.preventDefault()
+        event.stopImmediatePropagation()
+      }
+    },
+    true,
+  )
+}
+
+export const __test = { isMonacoCanceled }


### PR DESCRIPTION
## Summary

- "Uncaught Error: Canceled" dev overlay was firing during normal navigation (e.g. creating a new project from the projects index while attaching a `.md` to the initial prompt — repro: the project layout mounts `IDEPanel` under `display: none`, `@monaco-editor/react`'s `<Editor>` calls `editor.setModel` on first mount, a disposing contribution's cancel cascade throws, the error escapes Monaco's internal `_deliver` → `onUnexpectedError` filter, and React surfaces it as uncaught).
- This is a well-known Monaco issue — the cancellation token's `Canceled` error skirts Monaco's own `isCancellationError` filter in several contribution-dispose paths: microsoft/monaco-editor#5135, #4904, #4312, #4389; suren-atoyan/monaco-react#575. Nothing is actually broken; the dev overlay just looks like a crash.

## Fix

Add `monaco/suppressCanceled.ts`. It installs one capture-phase `error` listener and one `unhandledrejection` listener that call `preventDefault()` + `stopImmediatePropagation()` **only** when the payload matches Monaco's exact signature — `name === "Canceled" && message === "Canceled"`. Anything else (real bugs, unrelated rejected promises) flows through untouched. The installer is idempotent via a module-level flag, so split-editor remounts / Fast Refresh don't pile up listeners.

Hook into `CodeEditor.tsx` at module load (same place as `loader.config({ paths: { vs: "/vs" } })`) so the filter is live before any `<Editor>` mounts.

Pin the match predicate with 6 unit tests (`__tests__/suppressCanceled.test.ts`) so a future refactor can't accidentally broaden it to swallow real errors:
- Error with `name === message === "Canceled"` → suppressed
- Plain object with same shape (PromiseRejectionEvent.reason) → suppressed
- `TypeError("Canceled")` (different `name`) → passes through
- `new Error("Network request canceled")` (different `message`) → passes through
- `null` / `undefined` / strings / numbers → passes through
- `name` matches but `message` doesn't (or vice versa) → passes through

## Test plan

- [x] `bun test apps/mobile/components/project/panels/ide/__tests__/suppressCanceled.test.ts` — 6/6 pass
- [x] `bun test apps/mobile/components/project/panels/ide/__tests__/extraLibs.test.ts lspProviders.test.ts workspaceModels.test.ts suppressCanceled.test.ts` — 45/45 pass (no regression in sibling Monaco unit tests)
- [ ] Repro the original scenario: from the projects index, create a new project, attach a `.md` to the initial prompt → no "Uncaught Error: Canceled" overlay
- [ ] Throw a `new Error("real bug")` from somewhere in the IDE on purpose → still surfaces normally (filter didn't broaden)
- [ ] Open / close / split-edit a file repeatedly to exercise `setModel` churn → no overlay
