### PR TITLE
fix(api/local): auto-recycle Prisma SQLite connection on disk I/O error (closes #654, SHOG-673)

### DIFF
--- a/apps/api/src/lib/prisma.ts
+++ b/apps/api/src/lib/prisma.ts
@@ -127,7 +127,15 @@ async function createPrismaClient(): Promise<PrismaClient> {
   if (isLocalMode) {
     const { PrismaClient: SqliteClient } = await import('../generated/prisma-sqlite/client')
     const { PrismaBunSqlite } = await import('prisma-adapter-bun-sqlite')
-    const adapter = new PrismaBunSqlite({ url: getSqliteUrl() })
+    // WAL + a generous busy_timeout reduces the rate of transient
+    // SQLITE_BUSY / SQLITE_IOERR faults dramatically vs. the default
+    // rollback journal: WAL lets readers run while one writer holds
+    // the lock, and a 15s timeout absorbs Time Machine / Spotlight /
+    // AV-scanner blips that previously caused immediate failures.
+    const adapter = new PrismaBunSqlite({
+      url: getSqliteUrl(),
+      wal: { enabled: true, busyTimeout: 15_000, synchronous: 'NORMAL' },
+    })
     const client = new SqliteClient({ adapter, log: [...logConfig] })
     return wrapForSqlite(client as unknown as PrismaClient)
   }
@@ -150,10 +158,191 @@ async function createPrismaClient(): Promise<PrismaClient> {
   })
 }
 
-export const prisma = globalForPrisma.prisma ?? await createPrismaClient();
+// ─── Auto-recovering Prisma proxy ────────────────────────────────────────
+//
+// Why this exists
+// ---------------
+// The bun:sqlite driver behind prisma-adapter-bun-sqlite holds a single
+// long-lived Database handle for the lifetime of the process. When that
+// handle hits SQLITE_IOERR (raw text "disk I/O error") — typically from a
+// brief macOS sleep/wake fd invalidation, a Spotlight/AV scanner touching
+// the WAL, a Time Machine snapshot, or a transient FS hiccup — bun:sqlite
+// surfaces the error to Prisma, but every SUBSEQUENT statement on the same
+// handle also returns SQLITE_IOERR. The handle is poisoned for the rest of
+// the process.
+//
+// In Shogo Desktop this showed up as a "disk I/O error" toast in the chat
+// panel with a Retry button that did nothing. Retry re-issued the same
+// HTTP request which hit the same poisoned client → same error. The only
+// recovery path users had was Quit + relaunch.
+//
+// Root fix: detect a disk-I/O error at the Prisma boundary, dispose the
+// underlying adapter (which closes the broken Database handle), build a
+// fresh PrismaClient, and re-issue the failed call once against the new
+// client. Subsequent calls then go straight through. Side effects:
+//
+//   - The Retry button now works on the first click — there's nothing
+//     to "retry" by then because the next call already succeeded, but
+//     pressing it is safe and fast.
+//   - Even without Retry, the next user message (or background poll)
+//     transparently recovers the connection.
+//   - If the underlying fault is persistent (genuinely out of disk,
+//     permissions revoked), the recycled client also fails on its first
+//     query and we propagate the error normally — no infinite loop.
+//
+// Why a Proxy and not a wrapper class
+// -----------------------------------
+// Prisma's generated client surface is large (every model × every method)
+// and the SQLite path is further wrapped by `$extends`. Listing every
+// callable by hand is fragile. The Proxy below intercepts ALL model
+// accessors (`prisma.user`, `prisma.project`, ...) and ALL of their
+// methods (`findFirst`, `create`, `update`, ...), plus top-level methods
+// (`$transaction`, `$queryRaw`, etc.), and applies recovery uniformly.
+
+const IO_ERROR_PATTERNS = [
+  /disk\s*i\/?o\s*error/i,
+  /SQLITE_IOERR/i,
+  /database\s+disk\s+image\s+is\s+malformed/i,
+  /database\s+is\s+locked/i, // SQLITE_BUSY past busy_timeout — also handle-level
+]
+
+function isRecoverableDbError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const msg = String((err as any).message ?? '')
+  const cause = String((err as any).cause?.message ?? '')
+  return IO_ERROR_PATTERNS.some((p) => p.test(msg) || p.test(cause))
+}
+
+interface PrismaSlot {
+  client: PrismaClient
+  // Monotonic id so concurrent in-flight callers can tell whether the
+  // client they failed against has already been recycled by someone
+  // else and avoid stampeding the rebuild.
+  generation: number
+}
+
+let slot: PrismaSlot = {
+  client: globalForPrisma.prisma ?? await createPrismaClient(),
+  generation: 0,
+}
+
+let recycleInFlight: Promise<PrismaSlot> | null = null
+
+async function recyclePrismaClient(failedGeneration: number): Promise<PrismaSlot> {
+  // Coalesce concurrent recovery attempts. The first caller does the
+  // rebuild; everyone else awaits the same promise.
+  if (recycleInFlight) return recycleInFlight
+  if (slot.generation > failedGeneration) return slot
+
+  recycleInFlight = (async () => {
+    const broken = slot.client
+    try {
+      // $disconnect calls the adapter's dispose(), which closes the
+      // underlying bun:sqlite Database. Swallow errors here — the
+      // handle is already poisoned; we just want to release the fd.
+      await broken.$disconnect().catch(() => {})
+    } finally {
+      const fresh = await createPrismaClient()
+      slot = { client: fresh, generation: slot.generation + 1 }
+      if (process.env.NODE_ENV !== 'production') {
+        globalForPrisma.prisma = fresh
+      }
+      console.warn(
+        `[prisma] Recycled database connection after I/O fault ` +
+        `(generation ${slot.generation}).`,
+      )
+    }
+    return slot
+  })().finally(() => {
+    recycleInFlight = null
+  })
+
+  return recycleInFlight
+}
+
+function wrapMethod<T extends (...args: any[]) => any>(
+  modelName: string | null,
+  methodName: string,
+  capturedGeneration: number,
+  fn: T,
+  thisArg: unknown,
+): T {
+  return (async (...args: any[]) => {
+    try {
+      return await fn.apply(thisArg, args)
+    } catch (err) {
+      if (!isRecoverableDbError(err)) throw err
+      console.warn(
+        `[prisma] disk I/O error on ${modelName ?? '$client'}.${methodName} ` +
+        `— recycling connection and retrying once.`,
+      )
+      const next = await recyclePrismaClient(capturedGeneration)
+      // Re-resolve the method against the fresh client and retry exactly
+      // once. If THIS call also fails (real disk full, etc.) we let the
+      // error propagate so the API returns its normal proxy_error response
+      // and the UI surfaces it — no infinite loop.
+      const target: any = modelName ? (next.client as any)[modelName] : next.client
+      const retryFn = target?.[methodName]
+      if (typeof retryFn !== 'function') throw err
+      return await retryFn.apply(target, args)
+    }
+  }) as T
+}
+
+function makeModelProxy(modelName: string): unknown {
+  return new Proxy(
+    {},
+    {
+      get(_t, methodKey) {
+        if (typeof methodKey !== 'string') return undefined
+        const captured = slot
+        const target: any = (captured.client as any)[modelName]
+        if (!target) return undefined
+        const value = target[methodKey]
+        if (typeof value !== 'function') return value
+        return wrapMethod(modelName, methodKey, captured.generation, value, target)
+      },
+    },
+  )
+}
+
+const TOP_LEVEL_RECOVERABLE_METHODS = new Set([
+  '$transaction',
+  '$queryRaw',
+  '$queryRawUnsafe',
+  '$executeRaw',
+  '$executeRawUnsafe',
+])
+
+export const prisma: PrismaClient = new Proxy({} as PrismaClient, {
+  get(_t, key) {
+    if (typeof key !== 'string') return undefined
+    const captured = slot
+    const value = (captured.client as any)[key]
+    if (typeof value === 'function') {
+      // Top-level helpers: only wrap the ones that issue queries —
+      // wrapping $extends / $on would break Prisma's builder API.
+      if (TOP_LEVEL_RECOVERABLE_METHODS.has(key)) {
+        return wrapMethod(null, key, captured.generation, value, captured.client)
+      }
+      return value.bind(captured.client)
+    }
+    if (value && typeof value === 'object') {
+      // Model delegate (prisma.user, prisma.project, ...). Return a
+      // per-call proxy so the captured generation is always fresh.
+      return makeModelProxy(key)
+    }
+    return value
+  },
+})
 
 if (process.env.NODE_ENV !== 'production') {
-  globalForPrisma.prisma = prisma;
+  globalForPrisma.prisma = slot.client
+}
+
+/** Test-only: force a recovery cycle. Not part of the public surface. */
+export async function __recyclePrismaForTest(): Promise<void> {
+  await recyclePrismaClient(slot.generation)
 }
 
 export type { PrismaClient } from '../generated/prisma-pg/client';


### PR DESCRIPTION
Closes #654 · Jira: [SHOG-673](https://odin-ai.atlassian.net/browse/SHOG-673)

## TL;DR

The Shogo Desktop chat panel shows a red **`disk I/O error`** toast that the Retry button cannot dismiss — only Quit + relaunch recovers. This PR fixes both the **trigger** (the bun:sqlite handle was opened once at process start and reused forever; one transient `SQLITE_IOERR` poisoned it for the rest of the process lifetime) and the **recovery gap** (Retry re-hit the same poisoned singleton, so it was a no-op). Single-file change.

```
apps/api/src/lib/prisma.ts | +192 / −3
```

## Root cause

`apps/api/src/lib/prisma.ts` exports a process-wide singleton `PrismaClient`. In `SHOGO_LOCAL_MODE` it is backed by `prisma-adapter-bun-sqlite`, which opens **one** `bun:sqlite` `Database(dbPath)` handle at module load and reuses it for the lifetime of the api process. That handle is fragile:

- A transient `SQLITE_IOERR` from the OS — macOS sleep/wake invalidating an fd, Spotlight/AV touching the WAL, a Time Machine snapshot mid-write, brief FS pressure — is enough to poison it.
- Once poisoned, every subsequent statement on that handle returns the same `disk I/O error` until the process exits.
- The error propagates up the chat pipeline unmodified: `project-chat.ts` catches it and returns `{ error: { code: 'proxy_error', message: 'disk I/O error' } }`; `formatErrorMessage()` renders that string in the toast.

The Retry button in `ChatPanel.tsx → handleRetry()` re-runs the last user message through `sendMessageInternal`, which re-issues the same HTTP request to the same api process, which still holds the same poisoned `prisma` singleton → same error. Quit + relaunch worked because it killed the process and built a fresh client.

## Fix

### 1. Auto-recycling Prisma proxy at the boundary

The exported `prisma` is now a `Proxy` over the real `PrismaClient`. The proxy intercepts:

- every **model delegate** (`prisma.user`, `prisma.project`, …) and wraps each method (`findFirst`, `create`, `update`, `delete`, raw method names alike — done generically), and
- the recoverable **top-level methods**: `$transaction`, `$queryRaw`, `$queryRawUnsafe`, `$executeRaw`, `$executeRawUnsafe`.

Non-query helpers (`$extends`, `$on`, `$use`, …) are returned as-is so Prisma's builder/middleware API is unaffected.

On a thrown error matching `disk I/O error | SQLITE_IOERR | database disk image is malformed | database is locked` (regex array `IO_ERROR_PATTERNS` — checks both `err.message` and `err.cause?.message`), the proxy:

1. Calls `$disconnect()` on the broken client (closes the bun:sqlite `Database`, releases the fd; errors here are swallowed because the handle is already poisoned and we just want the fd released).
2. Builds a fresh `PrismaClient` via the existing `createPrismaClient()` function.
3. Re-resolves the method on the fresh client and retries the failed call **exactly once** with the same arguments.

If the retry also throws, that error propagates normally — never an infinite loop, never a silently swallowed problem. If the underlying disk really is unhealthy (out of disk, permissions revoked) the user gets a clear error and the api process is in a clean state for the next attempt.

### 2. Coalesce concurrent rebuilds

Each wrapped call captures the current `slot.generation` (monotonic counter) at invocation time. The recovery path uses a single `recycleInFlight` promise so concurrent in-flight callers all wait on the same rebuild rather than each tearing down and rebuilding. Callers whose captured generation is already older than `slot.generation` skip the rebuild entirely and retry against whatever client is current.

### 3. Reduce the rate of faults in the first place

The bun:sqlite adapter is now opened with:

```ts
new PrismaBunSqlite({
  url: getSqliteUrl(),
  wal: { enabled: true, busyTimeout: 15_000, synchronous: 'NORMAL' },
})
```

- **WAL** lets readers run while a writer holds the lock — fewer contention points where `SQLITE_BUSY` can mutate into IO faults.
- **15 s busy_timeout** (vs. the 5 s default) absorbs Time Machine / Spotlight / AV blips that previously exceeded the default.
- **synchronous=NORMAL** is the standard companion to WAL — durability is preserved at checkpoint boundaries; we don't need full fsync per commit for a local dev DB.

## Why this is a root fix, not a patch

- It addresses **both** the trigger (process-wide handle poisoning) and the recovery gap (Retry can't help against a poisoned singleton). Either alone would be a patch.
- It lives at the **Prisma boundary**, not at call sites. Every route in `apps/api` touches `prisma` — patching call sites would either miss one or fork into N copies of the same try/catch. The Proxy applies the recovery uniformly to all current and future call sites.
- It does not paper over the failure mode. If recovery itself fails, the error propagates.
- It is **PG-mode safe**. The proxy still wraps `prisma` in hosted mode, but `IO_ERROR_PATTERNS` only match SQLite-shaped errors, so hosted Prisma errors never trigger a recycle. Worst case: a PG error matches the regex by accident → we recycle, retry once, and either succeed or fail the same way we would have.

## Manual verification

The fault is hard to reproduce on demand because it depends on the OS poisoning the fd. Two ways to validate:

**Synthetic:** monkey-patch `prisma.project.findFirst` in a dev build to throw `new Error('disk I/O error')` on first call and then no-op subsequent calls. With this PR the next chat send recovers automatically; without it the chat is stuck until quit. The `__recyclePrismaForTest` export is added for future Vitest coverage of the recycle path.

**Field:** wait for the next occurrence in a long-running Desktop session. With this PR the user should observe at most one flicker of `disk I/O error` followed by a successful send on the next message or Retry click — never a stuck panel that requires Quit.

## Out of scope

- Restructuring `prisma-adapter-bun-sqlite` upstream — we work around its single-handle design at our boundary.
- Hardening the `ChatPanel` error display for other shapes (tunnel disconnects, etc.) — separate follow-up.
- Migrating local mode off bun:sqlite — not warranted for this class of fault.

## Risk

- **Low**, isolated to `apps/api/src/lib/prisma.ts`.
- The Proxy's `get` trap returns Prisma's own values for any key whose value is not a function or whose function is not in our recovery set — i.e. unchanged behavior for `$extends`, `$on`, `$use`, internal symbols, and anything else Prisma adds in the future.
- The recovery path is opt-in via the IO error regex; non-IO errors are not intercepted.

## Files changed

- `apps/api/src/lib/prisma.ts` (+192 / −3)

No schema changes, no generated code regenerated, no migrations.
