### PR TITLE
fix(import): navigate to project after Home-page import

### DIFF
--- a/apps/mobile/components/project/ProjectSourceMenu.tsx
+++ b/apps/mobile/components/project/ProjectSourceMenu.tsx
@@ -29,6 +29,7 @@
  */
 import React, { useCallback, useState } from 'react'
 import { Pressable, Text, View } from 'react-native'
+import { useRouter } from 'expo-router'
 import { cn } from '@shogo/shared-ui/primitives'
 import {
   Popover,
@@ -74,6 +75,7 @@ export function ProjectSourceMenu({
   onSelectBlank,
   onProjectOpened,
 }: ProjectSourceMenuProps) {
+  const router = useRouter()
   const [open, setOpen] = useState(false)
   const [importOpen, setImportOpen] = useState(false)
 
@@ -104,9 +106,13 @@ export function ProjectSourceMenu({
   const handleImportCompleted = useCallback(
     (project: { id: string; name: string }) => {
       setImportOpen(false)
-      onProjectOpened?.(project)
+      if (onProjectOpened) {
+        onProjectOpened(project)
+      } else {
+        router.push({ pathname: '/(app)/projects/[id]', params: { id: project.id } } as any)
+      }
     },
-    [onProjectOpened],
+    [onProjectOpened, router],
   )
 
   const trigger = (triggerProps: any) =>


### PR DESCRIPTION
## Summary

- **Bug:** Clicking 'Open project' after a successful \.shogo-project\ import from the Home page did nothing — the modal closed but the user was never navigated to the imported project.
- **Root cause:** The Home page renders \ProjectSourceMenu\ without an \onProjectOpened\ callback. When the import modal fires \onOpenProject\, the chain calls \onProjectOpened?.(project)\ which is a no-op since the prop is \undefined\.
- **Fix:** Added a \outer.push()\ fallback inside \ProjectSourceMenu.handleImportCompleted\ so the component navigates to the imported project when no explicit callback is provided. This matches the existing pattern used by \useOpenLocalFolder\ for the 'Open folder' flow.

## Test plan

- [x] Import a \.shogo-project\ from the **Home page** 'New' dropdown → click 'Open project' → verify navigation to the imported project.
- [ ] Import from the **/projects** page → verify existing behavior is unchanged (toast + navigation).
- [ ] Verify 'Open folder' from the Home page still works as before.
