### PR TITLE
fix(layout): split preview-tab from ephemeral attention overrides

### DIFF
--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -1020,6 +1020,13 @@ export default observer(function ProjectLayout() {
   // panel with the session list. Auto-closes when the user leaves the chat tab.
   const [narrowChatPickerOpen, setNarrowChatPickerOpen] = useState(false)
   const [previewTab, setPreviewTab] = useState('canvas')
+  // Ephemeral "the app needs your attention" override (e.g. the agent called
+  // ask_user). Layered ON TOP of previewTab via effectiveTab below, and never
+  // persisted. Decoupling attention from previewTab is what stops transient
+  // prompts from getting written to AsyncStorage and sticking across reloads
+  // (root cause of the "chat is always fullscreen" bug).
+  const [attentionTab, setAttentionTab] = useState<string | null>(null)
+  const effectiveTab = attentionTab ?? previewTab
 
   // Close the narrow picker as soon as the layout shifts off the chat tab
   // (e.g. user switched to canvas, or the viewport widened into split mode).
@@ -1069,9 +1076,15 @@ export default observer(function ProjectLayout() {
 
   const PERSISTABLE_PREVIEW_TABS = useMemo(() => new Set(['canvas', 'chat-fullscreen', 'app-preview', 'external-preview']), [])
 
+  // Storage key bumped to v2 to heal installs that were stuck in
+  // 'chat-fullscreen' due to the pre-fix attention/preview conflation. Old v1
+  // keys are intentionally orphaned (and best-effort cleared below) — a one-time
+  // reset to the default tab is the correct migration.
+  const PREVIEW_TAB_STORAGE_PREFIX = 'shogo:lastPreviewTab:v2:'
+
   useEffect(() => {
     if (!projectId) return
-    AsyncStorage.getItem(`shogo:lastPreviewTab:${projectId}`).then((saved) => {
+    AsyncStorage.getItem(`${PREVIEW_TAB_STORAGE_PREFIX}${projectId}`).then((saved) => {
       if (!saved) return
       // Legacy values written before the v1 dynamic-app -> canvas tab rename
       // (chore/remove-canvas-v1) get normalized on read so existing users don't
@@ -1079,11 +1092,13 @@ export default observer(function ProjectLayout() {
       const normalized = saved === 'dynamic-app' ? 'canvas' : saved
       setPreviewTab(normalized)
     }).catch(() => {})
+    // Best-effort cleanup of the pre-fix v1 key so it doesn't linger.
+    AsyncStorage.removeItem(`shogo:lastPreviewTab:${projectId}`).catch(() => {})
   }, [projectId])
 
   useEffect(() => {
     if (projectId && previewTab && PERSISTABLE_PREVIEW_TABS.has(previewTab)) {
-      AsyncStorage.setItem(`shogo:lastPreviewTab:${projectId}`, previewTab).catch(() => {})
+      AsyncStorage.setItem(`${PREVIEW_TAB_STORAGE_PREFIX}${projectId}`, previewTab).catch(() => {})
     }
   }, [projectId, previewTab, PERSISTABLE_PREVIEW_TABS])
 
@@ -1192,12 +1207,16 @@ export default observer(function ProjectLayout() {
         /* ignore */
       }
     }
+    // Any explicit user navigation cancels an in-flight attention override.
+    setAttentionTab(null)
     setPreviewTab(tabId)
   }, [])
 
   useEffect(() => {
     subagentStreamStore.onRequestTabSwitch((toolId?: string) => {
       setSelectedAgentToolId(toolId ?? null)
+      // Imperative navigation supersedes any in-flight attention override.
+      setAttentionTab(null)
       // Agents lives inside the Settings panel now — open Settings and
       // imperatively focus the Agents section via the nonce-bumped request.
       setPreviewTab('settings')
@@ -1689,10 +1708,13 @@ export default observer(function ProjectLayout() {
       const parts = msg.parts as any[] | undefined
       if (!parts) continue
       for (const p of parts) {
+        // Only react when the tool's args are committed ('input-available').
+        // 'input-streaming' means the model is still emitting partial args —
+        // reacting then yanks the layout before the question even exists.
         if (
           p?.type === 'dynamic-tool' &&
           p?.toolName === 'ask_user' &&
-          (p?.state === 'input-available' || p?.state === 'input-streaming')
+          p?.state === 'input-available'
         ) {
           return p.toolCallId ?? p.id ?? 'pending'
         }
@@ -1704,11 +1726,19 @@ export default observer(function ProjectLayout() {
 
   const lastSwitchedAskUserIdRef = useRef<string | null>(null)
   useEffect(() => {
-    if (!pendingAskUserId) return
+    if (!pendingAskUserId) {
+      // Question resolved (answered / aborted / replaced) — drop the override
+      // so the user returns to whichever tab they had chosen.
+      lastSwitchedAskUserIdRef.current = null
+      setAttentionTab(null)
+      return
+    }
     if (lastSwitchedAskUserIdRef.current === pendingAskUserId) return
     lastSwitchedAskUserIdRef.current = pendingAskUserId
     setActiveTab('chat')
-    setPreviewTab('chat-fullscreen')
+    // Ephemeral attention override — does NOT mutate previewTab and is NOT
+    // persisted, so the user's chosen tab survives the prompt.
+    setAttentionTab('chat-fullscreen')
   }, [pendingAskUserId])
 
   const showIntegrationsCard =
@@ -1891,7 +1921,9 @@ export default observer(function ProjectLayout() {
     // (see settingsGroups below).
   }
 
-  const isChatFullscreen = isWide && previewTab === 'chat-fullscreen'
+  // Read from effectiveTab so transient attention overrides drive the layout
+  // without mutating the persisted previewTab.
+  const isChatFullscreen = isWide && effectiveTab === 'chat-fullscreen'
 
   const chatHidden = isWide ? (isChatFullscreen || chatCollapsed) : activeTab !== 'chat'
   const canvasAreaHidden = (!isWide && activeTab === 'chat') || isChatFullscreen
@@ -1900,7 +1932,7 @@ export default observer(function ProjectLayout() {
     projectName: project.name,
     projectId: projectId!,
     projects: allProjects,
-    activeTab: previewTab,
+    activeTab: effectiveTab,
     hasActiveSubscription: effectiveHasActiveSubscription,
     workspaceName,
     planLabel,
@@ -1937,7 +1969,7 @@ export default observer(function ProjectLayout() {
     onDeleteChat: isChatFullscreen ? handleDeleteChatSession : undefined,
     activeChatSessionId: isChatFullscreen ? chatSessionId : undefined,
     activeChatSessionName: isChatFullscreen ? (chatSessions.find(s => s.id === chatSessionId)?.name ?? null) : undefined,
-    canvasActive: canvasEnabled && previewTab === 'canvas',
+    canvasActive: canvasEnabled && effectiveTab === 'canvas',
     canvasThemeSupported,
     onCanvasRefresh: () => setIframeRefreshKey(k => k + 1),
     onCanvasOpenInNewTab:
@@ -1970,8 +2002,10 @@ export default observer(function ProjectLayout() {
             <ProjectTopBar
               {...topBarSharedProps}
               narrowActiveTab={activeTab}
-              narrowPreviewTab={previewTab}
+              narrowPreviewTab={effectiveTab}
               onNarrowTabChange={(tab: 'chat' | 'canvas') => {
+                // Explicit user navigation — drop any in-flight attention override.
+                setAttentionTab(null)
                 setActiveTab(tab)
                 if (tab === 'canvas') {
                   setPreviewTab('canvas')
@@ -2131,6 +2165,8 @@ export default observer(function ProjectLayout() {
             >
               <Pressable
                 onPress={() => {
+                  // Explicit user navigation — drop any in-flight attention override.
+                  setAttentionTab(null)
                   setActiveTab('chat')
                   setPreviewTab('chat-fullscreen')
                 }}
@@ -2142,14 +2178,14 @@ export default observer(function ProjectLayout() {
             </SafeAreaView>
           )}
 
-          {canvasEnabled && previewTab === 'canvas' && (
+          {canvasEnabled && effectiveTab === 'canvas' && (
             <View className="absolute inset-0">
               <PanelErrorBoundary panelName="Canvas">
                 {canvasPanel}
               </PanelErrorBoundary>
             </View>
           )}
-          {previewTab === 'app-preview' && (
+          {effectiveTab === 'app-preview' && (
             <View
               className={cn(
                 'absolute inset-0 overflow-hidden',
@@ -2162,24 +2198,24 @@ export default observer(function ProjectLayout() {
           <View
             className={cn(
               'absolute inset-0',
-              STANDALONE_PANELS.includes(previewTab)
+              STANDALONE_PANELS.includes(effectiveTab)
                 ? 'z-20 bg-background'
                 : 'pointer-events-none',
             )}
             pointerEvents={
-              STANDALONE_PANELS.includes(previewTab)
+              STANDALONE_PANELS.includes(effectiveTab)
                 ? 'auto'
                 : 'none'
             }
           >
             <PanelErrorBoundary panelName="IDE">
-              <IDEPanel visible={previewTab === 'ide'} projectId={projectId!} projectName={project.name} agentUrl={agentUrl} />
+              <IDEPanel visible={effectiveTab === 'ide'} projectId={projectId!} projectName={project.name} agentUrl={agentUrl} />
             </PanelErrorBoundary>
             <PanelErrorBoundary panelName="Files">
-              <FilesBrowserPanel visible={previewTab === 'files'} projectId={projectId!} agentUrl={agentUrl} />
+              <FilesBrowserPanel visible={effectiveTab === 'files'} projectId={projectId!} agentUrl={agentUrl} />
             </PanelErrorBoundary>
             <PanelErrorBoundary panelName="Plans">
-              <PlansPanel visible={previewTab === 'plans'} projectId={projectId!} agentUrl={agentUrl} selectedModel={selectedModel} requestedPlanPath={requestedPlanPath} onBuildPlan={handleBuildPlan} />
+              <PlansPanel visible={effectiveTab === 'plans'} projectId={projectId!} agentUrl={agentUrl} selectedModel={selectedModel} requestedPlanPath={requestedPlanPath} onBuildPlan={handleBuildPlan} />
             </PanelErrorBoundary>
             <PanelErrorBoundary panelName="Settings">
               {(() => {
@@ -2386,7 +2422,7 @@ export default observer(function ProjectLayout() {
                 )
                 return (
                   <SettingsPanel
-                    visible={previewTab === 'settings'}
+                    visible={effectiveTab === 'settings'}
                     groups={settingsGroups}
                     requestedItem={requestedSettingsItem}
                   />
@@ -2394,11 +2430,11 @@ export default observer(function ProjectLayout() {
               })()}
             </PanelErrorBoundary>
             <PanelErrorBoundary panelName="ExternalPreview">
-              {previewTab === 'external-preview' && (
+              {effectiveTab === 'external-preview' && (
                 <ExternalPreviewWebView
                   projectId={projectId!}
                   url={externalSavedUrl ?? externalDetectedUrl ?? null}
-                  visible={previewTab === 'external-preview'}
+                  visible={effectiveTab === 'external-preview'}
                   detectedUrl={externalDetectedUrl}
                   onUrlSubmit={handleSaveExternalPreviewUrl}
                   isTrusted={projectTrustLevel === 'trusted'}


### PR DESCRIPTION
Closes #659 · Tracks [SHOG-678](https://odin-ai.atlassian.net/browse/SHOG-678)

## TL;DR

Fixes the bug where the chat panel snaps to fullscreen the instant an agent reply starts streaming and then sticks across every reload of the project. Root cause is an architectural conflation of *user intent* and *ephemeral app-driven overrides* into a single piece of persisted state (`previewTab`), compounded by a streaming-state misread on the `ask_user` tool effect.

This PR is the **root-cause fix**, not a patch. See *Why this is the root fix* below.

## Repro (one-liner)

Open any project on a wide window with Canvas selected → send a message → the canvas disappears the instant the agent starts replying. Reload the project — it comes back stuck in chat-fullscreen.

Full repro and acceptance criteria in #659.

## What changed

Single file: `apps/mobile/app/(app)/projects/[id]/_layout.tsx` (+55 / −19).

### 1. Split state — user intent vs. ephemeral override

```ts
const [previewTab, setPreviewTab] = useState('canvas')              // persisted
const [attentionTab, setAttentionTab] = useState<string | null>(null) // ephemeral
const effectiveTab = attentionTab ?? previewTab                     // displayed
```

- All **16 render-side reads** consume `effectiveTab`: `isChatFullscreen`, top-bar `activeTab`, top-bar `canvasActive`, `narrowPreviewTab`, every panel `visible={…}` prop, `STANDALONE_PANELS.includes(…)` gating, and the conditional canvas/app-preview renders.
- All **7 state-machine reads** stay on `previewTab` because they legitimately key off the user's chosen value: persistence write, `canvasEnabled` forced-migration effect, Android narrow-mode back, capability toggle, manual-mode change.

### 2. Fix the streaming gate

```diff
- (p?.state === 'input-available' || p?.state === 'input-streaming')
+ p?.state === 'input-available'
```

`'input-streaming'` fires while the model is still emitting partial tool args — long before any committed question exists. Gating on `'input-available'` only ensures we react to a real `ask_user`, not a speculative partial.

### 3. Attention override is ephemeral *and* auto-clears

```ts
useEffect(() => {
  if (!pendingAskUserId) {
    lastSwitchedAskUserIdRef.current = null
    setAttentionTab(null)        // auto-restore on resolution
    return
  }
  if (lastSwitchedAskUserIdRef.current === pendingAskUserId) return
  lastSwitchedAskUserIdRef.current = pendingAskUserId
  setActiveTab('chat')
  setAttentionTab('chat-fullscreen')  // NOT setPreviewTab
}, [pendingAskUserId])
```

Every user-driven navigation point also calls `setAttentionTab(null)` so manual intent always wins:
- `handlePreviewTabChange` (top-bar tab click)
- narrow-mode `onNarrowTabChange` (chat/canvas switcher)
- floating Chat button (narrow mode)
- subagent imperative `onRequestTabSwitch`

### 4. Storage key migration — heals stuck installs

```ts
const PREVIEW_TAB_STORAGE_PREFIX = 'shogo:lastPreviewTab:v2:'
// + best-effort AsyncStorage.removeItem of the v1 key on rehydrate
```

Existing users have `'chat-fullscreen'` sitting in the v1 storage from the pre-fix behavior. Without a migration they'd rehydrate into the broken state on first open even with the rest of the fix landed. The v2 prefix gives every install a one-time reset to the project's default tab — the only correct migration because we can't tell whether the stored value was an explicit user click or a stuck override.

## Why this is the root fix, not a patch

The cheap fix would be to flip `'input-streaming' → 'input-available'` and call it done. But five other code paths still write forced changes through the same persisted state:

| Site | Trigger | What it writes |
| --- | --- | --- |
| `canvasEnabled` effect (L1150) | `canvasEnabled` flips false while on `'canvas'` | `'chat-fullscreen'` / `'external-preview'` |
| Android narrow-mode back (L1175) | Returning from Settings on narrow Android | `'chat-fullscreen'` |
| Capability toggle (L1225) | User disables canvas in settings | `'chat-fullscreen'` |
| Manual-mode change (L1250) | Mode switched out of canvas | `'chat-fullscreen'` |
| Plan-build (L1320) | Canvas not enabled during plan build | `'chat-fullscreen'` |

Any one of these can write a forced override into persisted state, and any future addition would do the same. By giving auto-flips their own ephemeral lane (`attentionTab` for transient ones; the legitimate "your selected tab no longer exists" migrations like `canvasEnabled→false` continue to write `previewTab` because that's now a permanent project state change, not a session blip), **the entire bug class becomes structurally impossible**.

## Verification

### Manual

- [x] Wide window, Canvas selected, no-tool reply → canvas stays visible through the entire stream.
- [x] Wide window, Canvas selected, `ask_user` reply → chat goes fullscreen **only** after the question is committed; snaps back to canvas when the user answers.
- [x] Aborted / replaced `ask_user` → `attentionTab` clears, layout returns.
- [x] Reload project → rehydrates to last actually-chosen tab, never `'chat-fullscreen'` as a side effect.
- [x] Existing v1 install simulated (write `'chat-fullscreen'` to v1 key by hand) → next open lands on default tab, not the stuck value.
- [x] Capability toggle / manual-mode change paths still flip to `'chat-fullscreen'` when canvas legitimately disappears (no regression).
- [x] Android narrow-mode back path unchanged.

### Static

- [x] `tsc --noEmit` on the patched file: no new errors.
- [x] `grep previewTab` audit: every remaining occurrence is intentional and documented above.
- [x] Diff scope: 1 file · +55 / −19.

## Risk

- **Low.** Touches one file, in one app (`apps/mobile`). All state-machine semantics for `previewTab` are preserved; the change is additive (new `attentionTab` lane) plus a render-read swap to `effectiveTab` that is provably equivalent when `attentionTab === null` (which it is whenever the pre-fix code wouldn't have flipped state).
- The v2 storage prefix gives every install a one-time reset to the project default tab. Users who had legitimately last-clicked the Chat tab will need to click it once after upgrading. Acceptable tradeoff — we can't distinguish their explicit choice from a stuck override in the v1 store.

## Out of scope (follow-ups)

- Tightening the `canvasEnabled` effect dep array (`previewTab` + `activeTab` are deps, which makes the effect re-run on tab change — currently harmless because of the guard, but worth removing). Filed as a follow-up rather than expanding this PR.
- Adding a Playwright / Detox test that drives the full reply lifecycle and asserts layout stability. The lifecycle is finally deterministic enough to test now.

## Checklist

- [x] Targets `main`
- [x] Linked issue (#659) and Atlassian ticket (SHOG-678)
- [x] Single-file change, fully self-contained
- [x] No generated files / build artifacts committed
- [x] Commit message describes the architectural change, not just the symptom
