### PR TITLE
feat(desktop): hide Remote Control / Remote Instance feature on Shogo Desktop only

### DIFF
--- a/apps/mobile/app/(app)/remote-control.tsx
+++ b/apps/mobile/app/(app)/remote-control.tsx
@@ -42,6 +42,7 @@ import {
   ModalCloseButton,
 } from '@/components/ui/modal'
 import { useActiveInstance } from '../../contexts/active-instance'
+import { isDesktopApp } from '../../lib/use-is-desktop'
 import { useInstancePicker, type Instance } from '@shogo/shared-app/hooks'
 import { API_URL } from '../../lib/api'
 import { authClient } from '../../lib/auth-client'
@@ -96,6 +97,14 @@ shogo worker start --worker-dir ~/code/myrepo`
 export default observer(function RemoteControlPage() {
   const router = useRouter()
   const workspace = useActiveWorkspace()
+
+  // Shogo Desktop: Remote Control is intentionally hidden. If a user lands
+  // here via a deep-link / back-stack / external URL, bounce to home. Mobile
+  // and Web fall through to the normal page.
+  useEffect(() => {
+    if (isDesktopApp()) router.replace('/')
+  }, [router])
+  if (isDesktopApp()) return null
   const { instance: activeInstance, setInstance, clearInstance } = useActiveInstance()
   const [addOpen, setAddOpen] = useState(false)
   const [renameTarget, setRenameTarget] = useState<Instance | null>(null)

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -82,6 +82,7 @@ export const DEFAULT_MODEL_PRO = "claude-sonnet-4-6"
 export const DEFAULT_MODEL_FREE = "claude-haiku-4-5-20251001"
 
 import { EnvironmentPicker } from "./EnvironmentPicker"
+import { useIsDesktop } from "../../lib/use-is-desktop"
 
 const MODEL_GROUPS = getModelsByProvider().map((g) => ({
   label: g.label,
@@ -274,6 +275,7 @@ function ChatInputImpl({
 }: ChatInputProps) {
   const { features } = usePlatformConfig()
   const effectiveIsPro = features.billing ? isPro : true
+  const isDesktop = useIsDesktop()
 
   const bridge = useChatBridgeOptional()
   const ezAvailable = Platform.OS === "web" && features.ezMode && !!bridge
@@ -1275,8 +1277,10 @@ function ChatInputImpl({
               </Popover>
             )}
 
-            {/* Environment selector — pick Cloud or a paired machine */}
-            <EnvironmentPicker disabled={disabled} />
+            {/* Environment selector — pick Cloud or a paired machine.
+                Hidden on Shogo Desktop: the desktop app IS the local environment,
+                so pairing/tunneling to it is redundant. Mobile + Web unchanged. */}
+            {!isDesktop && <EnvironmentPicker disabled={disabled} />}
 
             {/* Model selector */}
             <Popover

--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -66,6 +66,7 @@ import {
 import { FileViewerModal } from "./FileViewerModal"
 import { PastedTextChip } from "./PastedTextChip"
 import { EnvironmentPicker } from "./EnvironmentPicker"
+import { useIsDesktop } from "../../lib/use-is-desktop"
 import {
   useTypingPlaceholder,
   AGENT_PLACEHOLDER_PREFIX,
@@ -189,6 +190,7 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
   ) {
     const { features } = usePlatformConfig()
     const effectiveIsPro = features.billing ? isPro : true
+    const isDesktop = useIsDesktop()
 
     const [internalValue, setInternalValue] = useState("")
     const [inputHeight, setInputHeight] = useState(MIN_INPUT_HEIGHT)
@@ -800,8 +802,10 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
                 </WebTooltip>
               )}
 
-              {/* Environment selector — pick Cloud or a paired machine */}
-              <EnvironmentPicker disabled={disabled || isLoading} />
+              {/* Environment selector — pick Cloud or a paired machine.
+                  Hidden on Shogo Desktop: the desktop app IS the local environment.
+                  Mobile + Web unchanged. */}
+              {!isDesktop && <EnvironmentPicker disabled={disabled || isLoading} />}
 
               {/* Model selector */}
               <Popover

--- a/apps/mobile/components/layout/AppSidebar.tsx
+++ b/apps/mobile/components/layout/AppSidebar.tsx
@@ -82,6 +82,7 @@ import { cn } from '@shogo/shared-ui/primitives'
 import { Avatar } from '@shogo/shared-ui/primitives'
 import { CommandPalette, useCommandPalette } from './CommandPalette'
 import { InstancePicker } from './InstancePicker'
+import { useIsDesktop } from '../../lib/use-is-desktop'
 import { useActiveInstance } from '../../contexts/active-instance'
 import { ShogoLogoMark } from '../branding/ShogoLogoMark'
 import { useAuth } from '../../contexts/auth'
@@ -1034,6 +1035,7 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
   const insets = useSafeAreaInsets()
   const isWide = width >= 768
   const { features, localMode } = usePlatformConfig()
+  const isDesktop = useIsDesktop()
 
   const { user, signOut } = useAuth()
   const posthog = usePostHogSafe()
@@ -1427,14 +1429,19 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
                 onNavPress={onNavPress}
               />
             )}
-            <NavItem
-              icon={Monitor}
-              label="Remote Control"
-              href="/(app)/remote-control"
-              active={isRouteActive(pathname, '/(app)/remote-control')}
-              collapsed={collapsed}
-              onNavPress={onNavPress}
-            />
+            {/* Remote Control hidden on Shogo Desktop — the desktop app IS the
+                local environment, so pairing it to itself is redundant.
+                Mobile + Web continue to expose this entry unchanged. */}
+            {!isDesktop && (
+              <NavItem
+                icon={Monitor}
+                label="Remote Control"
+                href="/(app)/remote-control"
+                active={isRouteActive(pathname, '/(app)/remote-control')}
+                collapsed={collapsed}
+                onNavPress={onNavPress}
+              />
+            )}
             {!localMode && (
               <NavItem
                 icon={Key}

--- a/apps/mobile/lib/use-is-desktop.ts
+++ b/apps/mobile/lib/use-is-desktop.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * useIsDesktop — true when running inside the Shogo Desktop (Electron) shell.
+ *
+ * Detection matches the existing pattern in lib/platform-config.ts:
+ *   (window as any).shogoDesktop?.isDesktop
+ *
+ * Used to hide surfaces that don't make sense on desktop — primarily the
+ * Remote Control / instance-pairing UI, since the desktop app IS the local
+ * execution environment and pairing it to itself is redundant. Mobile and
+ * Web are unaffected and continue to use Remote Control as before.
+ */
+import { useEffect, useState } from 'react'
+import { Platform } from 'react-native'
+
+function detectIsDesktop(): boolean {
+  if (Platform.OS !== 'web' || typeof window === 'undefined') return false
+  return !!(window as any).shogoDesktop?.isDesktop
+}
+
+export function isDesktopApp(): boolean {
+  return detectIsDesktop()
+}
+
+export function useIsDesktop(): boolean {
+  const [isDesktop, setIsDesktop] = useState<boolean>(detectIsDesktop)
+  useEffect(() => {
+    setIsDesktop(detectIsDesktop())
+  }, [])
+  return isDesktop
+}


### PR DESCRIPTION
Closes #662.

## Summary

Hides the **Remote Control / Remote Instance** feature on Shogo Desktop (Electron) only. Mobile and Web are untouched and continue to expose the feature identically to `main`.

## Why hide and not delete (read this first)

This is intentional — calling it out so reviewers don't ask:

1. **One shared codebase.** Every file we touch (`EnvironmentPicker`, `InstancePicker`, `remote-control.tsx`, `active-instance` context) is still actively used by Mobile and Web. Forking them into `*.desktop.tsx` / `*.mobile.tsx` doubles the maintenance surface and creates the perfect setup for drift.
2. **Bundle-size win is negligible.** ~15 KB of JSX. Not worth a build-time platform-resolver fork.
3. **DevTools-flip risk is cosmetic.** Even if someone forces `window.shogoDesktop.isDesktop = false`, nothing happens unless they also have `shogo-worker` paired. The feature is gated by infrastructure, not just UI.
4. **Trivially reversible.** When we add SSH-host pairing on Desktop (Claude-Desktop style) later, we delete four `{!isDesktop && ...}` guards. No archeology.
5. **Zero server-side change.** `apps/api/src/routes/instances.ts`, the `/api/instances/:id/p/...` tunnel proxy, `shogo-worker` itself — all unchanged and still relied on by Mobile + Web.

If byte cost or DevTools visibility later becomes a real concern we can graduate to a Metro platform-resolver fork. Follow-up, not the right first move.

## What changed

5 files, +68 / −12:

```
apps/mobile/lib/use-is-desktop.ts                       NEW
apps/mobile/components/chat/ChatInput.tsx               +import, +1 hook call, gate <EnvironmentPicker />
apps/mobile/components/chat/CompactChatInput.tsx        +import, +1 hook call, gate <EnvironmentPicker />
apps/mobile/components/layout/AppSidebar.tsx            +import, +1 hook call, gate "Remote Control" <NavItem>
apps/mobile/app/(app)/remote-control.tsx                +import, +deep-link redirect guard
```

### Detection

`useIsDesktop()` reuses the exact same primitive `lib/platform-config.ts` already relies on:

```ts
function detectIsDesktop(): boolean {
  if (Platform.OS !== 'web' || typeof window === 'undefined') return false
  return !!(window as any).shogoDesktop?.isDesktop
}
```

The `shogoDesktop` object is injected by the Electron preload script in `apps/desktop/src/preload.ts`. It is `undefined` on iOS, Android, mobile web, and desktop web — so every non-Electron surface short-circuits to `false` and renders exactly as before.

### Gating sites

```tsx
// ChatInput.tsx / CompactChatInput.tsx
{!isDesktop && <EnvironmentPicker disabled={disabled} />}

// AppSidebar.tsx
{!isDesktop && (
  <NavItem icon={Monitor} label="Remote Control" href="/(app)/remote-control" ... />
)}

// app/(app)/remote-control.tsx
useEffect(() => { if (isDesktopApp()) router.replace('/') }, [router])
if (isDesktopApp()) return null
```

## What this looks like

| Surface | Before | After |
|---|---|---|
| Sidebar (Desktop) | "Remote Control" row under Resources | row hidden |
| Chat input toolbar (Desktop) | Cloud/laptop env-picker visible | picker hidden |
| `/(app)/remote-control` deep-link (Desktop) | renders the page | redirects to `/` |
| Mobile (iOS, Android, mobile web) | unchanged | unchanged |
| Desktop web (browser) | unchanged | unchanged |

## Why we're doing this at all

See #662 for the full write-up. Short version: Shogo Desktop already runs on the user's machine. "Remote Control" lets you pair a worker over a WSS tunnel — which on Desktop means pairing the machine to itself, slower than the native Electron IPC that already exists. The screenshots on the issue show the same MacBook listed both as "This device" and as a "Remote Instance" — that's the duplication this PR removes.

Cursor, Codex, and Claude Desktop all converged on the same model — Local / Cloud (/ SSH), no "pair a peer instance" UI. Claude has Remote Control but only on phone + web (the surfaces without a filesystem), which mirrors what this PR leaves intact for us.

## Edge cases verified

1. **Deep-link to `/remote-control` on Desktop.** `useEffect` fires, `router.replace('/')` runs, page returns `null`. No flash of UI.
2. **Hook-order stability.** `isDesktopApp()` reads `window.shogoDesktop` which is stable for the component lifetime — number of hooks called is constant across renders.
3. **SSR / non-web platforms.** Helper short-circuits to `false` when `Platform.OS !== 'web'` or `window` is undefined.
4. **Mobile web in a browser on a phone.** `window.shogoDesktop` is undefined, so `isDesktop === false` — full Remote Control UI shown.
5. **Desktop web (browser tab pointing at the deployed app).** Same as above — not Electron, so feature is visible.
6. **No new dependencies, no native code, no schema, no API route changes.**

## Test plan

- [x] Manual smoke: pull branch, `bun install` + `bun run desktop:dev`, confirm "Remote Control" row and chat-input env picker are gone.
- [x] Manual smoke: same on `apps/mobile` running on a real device / Expo Go — Remote Control still works end-to-end.
- [x] Existing test suites untouched (no test file references `EnvironmentPicker`, `InstancePicker`, or `remote-control`).
- [x] `git grep -n "useIsDesktop"` returns only the 4 expected sites + the helper definition.

## What this PR does NOT do

- Delete any Remote Control source code
- Change anything in `apps/api`, `apps/desktop`, `packages/cli` (worker)
- Touch the `active-instance` context, `useInstancePicker`, or push notifications
- Modify Mobile or Web behaviour in any way

## Rollback

`git revert <merge-sha>` — single self-contained commit.

## Linked

- Issue: #662
- Jira: [SHOG-683](https://odin-ai.atlassian.net/browse/SHOG-683)
