### PR TITLE
fix(billing): refresh spending limit in UI after saving cap

### DIFF
--- a/packages/shared-app/src/hooks/useBillingData.ts
+++ b/packages/shared-app/src/hooks/useBillingData.ts
@@ -162,6 +162,13 @@ export function useBillingData(workspaceId: string | undefined): BillingDataStat
     } catch { return undefined }
   }, [workspaceId, store, isLoadingUsageWallet, walletLength])
 
+  // Track mutable wallet fields so downstream memos recompute when the
+  // MobX model is updated in-place (same reference, new property values).
+  const walletUpdatedAt = usageWallet?.updatedAt ?? 0
+  const walletOverageHardLimitUsd = usageWallet?.overageHardLimitUsd
+  const walletOverageEnabled = usageWallet?.overageEnabled
+  const walletOverageAccumulatedUsd = usageWallet?.overageAccumulatedUsd
+
   const effectiveBalance = useMemo<EffectiveBalance | undefined>(() => {
     if (!usageWallet) return undefined
     try {
@@ -190,7 +197,7 @@ export function useBillingData(workspaceId: string | undefined): BillingDataStat
         total: daily + monthly,
       }
     } catch { return undefined }
-  }, [usageWallet, effectivePlan])
+  }, [usageWallet, effectivePlan, walletUpdatedAt, walletOverageHardLimitUsd, walletOverageEnabled, walletOverageAccumulatedUsd])
 
   const usageEvents = useMemo(() => {
     if (!workspaceId || !store?.usageEventCollection) return []


### PR DESCRIPTION
## Summary
- After saving a monthly spending cap via **Set Limit**, the Billing tab still showed the old value until a full page refresh.
- useBillingData now tracks wallet updatedAt and overage fields as primitive dependencies so effectiveBalance recomputes when MobX updates the usage wallet in place.

## Root cause
effectiveBalance was memoized with [usageWallet, effectivePlan]. efetchUsageWallet() reloads the same MobX model instance with new property values, so React saw an unchanged reference and skipped recomputation.

## Test plan
- [ ] Open workspace **Settings → Billing** (web, non-iOS)
- [ ] Note current **Monthly spending cap** (e.g. $100)
- [ ] Click **Set Limit**, change cap (e.g. $200), save
- [ ] Confirm cap updates immediately without refresh
- [ ] Repeat on **Usage** tab On-Demand card **Set Limit**
- [ ] Set blank cap → UI shows **No cap** without refresh

Made with [Cursor](https://cursor.com)