### PR TITLE
fix(mobile): show toast when follow/unfollow creator fails

### DIFF
--- a/apps/mobile/components/marketplace/FollowCreatorButton.tsx
+++ b/apps/mobile/components/marketplace/FollowCreatorButton.tsx
@@ -6,6 +6,7 @@ import { Pressable, Text, Alert } from 'react-native'
 import { UserPlus, UserCheck } from 'lucide-react-native'
 import { useAuth } from '../../contexts/auth'
 import { useDomainHttp } from '../../contexts/domain'
+import { useToast, Toast, ToastTitle, ToastDescription } from '../ui/toast'
 
 interface FollowCreatorButtonProps {
   creatorId: string
@@ -24,9 +25,27 @@ export function FollowCreatorButton({
 }: FollowCreatorButtonProps) {
   const { user } = useAuth()
   const http = useDomainHttp()
+  const toast = useToast()
   const [following, setFollowing] = useState(initialFollowing)
   const [count, setCount] = useState(followerCount)
   const [loading, setLoading] = useState(false)
+
+  const showErrorToast = useCallback(
+    (action: 'follow' | 'unfollow', message: string) => {
+      const title = action === 'follow' ? "Couldn't follow" : "Couldn't unfollow"
+      toast.show({
+        placement: 'top',
+        duration: 5000,
+        render: ({ id: toastId }: { id: string }) => (
+          <Toast nativeID={toastId} variant="outline" action="error">
+            <ToastTitle>{title}</ToastTitle>
+            <ToastDescription>{message}</ToastDescription>
+          </Toast>
+        ),
+      })
+    },
+    [toast],
+  )
 
   const handlePress = useCallback(async () => {
     if (!user?.id) {
@@ -53,14 +72,20 @@ export function FollowCreatorButton({
       setCount(serverCount)
       setFollowing(!wasFollowing)
       onToggle?.(!wasFollowing, serverCount)
-    } catch {
-      // Revert on failure
+    } catch (error: unknown) {
       setFollowing(wasFollowing)
       setCount(prevCount)
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : wasFollowing
+            ? 'Failed to unfollow. Please try again.'
+            : 'Failed to follow. Please try again.'
+      showErrorToast(wasFollowing ? 'unfollow' : 'follow', message)
     } finally {
       setLoading(false)
     }
-  }, [user?.id, following, count, creatorId, http, onToggle])
+  }, [user?.id, following, count, creatorId, http, onToggle, showErrorToast])
 
   const isSmall = size === 'sm'
   const iconSize = isSmall ? 12 : 14


### PR DESCRIPTION
## Summary
- Show an error toast when follow/unfollow API calls fail in `FollowCreatorButton`, matching the pattern used in billing, settings, and projects.
- Surfaces server messages such as **Cannot follow yourself** instead of silently reverting the optimistic UI update.

## Test plan
- [ ] Open your own creator profile on staging (/marketplace/creators/<your-id>)
- [ ] Click **Follow** while signed in
- [ ] Confirm a top error toast appears with title **Couldn't follow** and description **Cannot follow yourself**
- [ ] Confirm the button reverts to **Follow** (not stuck on **Following**)
- [ ] Follow another creator and unfollow — confirm success still works with no toast
- [ ] Trigger a generic follow failure (e.g. offline) and confirm fallback error message appears

<img width="1181" height="616" alt="image" src="https://github.com/user-attachments/assets/0ee12cab-83f3-4077-88b4-47292b8d7966" />