### PR TITLE
fix(api): invitation emails use correct accept URL per environment

### DIFF
--- a/apps/api/src/generated/invitation.hooks.ts
+++ b/apps/api/src/generated/invitation.hooks.ts
@@ -8,6 +8,7 @@
  */
 
 import { sendInvitationEmail, sendProjectInviteEmail, sendInviteAcceptedEmail } from "../services/email.service"
+import { getFrontendUrl } from "../lib/cloud-urls"
 
 /**
  * Result from a hook that can modify or reject the operation
@@ -274,7 +275,7 @@ export const invitationHooks: InvitationHooks = {
     const resourceName = project?.name || workspace?.name
     if (!resourceName) return
 
-    const baseUrl = process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3001'
+    const baseUrl = getFrontendUrl()
     const acceptUrl = `${baseUrl}/invitations/${invitation.id}/accept`
 
     const inviterName = inviter?.name || inviter?.email || 'A team member'
@@ -321,7 +322,7 @@ export const invitationHooks: InvitationHooks = {
       const resourceName = project?.name || workspace?.name
       if (!resourceName) return
 
-      const baseUrl = process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3001'
+      const baseUrl = getFrontendUrl()
       sendInviteAcceptedEmail({
         to: inviter.email,
         inviteeName: invitee?.name || record.email,


### PR DESCRIPTION
## Summary

- Fix invitation emails sending `http://localhost:3001` accept links in staging/production by using `getFrontendUrl()` instead of a hardcoded localhost fallback.

## Root cause

`invitation.hooks.ts` built accept URLs with `APP_URL || NEXT_PUBLIC_APP_URL || 'http://localhost:3001'`. Deployed environments set `ALLOWED_ORIGINS` (e.g. `https://studio.shogo.ai`) but not `APP_URL`, so emails always fell back to localhost.

## Test plan

- [ ] Send a workspace invitation on staging; verify Accept CTA links to `https://studio.staging.shogo.ai/invitations/{id}/accept`
- [ ] Send a workspace invitation on production; verify Accept CTA links to `https://studio.shogo.ai/invitations/{id}/accept`
- [ ] Local dev: verify link uses `APP_URL` or `ALLOWED_ORIGINS` (not port 3001)
