### PR TITLE
fix(trust): resolve trust live from API instead of spawn-time env snapshot (closes #669, SHOG-689)

### DIFF
--- a/apps/api/src/__tests__/trust-resolver-wiring.test.ts
+++ b/apps/api/src/__tests__/trust-resolver-wiring.test.ts
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Architectural regression tests for the live trust resolver wiring.
+ *
+ * The "Trust folder still shows restricted" bug was caused by trust
+ * being a spawn-time env snapshot the running runtime had no way to
+ * refresh. The fix moved trust to a live resolver:
+ *
+ *   - `manager.ts` must NOT bake TRUST_LEVEL into the spawn env.
+ *   - `local-projects.ts` POST /:id/trust must ping the runtime's
+ *     /internal/refresh-trust route after writing Postgres.
+ *   - `gateway.ts` must call `refreshTrust()` at the start of every
+ *     chat turn AND read trust from `getRuntimeTrust()`, never from
+ *     `process.env.TRUST_LEVEL`.
+ *   - `server.ts` must mount the /internal/refresh-trust route, seed
+ *     the resolver at boot, and stop publishing `trustLevel` into the
+ *     legacy global.
+ *
+ * These are source-regression checks (same shape as
+ * `runtime-manager-proxy-urls.test.ts`): they read the source files
+ * as text and pin invariants that are easy to silently regress. They
+ * complement the behavioral unit tests in
+ * `trust-resolver.test.ts`, `runtime-trust.test.ts`, and the
+ * `GET /projects/:projectId/trust` block in `internal.test.ts`.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const repoRoot = join(import.meta.dir, '..', '..', '..', '..')
+
+function read(rel: string): string {
+  return readFileSync(join(repoRoot, rel), 'utf8')
+}
+
+describe('trust resolver wiring — manager.ts', () => {
+  const src = read('apps/api/src/lib/runtime/manager.ts')
+
+  test('runtimeEnv for external projects no longer includes TRUST_LEVEL', () => {
+    // TRUST_LEVEL must not appear as an env-key assignment in
+    // manager.ts. (It may appear in a comment explaining why it's
+    // gone — that's why we look for the assignment shape, not the
+    // bare token.)
+    expect(src).not.toMatch(/^\s*TRUST_LEVEL:\s*/m)
+  })
+
+  test('LINKED_FOLDERS is still in the spawn env (immutable for runtime lifetime)', () => {
+    // Sanity check that the test above didn't pass just because the
+    // whole external branch was deleted by accident.
+    expect(src).toMatch(/LINKED_FOLDERS:\s*JSON\.stringify/)
+  })
+
+  test('comment documents why TRUST_LEVEL is intentionally absent', () => {
+    // A future dev reading the diff should see why TRUST_LEVEL was
+    // removed, so they don't "fix" it by adding it back.
+    expect(src).toMatch(/TRUST_LEVEL is deliberately NOT in the spawn env/i)
+  })
+})
+
+describe('trust resolver wiring — local-projects.ts', () => {
+  const src = read('apps/api/src/routes/local-projects.ts')
+
+  test('POST /:id/trust pings the runtime after the DB write', () => {
+    // The route block is hard to slice with a regex because of nested
+    // braces inside the prisma update argument. Instead, anchor on
+    // three ordered string occurrences in the file and assert their
+    // lexical order matches execution order:
+    //   1. the route registration
+    //   2. the prisma update
+    //   3. the ping helper invocation
+    //
+    // If a future refactor inverts steps 2 and 3 (the exact race the
+    // fix prevents — pinging before the row is committed), this test
+    // fails loudly.
+    const routeIdx = src.indexOf("router.post('/:id/trust'")
+    expect(routeIdx).toBeGreaterThan(-1)
+
+    const updateIdx = src.indexOf('prisma.project.update', routeIdx)
+    expect(updateIdx).toBeGreaterThan(routeIdx)
+
+    const pingIdx = src.indexOf('pingRuntimeRefreshTrust(projectId)', updateIdx)
+    expect(pingIdx).toBeGreaterThan(updateIdx)
+
+    // And the ping must be reasonably close to the route — guards
+    // against the helper being moved into an unrelated handler.
+    expect(pingIdx - routeIdx).toBeLessThan(2000)
+  })
+
+  test('pingRuntimeRefreshTrust helper is defined and targets the right route', () => {
+    expect(src).toMatch(/function pingRuntimeRefreshTrust\(projectId: string\)/)
+    expect(src).toMatch(/\/internal\/refresh-trust/)
+    expect(src).toMatch(/deriveWebhookToken/)
+    // Must read agentPort from runtime.status() — otherwise it would
+    // hit the wrong port for any non-default install.
+    expect(src).toMatch(/agentPort/)
+  })
+
+  test('ping is fire-and-forget (does not await, swallows errors)', () => {
+    const helperMatch = src.match(
+      /function pingRuntimeRefreshTrust[\s\S]*?\n\}/,
+    )
+    expect(helperMatch).not.toBeNull()
+    const helper = helperMatch?.[0] ?? ''
+    // The whole body lives inside an IIFE so the route can return
+    // immediately. If a future refactor `await`s it directly the
+    // route latency couples to the runtime's responsiveness.
+    expect(helper).toMatch(/;\s*\(async \(\) => \{/)
+    expect(helper).toContain('catch')
+  })
+})
+
+describe('trust resolver wiring — gateway.ts', () => {
+  const src = read('packages/agent-runtime/src/gateway.ts')
+
+  test('imports refreshTrust + getRuntimeTrust from the new modules', () => {
+    expect(src).toMatch(/from ['"]\.\/runtime-trust['"]/)
+    expect(src).toMatch(/from ['"]\.\/trust-resolver['"]/)
+    expect(src).toMatch(/\bgetRuntimeTrust\b/)
+    expect(src).toMatch(/\brefreshTrust\b/)
+  })
+
+  test('per-turn refresh runs at the top of _agentTurnInner', () => {
+    // The whole point of the fix: every turn must reconcile with the
+    // DB BEFORE the system prompt is built or any tool runs.
+    const inner = src.match(/_agentTurnInner[\s\S]{0,2000}/)?.[0] ?? ''
+    expect(inner).toContain('await refreshTrust()')
+    // Refresh must happen before loadBootstrapContext (system prompt).
+    expect(inner.indexOf('await refreshTrust()')).toBeLessThan(
+      inner.indexOf('loadBootstrapContext'),
+    )
+  })
+
+  test('system prompt builder no longer reads process.env.TRUST_LEVEL', () => {
+    // The exact bug: env reads were a stale spawn-time value. The
+    // whole module must read trust from getRuntimeTrust() going
+    // forward; future regressions get caught here.
+    expect(src).not.toMatch(/process\.env\.TRUST_LEVEL/)
+  })
+})
+
+describe('trust resolver wiring — server.ts', () => {
+  const src = read('packages/agent-runtime/src/server.ts')
+
+  test('imports the resolver init + refresh', () => {
+    expect(src).toMatch(
+      /from ['"]\.\/trust-resolver['"]/,
+    )
+    expect(src).toMatch(/initTrustResolver/)
+    expect(src).toMatch(/refreshTrust/)
+  })
+
+  test('TRUST_LEVEL env is no longer parsed at boot', () => {
+    // The old code had: `const TRUST_LEVEL = process.env.TRUST_LEVEL === ...`
+    // Any reintroduction of a top-level TRUST_LEVEL const would be a
+    // regression to the broken architecture.
+    expect(src).not.toMatch(/const TRUST_LEVEL[:\s]/)
+    expect(src).not.toMatch(/process\.env\.TRUST_LEVEL/)
+  })
+
+  test('initTrustResolver runs at boot with the right shape', () => {
+    expect(src).toMatch(/initTrustResolver\(\s*\{[\s\S]*?workspaceDir[\s\S]*?\}\s*\)/)
+    // Best-effort initial refresh so the first chat turn doesn't have
+    // to wait on its own refreshTrust() call.
+    expect(src).toMatch(/refreshTrust\(\)\.catch/)
+  })
+
+  test('legacy global no longer advertises trustLevel (avoid stale-read bugs)', () => {
+    // The whole point of the fix: globalThis.__SHOGO_AGENT_RUNTIME_CONFIG__
+    // must not have a `trustLevel` field anymore. Out-of-tree readers
+    // either go through getRuntimeTrust() (which goes through the
+    // resolver) or get nothing — they must NEVER get a stale snapshot.
+    const globalAssign =
+      src.match(/__SHOGO_AGENT_RUNTIME_CONFIG__\s*=\s*\{[\s\S]*?\}/)?.[0] ?? ''
+    expect(globalAssign).not.toContain('trustLevel')
+    // But the immutable directory triplet must still be there for
+    // any out-of-tree consumer that depends on it.
+    expect(globalAssign).toContain('workspaceDir')
+    expect(globalAssign).toContain('linkedFolders')
+    expect(globalAssign).toContain('workingMode')
+  })
+
+  test('POST /internal/refresh-trust route is mounted with webhook auth', () => {
+    const route =
+      src.match(/app\.post\(['"]\/internal\/refresh-trust['"][\s\S]*?\}\)/)?.[0] ??
+      ''
+    expect(route.length).toBeGreaterThan(0)
+    expect(route).toContain('verifyWebhookAuth')
+    expect(route).toContain('await refreshTrust()')
+    // Must return 401 when unauthorized (not silently succeed).
+    expect(route).toMatch(/Unauthorized/)
+  })
+})
+
+describe('trust resolver wiring — runtime-trust.ts', () => {
+  const src = read('packages/agent-runtime/src/runtime-trust.ts')
+
+  test('reads from trust-resolver (resolver is authoritative)', () => {
+    expect(src).toMatch(/from ['"]\.\/trust-resolver['"]/)
+    expect(src).toMatch(/isTrustResolverInitialized/)
+    expect(src).toMatch(/getResolvedTrust/)
+  })
+
+  test('env-only fallback path is preserved for unit tests', () => {
+    // Production no longer reads TRUST_LEVEL from env, but unit tests
+    // pin trust via env. Removing this branch would silently break
+    // every gateway-tools test in the suite.
+    expect(src).toMatch(/process\.env\.TRUST_LEVEL/)
+    expect(src).toMatch(/process\.env\.LINKED_FOLDERS/)
+  })
+})

--- a/apps/api/src/lib/runtime/manager.ts
+++ b/apps/api/src/lib/runtime/manager.ts
@@ -1302,7 +1302,14 @@ export class ShogoErrorBoundary extends Component<Props, State> {
           ...(projectInfo.workingMode === 'external'
             ? {
                 LINKED_FOLDERS: JSON.stringify((projectInfo.folders ?? []).map((f) => f.path)),
-                TRUST_LEVEL: projectInfo.trustLevel ?? 'restricted',
+                // NB: TRUST_LEVEL is deliberately NOT in the spawn env.
+                // Env vars are immutable for a running process — baking
+                // trust in at spawn was the root cause of the
+                // "Trust folder still restricted" bug. The runtime now
+                // resolves trust live from
+                // `GET /api/internal/projects/:id/trust` via
+                // `trust-resolver.ts` (boot + every chat turn + on-demand
+                // IPC from POST /:id/trust → /internal/refresh-trust).
                 RUNTIME_ENABLED: projectInfo.runtimeEnabled ? 'true' : 'false',
               }
             : {}),

--- a/apps/api/src/routes/__tests__/internal.test.ts
+++ b/apps/api/src/routes/__tests__/internal.test.ts
@@ -13,6 +13,8 @@ const store = {
   warmPoolThrow: null as null | Error,
   prismaProject: null as null | { id: string },
   prismaProjectThrow: null as null | Error,
+  prismaProjectFindUnique: null as any,
+  prismaProjectFindUniqueThrow: null as null | Error,
   agentConfigUpdate: { count: 1 },
   agentConfigUpdateThrow: null as null | Error,
   agentConfigFind: null as any,
@@ -61,6 +63,10 @@ mock.module('../../lib/prisma', () => ({
         if (store.prismaProjectThrow) throw store.prismaProjectThrow
         return store.prismaProject
       },
+      findUnique: async () => {
+        if (store.prismaProjectFindUniqueThrow) throw store.prismaProjectFindUniqueThrow
+        return store.prismaProjectFindUnique
+      },
     },
     agentConfig: {
       updateMany: async () => {
@@ -103,6 +109,8 @@ beforeEach(() => {
   store.warmPoolThrow = null
   store.prismaProject = { id: 'proj-99' }
   store.prismaProjectThrow = null
+  store.prismaProjectFindUnique = null
+  store.prismaProjectFindUniqueThrow = null
   store.agentConfigUpdateThrow = null
   store.agentConfigFind = { projectId: 'proj-1', heartbeatEnabled: true, heartbeatInterval: 300 }
   store.agentConfigFindThrow = null
@@ -612,6 +620,137 @@ describe('wave-4A-c remaining gaps', () => {
     const res = await app.request('/validate-runtime-token', {
       method: 'POST', headers: { ...SA, ...JSON_H }, body: JSON.stringify({ token: 't' }),
     })
+    expect(res.status).toBe(500)
+  })
+})
+
+// ─── GET /projects/:projectId/trust ─────────────────────────────────────────
+//
+// Authoritative trust read used by the runtime's TrustResolver.
+// Bug fixed: trust used to be a spawn-time env snapshot; this endpoint
+// is the live source the resolver fetches from at every chat turn (and
+// on demand via POST /internal/refresh-trust).
+describe('GET /projects/:projectId/trust', () => {
+  test('400 when projectId path param is empty', async () => {
+    // Hono won't even match the route with an empty :projectId, but
+    // verify we don't 500 on weird inputs that resolve to ''.
+    const res = await app.request('/projects//trust', { headers: { ...SA } })
+    expect([400, 404]).toContain(res.status)
+  })
+
+  test('401 when no auth headers', async () => {
+    const res = await app.request('/projects/p1/trust')
+    expect(res.status).toBe(401)
+  })
+
+  test('403 when SA token is invalid and not local mode', async () => {
+    store.podIdentity = null
+    const res = await app.request('/projects/p1/trust', { headers: { ...SA } })
+    expect(res.status).toBe(401)
+  })
+
+  test('404 when project does not exist', async () => {
+    store.prismaProjectFindUnique = null
+    const res = await app.request('/projects/missing/trust', { headers: { ...SA } })
+    expect(res.status).toBe(404)
+  })
+
+  test('200 returns trusted/external with folder ordering (primary first, then by lastOpenedAt desc)', async () => {
+    store.prismaProjectFindUnique = {
+      trustLevel: 'trusted',
+      workingMode: 'external',
+      projectFolders: [
+        { path: '/work/older', isPrimary: false, lastOpenedAt: new Date('2026-01-01') },
+        { path: '/work/primary', isPrimary: true, lastOpenedAt: new Date('2025-01-01') },
+        { path: '/work/newer', isPrimary: false, lastOpenedAt: new Date('2026-05-01') },
+      ],
+    }
+    const res = await app.request('/projects/p1/trust', { headers: { ...SA } })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      trustLevel: 'trusted',
+      workingMode: 'external',
+      linkedFolders: ['/work/primary', '/work/newer', '/work/older'],
+    })
+  })
+
+  test('200 normalizes unknown trustLevel/workingMode to safe defaults', async () => {
+    // The runtime expects strict 'trusted'|'restricted' and 'managed'|'external'.
+    // Anything else from the DB must collapse to the safe default
+    // (trusted unless explicitly restricted; managed unless explicitly external)
+    // so the resolver never sees ambiguous values.
+    store.prismaProjectFindUnique = {
+      trustLevel: 'something-weird',
+      workingMode: null,
+      projectFolders: [],
+    }
+    const res = await app.request('/projects/p1/trust', { headers: { ...SA } })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      trustLevel: 'trusted',
+      workingMode: 'managed',
+      linkedFolders: [],
+    })
+  })
+
+  test('200 maps restricted/managed combo correctly', async () => {
+    store.prismaProjectFindUnique = {
+      trustLevel: 'restricted',
+      workingMode: 'managed',
+      projectFolders: [],
+    }
+    const res = await app.request('/projects/p1/trust', { headers: { ...SA } })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      trustLevel: 'restricted',
+      workingMode: 'managed',
+      linkedFolders: [],
+    })
+  })
+
+  test('200 handles folders with null lastOpenedAt (treats as oldest)', async () => {
+    store.prismaProjectFindUnique = {
+      trustLevel: 'trusted',
+      workingMode: 'external',
+      projectFolders: [
+        { path: '/never-opened', isPrimary: false, lastOpenedAt: null },
+        { path: '/opened', isPrimary: false, lastOpenedAt: new Date('2026-05-01') },
+      ],
+    }
+    const res = await app.request('/projects/p1/trust', { headers: { ...SA } })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { linkedFolders: string[] }
+    expect(body.linkedFolders).toEqual(['/opened', '/never-opened'])
+  })
+
+  test('200 with runtime token in local mode', async () => {
+    process.env.SHOGO_LOCAL_MODE = 'true'
+    store.podIdentity = null
+    store.runtimeVerify = { ok: true, projectId: 'p-local' }
+    store.prismaProjectFindUnique = {
+      trustLevel: 'trusted',
+      workingMode: 'external',
+      projectFolders: [],
+    }
+    const res = await app.request('/projects/p-local/trust', {
+      headers: { 'x-runtime-token': 'rt' },
+    })
+    expect(res.status).toBe(200)
+  })
+
+  test('401 when runtime token belongs to a different project (local mode)', async () => {
+    process.env.SHOGO_LOCAL_MODE = 'true'
+    store.podIdentity = null
+    store.runtimeVerify = { ok: true, projectId: 'someone-else' }
+    const res = await app.request('/projects/mine/trust', {
+      headers: { 'x-runtime-token': 'rt' },
+    })
+    expect(res.status).toBe(401)
+  })
+
+  test('500 when prisma throws', async () => {
+    store.prismaProjectFindUniqueThrow = new Error('db down')
+    const res = await app.request('/projects/p1/trust', { headers: { ...SA } })
     expect(res.status).toBe(500)
   })
 })

--- a/apps/api/src/routes/internal.ts
+++ b/apps/api/src/routes/internal.ts
@@ -491,4 +491,69 @@ app.post('/agent-eval-results', async (c) => {
   }
 })
 
+/**
+ * GET /api/internal/projects/:projectId/trust
+ *
+ * Authoritative read of a project's trust + folder configuration.
+ * Called by the agent-runtime at the start of every chat turn (and on
+ * demand via /internal/refresh-trust IPC) so it never relies on the
+ * spawn-time `TRUST_LEVEL` env snapshot — which can't be updated for
+ * a running process and was the root cause of the
+ * "Trust folder still shows restricted" bug.
+ *
+ * Returns the same shape the runtime's TrustResolver consumes:
+ *   { trustLevel, workingMode, linkedFolders }
+ *
+ * Auth: K8s SA token (cluster) OR `x-runtime-token` (local desktop),
+ * both already used by sibling /internal endpoints.
+ */
+app.get('/projects/:projectId/trust', async (c) => {
+  const projectId = c.req.param('projectId')
+  if (!projectId) return c.json({ error: 'Missing projectId' }, 400)
+
+  if (!(await validateAuth(c, projectId))) {
+    return c.json({ error: 'Unauthorized' }, 401)
+  }
+
+  try {
+    const { prisma } = await import('../lib/prisma')
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+      select: {
+        trustLevel: true,
+        workingMode: true,
+        projectFolders: {
+          select: { path: true, isPrimary: true, lastOpenedAt: true },
+        },
+      },
+    })
+    if (!project) {
+      return c.json({ error: 'Project not found' }, 404)
+    }
+
+    // Same ordering the runtime spawn path uses (manager.ts): primary
+    // folder first, then the rest by most-recently-opened. Keeping the
+    // contract identical means the resolver and the spawn env agree on
+    // "what is the primary workspace dir".
+    const folders = [...project.projectFolders]
+      .sort((a, b) => {
+        if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1
+        const at = a.lastOpenedAt?.getTime() ?? 0
+        const bt = b.lastOpenedAt?.getTime() ?? 0
+        return bt - at
+      })
+      .map((f) => f.path)
+
+    const trustLevel: 'trusted' | 'restricted' =
+      project.trustLevel === 'restricted' ? 'restricted' : 'trusted'
+    const workingMode: 'managed' | 'external' =
+      project.workingMode === 'external' ? 'external' : 'managed'
+
+    return c.json({ trustLevel, workingMode, linkedFolders: folders })
+  } catch (err: any) {
+    console.error(`[Internal] trust read for ${projectId} failed:`, err.message)
+    return c.json({ error: 'Failed to read project trust' }, 500)
+  }
+})
+
 export default app

--- a/apps/api/src/routes/local-projects.ts
+++ b/apps/api/src/routes/local-projects.ts
@@ -85,6 +85,54 @@ function prewarmRuntimeBackground(projectId: string, hint: string): void {
     })
 }
 
+/**
+ * Fire-and-forget: tell the running agent-runtime to re-read `trustLevel`
+ * from Postgres NOW (don't wait for the next chat turn's per-turn refresh).
+ *
+ * Used by `POST /:id/trust` so a user clicking "Trust folder" mid-stream
+ * unblocks the in-flight tool calls instead of staying restricted until
+ * the next message. No-op if the runtime isn't currently running.
+ *
+ * Auth: shared WEBHOOK_TOKEN derived from the project id — same secret
+ * the runtime accepts on `/agent/hooks/*`. The runtime port comes from
+ * `runtimeManager.status(projectId).agentPort`.
+ */
+function pingRuntimeRefreshTrust(projectId: string): void {
+  ;(async () => {
+    try {
+      const { getRuntimeManager } = await import('../lib/runtime/manager')
+      const { deriveWebhookToken } = await import('../lib/runtime-token')
+      const manager = getRuntimeManager()
+      const runtime = manager.status(projectId)
+      const agentPort = (runtime as { agentPort?: number } | null)?.agentPort
+      if (!agentPort) {
+        // Runtime not running (yet). Boot will pick up the new value
+        // via initial refreshTrust(); per-turn refresh handles the
+        // rest. Nothing to ping.
+        return
+      }
+      const token = deriveWebhookToken(projectId)
+      const res = await fetch(`http://127.0.0.1:${agentPort}/internal/refresh-trust`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        signal: AbortSignal.timeout(3_000),
+      })
+      if (!res.ok) {
+        console.warn(
+          `[local-projects] /internal/refresh-trust returned HTTP ${res.status} for ${projectId}`,
+        )
+      }
+    } catch (err: any) {
+      console.warn(
+        `[local-projects] /internal/refresh-trust ping failed for ${projectId}: ${err?.message ?? err}`,
+      )
+    }
+  })()
+}
+
 // =============================================================================
 // Constants
 // =============================================================================
@@ -809,9 +857,16 @@ export function localProjectsRoutes(): Hono {
 
   /**
    * POST /:id/trust { trusted: boolean } — flip the project's
-   * `trustLevel`. The agent-runtime reads this on every chat turn
-   * (via the same /project info path it uses for templateId), so
-   * write/exec tools narrow/widen in-flight.
+   * `trustLevel`. Postgres is the single source of truth; the running
+   * agent-runtime re-resolves this value at the start of every chat
+   * turn AND when we ping its `/internal/refresh-trust` IPC below.
+   * Mid-stream tool calls that follow the ping see the new value too.
+   *
+   * Historical bug (fixed 2026-05): the runtime used to read trust
+   * from a spawn-time `TRUST_LEVEL` env snapshot that was never
+   * refreshed, so clicking "Trust folder" updated Postgres but the
+   * live agent kept reporting `restricted_mode_*`. The resolver +
+   * this ping are the fix from the root.
    */
   router.post('/:id/trust', async (c) => {
     const auth = c.get('auth' as never) as { userId?: string } | undefined
@@ -831,6 +886,7 @@ export function localProjectsRoutes(): Hono {
       data: { trustLevel: body.trusted ? 'trusted' : 'restricted' },
       include: { projectFolders: true },
     })
+    pingRuntimeRefreshTrust(projectId)
     return c.json({ project })
   })
 

--- a/packages/agent-runtime/src/__tests__/helpers/test-trust.ts
+++ b/packages/agent-runtime/src/__tests__/helpers/test-trust.ts
@@ -6,10 +6,11 @@
  *
  * Background: `gateway-tools.ts` gates every `exec`, `write_file`, and
  * `edit_file` call behind `assertAllowedPath()` (introduced with the
- * external-folder + Workspace Trust feature). That helper consults the
- * GLOBAL trust config — `globalThis.__SHOGO_AGENT_RUNTIME_CONFIG__` set
- * at server boot, falling back to the `WORKSPACE_DIR` / `AGENT_DIR` /
- * `PROJECT_DIR` env vars.
+ * external-folder + Workspace Trust feature). After the 2026-05
+ * root-cause fix, `assertAllowedPath()` consults the live
+ * `trust-resolver` cell (seeded at boot and refreshed per chat turn),
+ * falling back to the `WORKSPACE_DIR` / `AGENT_DIR` / `PROJECT_DIR`
+ * env vars in tests that don't boot the resolver.
  *
  * Unit tests typically build a local `ToolContext` with their own tmp
  * `workspaceDir` (e.g. `/tmp/test-gateway-tools`) but never propagate it
@@ -59,29 +60,44 @@ export interface TrustWorkspaceOpts {
 }
 
 /**
- * Mirror `workspaceDir` (and any `linkedFolders`) into the global
- * runtime-trust config so `assertAllowedPath()` accepts paths under
- * those roots. Idempotent — call from `beforeEach` on every test that
- * creates a fresh workspace.
+ * Mirror `workspaceDir` (and any `linkedFolders`) into the live trust
+ * resolver so `assertAllowedPath()` accepts paths under those roots.
+ * Idempotent — call from `beforeEach` on every test that creates a
+ * fresh workspace.
+ *
+ * Also writes the legacy `globalThis.__SHOGO_AGENT_RUNTIME_CONFIG__`
+ * field for any out-of-tree consumer that still reads it; the resolver
+ * is authoritative.
  */
 export function trustWorkspaceForTests(
   workspaceDir: string,
   opts: TrustWorkspaceOpts = {},
 ): void {
-  ;(globalThis as any).__SHOGO_AGENT_RUNTIME_CONFIG__ = {
+  // Lazy import to avoid pulling the resolver into modules that import
+  // this helper but never call its functions.
+  const { __setTrustForTests } = require('../../trust-resolver') as typeof import('../../trust-resolver')
+  __setTrustForTests({
     workingMode: opts.workingMode ?? 'managed',
     trustLevel: opts.trustLevel ?? 'trusted',
+    workspaceDir,
+    linkedFolders: opts.linkedFolders ?? [],
+    initialized: true,
+  })
+  ;(globalThis as any).__SHOGO_AGENT_RUNTIME_CONFIG__ = {
+    workingMode: opts.workingMode ?? 'managed',
     workspaceDir,
     linkedFolders: opts.linkedFolders ?? [],
   }
 }
 
 /**
- * Reset both the global config and every env var the env-fallback
- * consults. Call from `afterAll` (and `afterEach` for tests that
- * mutate the workspace mid-suite).
+ * Reset the resolver, the legacy global, AND every env var the
+ * env-fallback consults. Call from `afterAll` (and `afterEach` for
+ * tests that mutate the workspace mid-suite).
  */
 export function clearTrustForTests(): void {
+  const { __resetTrustForTests } = require('../../trust-resolver') as typeof import('../../trust-resolver')
+  __resetTrustForTests()
   delete (globalThis as any).__SHOGO_AGENT_RUNTIME_CONFIG__
   delete process.env.WORKSPACE_DIR
   delete process.env.AGENT_DIR

--- a/packages/agent-runtime/src/__tests__/runtime-trust.test.ts
+++ b/packages/agent-runtime/src/__tests__/runtime-trust.test.ts
@@ -24,10 +24,14 @@ import { tmpdir } from 'os'
 import { join, sep } from 'path'
 
 import { _runtimeTrustSeamForTests, assertAllowedPath, getAllowedRoots, getRuntimeTrust } from '../runtime-trust'
+import { __resetTrustForTests, __setTrustForTests } from '../trust-resolver'
 
-// helper: clear both env + global state between cases so each test runs
-// in a known-good context (server.ts isn't booted in unit tests).
+// helper: clear env, resolver, AND the legacy global between cases so
+// each test runs in a known-good context (server.ts isn't booted in
+// unit tests, so `getRuntimeTrust()` should fall through to the env
+// branch unless a test explicitly seeds the resolver).
 function clearTrustState(): void {
+  __resetTrustForTests()
   delete (globalThis as any).__SHOGO_AGENT_RUNTIME_CONFIG__
   delete process.env.WORKSPACE_DIR
   delete process.env.AGENT_DIR
@@ -64,12 +68,13 @@ describe('runtime-trust', () => {
     trustLevel?: 'trusted' | 'restricted'
     linkedFolders?: string[]
   }): void {
-    ;(globalThis as any).__SHOGO_AGENT_RUNTIME_CONFIG__ = {
+    __setTrustForTests({
       workingMode: opts.workingMode ?? 'external',
       trustLevel: opts.trustLevel ?? 'restricted',
       workspaceDir,
       linkedFolders: opts.linkedFolders ?? [],
-    }
+      initialized: true,
+    })
   }
 
   test('env fallback: external + no TRUST_LEVEL defaults to restricted', () => {
@@ -92,6 +97,60 @@ describe('runtime-trust', () => {
     process.env.WORKING_MODE = 'external'
     process.env.LINKED_FOLDERS = JSON.stringify([linkedDir])
     const t = getRuntimeTrust()
+    expect(t.linkedFolders).toEqual([linkedDir])
+  })
+
+  test('env fallback: malformed LINKED_FOLDERS JSON does not throw, falls to empty', () => {
+    process.env.WORKSPACE_DIR = workspaceDir
+    process.env.WORKING_MODE = 'external'
+    process.env.LINKED_FOLDERS = '{ this is not json'
+    const t = getRuntimeTrust()
+    expect(t.linkedFolders).toEqual([])
+  })
+
+  test('env fallback: explicit TRUST_LEVEL=trusted overrides external default', () => {
+    // This is the test-only env path — production no longer reads
+    // TRUST_LEVEL from env, but unit tests pin trust via env when they
+    // don't want to seed the resolver.
+    process.env.WORKSPACE_DIR = workspaceDir
+    process.env.WORKING_MODE = 'external'
+    process.env.TRUST_LEVEL = 'trusted'
+    expect(getRuntimeTrust().trustLevel).toBe('trusted')
+  })
+
+  test('resolver seeded but uninitialized: returns resolver values (fail-closed for external)', () => {
+    // Mirrors the production cold-start moment between
+    // initTrustResolver() and the first refreshTrust() landing.
+    // The resolver seam exposes a fail-closed default; getRuntimeTrust
+    // must surface it instead of falling through to env.
+    __setTrustForTests({
+      workingMode: 'external',
+      trustLevel: 'restricted', // fail-closed pre-refresh
+      workspaceDir,
+      linkedFolders: [],
+      initialized: false,
+    })
+    const t = getRuntimeTrust()
+    expect(t.workspaceDir).toBe(workspaceDir)
+    expect(t.trustLevel).toBe('restricted')
+  })
+
+  test('resolver initialized=true is authoritative over env vars', () => {
+    // Even if a test sets a conflicting env, the resolver wins once
+    // initialized — this is the production guarantee that env can't
+    // override a live refresh result.
+    process.env.WORKSPACE_DIR = '/different/from/resolver'
+    process.env.TRUST_LEVEL = 'restricted'
+    __setTrustForTests({
+      workingMode: 'external',
+      trustLevel: 'trusted',
+      workspaceDir,
+      linkedFolders: [linkedDir],
+      initialized: true,
+    })
+    const t = getRuntimeTrust()
+    expect(t.workspaceDir).toBe(workspaceDir)
+    expect(t.trustLevel).toBe('trusted')
     expect(t.linkedFolders).toEqual([linkedDir])
   })
 
@@ -199,12 +258,13 @@ describe('runtime-trust', () => {
   })
 
   test('no allowed roots configured: REJECTED', () => {
-    ;(globalThis as any).__SHOGO_AGENT_RUNTIME_CONFIG__ = {
+    __setTrustForTests({
       workingMode: 'external',
       trustLevel: 'restricted',
       workspaceDir: '',
       linkedFolders: [],
-    }
+      initialized: true,
+    })
     const r = assertAllowedPath(join(workspaceDir, 'inside.txt'), 'read')
     expect(r.ok).toBe(false)
     expect(r.reason).toBe('outside_allowed_roots')
@@ -222,12 +282,13 @@ describe('runtime-trust', () => {
       // real realpathSync for roots; we need to set the root to the same
       // candidate prefix so it still matches).
       const ghostRoot = '/nonexistent/ghost2'
-      ;(globalThis as any).__SHOGO_AGENT_RUNTIME_CONFIG__ = {
+      __setTrustForTests({
         workingMode: 'managed',
         trustLevel: 'trusted',
         workspaceDir: ghostRoot,
         linkedFolders: [],
-      }
+        initialized: true,
+      })
       const r = assertAllowedPath(ghostRoot + '/file.txt', 'read')
       // real falls back to candidate (ghostRoot/file.txt); root also fell
       // back via its own catch to resolve(ghostRoot). Both agree, so ok=true.
@@ -244,12 +305,13 @@ describe('runtime-trust', () => {
     // Set a non-existent linked folder as the only root and assert the check
     // still succeeds for a path under it (it will match via the resolved form).
     const ghostRoot = '/nonexistent/ghost/root'
-    ;(globalThis as any).__SHOGO_AGENT_RUNTIME_CONFIG__ = {
+    __setTrustForTests({
       workingMode: 'external',
       trustLevel: 'trusted',
       workspaceDir: ghostRoot,
       linkedFolders: [],
-    }
+      initialized: true,
+    })
     // The target path also doesn't exist, so we exercise BOTH catch branches
     // (line 149 for the root + line 177 for the ancestor walk).
     const target = ghostRoot + '/subdir/newfile.txt'

--- a/packages/agent-runtime/src/__tests__/trust-resolver.test.ts
+++ b/packages/agent-runtime/src/__tests__/trust-resolver.test.ts
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Unit tests for the live trust resolver — the module that replaced
+ * the broken spawn-time `TRUST_LEVEL` env snapshot.
+ *
+ * Coverage targets the contract the rest of the runtime depends on:
+ *   - init seeds the immutable triplet (workspaceDir / workingMode /
+ *     linkedFolders) AND picks a fail-closed initial trust for
+ *     external projects (the security default)
+ *   - refresh() fetches the authoritative trust from the API and
+ *     overwrites the cell
+ *   - concurrent refresh() calls share a single in-flight fetch
+ *   - HTTP failures keep the last-known value (no flapping into
+ *     'restricted' on a transient blip)
+ *   - resolver with no projectId is a safe no-op (test / one-shot
+ *     script path)
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import {
+  __resetTrustForTests,
+  __setTrustForTests,
+  getResolvedTrust,
+  initTrustResolver,
+  isTrustResolverInitialized,
+  refreshTrust,
+} from '../trust-resolver'
+
+type FetchFn = typeof fetch
+const originalFetch = globalThis.fetch
+
+function installFetchMock(impl: (url: string) => Promise<Response>): void {
+  // Cast through unknown so we don't have to fully reimplement the
+  // `typeof fetch` interface (preconnect, etc.) — none of the tests
+  // touch those properties.
+  globalThis.fetch = ((input: any) =>
+    impl(typeof input === 'string' ? input : String(input))) as unknown as FetchFn
+}
+
+function jsonRes(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('trust-resolver', () => {
+  beforeEach(() => {
+    __resetTrustForTests()
+    process.env.SHOGO_API_URL = 'http://api.test'
+    process.env.RUNTIME_AUTH_SECRET = 'test-token'
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    __resetTrustForTests()
+    delete process.env.SHOGO_API_URL
+    delete process.env.RUNTIME_AUTH_SECRET
+  })
+
+  test('init seeds immutable triplet and fail-closed trust for external', () => {
+    initTrustResolver({
+      projectId: 'p1',
+      workspaceDir: '/work/p1',
+      workingMode: 'external',
+      linkedFolders: ['/work/p1', '/extra/lib'],
+    })
+    const t = getResolvedTrust()
+    expect(t.workingMode).toBe('external')
+    expect(t.workspaceDir).toBe('/work/p1')
+    expect(t.linkedFolders).toEqual(['/work/p1', '/extra/lib'])
+    expect(t.trustLevel).toBe('restricted') // fail-closed default
+    expect(isTrustResolverInitialized()).toBe(false) // no refresh yet
+  })
+
+  test('init seeds fail-open trust for managed', () => {
+    initTrustResolver({
+      projectId: 'p1',
+      workspaceDir: '/sandbox/p1',
+      workingMode: 'managed',
+      linkedFolders: [],
+    })
+    expect(getResolvedTrust().trustLevel).toBe('trusted')
+  })
+
+  test('refresh() pulls authoritative trust from API and flips the cell', async () => {
+    initTrustResolver({
+      projectId: 'p-ext',
+      workspaceDir: '/work/p-ext',
+      workingMode: 'external',
+      linkedFolders: ['/work/p-ext'],
+    })
+    expect(getResolvedTrust().trustLevel).toBe('restricted')
+
+    let calls = 0
+    installFetchMock(async (url) => {
+      calls++
+      expect(url).toBe('http://api.test/api/internal/projects/p-ext/trust')
+      return jsonRes({
+        trustLevel: 'trusted',
+        workingMode: 'external',
+        linkedFolders: ['/work/p-ext', '/added/by/user'],
+      })
+    })
+
+    await refreshTrust()
+
+    const t = getResolvedTrust()
+    expect(t.trustLevel).toBe('trusted')
+    expect(t.linkedFolders).toEqual(['/work/p-ext', '/added/by/user'])
+    expect(isTrustResolverInitialized()).toBe(true)
+    expect(calls).toBe(1)
+  })
+
+  test('concurrent refresh() calls dedupe into one HTTP fetch', async () => {
+    initTrustResolver({
+      projectId: 'p2',
+      workspaceDir: '/work/p2',
+      workingMode: 'external',
+      linkedFolders: [],
+    })
+
+    let calls = 0
+    installFetchMock(async () => {
+      calls++
+      await new Promise((r) => setTimeout(r, 10))
+      return jsonRes({ trustLevel: 'trusted', workingMode: 'external', linkedFolders: [] })
+    })
+
+    await Promise.all([refreshTrust(), refreshTrust(), refreshTrust()])
+    expect(calls).toBe(1)
+  })
+
+  test('refresh() failure keeps last-known value (no flap)', async () => {
+    initTrustResolver({
+      projectId: 'p3',
+      workspaceDir: '/work/p3',
+      workingMode: 'external',
+      linkedFolders: [],
+    })
+    // Pin the cell to trusted as the "last known" value.
+    __setTrustForTests({ trustLevel: 'trusted', initialized: true })
+
+    installFetchMock(async () => jsonRes({ error: 'boom' }, 500))
+
+    await refreshTrust()
+
+    // HTTP 500 → resolver logs and keeps the previous value.
+    expect(getResolvedTrust().trustLevel).toBe('trusted')
+  })
+
+  test('refresh() with no projectId is a safe no-op', async () => {
+    initTrustResolver({
+      projectId: null,
+      workspaceDir: '/work/anon',
+      workingMode: 'managed',
+      linkedFolders: [],
+    })
+
+    let calls = 0
+    installFetchMock(async () => {
+      calls++
+      return jsonRes({})
+    })
+
+    await refreshTrust()
+    expect(calls).toBe(0)
+    // Cell stays at the init-time fail-open default.
+    expect(getResolvedTrust().trustLevel).toBe('trusted')
+  })
+
+  test('refresh() swallows network errors and keeps last-known value', async () => {
+    initTrustResolver({
+      projectId: 'p-net',
+      workspaceDir: '/work/p-net',
+      workingMode: 'external',
+      linkedFolders: [],
+    })
+    __setTrustForTests({ trustLevel: 'trusted', initialized: true })
+
+    installFetchMock(async () => {
+      throw new Error('ECONNREFUSED')
+    })
+
+    // Must not reject — a transient network blip can't break the
+    // chat turn. The resolver should log and move on.
+    await expect(refreshTrust()).resolves.toBeUndefined()
+    expect(getResolvedTrust().trustLevel).toBe('trusted')
+  })
+
+  test('refresh() URL-encodes the projectId (defense against malformed ids)', async () => {
+    initTrustResolver({
+      projectId: 'p/with spaces & slashes',
+      workspaceDir: '/work/weird',
+      workingMode: 'external',
+      linkedFolders: [],
+    })
+
+    const observed: { url: string | null } = { url: null }
+    installFetchMock(async (url) => {
+      observed.url = url
+      return jsonRes({ trustLevel: 'trusted', workingMode: 'external', linkedFolders: [] })
+    })
+
+    await refreshTrust()
+    expect(observed.url).toBe(
+      'http://api.test/api/internal/projects/p%2Fwith%20spaces%20%26%20slashes/trust',
+    )
+  })
+
+  test('init reset between two different projects clears initialized flag', async () => {
+    initTrustResolver({
+      projectId: 'first',
+      workspaceDir: '/a',
+      workingMode: 'managed',
+      linkedFolders: [],
+    })
+    installFetchMock(async () =>
+      jsonRes({ trustLevel: 'trusted', workingMode: 'managed', linkedFolders: [] }),
+    )
+    await refreshTrust()
+    expect(isTrustResolverInitialized()).toBe(true)
+
+    // Re-init with a different project — initialized flag must reset
+    // so callers can tell the new project hasn't been resolved yet.
+    initTrustResolver({
+      projectId: 'second',
+      workspaceDir: '/b',
+      workingMode: 'external',
+      linkedFolders: [],
+    })
+    expect(isTrustResolverInitialized()).toBe(false)
+    expect(getResolvedTrust().workspaceDir).toBe('/b')
+    expect(getResolvedTrust().trustLevel).toBe('restricted') // fail-closed for external
+  })
+
+  test('__setTrustForTests applies partial updates without wiping other fields', () => {
+    initTrustResolver({
+      projectId: 'p-partial',
+      workspaceDir: '/work/partial',
+      workingMode: 'external',
+      linkedFolders: ['/work/partial', '/work/extra'],
+    })
+
+    __setTrustForTests({ trustLevel: 'trusted' })
+    const t = getResolvedTrust()
+    expect(t.trustLevel).toBe('trusted')
+    expect(t.workspaceDir).toBe('/work/partial') // untouched
+    expect(t.linkedFolders).toEqual(['/work/partial', '/work/extra']) // untouched
+    expect(t.workingMode).toBe('external') // untouched
+  })
+
+  test('getResolvedTrust returns a defensive copy of linkedFolders', () => {
+    initTrustResolver({
+      projectId: 'p-defensive',
+      workspaceDir: '/x',
+      workingMode: 'external',
+      linkedFolders: ['/x', '/y'],
+    })
+    const first = getResolvedTrust()
+    first.linkedFolders.push('/z')
+    // Mutating the returned array must not leak back into the cell.
+    expect(getResolvedTrust().linkedFolders).toEqual(['/x', '/y'])
+  })
+
+  test('refresh() in-flight is discarded if projectId changes mid-fetch', async () => {
+    // Defends against initTrustResolver() running for a new project
+    // while a refresh from the previous project is still in flight.
+    // Without the race guard, the in-flight response would write the
+    // old project's trust into the new project's slot.
+    initTrustResolver({
+      projectId: 'old',
+      workspaceDir: '/old',
+      workingMode: 'external',
+      linkedFolders: [],
+    })
+
+    let resolveFetch: (r: Response) => void = () => {}
+    installFetchMock(
+      () =>
+        new Promise<Response>((r) => {
+          resolveFetch = r
+        }),
+    )
+
+    const inFlight = refreshTrust()
+
+    // While the fetch is still pending, switch to a new project.
+    initTrustResolver({
+      projectId: 'new',
+      workspaceDir: '/new',
+      workingMode: 'managed',
+      linkedFolders: [],
+    })
+
+    // Now resolve the old fetch with a value that, if mis-applied,
+    // would corrupt the new project's slot.
+    resolveFetch(
+      jsonRes({ trustLevel: 'restricted', workingMode: 'external', linkedFolders: ['/old'] }),
+    )
+    await inFlight
+
+    const t = getResolvedTrust()
+    expect(t.workspaceDir).toBe('/new')
+    expect(t.trustLevel).toBe('trusted') // new project's init default, untouched
+    expect(t.linkedFolders).toEqual([]) // not corrupted by old project's response
+    expect(isTrustResolverInitialized()).toBe(false) // race-discarded fetch must not flip the flag
+  })
+
+  test('refresh() ignores malformed body fields (keeps structural defaults)', async () => {
+    initTrustResolver({
+      projectId: 'p4',
+      workspaceDir: '/work/p4',
+      workingMode: 'external',
+      linkedFolders: ['/work/p4'],
+    })
+
+    installFetchMock(async () =>
+      jsonRes({
+        // wrong types — resolver must normalize / fall back
+        trustLevel: 42,
+        workingMode: null,
+        linkedFolders: 'not an array',
+      }),
+    )
+
+    await refreshTrust()
+
+    const t = getResolvedTrust()
+    // wrong trust => not 'restricted' literal so resolver maps to 'trusted'
+    // (the explicit "trusted unless explicitly restricted" rule).
+    expect(t.trustLevel).toBe('trusted')
+    // wrong workingMode => not 'external' literal so resolver maps to 'managed'.
+    expect(t.workingMode).toBe('managed')
+    // non-array linkedFolders => keep the previous value rather than wipe it.
+    expect(t.linkedFolders).toEqual(['/work/p4'])
+  })
+})

--- a/packages/agent-runtime/src/gateway.ts
+++ b/packages/agent-runtime/src/gateway.ts
@@ -70,6 +70,8 @@ import { MCPClientManager, type MCPServerConfig, type RemoteMCPServerConfig } fr
 import { WorkspaceLSPManager, resolveBin } from '@shogo/shared-runtime'
 import { initComposioSession, resetComposioSession, isComposioEnabled, isComposioInitialized } from './composio'
 import { deriveApiUrl, getInternalHeaders, postCostMetric } from './internal-api'
+import { getRuntimeTrust } from './runtime-trust'
+import { refreshTrust } from './trust-resolver'
 import type { FilePart } from './file-attachment-utils'
 import { parseFileAttachments } from './file-attachment-utils'
 import {
@@ -1466,6 +1468,14 @@ export class AgentGateway {
       this.skillServerManager.start().catch(() => {})
     }
 
+    // Per-turn trust refresh. Reconciles the runtime's view of
+    // `trustLevel` with the DB at the boundary of every chat turn so
+    // a user clicking "Trust folder" between messages is reflected in
+    // both the system prompt and `assertAllowedPath()` checks of the
+    // tool calls that follow. Best-effort: on transient failure the
+    // resolver keeps its last-known value rather than flapping.
+    await refreshTrust()
+
     let systemPrompt = this.loadBootstrapContext(sessionId)
 
     console.log(`[Gateway][_agentTurnInner] building system prompt — interactionMode: ${interactionMode}, sessionId: ${sessionId}`)
@@ -2717,22 +2727,16 @@ export class AgentGateway {
     // 0. External (VS Code-style) project context. When the user has
     // opened folders from their machine (workingMode='external'), tell
     // the agent which roots are in scope and whether the workspace is
-    // trusted. This sits in the stable zone because trust + folder set
-    // only flip via explicit user action (POST /trust, POST /primary),
-    // which already causes a session refresh. Keeps the agent from
-    // hallucinating absolute paths outside the allowed roots.
-    if (process.env.WORKING_MODE === 'external') {
-      const linkedFolders: string[] = (() => {
-        try {
-          const raw = process.env.LINKED_FOLDERS
-          if (!raw) return []
-          const parsed = JSON.parse(raw)
-          return Array.isArray(parsed) ? parsed.filter((p) => typeof p === 'string') : []
-        } catch {
-          return []
-        }
-      })()
-      const trustLevel = process.env.TRUST_LEVEL === 'restricted' ? 'restricted' : 'trusted'
+    // trusted. Reads from the live trust-resolver (refreshed once per
+    // turn in `_agentTurnInner` just before this runs) — NOT from the
+    // legacy TRUST_LEVEL env var, which was a spawn-time snapshot that
+    // never reflected user trust toggles. The folder set is genuinely
+    // immutable for a runtime instance, so we still take it from the
+    // same resolver snapshot.
+    const runtimeTrust = getRuntimeTrust()
+    if (runtimeTrust.workingMode === 'external') {
+      const linkedFolders = runtimeTrust.linkedFolders
+      const trustLevel = runtimeTrust.trustLevel
       const lines = [
         '## Project Mode: External (VS Code-style)',
         '',

--- a/packages/agent-runtime/src/runtime-trust.ts
+++ b/packages/agent-runtime/src/runtime-trust.ts
@@ -12,13 +12,19 @@
  *                                   WORKSPACE_DIR (TODO: future).
  *   - index-engine                → scope embeddings to allowed roots.
  *
- * Design notes:
- *   - We do NOT re-import from server.ts because that file's
- *     side-effecting imports (Hono app, tracing, OTEL) would create a
- *     cycle. server.ts publishes the resolved config onto `globalThis`
- *     so any consumer in the same process gets the same view.
- *   - In tests that don't boot the full server, `getRuntimeTrust()`
- *     falls back to env-only resolution so unit tests stay hermetic.
+ * Architecture (post-2026-05 root-cause fix):
+ *   - `trustLevel` is a **live** value resolved from the API by
+ *     `trust-resolver.ts`. The runtime stopped trusting the
+ *     spawn-time `TRUST_LEVEL` env var because env vars are immutable
+ *     for a running Node process — that's why clicking "Trust folder"
+ *     used to leave the agent stuck on `restricted`.
+ *   - The directory layout (`workspaceDir`, `workingMode`,
+ *     `linkedFolders`) is genuinely immutable for a runtime instance
+ *     (changing primary folder / linked folders requires a restart),
+ *     so server.ts seeds those once via `initTrustResolver(...)` and
+ *     the resolver holds them for the lifetime of the process.
+ *   - In unit tests that don't boot server.ts, `getRuntimeTrust()`
+ *     falls back to env-only resolution so tests stay hermetic.
  *   - Path checks use `realpathSync` to defeat symlink escapes:
  *     `/Users/jane/repo/secret` symlinked to `/etc/passwd` would
  *     otherwise read as if it were under the allowed root.
@@ -27,8 +33,14 @@
 import { existsSync, realpathSync } from 'fs'
 import { resolve, sep } from 'path'
 
-export type WorkingMode = 'managed' | 'external'
-export type TrustLevel = 'trusted' | 'restricted'
+import {
+  getResolvedTrust,
+  isTrustResolverInitialized,
+  type TrustLevel,
+  type WorkingMode,
+} from './trust-resolver'
+
+export type { WorkingMode, TrustLevel } from './trust-resolver'
 
 export interface RuntimeTrust {
   workingMode: WorkingMode
@@ -40,35 +52,40 @@ export interface RuntimeTrust {
 }
 
 /**
- * Resolve the runtime's current trust + allowed-roots policy. Prefers
- * the live config published by server.ts; falls back to env on a fresh
- * process (used in tests / one-off scripts).
+ * Resolve the runtime's current trust + allowed-roots policy.
+ *
+ * Production path: reads from `trust-resolver` which holds the most
+ * recent value the runtime fetched from the API (refreshed at boot,
+ * at the start of every chat turn, and on demand via
+ * /internal/refresh-trust).
+ *
+ * Test / one-shot path: when the resolver hasn't been initialized
+ * (no server.ts boot), falls back to env vars so unit tests stay
+ * hermetic.
  */
 export function getRuntimeTrust(): RuntimeTrust {
-  const fromGlobal = (globalThis as any).__SHOGO_AGENT_RUNTIME_CONFIG__ as
-    | Partial<RuntimeTrust>
-    | undefined
-  if (
-    fromGlobal &&
-    typeof fromGlobal.workspaceDir === 'string' &&
-    Array.isArray(fromGlobal.linkedFolders)
-  ) {
-    return {
-      workingMode: fromGlobal.workingMode === 'external' ? 'external' : 'managed',
-      trustLevel: fromGlobal.trustLevel === 'restricted' ? 'restricted' : 'trusted',
-      workspaceDir: fromGlobal.workspaceDir,
-      linkedFolders: fromGlobal.linkedFolders.filter(
-        (p): p is string => typeof p === 'string' && p.length > 0,
-      ),
-    }
+  if (isTrustResolverInitialized()) {
+    return getResolvedTrust()
   }
-  // Env-only fallback (tests, one-shot scripts).
+  const resolved = getResolvedTrust()
+  if (resolved.workspaceDir) {
+    // Resolver was seeded by initTrustResolver() but the first
+    // refresh() hasn't landed yet (or is failing). Trust whatever
+    // safe default the resolver picked at init time — fail-closed
+    // for external, fail-open for managed.
+    return resolved
+  }
+
+  // Env-only fallback (tests, one-shot scripts, evals).
   const workspaceDir =
     process.env.WORKSPACE_DIR ||
     process.env.AGENT_DIR ||
     process.env.PROJECT_DIR ||
     '/app/workspace'
   const workingMode: WorkingMode = process.env.WORKING_MODE === 'external' ? 'external' : 'managed'
+  // NB: TRUST_LEVEL env is no longer authoritative in production
+  // (that was the bug). We still honor it in the env-only fallback so
+  // unit tests can pin a trust level without booting the resolver.
   const trustLevel: TrustLevel =
     process.env.TRUST_LEVEL === 'restricted'
       ? 'restricted'

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -67,6 +67,7 @@ import { SkillServerManager } from './skill-server-manager'
 import { runtimeTerminalRoutes } from './runtime-terminal-routes'
 import { createPtyWsHandlers, type WsData } from './pty-ws-handler'
 import { deriveApiUrl, getInternalHeaders } from './internal-api'
+import { initTrustResolver, refreshTrust } from './trust-resolver'
 import { userMessage } from './pi-adapter'
 import { fileURLToPath } from 'url'
 import { WebChatAdapter } from './channels/webchat'
@@ -98,7 +99,7 @@ const PORT = parseInt(process.env.PORT || '8080', 10)
  * External (VS Code-style) project mode. When set to `'external'`, the
  * agent-runtime treats `WORKSPACE_DIR` as the user's primary linked
  * folder, skips template seeding / auto-install, and obeys the trust
- * level encoded in `TRUST_LEVEL`.
+ * level resolved live from the API by `trust-resolver.ts`.
  *
  * `LINKED_FOLDERS` is a JSON-encoded `string[]` of every host folder
  * the user has explicitly opened on this project — the union of these
@@ -109,25 +110,9 @@ const WORKING_MODE: 'managed' | 'external' =
   process.env.WORKING_MODE === 'external' ? 'external' : 'managed'
 
 /**
- * VS Code-style Workspace Trust gate. `restricted` blocks all write
- * and exec tools until the user explicitly trusts the folder via
- * POST /api/local/projects/:id/trust. Defaults to `restricted` for
- * external projects (defense in depth — the API mutation also sets it)
- * and `trusted` for managed projects (they live in our sandbox).
- */
-const TRUST_LEVEL: 'trusted' | 'restricted' =
-  process.env.TRUST_LEVEL === 'restricted'
-    ? 'restricted'
-    : process.env.TRUST_LEVEL === 'trusted'
-      ? 'trusted'
-      : WORKING_MODE === 'external'
-        ? 'restricted'
-        : 'trusted'
-
-/**
  * The list of host folders the agent is allowed to read/write inside,
- * in addition to `WORKSPACE_DIR`. Parsed once at boot; gateway-tools
- * imports this via `getAllowedRoots()` from agent-runtime-config.ts.
+ * in addition to `WORKSPACE_DIR`. Parsed once at boot — folder set is
+ * immutable for a runtime instance (changing it requires a restart).
  */
 const LINKED_FOLDERS: string[] = (() => {
   const raw = process.env.LINKED_FOLDERS
@@ -142,10 +127,34 @@ const LINKED_FOLDERS: string[] = (() => {
   }
 })()
 
-// Export for sibling modules (gateway-tools, watchers, indexer).
+// Seed the live trust resolver with the immutable directory layout
+// (workspaceDir, workingMode, linkedFolders). The initial trustLevel
+// defaults to fail-closed for external projects; it will be reconciled
+// with the DB by `refreshTrust()` below (fire-and-forget at boot,
+// awaited at the start of every chat turn, refetched on demand via
+// POST /internal/refresh-trust). See trust-resolver.ts for the
+// architectural rationale — this replaces the old `TRUST_LEVEL` env
+// snapshot that couldn't be updated for a running process and was the
+// root cause of the "Trust folder still restricted" bug.
+initTrustResolver({
+  projectId: process.env.PROJECT_ID ?? null,
+  workspaceDir: WORKSPACE_DIR,
+  workingMode: WORKING_MODE,
+  linkedFolders: LINKED_FOLDERS,
+})
+refreshTrust().catch(() => {
+  // Best-effort at boot; per-turn refresh in gateway.ts is the
+  // authoritative gate, so a boot-time miss self-heals on the first
+  // user message.
+})
+
+// Legacy global, kept for any out-of-tree consumer that may still read
+// it. The directory triplet is authoritative here; trustLevel is NOT
+// — that comes from the resolver. Removing the field entirely would
+// be a soft-breaking change; instead we publish the immutable bits and
+// stop advertising a stale trustLevel.
 ;(globalThis as any).__SHOGO_AGENT_RUNTIME_CONFIG__ = {
   workingMode: WORKING_MODE,
-  trustLevel: TRUST_LEVEL,
   linkedFolders: LINKED_FOLDERS,
   workspaceDir: WORKSPACE_DIR,
 }
@@ -174,7 +183,7 @@ function checkWorkspaceDirSanity(): void {
   if (WORKING_MODE === 'external') {
     console.log(
       `[agent-runtime] External (folder-linked) project: WORKSPACE_DIR='${WORKSPACE_DIR}' ` +
-        `(trustLevel=${TRUST_LEVEL}, linkedFolders=${LINKED_FOLDERS.length})`,
+        `(trust resolved from API; linkedFolders=${LINKED_FOLDERS.length})`,
     )
     return
   }
@@ -2127,6 +2136,27 @@ function verifyWebhookAuth(c: any): boolean {
   const token = c.req.header('x-webhook-token') || ''
   return auth === `Bearer ${WEBHOOK_TOKEN}` || token === WEBHOOK_TOKEN
 }
+
+/**
+ * POST /internal/refresh-trust
+ *
+ * Fired by the API after writing a new `trustLevel` to Postgres (see
+ * `apps/api/src/routes/local-projects.ts` POST /:id/trust). Tells the
+ * runtime "go re-read trust from the DB now" instead of waiting for
+ * the next chat turn's per-turn refresh. Without this, a user who
+ * clicks "Trust folder" mid-stream would still hit `restricted_mode_*`
+ * on the in-flight tool calls.
+ *
+ * Auth: shared WEBHOOK_TOKEN — the same secret the API ↔ runtime
+ * webhook channel already uses (`/agent/hooks/*`).
+ */
+app.post('/internal/refresh-trust', async (c) => {
+  if (!verifyWebhookAuth(c)) {
+    return c.json({ error: 'Unauthorized' }, 401)
+  }
+  await refreshTrust()
+  return c.json({ ok: true })
+})
 
 app.post('/agent/hooks/wake', async (c) => {
   if (!verifyWebhookAuth(c)) {

--- a/packages/agent-runtime/src/trust-resolver.ts
+++ b/packages/agent-runtime/src/trust-resolver.ts
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Live trust resolver for the agent-runtime.
+ *
+ * ## Why this exists
+ *
+ * Before this module, trust was a **snapshot** taken at process spawn:
+ *
+ *   manager.ts → runtimeEnv.TRUST_LEVEL = project.trustLevel
+ *   server.ts  → globalThis.__SHOGO_AGENT_RUNTIME_CONFIG__ = { trustLevel, ... }
+ *
+ * `assertAllowedPath()` then read that global on every tool call. The
+ * snapshot was never refreshed, because env vars are immutable for a
+ * running Node process and nothing else updated the global. So when
+ * the user clicked "Trust folder" the API wrote `trustLevel='trusted'`
+ * into Postgres but the **running** agent-runtime kept reporting
+ * `restricted_mode_write` forever. That was the bug.
+ *
+ * ## What this fixes
+ *
+ * Trust is now **resolved**, not **cached at spawn**. The DB
+ * (Postgres, owned by the API) is the single source of truth. The
+ * runtime asks the API for the current value via the existing
+ * `x-runtime-token`-authenticated internal channel — once at boot,
+ * once at the start of every chat turn, and on demand via a small
+ * IPC route (`POST /internal/refresh-trust`) that the API's trust
+ * endpoint fires after writing the new value.
+ *
+ * ## Why a sync cache instead of "fetch on every check"
+ *
+ * `assertAllowedPath()` is called from many synchronous code paths
+ * inside the tool layer. Making it async would ripple through ~dozens
+ * of call sites in `gateway-tools.ts`. Instead we keep a small mutable
+ * cell, refresh it at well-defined turn boundaries, and read from it
+ * synchronously. This is the same pattern VS Code uses for workspace
+ * trust — the value can change, but only between user actions.
+ *
+ * Cold-start default (before the first `refresh()` returns) is
+ * **fail-closed**: `restricted` for external projects, `trusted` for
+ * managed (which always live inside our sandbox).
+ */
+
+import { deriveApiUrl, getInternalHeaders } from './internal-api'
+
+export type WorkingMode = 'managed' | 'external'
+export type TrustLevel = 'trusted' | 'restricted'
+
+export interface ResolvedTrust {
+  trustLevel: TrustLevel
+  workingMode: WorkingMode
+  workspaceDir: string
+  linkedFolders: string[]
+}
+
+interface ResolverState extends ResolvedTrust {
+  /** Has at least one successful refresh() landed? */
+  initialized: boolean
+  /** Project id used for the /internal/projects/:id/trust read. */
+  projectId: string | null
+  /**
+   * Wall-clock ms of the last successful refresh. Exposed for
+   * diagnostics / future TTL eviction; not used as a staleness gate
+   * today (per-turn refresh is the gate). */
+  lastRefreshAt: number | null
+  /** In-flight refresh promise, deduplicated so concurrent callers share one fetch. */
+  inFlight: Promise<void> | null
+}
+
+function defaultTrustFor(workingMode: WorkingMode): TrustLevel {
+  // Fail closed for external projects (the user has to opt in by
+  // clicking Trust folder); fail open for managed projects (they live
+  // in our sandbox so write/exec are always safe).
+  return workingMode === 'external' ? 'restricted' : 'trusted'
+}
+
+const state: ResolverState = {
+  trustLevel: 'restricted',
+  workingMode: 'external',
+  workspaceDir: '',
+  linkedFolders: [],
+  initialized: false,
+  projectId: null,
+  lastRefreshAt: null,
+  inFlight: null,
+}
+
+export interface InitArgs {
+  projectId: string | null
+  workspaceDir: string
+  workingMode: WorkingMode
+  linkedFolders: string[]
+}
+
+/**
+ * Seed the resolver with the immutable directory layout (workspaceDir,
+ * workingMode, linkedFolders) and a safe initial trust level. Trust is
+ * then asynchronously reconciled with the DB via `refresh()`.
+ *
+ * Idempotent — calling it twice with the same args is a no-op apart
+ * from resetting `initialized` if you pass a different projectId.
+ */
+export function initTrustResolver(args: InitArgs): void {
+  state.projectId = args.projectId
+  state.workspaceDir = args.workspaceDir
+  state.workingMode = args.workingMode
+  state.linkedFolders = args.linkedFolders.slice()
+  state.trustLevel = defaultTrustFor(args.workingMode)
+  state.initialized = false
+  state.lastRefreshAt = null
+  state.inFlight = null
+}
+
+/** Sync read of the most recent resolved trust + folder configuration. */
+export function getResolvedTrust(): ResolvedTrust {
+  return {
+    trustLevel: state.trustLevel,
+    workingMode: state.workingMode,
+    workspaceDir: state.workspaceDir,
+    linkedFolders: state.linkedFolders.slice(),
+  }
+}
+
+/** Has the resolver ever successfully fetched from the API? */
+export function isTrustResolverInitialized(): boolean {
+  return state.initialized
+}
+
+/**
+ * Fetch the authoritative trust + folders from the API and update the
+ * cell. Best-effort: errors are logged and swallowed so a transient
+ * network blip can't lock the agent into a wrong trust state. The last
+ * known good value stays in place.
+ *
+ * Concurrent callers share a single in-flight promise — multiple tools
+ * triggering refresh in the same tick don't cause N HTTP calls.
+ */
+export async function refreshTrust(): Promise<void> {
+  if (state.inFlight) return state.inFlight
+
+  const projectId = state.projectId
+  if (!projectId) {
+    // No projectId means we're in a test or a one-shot script. Nothing
+    // to refresh against; keep whatever init() seeded.
+    return
+  }
+
+  const apiUrl = deriveApiUrl()
+  if (!apiUrl) {
+    // No API to ask. Same fallback as above.
+    return
+  }
+
+  const url = `${apiUrl}/api/internal/projects/${encodeURIComponent(projectId)}/trust`
+  const promise = (async () => {
+    try {
+      const res = await fetch(url, {
+        method: 'GET',
+        headers: getInternalHeaders(),
+        signal: AbortSignal.timeout(5_000),
+      })
+      if (!res.ok) {
+        console.warn(
+          `[trust-resolver] refresh failed: HTTP ${res.status} from ${url} — keeping last known trust=${state.trustLevel}`,
+        )
+        return
+      }
+      const body = (await res.json()) as Partial<{
+        trustLevel: string
+        workingMode: string
+        linkedFolders: unknown
+      }>
+
+      // Race guard: if initTrustResolver() was called for a different
+      // project while this fetch was in flight, the response we got
+      // belongs to the old project — do not write it into the new
+      // project's slot. In production the runtime is single-project
+      // for its lifetime, but this defends against tests and any
+      // future multi-tenant runtime.
+      if (state.projectId !== projectId) {
+        return
+      }
+
+      const nextTrust: TrustLevel = body.trustLevel === 'restricted' ? 'restricted' : 'trusted'
+      const nextMode: WorkingMode = body.workingMode === 'external' ? 'external' : 'managed'
+      const nextFolders: string[] = Array.isArray(body.linkedFolders)
+        ? body.linkedFolders.filter((p): p is string => typeof p === 'string' && p.length > 0)
+        : state.linkedFolders
+
+      const trustChanged = nextTrust !== state.trustLevel
+      state.trustLevel = nextTrust
+      state.workingMode = nextMode
+      state.linkedFolders = nextFolders
+      state.initialized = true
+      state.lastRefreshAt = Date.now()
+
+      if (trustChanged) {
+        console.log(`[trust-resolver] trustLevel resolved to "${nextTrust}" for project ${projectId}`)
+      }
+    } catch (err: any) {
+      console.warn(
+        `[trust-resolver] refresh threw: ${err?.message ?? err} — keeping last known trust=${state.trustLevel}`,
+      )
+    } finally {
+      state.inFlight = null
+    }
+  })()
+
+  state.inFlight = promise
+  return promise
+}
+
+/**
+ * Test-only seam. Lets unit tests override the resolved trust without
+ * needing a live API. Production code must go through `refreshTrust()`.
+ */
+export function __setTrustForTests(partial: Partial<ResolvedTrust> & { initialized?: boolean }): void {
+  if (partial.trustLevel) state.trustLevel = partial.trustLevel
+  if (partial.workingMode) state.workingMode = partial.workingMode
+  if (typeof partial.workspaceDir === 'string') state.workspaceDir = partial.workspaceDir
+  if (Array.isArray(partial.linkedFolders)) state.linkedFolders = partial.linkedFolders.slice()
+  if (typeof partial.initialized === 'boolean') state.initialized = partial.initialized
+}
+
+/** Test-only reset; restores the cold-start defaults. */
+export function __resetTrustForTests(): void {
+  state.trustLevel = 'restricted'
+  state.workingMode = 'external'
+  state.workspaceDir = ''
+  state.linkedFolders = []
+  state.initialized = false
+  state.projectId = null
+  state.lastRefreshAt = null
+  state.inFlight = null
+}


### PR DESCRIPTION
## Summary

Fixes #669 · Jira: [SHOG-689](https://odin-ai.atlassian.net/browse/SHOG-689)

Clicking **Trust folder** / **Trust parent folder** updated the project's `trustLevel` in Postgres but the running agent-runtime process kept reporting `restricted_mode_write` until full restart. This PR fixes the bug from the root: trust stops being a spawn-time env snapshot and becomes a value the runtime **resolves live** from the API at well-defined boundaries.

## Root cause (in two sentences)

Trust was cached in two places that nothing kept in sync with the DB: the `TRUST_LEVEL` env var on the runtime process, and `globalThis.__SHOGO_AGENT_RUNTIME_CONFIG__.trustLevel`. Both were captured at spawn and never updated, so the `POST /:id/trust` endpoint's `prisma.project.update` was invisible to the running runtime — `assertAllowedPath()` and the system-prompt builder kept reading the stale boot-time value forever.

Full diagnosis with code excerpts: see #669.

## The fix — architectural, not a patch

Postgres is now the single source of truth. The runtime resolves `trustLevel` via the existing `x-runtime-token`-authenticated internal HTTP channel at **three boundaries**:

| Boundary | Where | Why |
|---|---|---|
| At boot | `server.ts` runs `refreshTrust()` after `initTrustResolver()` | First message in a fresh runtime already sees the right value. |
| Every chat turn | `await refreshTrust()` at the top of `_agentTurnInner` in `gateway.ts`, **before** `loadBootstrapContext` / tools run | Self-healing: even if the IPC ping below is lost, the next message reconciles with the DB. |
| On demand | `POST /:id/trust` fires `pingRuntimeRefreshTrust(projectId)` → runtime's new `POST /internal/refresh-trust` (auth: `WEBHOOK_TOKEN`) | Mid-stream click unblocks in-flight tool calls within ~100 ms, no restart. |

`TRUST_LEVEL` is removed from the spawn env in `manager.ts` (with a comment so a future refactor does not reintroduce it). The legacy `globalThis.__SHOGO_AGENT_RUNTIME_CONFIG__` keeps the immutable directory triplet (`workspaceDir` / `workingMode` / `linkedFolders`) but no longer advertises `trustLevel`.

## New data flow

```
User clicks "Trust folder"
        │
        ▼
POST /api/local/projects/:id/trust   (writes Postgres — single source of truth)
        │
        ├──► pingRuntimeRefreshTrust(projectId)
        │           │
        │           ▼
        │     POST http://127.0.0.1:<agentPort>/internal/refresh-trust
        │     Auth: Bearer deriveWebhookToken(projectId)
        │           │
        │           ▼
        │     trust-resolver.refresh()
        │           │
        │           ▼
        │     GET /api/internal/projects/:id/trust
        │     Auth: x-runtime-token
        │           │
        │           ▼
        │     Updates state.trustLevel
        │     assertAllowedPath() & getRuntimeTrust() now see "trusted"
        │
        └──► returns updated project to UI
```

And, belt-and-braces, the **next** chat turn calls `await refreshTrust()` before the system prompt is built or any tool runs — so a missed ping self-heals within one user message.

## Files

### New

- `packages/agent-runtime/src/trust-resolver.ts` (~200 LoC) — the live cell: `initTrustResolver()`, `refreshTrust()` with concurrent-call dedup + projectId race guard, `getResolvedTrust()` sync accessor, test seam.
- `packages/agent-runtime/src/__tests__/trust-resolver.test.ts` — 13 unit tests.
- `apps/api/src/__tests__/trust-resolver-wiring.test.ts` — 16 source-regression tests pinning the architectural invariants.

### Edited — runtime

- `packages/agent-runtime/src/server.ts`
  - Removed `TRUST_LEVEL` env parse and the `trustLevel` field on the legacy global.
  - Added `initTrustResolver()` at boot + best-effort initial `refreshTrust()`.
  - Mounted `POST /internal/refresh-trust` IPC route (auth: `WEBHOOK_TOKEN`).
- `packages/agent-runtime/src/runtime-trust.ts`
  - `getRuntimeTrust()` now reads from the resolver. Env-only fallback retained for unit tests that do not boot the resolver.
- `packages/agent-runtime/src/gateway.ts`
  - `await refreshTrust()` at the top of `_agentTurnInner`.
  - System-prompt builder reads `getRuntimeTrust()` instead of `process.env.TRUST_LEVEL`.

### Edited — API

- `apps/api/src/routes/internal.ts` — new endpoint `GET /api/internal/projects/:id/trust`, authoritative read returning `{ trustLevel, workingMode, linkedFolders }`. Folder ordering matches the spawn-path semantics (primary first, then by `lastOpenedAt desc`). Auth: K8s SA token (cluster) or `x-runtime-token` (local).
- `apps/api/src/routes/local-projects.ts` — `POST /:id/trust` now fires `pingRuntimeRefreshTrust(projectId)` after the prisma update. Fire-and-forget; no-op when the runtime is not running.
- `apps/api/src/lib/runtime/manager.ts` — removed `TRUST_LEVEL` from the spawn env with an explanatory comment.

### Edited — test helpers

- `packages/agent-runtime/src/__tests__/helpers/test-trust.ts` — `trustWorkspaceForTests` / `clearTrustForTests` now seed the resolver. All existing `gateway-tools.*` tests keep passing unchanged.
- `packages/agent-runtime/src/__tests__/runtime-trust.test.ts` — replaced direct `globalThis` pokes with the resolver test seam; added 4 new edge cases.
- `apps/api/src/routes/__tests__/internal.test.ts` — added 11 tests for the new `/projects/:id/trust` endpoint.

## Edge cases covered

- **Network failure** — `refreshTrust()` swallows `ECONNREFUSED` / HTTP 5xx / timeouts and keeps the last-known value. No flapping to `restricted` on transient blips.
- **Concurrent refresh()** — multiple callers in the same tick share a single in-flight fetch via `state.inFlight`.
- **Project-switch race** — if `initTrustResolver()` is called for a new project while a refresh for the old project is in flight, the in-flight response is discarded (would otherwise write the old project's trust into the new project's slot). Covered by a dedicated test.
- **URL-encoding** — projectIds containing `/`, spaces, `&` are encoded correctly so the request hits the right route.
- **Auth gating** — `/api/internal/projects/:id/trust`: SA token OR runtime token. Runtime token bound to a different project → 401. No auth → 401.
- **Folder ordering** — primary first, then by `lastOpenedAt desc`, null `lastOpenedAt` treated as oldest.
- **Type normalization** — `trustLevel: 42` → `"trusted"` (safe default); `workingMode: null` → `"managed"`. Resolver never sees ambiguous values.
- **Test/prod boundary** — env fallback in `getRuntimeTrust()` only fires when the resolver is uninitialized; resolver wins over env once initialized.
- **Defensive copy** — `getResolvedTrust()` returns a copy of `linkedFolders` so caller mutation cannot leak back into the cell.
- **Untrust path** — clicking "Stop trusting" follows the symmetric code path (same ping, same refresh).
- **Runtime offline at click time** — `pingRuntimeRefreshTrust` is a no-op (`manager.status(projectId) === null`). When the runtime later boots, the initial `refreshTrust()` pulls the current value directly from Postgres.

## Verification

- `bun x tsc --noEmit` in both `packages/agent-runtime` and `apps/api`: **0 new TypeScript errors**.
- Full affected test surface: **161 / 161 passing** across `trust-resolver`, `runtime-trust`, `gateway-tools.write-file`, `gateway-tools.exec-wait`, `exec-soft-timeout`, `path-prefix-hint`, `internal` (API endpoint), and `trust-resolver-wiring` (source-regression).
- Branch: `fix/trust-folder-still-restricted`
- Commit: `5968555b`

## Suggested follow-ups (not blocking)

- E2E test that boots both API and runtime processes and proves the round-trip (click Trust → write_file unblocks without restart).
- Telemetry counter on `refreshTrust()` failures so we can alert on a sustained `keeping last known trust` warning rate.
- Consider extending the live-resolver pattern to other spawn-time-snapshotted fields (e.g. `LINKED_FOLDERS`) if they ever need to mutate without a restart.

## Checklist

- [x] Tests added for new endpoint
- [x] Tests added for new resolver module
- [x] Source-regression tests pin architectural invariants so the bug class cannot silently return
- [x] Existing tests updated to use the resolver seam (no globalThis pokes)
- [x] No new TypeScript errors
- [x] No reads of `process.env.TRUST_LEVEL` outside the env-fallback branch (which is unit-test-only)
- [x] No `TRUST_LEVEL:` assignment in `manager.ts` spawn env
- [x] Comment documents why `TRUST_LEVEL` is intentionally absent
