### PR TITLE
fix(desktop): ship canvas-bridge.js in the bundle so the "Update available — Refresh" pill works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,7 @@ apps/desktop/resources/scripts/
 apps/desktop/resources/templates/
 apps/desktop/resources/runtime-template/
 apps/desktop/resources/canvas-runtime/
+apps/desktop/resources/static/
 apps/desktop/resources/seed.db
 apps/desktop/resources/package.json
 apps/desktop/resources/bun.lock
@@ -224,3 +225,6 @@ vendor/agent-native
 apps/api/coverage/
 *.tmp
 *.info
+
+# Shogo — IDE-mode local state (safe to ignore)
+.shogo/local/

--- a/.shogo/reports/desktop-canvas-refresh-fix.html
+++ b/.shogo/reports/desktop-canvas-refresh-fix.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Desktop canvas refresh pill — root-cause report</title>
+<style>
+  :root {
+    --bg: #0b0d11;
+    --panel: #12151b;
+    --panel-2: #181c24;
+    --border: #232936;
+    --text: #e6e8ec;
+    --muted: #8a93a3;
+    --green: #34d399;
+    --red: #f87171;
+    --amber: #fbbf24;
+    --cyan: #67e8f9;
+    --mono: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; background: var(--bg); color: var(--text); font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Inter", sans-serif; }
+  .wrap { max-width: 1100px; margin: 0 auto; padding: 40px 28px 80px; }
+  h1 { font-size: 28px; margin: 0 0 6px; }
+  h2 { font-size: 18px; margin: 36px 0 12px; color: var(--text); }
+  h3 { font-size: 14px; margin: 18px 0 8px; color: var(--muted); text-transform: uppercase; letter-spacing: .04em; font-weight: 600; }
+  .sub { color: var(--muted); margin: 0 0 24px; }
+  .pill { display: inline-flex; align-items: center; gap: 6px; padding: 3px 10px; border-radius: 999px; font-size: 12px; border: 1px solid var(--border); background: var(--panel-2); }
+  .pill.ok { color: var(--green); border-color: rgba(52,211,153,.35); }
+  .pill.bad { color: var(--red); border-color: rgba(248,113,113,.35); }
+  .pill.warn { color: var(--amber); border-color: rgba(251,191,36,.35); }
+  .grid { display: grid; gap: 16px; }
+  .grid.two { grid-template-columns: 1fr 1fr; }
+  @media (max-width: 720px) { .grid.two { grid-template-columns: 1fr; } }
+  .card { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 18px 20px; }
+  .card h4 { margin: 0 0 8px; font-size: 14px; color: var(--text); font-weight: 600; }
+  .card .meta { color: var(--muted); font-size: 12px; }
+  code, pre { font-family: var(--mono); font-size: 12.5px; }
+  pre { background: var(--panel-2); border: 1px solid var(--border); border-radius: 8px; padding: 12px 14px; overflow-x: auto; margin: 8px 0 0; }
+  .diff-add { color: var(--green); }
+  .diff-del { color: var(--red); }
+  .diff-meta { color: var(--muted); }
+  .flow { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin: 8px 0; font-family: var(--mono); font-size: 12px; }
+  .flow .box { background: var(--panel-2); border: 1px solid var(--border); border-radius: 6px; padding: 6px 10px; }
+  .flow .arrow { color: var(--muted); }
+  table { width: 100%; border-collapse: collapse; margin-top: 8px; }
+  th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border); font-size: 13px; }
+  th { color: var(--muted); font-weight: 500; font-size: 12px; text-transform: uppercase; letter-spacing: .04em; }
+  td.mono { font-family: var(--mono); font-size: 12.5px; }
+  .check { color: var(--green); }
+  .cross { color: var(--red); }
+  .banner { display: flex; align-items: center; gap: 12px; padding: 14px 16px; border-radius: 10px; background: linear-gradient(135deg, rgba(52,211,153,.08), rgba(103,232,249,.08)); border: 1px solid rgba(103,232,249,.25); margin-bottom: 28px; }
+  .banner .ok-dot { width: 8px; height: 8px; background: var(--green); border-radius: 50%; box-shadow: 0 0 0 4px rgba(52,211,153,.15); }
+  .toast-demo { display: inline-flex; align-items: center; gap: 10px; padding: 8px 12px; border-radius: 999px; background: rgba(255,255,255,.04); border: 1px solid rgba(255,255,255,.08); box-shadow: 0 0 24px 4px rgba(167,139,250,.18), 0 0 8px 1px rgba(251,191,36,.18); font-size: 13px; }
+  .toast-demo button { background: #1f242d; border: 1px solid #2c333f; color: var(--text); padding: 4px 10px; border-radius: 6px; font-size: 12px; cursor: pointer; }
+  .toast-demo .x { color: var(--muted); margin-left: 4px; }
+  .legend { display: flex; gap: 14px; flex-wrap: wrap; margin-top: 8px; }
+  .legend span { color: var(--muted); font-size: 12px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="banner">
+    <div class="ok-dot"></div>
+    <div>
+      <div style="font-weight:600">Branch <code>fix/desktop-canvas-refresh-button</code> · root-cause fix · 13/13 tests pass · E2E verified</div>
+      <div class="meta" style="color:var(--muted);font-size:12px">Repo <code>shogo-labs/shogo-ai</code> · pushed at HEAD of branch</div>
+    </div>
+  </div>
+
+  <h1>Canvas refresh pill missing on Desktop</h1>
+  <p class="sub">Root-cause analysis, fix, before/after, tests, E2E.</p>
+
+  <h2>The symptom</h2>
+  <div class="grid two">
+    <div class="card">
+      <h4>Before — Desktop</h4>
+      <div class="meta">After every agent rebuild, the canvas <em>silently</em> kept showing stale content. No pill, no toast, no signal.</div>
+      <div style="margin-top:14px;opacity:.4;font-family:var(--mono);font-size:12px;border:1px dashed var(--border);border-radius:8px;padding:24px;text-align:center;color:var(--muted)">
+        ( no toast rendered )
+      </div>
+    </div>
+    <div class="card">
+      <h4>After / Cloud — the working state</h4>
+      <div class="meta">SSE rebuild event → workspace iframe shows pill → user clicks Refresh.</div>
+      <div style="margin-top:14px;text-align:center">
+        <div class="toast-demo">Update available <button>Refresh</button><span class="x">✕</span></div>
+      </div>
+    </div>
+  </div>
+
+  <h2>Root cause</h2>
+  <div class="card">
+    <p style="margin:0 0 10px">The pill is rendered by <code>packages/agent-runtime/static/canvas-bridge.js</code>. The agent-runtime:</p>
+    <ol style="margin:0 0 12px 18px;padding:0">
+      <li>Reads the file at startup via <code>readFileSync(join(__dirname,'..','static','canvas-bridge.js'))</code></li>
+      <li>Serves the bytes at <code>GET /agent/canvas/bridge.js</code></li>
+      <li>Injects <code>&lt;script src="/agent/canvas/bridge.js" defer&gt;</code> into every workspace HTML response</li>
+      <li>Inside the iframe, the bridge opens <code>EventSource('/agent/canvas/stream')</code> and shows the pill on rebuild events</li>
+    </ol>
+    <p style="margin:0">On Cloud, <code>static/</code> sits next to the runtime, so step 1 succeeds. On Desktop, <code>apps/desktop/scripts/bundle-api.mjs</code> copied <em>everything except</em> the <code>static/</code> folder into <code>resources/</code>. The runtime then silently fell into its <code>console.warn</code> + empty-IIFE-stub fallback. No throw, no failed test, no failed build — the only signal was a buried stderr warning.</p>
+    <div class="flow">
+      <div class="box">workspace iframe HTML</div><span class="arrow">→</span>
+      <div class="box">&lt;script src="/agent/canvas/bridge.js"&gt;</div><span class="arrow">→</span>
+      <div class="box">agent-runtime route</div><span class="arrow">→</span>
+      <div class="box">readFileSync(static/canvas-bridge.js)</div><span class="arrow">→</span>
+      <div class="box" style="border-color:rgba(248,113,113,.4);color:var(--red)">ENOENT (Desktop only)</div><span class="arrow">→</span>
+      <div class="box" style="border-color:rgba(251,191,36,.4);color:var(--amber)">silent stub</div>
+    </div>
+  </div>
+
+  <h3>Why a stub, why silent?</h3>
+  <div class="card">
+    <pre><span class="diff-meta">// packages/agent-runtime/src/canvas-bridge.ts (was inline in server.ts)</span>
+export function loadCanvasBridgeSource(path: string = CANVAS_BRIDGE_PATH): string {
+  try {
+    return readFileSync(path, 'utf-8')
+  } catch (err) {
+    console.warn(`[canvas-bridge] Failed to load ${path}:`, (err as Error).message)
+    <span class="diff-meta">// Empty IIFE keeps the route honest (200 with valid JS) even when the</span>
+    <span class="diff-meta">// bridge file is missing — the canvas just won't show update toasts.</span>
+    return CANVAS_BRIDGE_MISSING_STUB
+  }
+}</pre>
+    <p style="margin-top:10px;color:var(--muted);font-size:13px">Soft-fail is the right behavior — a missing asset shouldn't 500 the iframe's script tag and break the whole canvas. The bug is one layer up: the bundle script wasn't shipping the asset. That's where the fix lives.</p>
+  </div>
+
+  <h2>The fix — patch vs root</h2>
+  <div class="grid two">
+    <div class="card">
+      <h4 style="color:var(--amber)"><span class="pill warn">rejected</span> &nbsp; patch fix</h4>
+      <ul style="margin:8px 0 0 18px;padding:0;color:var(--muted);font-size:13px">
+        <li>Inline the bridge JS as a string literal in <code>server.ts</code></li>
+        <li>Add a second fallback path (e.g. <code>resources/canvas-runtime/canvas-bridge.js</code>)</li>
+        <li>Conditional Desktop-only branch in the loader</li>
+      </ul>
+      <p style="margin-top:10px;color:var(--muted);font-size:12.5px">All of these treat the symptom (missing bytes at runtime) instead of the cause (missing bytes in the bundle output).</p>
+    </div>
+    <div class="card">
+      <h4 style="color:var(--green)"><span class="pill ok">applied</span> &nbsp; root fix</h4>
+      <ul style="margin:8px 0 0 18px;padding:0;font-size:13px">
+        <li><code>bundle-api.mjs</code> copies <code>static/</code> → <code>resources/static/</code></li>
+        <li><code>forge.config.ts</code> ships <code>./resources/static</code> as <code>extraResource</code></li>
+        <li><code>static</code> added to bundle cleanup list so rebuilds stay deterministic</li>
+        <li>Loader unchanged in behavior; extracted to <code>canvas-bridge.ts</code> for testability</li>
+      </ul>
+      <p style="margin-top:10px;color:var(--muted);font-size:12.5px">The runtime keeps its lookup formula. The bundle now satisfies it. Dev mode unaffected.</p>
+    </div>
+  </div>
+
+  <h3>Diff (4 files, +120/−14)</h3>
+  <pre><span class="diff-meta">apps/desktop/scripts/bundle-api.mjs</span>
+<span class="diff-add">+ 'static',</span>            <span class="diff-meta"># added to ITEMS_TO_CLEAN (deterministic rebuilds)</span>
+<span class="diff-add">+ logStep('Copying agent-runtime static assets...')</span>
+<span class="diff-add">+ fs.cpSync(packages/agent-runtime/static, RESOURCES_DIR/static, { recursive: true })</span>
+
+<span class="diff-meta">apps/desktop/forge.config.ts</span>
+<span class="diff-add">+ './resources/static',   // ship canvas-bridge.js in the .app</span>
+
+<span class="diff-meta">packages/agent-runtime/src/canvas-bridge.ts  (new file)</span>
+<span class="diff-add">+ extracted loader + path const + missing-stub constant
++ same behavior, importable from tests without booting the server</span>
+
+<span class="diff-meta">packages/agent-runtime/src/server.ts</span>
+<span class="diff-del">- const CANVAS_BRIDGE_URL = '/agent/canvas/bridge.js'</span>
+<span class="diff-del">- const CANVAS_BRIDGE_PATH = join(__dirname, '..', 'static', 'canvas-bridge.js')</span>
+<span class="diff-del">- function loadCanvasBridgeSource(): string { ... }</span>
+<span class="diff-add">+ import { CANVAS_BRIDGE_URL, CANVAS_BRIDGE_PATH, loadCanvasBridgeSource, CANVAS_BRIDGE_SCRIPT_TAG } from './canvas-bridge'</span></pre>
+
+  <h2>Verification</h2>
+
+  <h3>Unit tests — <code>canvas-bridge-loader.test.ts</code></h3>
+  <div class="card" style="padding:14px 18px">
+    <table>
+      <thead><tr><th style="width:30px"></th><th>Assertion</th><th style="width:80px">Time</th></tr></thead>
+      <tbody>
+        <tr><td class="check">✓</td><td>returns real bridge content when CANVAS_BRIDGE_PATH points at a readable file</td><td class="mono">1.45ms</td></tr>
+        <tr><td class="check">✓</td><td>CANVAS_BRIDGE_PATH resolves to the real source file (runtime ↔ source agree)</td><td class="mono">0.13ms</td></tr>
+        <tr><td class="check">✓</td><td>loader output is byte-identical to the source file (no re-encoding)</td><td class="mono">0.04ms</td></tr>
+        <tr><td class="check">✓</td><td>explicit path argument is honored</td><td class="mono">0.24ms</td></tr>
+        <tr><td class="check">✓</td><td>falls back to valid-JS stub when file is missing (no throw)</td><td class="mono">0.36ms</td></tr>
+        <tr><td class="check">✓</td><td>falls back to stub when path is a directory, not a file (EISDIR)</td><td class="mono">0.07ms</td></tr>
+        <tr><td class="check">✓</td><td>stub is the canonical sentinel (grep-able in production logs)</td><td class="mono">0.06ms</td></tr>
+        <tr><td class="check">✓</td><td>URL + script-tag constants are coherent (injection points line up)</td><td class="mono">0.08ms</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h3>Integration test — <code>binary-ships-canvas-bridge.integration.test.ts</code></h3>
+  <div class="card" style="padding:14px 18px">
+    <table>
+      <thead><tr><th style="width:30px"></th><th>Assertion</th><th style="width:80px">Time</th></tr></thead>
+      <tbody>
+        <tr><td class="check">✓</td><td>bundle-api.mjs copies packages/agent-runtime/static → resources/static</td><td class="mono">0.83ms</td></tr>
+        <tr><td class="check">✓</td><td>forge.config.ts lists './resources/static' in extraResource (and not in a comment)</td><td class="mono">0.29ms</td></tr>
+        <tr><td class="check">✓</td><td>runtime CANVAS_BRIDGE_PATH formula resolves to the bundle destination from resources/bundle/</td><td class="mono">0.02ms</td></tr>
+        <tr><td class="check">✓</td><td>source canvas-bridge.js is a non-empty real script</td><td class="mono">0.31ms</td></tr>
+        <tr><td class="check">✓</td><td>if bundle has been built, shipped bytes equal source (opportunistic)</td><td class="mono">0.23ms</td></tr>
+      </tbody>
+    </table>
+    <p style="margin-top:12px;color:var(--muted);font-size:12.5px"><strong>Regression-detection proof:</strong> with the bundle fix reverted to <code>origin/main</code>, the first two assertions fail. After re-applying the fix, all five pass. The test is wired such that a future revert of either the copy step or the forge entry will fail CI before the bug ships.</p>
+  </div>
+
+  <h3>End-to-end — boot bundled runtime, curl the route</h3>
+  <pre>$ env -u AI_PROXY_URL bun run apps/desktop/resources/bundle/agent-runtime.js
+$ curl -i http://localhost:39711/agent/canvas/bridge.js | head -3
+<span class="diff-add">HTTP/1.1 200 OK
+Content-Type: application/javascript; charset=utf-8
+Content-Length: 16560</span>
+
+$ diff &lt;(curl -s http://localhost:39711/agent/canvas/bridge.js) packages/agent-runtime/static/canvas-bridge.js
+<span class="diff-meta"># (no output — bytes are identical)</span>
+
+✓ bytes match source canvas-bridge.js
+✓ REAL BRIDGE SERVED (not the stub)</pre>
+
+  <h2>Code-review notes (self-review)</h2>
+  <div class="card">
+    <table>
+      <thead><tr><th style="width:24%">Concern</th><th>Status</th></tr></thead>
+      <tbody>
+        <tr><td>Cross-platform paths</td><td><span class="check">✓</span> <code>path.join</code> + regex uses <code>[\\/]</code>; tested implicitly via existsSync on macOS, formula identical on Win/Linux.</td></tr>
+        <tr><td>Asar packing</td><td><span class="check">✓</span> Forge <code>extraResource</code> bypasses asar — the file lands in <code>.app/Contents/Resources/static/</code> next to <code>bundle/</code>.</td></tr>
+        <tr><td>Repeated builds accumulating stale copies</td><td><span class="check">✓</span> Added <code>static</code> to <code>ITEMS_TO_CLEAN</code> so each bundle starts from a clean slate.</td></tr>
+        <tr><td>Dev mode</td><td><span class="check">✓</span> Loader's <code>__dirname/../static/canvas-bridge.js</code> still resolves to the source file when running from <code>src/</code>; no change.</td></tr>
+        <tr><td>Concurrent reads at startup</td><td><span class="check">✓</span> Loader runs once into a module-scope const; route serves from memory.</td></tr>
+        <tr><td>Cache headers</td><td><span class="check">✓</span> Route already sets <code>Cache-Control: no-cache</code> — updates take effect on next runtime restart.</td></tr>
+        <tr><td>Soft-fail visibility</td><td><span class="pill warn">noted</span> Current behavior: stderr warn. Considered promoting to a structured event / fail-fast in production. Left as warn to preserve dev/test ergonomics; the new integration test catches the bundle-side regression class instead.</td></tr>
+        <tr><td>Git hygiene</td><td><span class="check">✓</span> Added <code>apps/desktop/resources/static/</code> to <code>.gitignore</code> so build artifacts don't leak into commits.</td></tr>
+        <tr><td>Bundle smoke check</td><td><span class="check">✓</span> The <code>bun run scripts/bundle-api.mjs</code> step now logs <code>Copied 1 static asset(s): canvas-bridge.js</code> — a positive ship signal in build logs.</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2>Files changed</h2>
+  <div class="card" style="padding:14px 18px">
+    <table>
+      <thead><tr><th>Path</th><th>Type</th><th style="width:120px">Lines</th></tr></thead>
+      <tbody>
+        <tr><td class="mono">apps/desktop/scripts/bundle-api.mjs</td><td>modified</td><td>+20</td></tr>
+        <tr><td class="mono">apps/desktop/forge.config.ts</td><td>modified</td><td>+4</td></tr>
+        <tr><td class="mono">packages/agent-runtime/src/canvas-bridge.ts</td><td>new</td><td>+59</td></tr>
+        <tr><td class="mono">packages/agent-runtime/src/server.ts</td><td>refactored</td><td>+9 / −14</td></tr>
+        <tr><td class="mono">packages/agent-runtime/src/__tests__/canvas-bridge-loader.test.ts</td><td>new</td><td>+148</td></tr>
+        <tr><td class="mono">packages/agent-runtime/src/__tests__/binary-ships-canvas-bridge.integration.test.ts</td><td>new</td><td>+112</td></tr>
+        <tr><td class="mono">.gitignore</td><td>modified</td><td>+1</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <p class="sub" style="margin-top:32px">Branch: <code>fix/desktop-canvas-refresh-button</code> &nbsp;·&nbsp; PR: <a style="color:var(--cyan)" href="https://github.com/shogo-labs/shogo-ai/pull/new/fix/desktop-canvas-refresh-button">open new PR</a></p>
+</div>
+</body>
+</html>

--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -15,6 +15,10 @@ const extraResourceCandidates = [
   './resources/templates',
   './resources/runtime-template',
   './resources/canvas-runtime',
+  // agent-runtime static assets (canvas-bridge.js served at /agent/canvas/bridge.js).
+  // Without this, the workspace iframe never installs the SSE listener and the
+  // "Update available — Refresh" toast never shows on Desktop.
+  './resources/static',
   './resources/tree-sitter-wasm',
   './resources/vm',
   './resources/vm-helper',

--- a/apps/desktop/scripts/bundle-api.mjs
+++ b/apps/desktop/scripts/bundle-api.mjs
@@ -47,6 +47,7 @@ const ITEMS_TO_CLEAN = [
   'templates',
   'runtime-template',
   'canvas-runtime',
+  'static',
   'tree-sitter-wasm',
   'scripts',
   'mcp-packages',
@@ -355,6 +356,25 @@ function main() {
         console.warn('  ⚠ MCP package preinstall failed (non-fatal — runtime will fall back to npx):', err.message)
       }
     }
+  }
+
+  // --- Copy agent-runtime static assets (canvas-bridge.js, etc.) ---
+  // The bundled agent-runtime resolves these via
+  //   join(__dirname, '..', 'static', 'canvas-bridge.js')
+  // which lands at resources/static/canvas-bridge.js. Without this copy the
+  // runtime falls back to an empty IIFE stub and the workspace iframe never
+  // shows the "Update available — Refresh" toast (the SSE listener never
+  // gets installed). This is what makes Cloud show the pill while Desktop
+  // doesn't.
+  logStep('Copying agent-runtime static assets...')
+  const agentRuntimeStaticSource = path.join(REPO_ROOT, 'packages', 'agent-runtime', 'static')
+  const agentRuntimeStaticDest = path.join(RESOURCES_DIR, 'static')
+  if (fs.existsSync(agentRuntimeStaticSource)) {
+    fs.cpSync(agentRuntimeStaticSource, agentRuntimeStaticDest, { recursive: true })
+    const files = fs.readdirSync(agentRuntimeStaticDest).filter((f) => fs.statSync(path.join(agentRuntimeStaticDest, f)).isFile())
+    console.log(`  ✓ Copied ${files.length} static asset(s): ${files.join(', ')}`)
+  } else {
+    console.warn('  ⚠ agent-runtime/static not found at', agentRuntimeStaticSource)
   }
 
   // --- Copy canvas-runtime type definitions (used by LSP for canvas code linting) ---

--- a/packages/agent-runtime/src/__tests__/binary-ships-canvas-bridge.integration.test.ts
+++ b/packages/agent-runtime/src/__tests__/binary-ships-canvas-bridge.integration.test.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Integration test guarding the Desktop bundle ↔ agent-runtime contract for
+ * the canvas bridge.
+ *
+ * What broke (May 2026):
+ *   `apps/desktop/scripts/bundle-api.mjs` shipped the bundled agent-runtime
+ *   into `apps/desktop/resources/bundle/` but never copied
+ *   `packages/agent-runtime/static/` into `apps/desktop/resources/static/`.
+ *   At runtime the bundled agent-runtime computes its bridge path as
+ *   `join(__dirname, '..', 'static', 'canvas-bridge.js')`, which from
+ *   `resources/bundle/agent-runtime.js` resolves to `resources/static/...`.
+ *   That folder didn't exist, so `loadCanvasBridgeSource()` silently fell
+ *   into its stub branch and the Desktop canvas lost its
+ *   "Update available — Refresh" toast while Cloud kept working.
+ *
+ * What this test pins:
+ *   1. `bundle-api.mjs` source contains the copy step that lands the static
+ *      folder at `resources/static/`. (Cheap — protects against an
+ *      accidental revert of the fix.)
+ *   2. `forge.config.ts` lists `./resources/static` in `extraResource`. The
+ *      copy alone is not enough — without this, electron-forge will ship a
+ *      packaged `.app` that *still* lacks the asset.
+ *   3. The path the bundled `agent-runtime.js` would compute at runtime is
+ *      exactly `<repo>/apps/desktop/resources/static/canvas-bridge.js` —
+ *      the bundle's destination directory.
+ *   4. If the resources directory has been built (post-`bundle-api.mjs`),
+ *      the shipped bytes are byte-identical to the source file the
+ *      agent-runtime tests verify in dev. We treat this assertion as
+ *      *opportunistic*: we don't trigger the heavy bundle from inside a
+ *      unit suite (it downloads ffmpeg / chromium and runs ~30s); we only
+ *      assert byte-equality when the artifact already exists locally / in
+ *      CI's post-bundle stage.
+ */
+import { describe, expect, test } from 'bun:test'
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { join, resolve, dirname } from 'node:path'
+
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..')
+const BUNDLE_SCRIPT = join(REPO_ROOT, 'apps', 'desktop', 'scripts', 'bundle-api.mjs')
+const FORGE_CONFIG = join(REPO_ROOT, 'apps', 'desktop', 'forge.config.ts')
+const SOURCE_BRIDGE = join(REPO_ROOT, 'packages', 'agent-runtime', 'static', 'canvas-bridge.js')
+const RESOURCES_DIR = join(REPO_ROOT, 'apps', 'desktop', 'resources')
+const SHIPPED_BRIDGE = join(RESOURCES_DIR, 'static', 'canvas-bridge.js')
+const BUNDLED_RUNTIME = join(RESOURCES_DIR, 'bundle', 'agent-runtime.js')
+
+describe('Desktop bundle ships canvas-bridge.js so the canvas refresh pill works', () => {
+  test('bundle-api.mjs copies packages/agent-runtime/static -> resources/static', () => {
+    expect(existsSync(BUNDLE_SCRIPT)).toBe(true)
+    const src = readFileSync(BUNDLE_SCRIPT, 'utf-8')
+    // The fix lives in this exact source path → dest path move. Match on
+    // both endpoints so a future refactor that moves the copy step still
+    // satisfies the invariant as long as the data flow is preserved.
+    expect(src).toMatch(/agent-runtime['"\s,]+['"]static['"]/)
+    expect(src).toMatch(/RESOURCES_DIR[^)]*['"]static['"]/)
+    // And the cleanup list must include 'static' so re-builds don't
+    // accumulate stale copies.
+    expect(src).toMatch(/['"]static['"]/)
+  })
+
+  test("forge.config.ts lists './resources/static' in extraResource", () => {
+    expect(existsSync(FORGE_CONFIG)).toBe(true)
+    const cfg = readFileSync(FORGE_CONFIG, 'utf-8')
+    // Strip comments so we don't pass on a commented-out entry.
+    const stripped = cfg
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^\s*\/\/.*$/gm, '')
+    expect(stripped).toMatch(/['"]\.\/resources\/static['"]/)
+  })
+
+  test('runtime CANVAS_BRIDGE_PATH formula resolves to the bundle destination from resources/bundle/', () => {
+    // Mirror the exact computation in server.ts:
+    //   const CANVAS_BRIDGE_PATH = join(__dirname, '..', 'static', 'canvas-bridge.js')
+    // For the bundled runtime, __dirname == dirname(BUNDLED_RUNTIME), so the
+    // resolved path must equal SHIPPED_BRIDGE. This is the wiring assertion
+    // the May 2026 regression would have failed.
+    const computed = resolve(dirname(BUNDLED_RUNTIME), '..', 'static', 'canvas-bridge.js')
+    expect(computed).toBe(SHIPPED_BRIDGE)
+  })
+
+  test('source canvas-bridge.js is a non-empty real script (the artifact we need to ship)', () => {
+    expect(existsSync(SOURCE_BRIDGE)).toBe(true)
+    const stat = statSync(SOURCE_BRIDGE)
+    expect(stat.isFile()).toBe(true)
+    expect(stat.size).toBeGreaterThan(1_000)
+    const src = readFileSync(SOURCE_BRIDGE, 'utf-8')
+    // Parses as JS (route serves it as application/javascript).
+    expect(() => new Function(src)).not.toThrow()
+    // And it's the bridge, not some unrelated file that happens to live here.
+    expect(src).toMatch(/canvas/i)
+  })
+
+  test('if the desktop bundle has been built, the shipped bytes match the source (opportunistic)', () => {
+    // We don't trigger the heavy bundle from this suite — it downloads
+    // ffmpeg/chromium and runs ~30s. We assert byte equality only when
+    // `resources/static/canvas-bridge.js` already exists locally or in
+    // CI's post-bundle test stage. This still catches the regression: a
+    // CI job that runs `bundle-api.mjs` then `bun test` will fail here
+    // if the copy step ever stops working.
+    if (!existsSync(SHIPPED_BRIDGE)) {
+      // Soft skip — log so failed expectations elsewhere are easier to diagnose.
+      console.warn(
+        `[canvas-bridge integration] skipping byte-equality check: ${SHIPPED_BRIDGE} not built yet`,
+      )
+      return
+    }
+    const shipped = readFileSync(SHIPPED_BRIDGE)
+    const sourceBytes = readFileSync(SOURCE_BRIDGE)
+    expect(shipped.equals(sourceBytes)).toBe(true)
+  })
+})

--- a/packages/agent-runtime/src/__tests__/canvas-bridge-loader.test.ts
+++ b/packages/agent-runtime/src/__tests__/canvas-bridge-loader.test.ts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Unit suite for `loadCanvasBridgeSource()` — the helper that backs the
+ * `GET /agent/canvas/bridge.js` route the agent-runtime injects into
+ * every workspace HTML response.
+ *
+ * Context: in May 2026 the Desktop build shipped without
+ * `packages/agent-runtime/static/canvas-bridge.js` (bundle script omitted
+ * the `static/` folder). The loader fell through to its silent
+ * `'/* canvas-bridge.js missing *\u002F (function () {})();'` stub, the
+ * SSE listener was never installed inside the iframe, and the
+ * "Update available — Refresh" pill stopped appearing on Desktop while
+ * still working on Cloud.
+ *
+ * These tests pin three invariants that together would have caught the
+ * regression in CI:
+ *
+ *   1. The loader returns the **real file bytes** when the path resolves.
+ *   2. The loader returns a **valid-JS stub** (not throws, not undefined)
+ *      when the path is missing, AND logs a warning so the regression is
+ *      observable in stderr.
+ *   3. `CANVAS_BRIDGE_PATH` resolves to the file that actually ships in
+ *      the source tree — i.e. the runtime and the source layout agree
+ *      about where the bridge lives. (The desktop-bundle counterpart
+ *      lives in `binary-ships-canvas-bridge.integration.test.ts`.)
+ */
+import { afterAll, beforeAll, describe, expect, spyOn, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync, existsSync, statSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import {
+  loadCanvasBridgeSource,
+  CANVAS_BRIDGE_PATH,
+  CANVAS_BRIDGE_MISSING_STUB,
+  CANVAS_BRIDGE_URL,
+  CANVAS_BRIDGE_SCRIPT_TAG,
+} from '../canvas-bridge'
+
+const STUB_MARKER = 'canvas-bridge.js missing'
+
+let tmpDir: string
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'shogo-canvas-bridge-loader-'))
+})
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('loadCanvasBridgeSource', () => {
+  test('returns the real bridge content when CANVAS_BRIDGE_PATH points at a readable file', () => {
+    // No args = uses CANVAS_BRIDGE_PATH = packages/agent-runtime/static/canvas-bridge.js
+    // That file is checked into the repo, so this should return the real source.
+    const src = loadCanvasBridgeSource()
+    expect(typeof src).toBe('string')
+    expect(src.length).toBeGreaterThan(1_000)
+    expect(src).not.toContain(STUB_MARKER)
+    // Cheap proof we got the actual bridge, not some other JS file.
+    expect(src).toMatch(/canvas/i)
+  })
+
+  test('CANVAS_BRIDGE_PATH resolves to the real source file in the repo (runtime ↔ source agree)', () => {
+    // If this drifts (e.g. the source file is moved without updating the
+    // const), every workspace iframe quietly loses its update toast.
+    expect(existsSync(CANVAS_BRIDGE_PATH)).toBe(true)
+    const stat = statSync(CANVAS_BRIDGE_PATH)
+    expect(stat.isFile()).toBe(true)
+    expect(stat.size).toBeGreaterThan(0)
+    expect(CANVAS_BRIDGE_PATH.endsWith('canvas-bridge.js')).toBe(true)
+    // Sanity: file ends in `/static/canvas-bridge.js`, not e.g.
+    // `/canvas-runtime/canvas-bridge.js`. Cross-platform: avoid hard-coded `/`.
+    expect(CANVAS_BRIDGE_PATH).toMatch(/[\\/]static[\\/]canvas-bridge\.js$/)
+  })
+
+  test('loader output for the real path is byte-identical to the source file (no re-encoding)', () => {
+    const fromLoader = loadCanvasBridgeSource()
+    const fromDisk = readFileSync(CANVAS_BRIDGE_PATH, 'utf-8')
+    expect(fromLoader).toBe(fromDisk)
+  })
+
+  test('explicit path argument is honored (custom file)', () => {
+    const fake = join(tmpDir, 'fake-bridge.js')
+    const body = '/* fake bridge */ window.__FAKE__ = 1;\n'
+    writeFileSync(fake, body, 'utf-8')
+    expect(loadCanvasBridgeSource(fake)).toBe(body)
+  })
+
+  test('falls back to a valid-JS stub when the file is missing (no throw)', () => {
+    const ghost = join(tmpDir, 'does-not-exist.js')
+    expect(existsSync(ghost)).toBe(false)
+    // Suppress the expected warning so the test output stays clean,
+    // then assert we *also* exercised the warn path (invariant #2).
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const src = loadCanvasBridgeSource(ghost)
+      expect(typeof src).toBe('string')
+      expect(src).toContain(STUB_MARKER)
+      // Must be parseable JS — the route serves it as application/javascript
+      // and a SyntaxError would 200 a broken script into every iframe.
+      expect(() => new Function(src)).not.toThrow()
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      const [msg, detail] = warnSpy.mock.calls[0]!
+      expect(String(msg)).toContain('[canvas-bridge]')
+      expect(String(msg)).toContain(ghost)
+      // ENOENT message format varies by platform — just assert *something*
+      // useful (path or error string) got logged for ops to grep.
+      expect(detail).toBeDefined()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  test('falls back to stub when the path is a directory, not a file (EISDIR)', () => {
+    // Edge case: someone replaces canvas-bridge.js with a directory
+    // (e.g. a botched git merge). readFileSync throws EISDIR, not ENOENT.
+    // The loader must still degrade gracefully.
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const src = loadCanvasBridgeSource(tmpDir) // tmpDir is a directory
+      expect(src).toContain(STUB_MARKER)
+      expect(() => new Function(src)).not.toThrow()
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  test('stub is exactly the canonical sentinel (kept stable for grep-ability in production logs)', () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const stub = loadCanvasBridgeSource(join(tmpDir, 'ghost.js'))
+      // Ops greps `canvas-bridge.js missing` to find this regression class
+      // in shipped builds. Don't reshape the string casually.
+      expect(stub).toBe(CANVAS_BRIDGE_MISSING_STUB)
+      expect(stub).toBe('/* canvas-bridge.js missing */ (function () {})();\n')
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  test('exported URL + script-tag constants are coherent (injection points line up)', () => {
+    // The `<script src="...">` injected into workspace HTML must point at
+    // the URL the runtime serves. A typo here breaks the bridge on every
+    // page load, not just on missing-file regressions.
+    expect(CANVAS_BRIDGE_URL).toBe('/agent/canvas/bridge.js')
+    expect(CANVAS_BRIDGE_SCRIPT_TAG).toContain(CANVAS_BRIDGE_URL)
+    expect(CANVAS_BRIDGE_SCRIPT_TAG).toMatch(/^<script\s/)
+    expect(CANVAS_BRIDGE_SCRIPT_TAG).toContain('defer')
+  })
+})

--- a/packages/agent-runtime/src/canvas-bridge.ts
+++ b/packages/agent-runtime/src/canvas-bridge.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Canvas iframe bridge — file lookup helpers.
+ *
+ * This module owns the *very small* contract between the runtime and the
+ * `canvas-bridge.js` asset it serves at `/agent/canvas/bridge.js`:
+ *
+ *   - `CANVAS_BRIDGE_PATH` is the filesystem path the runtime expects the
+ *     bridge to live at, resolved relative to `__dirname` of this module.
+ *     In dev that's `packages/agent-runtime/src/`, so the path is
+ *     `packages/agent-runtime/static/canvas-bridge.js`. In a bundled binary
+ *     it's `dist/static/canvas-bridge.js`, in the Desktop electron bundle
+ *     it's `resources/static/canvas-bridge.js`.
+ *   - `loadCanvasBridgeSource(path?)` reads that file and returns its
+ *     contents, or — if the file is missing — a valid-JS stub IIFE plus a
+ *     `console.warn`. The stub keeps `GET /agent/canvas/bridge.js` honest
+ *     (200 with parseable JS) but silently disables the "Update available
+ *     — Refresh" pill inside every workspace iframe.
+ *
+ * Lives in its own module (not `server.ts`) so unit + integration tests
+ * can exercise it without booting the agent runtime, config layer, AI
+ * proxy, etc. See `__tests__/canvas-bridge-loader.test.ts` for the
+ * loader-level invariants and
+ * `__tests__/binary-ships-canvas-bridge.integration.test.ts` for the
+ * Desktop bundle ↔ runtime wiring assertion.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const CANVAS_BRIDGE_URL = '/agent/canvas/bridge.js'
+export const CANVAS_BRIDGE_SCRIPT_TAG = `<script src="${CANVAS_BRIDGE_URL}" defer></script>`
+export const CANVAS_BRIDGE_PATH = join(__dirname, '..', 'static', 'canvas-bridge.js')
+
+/**
+ * Canonical fallback body served when `CANVAS_BRIDGE_PATH` cannot be read.
+ * Kept stable so ops can grep for `canvas-bridge.js missing` in shipped
+ * builds to diagnose this regression class. Don't reshape casually — the
+ * loader unit test pins the exact string.
+ */
+export const CANVAS_BRIDGE_MISSING_STUB = '/* canvas-bridge.js missing */ (function () {})();\n'
+
+export function loadCanvasBridgeSource(path: string = CANVAS_BRIDGE_PATH): string {
+  try {
+    return readFileSync(path, 'utf-8')
+  } catch (err) {
+    console.warn(`[canvas-bridge] Failed to load ${path}:`, (err as Error).message)
+    // Empty IIFE keeps the route honest (returns 200 with valid JS) even
+    // when the bridge file is missing — the canvas just won't show update
+    // toasts. The Desktop bundle regression (May 2026) hid behind exactly
+    // this fallback: `bundle-api.mjs` shipped the runtime without
+    // `static/canvas-bridge.js`, so this branch fired silently in
+    // production and the "Update available — Refresh" pill never appeared.
+    return CANVAS_BRIDGE_MISSING_STUB
+  }
+}

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -3762,20 +3762,15 @@ export { getCanvasRuntimeErrors, clearCanvasRuntimeErrors } from './canvas-runti
 // next page load — no template re-seed, no per-project rebuild.
 // =============================================================================
 
-const CANVAS_BRIDGE_URL = '/agent/canvas/bridge.js'
-const CANVAS_BRIDGE_SCRIPT_TAG = `<script src="${CANVAS_BRIDGE_URL}" defer></script>`
-const CANVAS_BRIDGE_PATH = join(__dirname, '..', 'static', 'canvas-bridge.js')
-
-function loadCanvasBridgeSource(): string {
-  try {
-    return readFileSync(CANVAS_BRIDGE_PATH, 'utf-8')
-  } catch (err) {
-    console.warn(`[canvas-bridge] Failed to load ${CANVAS_BRIDGE_PATH}:`, (err as Error).message)
-    // Empty IIFE keeps the route honest (returns 200 with valid JS) even when
-    // the bridge file is missing — the canvas just won't show update toasts.
-    return '/* canvas-bridge.js missing */ (function () {})();\n'
-  }
-}
+// Loader helpers extracted to `./canvas-bridge.ts` so they're unit-testable
+// without booting the full server (config, AI proxy, etc.). See that module
+// for the full contract and the bug-history comment.
+import {
+  CANVAS_BRIDGE_PATH,
+  CANVAS_BRIDGE_SCRIPT_TAG,
+  CANVAS_BRIDGE_URL,
+  loadCanvasBridgeSource,
+} from './canvas-bridge'
 
 const CANVAS_BRIDGE_SOURCE = loadCanvasBridgeSource()
 


### PR DESCRIPTION
Closes #676

## TL;DR

The Desktop bundle never shipped `packages/agent-runtime/static/canvas-bridge.js`. At runtime the bundled agent-runtime `readFileSync`'d a path that didn't exist, silently fell into its empty-IIFE stub, and the workspace iframe's SSE listener for build events was never installed — so the **"Update available — Refresh"** pill never rendered on Desktop while continuing to work on Cloud.

Root fix lives one layer up from the loader: add the missing copy step to `bundle-api.mjs`, add the missing `extraResource` entry to `forge.config.ts`, and pin both with an integration test that exercises the contract. Loader was untouched in behavior; it was extracted into its own module so a real unit suite can exercise its branches without booting the server.

## Before / after

| | Before (Desktop) | After (Desktop) | Cloud (unchanged) |
| --- | --- | --- | --- |
| `apps/desktop/resources/static/canvas-bridge.js` | missing | shipped, 16560 B | n/a |
| `GET /agent/canvas/bridge.js` | 200 with 49-byte stub | **200 with 16560-byte real bridge** | 200, real bridge |
| Iframe `EventSource('/agent/canvas/stream')` | never opened | opens on bridge load | opens on bridge load |
| "Update available — Refresh" pill | ❌ never appears | ✅ renders on rebuild | ✅ renders on rebuild |

## Flow diagrams

**Before (broken on Desktop):**

```
agent rebuild ─→ SSE reload broadcast ─→ iframe loads bridge.js script tag
   ─→ runtime reads resources/static/canvas-bridge.js
   ─→ ENOENT ─→ loader logs warn, returns empty IIFE stub
   ─→ iframe runs stub ─→ no EventSource, no toast
   ─→ canvas stays stale, no signal to user
```

**After (fixed):**

```
agent rebuild ─→ SSE reload broadcast ─→ iframe loads bridge.js script tag
   ─→ runtime reads resources/static/canvas-bridge.js  (shipped by bundle)
   ─→ returns real 16.5 KB bridge ─→ iframe opens EventSource
   ─→ subscribes to reload events ─→ pill renders
   ─→ user clicks Refresh ─→ canvas reloads ✨
```

## What changed (5 source files + 2 tests + .gitignore)

### `apps/desktop/scripts/bundle-api.mjs`

- Added `'static'` to `ITEMS_TO_CLEAN` so rebuilds don't accumulate stale copies.
- Added `fs.cpSync(packages/agent-runtime/static, RESOURCES_DIR/static, { recursive: true })` step with a `logStep("Copying agent-runtime static assets…")` banner. Build output now includes a positive ship signal:

  ```text
  [9/12] Copying agent-runtime static assets...
     ✓ Copied 1 static asset(s): canvas-bridge.js
  ```

### `apps/desktop/forge.config.ts`

- Added `./resources/static` to `extraResource`. Without this, the copy step works locally but `electron-forge package` would still ship an `.app` that omits the file because `extraResource` is the allow-list for files that escape asar.

### `packages/agent-runtime/src/canvas-bridge.ts` *(new)*

- Extracted `loadCanvasBridgeSource()`, `CANVAS_BRIDGE_PATH`, `CANVAS_BRIDGE_URL`, `CANVAS_BRIDGE_SCRIPT_TAG`, and `CANVAS_BRIDGE_MISSING_STUB` from `server.ts`.
- Pure refactor — behavior identical to before. Needed so the new unit suite can import the loader without triggering `server.ts`'s config / AI-proxy initialization.
- Includes a long bug-history comment so the next reader of the soft-fail branch understands what the stub hid and which test now guards against it.

### `packages/agent-runtime/src/server.ts`

- Replaced the inline loader with an import from `./canvas-bridge`. No runtime behavior change.

### `packages/agent-runtime/src/__tests__/canvas-bridge-loader.test.ts` *(new, 8 tests)*

| | Assertion |
| --- | --- |
| ✓ | Real path returns real bridge content |
| ✓ | `CANVAS_BRIDGE_PATH` resolves to a real file in the source tree (runtime ↔ source agree) |
| ✓ | Loader output is byte-identical to source (no re-encoding) |
| ✓ | Explicit `path` argument honored |
| ✓ | ENOENT → valid-JS stub + `console.warn` + no throw |
| ✓ | EISDIR (directory in place of file) → stub + warn + no throw |
| ✓ | Stub is exactly the canonical sentinel `'/* canvas-bridge.js missing */ (function () {})();\n'` (grep-able in prod logs) |
| ✓ | URL + injected `<script>` tag are coherent (route and injector match) |

### `packages/agent-runtime/src/__tests__/binary-ships-canvas-bridge.integration.test.ts` *(new, 5 tests)*

This is the test that would have caught the regression in CI:

| | Assertion |
| --- | --- |
| ✓ | `bundle-api.mjs` source contains a copy step landing `packages/agent-runtime/static` at `resources/static` |
| ✓ | `forge.config.ts` lists `./resources/static` in `extraResource` (regex strips `//` and `/* */` so a commented-out entry doesn't pass) |
| ✓ | Runtime's `CANVAS_BRIDGE_PATH` formula (`join(__dirname, '..', 'static', 'canvas-bridge.js')`) resolves exactly to the bundle destination when computed from `resources/bundle/agent-runtime.js` |
| ✓ | Source `canvas-bridge.js` is a non-empty real JS file |
| ✓ | Opportunistic byte-equality: if the bundle has been built, shipped bytes equal source bytes |

### `.gitignore`

- Added `apps/desktop/resources/static/` so the build artifact never leaks into commits.

## Why I'm calling this a root fix

The patch-fix options I rejected:

| Option | Why rejected |
| --- | --- |
| Inline `canvas-bridge.js` as a string literal in `server.ts` | Treats the symptom by side-stepping the asset pipeline. Couples runtime to bridge source. Defeats `Cache-Control: no-cache`. |
| Add a fallback search path (e.g. `resources/canvas-runtime/canvas-bridge.js`) | Papers over the missing ship-step and quietly drags an unrelated folder into bridge ownership. |
| Add a Desktop-only branch in the loader | Makes the loader bundle-layout-aware, which it shouldn't be. |

The applied fix changes only **what ships in the bundle**, not how the runtime looks for it. The runtime's `__dirname/../static/canvas-bridge.js` formula is preserved across dev, Cloud, and Desktop — the Desktop bundle now satisfies it.

## Verification

### Unit + integration suites

```bash
$ cd packages/agent-runtime
$ bun test src/__tests__/canvas-bridge-loader.test.ts \
           src/__tests__/binary-ships-canvas-bridge.integration.test.ts
 13 pass
  0 fail
 41 expect() calls
Ran 13 tests across 2 files. [240.00ms]
```

### Regression-detection proof

Reverted both `bundle-api.mjs` and `forge.config.ts` to `origin/main`, re-ran the integration suite — **2 of 5 assertions failed**, pointing at the exact missing copy step and `extraResource` entry. Restored the fix → 5/5 pass. The integration test would have caught the original regression in CI.

### Live end-to-end

```bash
$ rm -rf apps/desktop/resources/static apps/desktop/resources/bundle
$ bun run apps/desktop/scripts/bundle-api.mjs
...
[9/12] Copying agent-runtime static assets...
   ✓ Copied 1 static asset(s): canvas-bridge.js
...
$ env -u AI_PROXY_URL bun run apps/desktop/resources/bundle/agent-runtime.js &
$ curl -i http://localhost:39711/agent/canvas/bridge.js | head -3
HTTP/1.1 200 OK
Content-Type: application/javascript; charset=utf-8
Content-Length: 16560

$ diff <(curl -s http://localhost:39711/agent/canvas/bridge.js) \
       packages/agent-runtime/static/canvas-bridge.js
# (no output — bytes identical)
```

✅ The bundled runtime serves the **real 16560-byte bridge** instead of the 49-byte stub. The boot completed in ~600 ms with no errors.

## Self code-review

| Concern | Status |
| --- | --- |
| Cross-platform paths | ✓ `path.join` + `[\\/]` regex; tested implicitly via `existsSync` on macOS, formula identical on Win/Linux |
| Asar packing | ✓ Forge `extraResource` bypasses asar — file lands in `.app/Contents/Resources/static/` |
| Repeated builds accumulating stale copies | ✓ `'static'` added to `ITEMS_TO_CLEAN` |
| Dev mode | ✓ `__dirname/../static/canvas-bridge.js` still resolves to source in dev — no change |
| Concurrent reads at startup | ✓ Loader runs once into a module-scope const, served from memory |
| Cache headers | ✓ Route already sets `Cache-Control: no-cache`; updates take effect on runtime restart |
| Soft-fail visibility | Noted: stays as `console.warn`. Promoting to fail-fast considered out of scope; the new integration test catches the bundle-side regression class instead |
| Git hygiene | ✓ Added `apps/desktop/resources/static/` to `.gitignore` |
| Bundle smoke signal | ✓ Bundler now logs `Copied 1 static asset(s): canvas-bridge.js` — positive build-log evidence the asset shipped |

## Risk / blast radius

**Low.**

- Dev mode is unaffected (loader's `__dirname` is still `packages/agent-runtime/src/` in dev → resolves to source).
- Cloud is unaffected (no Dockerfile or runtime behavior change).
- Desktop bundle gains one ~16.5 KB file in `resources/static/` plus one `extraResource` entry. No code path on the hot loop changes.
- Loader refactor is bit-identical in behavior to before — verified by the byte-equality unit test and by the live HTTP curl against the bundled runtime.

## Out of scope

- Promoting the soft-fail `console.warn` to a structured-event / fail-fast startup check. Defensible, but a separate ergonomics decision; the new integration test covers the bundle regression class.
- Repo hygiene: `apps/desktop/resources/mcp-packages/`, `ms-playwright/`, and `sdk-cli.mjs` are not currently gitignored. Pre-existing.

## Checklist

- [x] Bundle copies `static/` into `resources/static/`
- [x] `forge.config.ts` ships the new folder
- [x] Unit tests for the loader (8 tests, all branches)
- [x] Integration test for the bundle-output contract (5 tests)
- [x] Integration test verified to fail on the unfixed baseline
- [x] Live HTTP verification against the real bundled runtime
- [x] `.gitignore` updated
- [x] No changes to dev-mode behavior
- [x] No changes to Cloud
- [x] Risk reviewed (low)
