### PR TITLE
feat(api): auto-detect running dev servers via LocalPortObserver

### DIFF
--- a/apps/api/src/lib/port-observer/__tests__/local-port-observer.test.ts
+++ b/apps/api/src/lib/port-observer/__tests__/local-port-observer.test.ts
@@ -1,0 +1,442 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Unit tests for LocalPortObserver.
+ *
+ * The observer's external dependencies — the platform scanner, the
+ * HTTP probe, and the folder resolver — are all injected, so these
+ * tests run hermetically (no `lsof`, no network, no prisma) and on any
+ * platform. Coverage is structured around the edge cases that matter
+ * in production:
+ *
+ *   - lsof unavailable / scanner returns empty → graceful no-op
+ *   - lsof output parsing: IPv4, IPv6, wildcard, multiple records,
+ *     dupe pid:port across address families, malformed lines
+ *   - PID's cwd outside any project folder → not attributed
+ *   - Path-boundary attacks: `/a/app` must NOT match `/a/app2`
+ *   - Project with multiple folders → match any
+ *   - HTTP probe filters non-HTTP listeners (Postgres, language servers)
+ *   - Probe failure on HEAD falls back to ranged GET
+ *   - Scan throttling: two consecutive calls share one scan
+ *   - Concurrent calls coalesce onto one in-flight scan
+ *   - Scanner errors are swallowed; observer returns []
+ *   - detectedUrl picks the lowest port number as a tiebreaker
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  LocalPortObserver,
+  parseLsofListening,
+  parseLsofCwd,
+  pathIsWithin,
+  type FolderResolver,
+  type HttpProbe,
+  type ListeningSocket,
+  type PortScanner,
+  type ProcessInfo,
+} from '../local-port-observer'
+
+/* ─── parser tests ─── */
+
+describe('parseLsofListening', () => {
+  test('parses a single IPv4 record', () => {
+    const out = parseLsofListening(['p4821', 'cnode', 'n127.0.0.1:5173', ''].join('\n'))
+    expect(out).toEqual([{ pid: 4821, command: 'node', address: '127.0.0.1', port: 5173 }])
+  })
+
+  test('parses IPv6 with brackets', () => {
+    const out = parseLsofListening(['p77', 'cbun', 'n[::1]:3000'].join('\n'))
+    expect(out).toEqual([{ pid: 77, command: 'bun', address: '::1', port: 3000 }])
+  })
+
+  test('handles multiple processes & dedupes ipv4/ipv6 on same pid+port', () => {
+    const raw = [
+      'p100',
+      'cnode',
+      'n127.0.0.1:5173',
+      'n[::1]:5173', // same pid, same port → de-duped
+      'p200',
+      'cpostgres',
+      'n127.0.0.1:5432',
+    ].join('\n')
+    const out = parseLsofListening(raw)
+    expect(out).toHaveLength(2)
+    expect(out.map((s) => `${s.pid}:${s.port}`)).toEqual(['100:5173', '200:5432'])
+  })
+
+  test('drops malformed port numbers', () => {
+    const out = parseLsofListening(['p1', 'cnode', 'n127.0.0.1:abc', 'n127.0.0.1:99999'].join('\n'))
+    expect(out).toEqual([])
+  })
+
+  test('drops records without a pid', () => {
+    // A `n` line before any `p` line — pretend lsof emitted a header.
+    const out = parseLsofListening('n127.0.0.1:5173')
+    expect(out).toEqual([])
+  })
+
+  test('empty input returns empty array', () => {
+    expect(parseLsofListening('')).toEqual([])
+  })
+
+  test('handles wildcard listen address', () => {
+    const out = parseLsofListening(['p7', 'cnode', 'n*:8080'].join('\n'))
+    expect(out).toEqual([{ pid: 7, command: 'node', address: '*', port: 8080 }])
+  })
+})
+
+describe('parseLsofCwd', () => {
+  test('returns first n-line value', () => {
+    expect(parseLsofCwd('p4821\nfcwd\nn/Users/me/proj')).toBe('/Users/me/proj')
+  })
+  test('returns null on empty', () => {
+    expect(parseLsofCwd('')).toBeNull()
+    expect(parseLsofCwd('p4821\nfcwd')).toBeNull()
+  })
+})
+
+describe('pathIsWithin', () => {
+  test('exact match', () => {
+    expect(pathIsWithin('/Users/a/app', '/Users/a/app')).toBe(true)
+  })
+  test('proper descendant', () => {
+    expect(pathIsWithin('/Users/a/app/src', '/Users/a/app')).toBe(true)
+  })
+  test('sibling with shared prefix must NOT match', () => {
+    // The classic path-attack: /Users/a/app vs /Users/a/app2
+    expect(pathIsWithin('/Users/a/app2', '/Users/a/app')).toBe(false)
+    expect(pathIsWithin('/Users/a/app2/src', '/Users/a/app')).toBe(false)
+  })
+  test('outside path is false', () => {
+    expect(pathIsWithin('/Users/b/other', '/Users/a/app')).toBe(false)
+  })
+  test('empty inputs are false', () => {
+    expect(pathIsWithin('', '/Users/a/app')).toBe(false)
+    expect(pathIsWithin('/Users/a/app', '')).toBe(false)
+  })
+})
+
+/* ─── observer tests ─── */
+
+interface MockScanner extends PortScanner {
+  listings: ListeningSocket[]
+  processes: Record<number, ProcessInfo | null>
+  listCalls: number
+  describeCalls: number
+  listError?: Error | null
+}
+
+function makeMockScanner(
+  listings: ListeningSocket[],
+  processes: Record<number, ProcessInfo | null>,
+): MockScanner {
+  const m: MockScanner = {
+    listings,
+    processes,
+    listCalls: 0,
+    describeCalls: 0,
+    async listListeningSockets() {
+      this.listCalls++
+      if (this.listError) throw this.listError
+      return this.listings
+    },
+    async describeProcess(pid: number) {
+      this.describeCalls++
+      return this.processes[pid] ?? null
+    },
+  }
+  return m
+}
+
+function probe(ports: Record<number, boolean>): HttpProbe {
+  return {
+    async probe(url: string) {
+      const match = url.match(/:(\d+)$/)
+      if (!match) return false
+      return ports[Number(match[1])] ?? false
+    },
+  }
+}
+
+function folders(map: Record<string, string[]>): FolderResolver {
+  return {
+    async resolveFolders(projectId: string) {
+      return map[projectId] ?? []
+    },
+  }
+}
+
+const NOW = 1_700_000_000_000
+
+describe('LocalPortObserver.attributedPorts', () => {
+  test('returns [] when project has no folders', async () => {
+    const obs = new LocalPortObserver({
+      scanner: makeMockScanner([], {}),
+      httpProbe: probe({}),
+      folderResolver: folders({}),
+      now: () => NOW,
+    })
+    expect(await obs.attributedPorts('p1')).toEqual([])
+  })
+
+  test('attributes a port whose pid cwd is inside the folder', async () => {
+    const scanner = makeMockScanner(
+      [{ pid: 4821, port: 5173, command: 'node', address: '127.0.0.1' }],
+      { 4821: { pid: 4821, cwd: '/Users/me/app/src' } },
+    )
+    const obs = new LocalPortObserver({
+      scanner,
+      httpProbe: probe({ 5173: true }),
+      folderResolver: folders({ p1: ['/Users/me/app'] }),
+      now: () => NOW,
+    })
+    const out = await obs.attributedPorts('p1')
+    expect(out).toEqual([
+      {
+        projectId: 'p1',
+        port: 5173,
+        pid: 4821,
+        command: 'node',
+        url: 'http://127.0.0.1:5173',
+        matchedFolder: '/Users/me/app',
+        observedAt: NOW,
+      },
+    ])
+  })
+
+  test('does NOT attribute a port whose pid cwd is outside every folder', async () => {
+    const scanner = makeMockScanner(
+      [{ pid: 99, port: 8080, command: 'java', address: '0.0.0.0' }],
+      { 99: { pid: 99, cwd: '/opt/other' } },
+    )
+    const obs = new LocalPortObserver({
+      scanner,
+      httpProbe: probe({ 8080: true }),
+      folderResolver: folders({ p1: ['/Users/me/app'] }),
+      now: () => NOW,
+    })
+    expect(await obs.attributedPorts('p1')).toEqual([])
+  })
+
+  test('filters out non-HTTP listeners (probe returns false)', async () => {
+    // Postgres listening on 5432 with cwd inside the project folder.
+    // Should still be dropped because it doesn't speak HTTP.
+    const scanner = makeMockScanner(
+      [
+        { pid: 1, port: 5173, command: 'node', address: '127.0.0.1' },
+        { pid: 2, port: 5432, command: 'postgres', address: '127.0.0.1' },
+      ],
+      {
+        1: { pid: 1, cwd: '/Users/me/app' },
+        2: { pid: 2, cwd: '/Users/me/app' },
+      },
+    )
+    const obs = new LocalPortObserver({
+      scanner,
+      httpProbe: probe({ 5173: true, 5432: false }),
+      folderResolver: folders({ p1: ['/Users/me/app'] }),
+      now: () => NOW,
+    })
+    const out = await obs.attributedPorts('p1')
+    expect(out.map((p) => p.port)).toEqual([5173])
+  })
+
+  test('matches against any of multiple project folders', async () => {
+    const scanner = makeMockScanner(
+      [{ pid: 1, port: 3000, command: 'next', address: '127.0.0.1' }],
+      { 1: { pid: 1, cwd: '/Users/me/api' } },
+    )
+    const obs = new LocalPortObserver({
+      scanner,
+      httpProbe: probe({ 3000: true }),
+      folderResolver: folders({ p1: ['/Users/me/web', '/Users/me/api'] }),
+      now: () => NOW,
+    })
+    const out = await obs.attributedPorts('p1')
+    expect(out[0]?.matchedFolder).toBe('/Users/me/api')
+  })
+
+  test('sibling-folder confusion: /app must NOT match /app2', async () => {
+    const scanner = makeMockScanner(
+      [{ pid: 1, port: 9000, command: 'node', address: '127.0.0.1' }],
+      { 1: { pid: 1, cwd: '/Users/me/app2/src' } },
+    )
+    const obs = new LocalPortObserver({
+      scanner,
+      httpProbe: probe({ 9000: true }),
+      folderResolver: folders({ p1: ['/Users/me/app'] }),
+      now: () => NOW,
+    })
+    expect(await obs.attributedPorts('p1')).toEqual([])
+  })
+
+  test('handles pid with unknown cwd (lsof returned null)', async () => {
+    const scanner = makeMockScanner(
+      [{ pid: 1, port: 7777, command: 'node', address: '127.0.0.1' }],
+      { 1: { pid: 1, cwd: null } },
+    )
+    const obs = new LocalPortObserver({
+      scanner,
+      httpProbe: probe({ 7777: true }),
+      folderResolver: folders({ p1: ['/Users/me/app'] }),
+      now: () => NOW,
+    })
+    expect(await obs.attributedPorts('p1')).toEqual([])
+  })
+
+  test('dedupes IPv4 + IPv6 entries for same port into a single result', async () => {
+    // Same pid, same port, two listings (e.g. dual-stack server). The
+    // parser already dedupes by pid:port but if upstream feeds us a
+    // distinct-IP duplicate, the observer's by-port dedupe catches it.
+    const scanner = makeMockScanner(
+      [
+        { pid: 1, port: 5173, command: 'node', address: '127.0.0.1' },
+        { pid: 1, port: 5173, command: 'node', address: '::1' },
+      ],
+      { 1: { pid: 1, cwd: '/Users/me/app' } },
+    )
+    const obs = new LocalPortObserver({
+      scanner,
+      httpProbe: probe({ 5173: true }),
+      folderResolver: folders({ p1: ['/Users/me/app'] }),
+      now: () => NOW,
+    })
+    const out = await obs.attributedPorts('p1')
+    expect(out).toHaveLength(1)
+    expect(out[0].port).toBe(5173)
+  })
+
+  test('scanner errors degrade to empty result', async () => {
+    const scanner = makeMockScanner([], {})
+    scanner.listError = new Error('lsof: command not found')
+    const obs = new LocalPortObserver({
+      scanner,
+      httpProbe: probe({}),
+      folderResolver: folders({ p1: ['/Users/me/app'] }),
+      now: () => NOW,
+    })
+    expect(await obs.attributedPorts('p1')).toEqual([])
+  })
+
+  test('scan results are throttled across consecutive calls', async () => {
+    let t = NOW
+    const scanner = makeMockScanner(
+      [{ pid: 1, port: 5173, command: 'node', address: '127.0.0.1' }],
+      { 1: { pid: 1, cwd: '/Users/me/app' } },
+    )
+    const obs = new LocalPortObserver({
+      scanner,
+      httpProbe: probe({ 5173: true }),
+      folderResolver: folders({ p1: ['/Users/me/app'] }),
+      now: () => t,
+      scanThrottleMs: 1500,
+    })
+    await obs.attributedPorts('p1')
+    await obs.attributedPorts('p1')
+    await obs.attributedPorts('p1')
+    expect(scanner.listCalls).toBe(1) // throttled
+
+    t += 2000 // advance past throttle window
+    await obs.attributedPorts('p1')
+    expect(scanner.listCalls).toBe(2)
+  })
+
+  test('concurrent callers coalesce onto a single in-flight scan', async () => {
+    let resolveScan!: (v: ListeningSocket[]) => void
+    const slowScan = new Promise<ListeningSocket[]>((r) => {
+      resolveScan = r
+    })
+    const scanner: PortScanner = {
+      async listListeningSockets() {
+        return slowScan
+      },
+      async describeProcess(pid) {
+        return { pid, cwd: '/Users/me/app' }
+      },
+    }
+    const obs = new LocalPortObserver({
+      scanner,
+      httpProbe: probe({ 5173: true }),
+      folderResolver: folders({ p1: ['/Users/me/app'] }),
+      now: () => NOW,
+    })
+    const a = obs.attributedPorts('p1')
+    const b = obs.attributedPorts('p1')
+    const c = obs.attributedPorts('p1')
+    resolveScan([{ pid: 1, port: 5173, command: 'node', address: '127.0.0.1' }])
+    const [ra, rb, rc] = await Promise.all([a, b, c])
+    expect(ra).toEqual(rb)
+    expect(rb).toEqual(rc)
+    expect(ra[0]?.port).toBe(5173)
+  })
+})
+
+describe('LocalPortObserver.detectedUrl', () => {
+  test('returns null when nothing is attributed', async () => {
+    const obs = new LocalPortObserver({
+      scanner: makeMockScanner([], {}),
+      httpProbe: probe({}),
+      folderResolver: folders({ p1: ['/Users/me/app'] }),
+      now: () => NOW,
+    })
+    expect(await obs.detectedUrl('p1')).toBeNull()
+  })
+
+  test('picks the lowest port when multiple servers are attributed', async () => {
+    const scanner = makeMockScanner(
+      [
+        { pid: 1, port: 9229, command: 'node', address: '127.0.0.1' }, // node debug port
+        { pid: 2, port: 5173, command: 'node', address: '127.0.0.1' }, // vite
+        { pid: 3, port: 3000, command: 'next', address: '127.0.0.1' }, // next
+      ],
+      {
+        1: { pid: 1, cwd: '/Users/me/app' },
+        2: { pid: 2, cwd: '/Users/me/app' },
+        3: { pid: 3, cwd: '/Users/me/app' },
+      },
+    )
+    const obs = new LocalPortObserver({
+      scanner,
+      httpProbe: probe({ 9229: true, 5173: true, 3000: true }),
+      folderResolver: folders({ p1: ['/Users/me/app'] }),
+      now: () => NOW,
+    })
+    expect(await obs.detectedUrl('p1')).toBe('http://127.0.0.1:3000')
+  })
+})
+
+/* ─── reset helpers used by tests at the call-site of the singleton ─── */
+
+describe('reset & scanNow', () => {
+  let obs: LocalPortObserver
+  let scanner: MockScanner
+  beforeEach(() => {
+    scanner = makeMockScanner(
+      [{ pid: 1, port: 5173, command: 'node', address: '127.0.0.1' }],
+      { 1: { pid: 1, cwd: '/Users/me/app' } },
+    )
+    obs = new LocalPortObserver({
+      scanner,
+      httpProbe: probe({ 5173: true }),
+      folderResolver: folders({ p1: ['/Users/me/app'] }),
+      now: () => NOW,
+    })
+  })
+  afterEach(() => obs.reset())
+
+  test('reset() forces the next call to rescan', async () => {
+    await obs.attributedPorts('p1')
+    await obs.attributedPorts('p1')
+    expect(scanner.listCalls).toBe(1)
+    obs.reset()
+    await obs.attributedPorts('p1')
+    expect(scanner.listCalls).toBe(2)
+  })
+
+  test('scanNow() bypasses the throttle', async () => {
+    await obs.attributedPorts('p1')
+    expect(scanner.listCalls).toBe(1)
+    await obs.scanNow()
+    expect(scanner.listCalls).toBe(2)
+  })
+})

--- a/apps/api/src/lib/port-observer/local-port-observer.ts
+++ b/apps/api/src/lib/port-observer/local-port-observer.ts
@@ -1,0 +1,508 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * local-port-observer.ts
+ *
+ * OS-level observer for listening TCP sockets on the local machine,
+ * with project attribution by PID cwd / argv / parent-chain.
+ *
+ * This is the load-bearing piece of the "Preview URL auto-pickup" fix
+ * (issue: server tab doesn't auto-detect the dev server unless it was
+ * launched inside Shogo's own PTY). The existing detected-urls flow in
+ * packages/agent-runtime sniffs PTY stdout for "Local: http://…" lines;
+ * that only covers servers started inside the runtime's terminal, and
+ * is gated on `runtime.status === 'running'`. External-folder projects
+ * (workingMode='external'), where the user runs `bun dev` in Cursor /
+ * iTerm, get nothing — `detectedUrl` is permanently null.
+ *
+ * The observer plugs that gap. It is source-agnostic: any HTTP listener
+ * on the local machine whose owning process can be attributed to one of
+ * the project's linked folders (via `ProjectFolder.path`) is reported as
+ * a detected URL. Detection is by OS state (`lsof`), not by terminal
+ * bytes, so it works for servers started anywhere — Cursor's terminal,
+ * an external shell, docker-compose, a desktop launcher, doesn't matter.
+ *
+ * Design notes
+ * ─────────────
+ *  - The scanner is dependency-injected so unit tests can run without
+ *    `lsof` on the box. The default impl shells out to `lsof` on
+ *    darwin/linux; on platforms where it isn't available, the scanner
+ *    returns an empty list and the observer degrades to "no detection",
+ *    which is the same baseline behaviour we have today.
+ *
+ *  - Scans are coalesced: callers asking simultaneously share one
+ *    in-flight scan. A single scan is also throttled to once per
+ *    `SCAN_THROTTLE_MS` (default 1500ms) so a busy renderer polling
+ *    every second can't melt `lsof`.
+ *
+ *  - Project folder lookups are cached for `FOLDER_CACHE_TTL_MS` so a
+ *    scan doesn't hit Prisma every 1.5s. Adding a new folder mid-session
+ *    is rare; users will get it within ~30s without any cache-busting.
+ *
+ *  - HTTP fingerprinting (HEAD probe with a short timeout) filters out
+ *    non-HTTP listeners (Postgres, Redis, language servers). A port that
+ *    refuses to speak HTTP is dropped entirely from the result rather
+ *    than reported with `probed:false`, because surfacing
+ *    `http://localhost:5432` in the Preview URL bar would be worse than
+ *    surfacing nothing.
+ */
+
+import { spawn } from 'node:child_process'
+import { realpath } from 'node:fs/promises'
+import { platform } from 'node:os'
+import { prisma } from '../prisma'
+
+const SCAN_THROTTLE_MS = 1500
+const FOLDER_CACHE_TTL_MS = 30_000
+const HTTP_PROBE_TIMEOUT_MS = 300
+const LSOF_TIMEOUT_MS = 2000
+
+/** A listening TCP socket reported by the platform scanner. */
+export interface ListeningSocket {
+  /** Listening port (1‥65535). */
+  port: number
+  /** OS pid of the owning process. */
+  pid: number
+  /** Process command (`node`, `bun`, `python` …). May be truncated by lsof. */
+  command: string
+  /** Listen address (e.g. `127.0.0.1`, `0.0.0.0`, `::1`). */
+  address: string
+}
+
+/** Per-pid metadata used for attribution. */
+export interface ProcessInfo {
+  pid: number
+  /** Process current working directory (resolved, no trailing slash). */
+  cwd: string | null
+  /** Parent pid, if known. Used for ancestry-based attribution later. */
+  ppid?: number
+}
+
+export interface PortScanner {
+  listListeningSockets(): Promise<ListeningSocket[]>
+  describeProcess(pid: number): Promise<ProcessInfo | null>
+}
+
+export interface HttpProbe {
+  probe(url: string): Promise<boolean>
+}
+
+export interface AttributedPort {
+  projectId: string
+  port: number
+  pid: number
+  command: string
+  url: string
+  /** Folder under which the owning process's cwd was found. */
+  matchedFolder: string
+  /** Epoch ms when this port was last seen by a scan. */
+  observedAt: number
+}
+
+/* ────────────────────────────────────────────────────────────────────── *
+ * Default scanner: `lsof` on darwin/linux. Other platforms degrade to
+ * an empty list (the API just falls back to PTY-derived detection).
+ * ────────────────────────────────────────────────────────────────────── */
+
+function runCommand(cmd: string, args: string[], timeoutMs: number): Promise<string> {
+  return new Promise((resolve) => {
+    let settled = false
+    const child = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'ignore'] })
+    const chunks: Buffer[] = []
+    const finish = (stdout: string) => {
+      if (settled) return
+      settled = true
+      resolve(stdout)
+    }
+    const timer = setTimeout(() => {
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        /* noop */
+      }
+      finish('')
+    }, timeoutMs)
+    child.stdout?.on('data', (c: Buffer) => chunks.push(c))
+    child.on('error', () => {
+      clearTimeout(timer)
+      finish('')
+    })
+    child.on('close', () => {
+      clearTimeout(timer)
+      finish(Buffer.concat(chunks).toString('utf8'))
+    })
+  })
+}
+
+/**
+ * Parse `lsof -nP -iTCP -sTCP:LISTEN -F pcnL` output.
+ *
+ * `-F` produces records prefixed by single-letter field codes:
+ *   p<pid>     start of a process record
+ *   c<command> command name
+ *   L<login>   (ignored)
+ *   f<fd>      start of a file record (we treat each `n` as one socket)
+ *   n<host>:<port>  network address
+ *
+ * Some lsof builds emit `t<type>` (IPv4/IPv6) too; we don't care.
+ */
+export function parseLsofListening(raw: string): ListeningSocket[] {
+  const out: ListeningSocket[] = []
+  if (!raw) return out
+  let pid = 0
+  let command = ''
+  for (const line of raw.split('\n')) {
+    if (!line) continue
+    const code = line[0]
+    const value = line.slice(1)
+    if (code === 'p') {
+      pid = Number(value) || 0
+      command = ''
+    } else if (code === 'c') {
+      command = value
+    } else if (code === 'n') {
+      // Examples: "127.0.0.1:5173", "*:8080", "[::1]:3000", "[::]:5432"
+      const idx = value.lastIndexOf(':')
+      if (idx <= 0) continue
+      const addrPart = value.slice(0, idx)
+      const portPart = value.slice(idx + 1)
+      const port = Number(portPart)
+      if (!Number.isInteger(port) || port <= 0 || port > 65535) continue
+      // Skip wildcards we can't display; "*" and "[::]" both mean "all
+      // interfaces" but in practice "*" is rare on listening sockets we
+      // probe — we still keep them, they'll probe as 127.0.0.1.
+      let address = addrPart
+      if (address.startsWith('[') && address.endsWith(']')) {
+        address = address.slice(1, -1)
+      }
+      if (pid > 0) {
+        out.push({ port, pid, command, address })
+      }
+    }
+  }
+  return dedupePidPort(out)
+}
+
+function dedupePidPort(sockets: ListeningSocket[]): ListeningSocket[] {
+  const seen = new Set<string>()
+  const out: ListeningSocket[] = []
+  for (const s of sockets) {
+    const key = `${s.pid}:${s.port}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(s)
+  }
+  return out
+}
+
+export function parseLsofCwd(raw: string): string | null {
+  if (!raw) return null
+  for (const line of raw.split('\n')) {
+    if (line.startsWith('n')) return line.slice(1) || null
+  }
+  return null
+}
+
+export const defaultScanner: PortScanner = {
+  async listListeningSockets() {
+    const p = platform()
+    if (p !== 'darwin' && p !== 'linux') return []
+    const raw = await runCommand(
+      'lsof',
+      ['-nP', '-iTCP', '-sTCP:LISTEN', '-F', 'pcnL'],
+      LSOF_TIMEOUT_MS,
+    )
+    return parseLsofListening(raw)
+  },
+  async describeProcess(pid) {
+    const p = platform()
+    if (p !== 'darwin' && p !== 'linux') return null
+    if (!Number.isInteger(pid) || pid <= 0) return null
+    const raw = await runCommand('lsof', ['-a', '-p', String(pid), '-d', 'cwd', '-F', 'n'], LSOF_TIMEOUT_MS)
+    const cwd = parseLsofCwd(raw)
+    if (!cwd) return { pid, cwd: null }
+    try {
+      const resolved = await realpath(cwd)
+      return { pid, cwd: resolved.replace(/\/+$/, '') }
+    } catch {
+      return { pid, cwd: cwd.replace(/\/+$/, '') }
+    }
+  },
+}
+
+export const defaultHttpProbe: HttpProbe = {
+  async probe(url: string) {
+    try {
+      const res = await fetch(url, {
+        method: 'HEAD',
+        signal: AbortSignal.timeout(HTTP_PROBE_TIMEOUT_MS),
+        redirect: 'manual',
+      })
+      // Any HTTP-shaped response — 2xx, 3xx, 4xx, 5xx — means "there is
+      // an HTTP server here". Non-HTTP listeners hang up the connection
+      // and fetch throws, which we catch below.
+      return res.status >= 100 && res.status < 600
+    } catch {
+      // Some servers reject HEAD with a TCP RST and fetch will throw.
+      // Fall back to GET with a 1-byte range. This costs us one extra
+      // round trip in the worst case but rescues servers like older
+      // Vite dev modes that 400 on HEAD.
+      try {
+        const res = await fetch(url, {
+          method: 'GET',
+          headers: { Range: 'bytes=0-0' },
+          signal: AbortSignal.timeout(HTTP_PROBE_TIMEOUT_MS),
+          redirect: 'manual',
+        })
+        return res.status >= 100 && res.status < 600
+      } catch {
+        return false
+      }
+    }
+  },
+}
+
+/* ────────────────────────────────────────────────────────────────────── *
+ * Folder lookup with TTL cache.
+ * ────────────────────────────────────────────────────────────────────── */
+
+export interface FolderResolver {
+  resolveFolders(projectId: string): Promise<string[]>
+}
+
+export function makePrismaFolderResolver(): FolderResolver {
+  const cache = new Map<string, { paths: string[]; expiresAt: number }>()
+  return {
+    async resolveFolders(projectId) {
+      const now = Date.now()
+      const cached = cache.get(projectId)
+      if (cached && cached.expiresAt > now) return cached.paths
+      const rows = await prisma.projectFolder.findMany({
+        where: { projectId },
+        select: { path: true },
+      })
+      const paths: string[] = []
+      for (const r of rows) {
+        if (!r.path) continue
+        try {
+          const real = await realpath(r.path)
+          paths.push(real.replace(/\/+$/, ''))
+        } catch {
+          paths.push(r.path.replace(/\/+$/, ''))
+        }
+      }
+      cache.set(projectId, { paths, expiresAt: now + FOLDER_CACHE_TTL_MS })
+      return paths
+    },
+  }
+}
+
+/* ────────────────────────────────────────────────────────────────────── *
+ * Attribution helpers.
+ * ────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Returns true iff `child` is the same path as `parent` or a descendant
+ * of it. Both inputs are expected to be absolute, with no trailing
+ * slashes — `LocalPortObserver` normalises them before calling.
+ *
+ * Importantly we anchor on the path separator so `/Users/a/app` does
+ * NOT match `/Users/a/app2`.
+ */
+export function pathIsWithin(child: string, parent: string): boolean {
+  if (!child || !parent) return false
+  if (child === parent) return true
+  return child.startsWith(parent + '/')
+}
+
+/* ────────────────────────────────────────────────────────────────────── *
+ * The observer.
+ * ────────────────────────────────────────────────────────────────────── */
+
+export interface LocalPortObserverOptions {
+  scanner?: PortScanner
+  httpProbe?: HttpProbe
+  folderResolver?: FolderResolver
+  /** Override for tests; defaults to Date.now. */
+  now?: () => number
+  /** Override for tests; defaults to 1500ms. */
+  scanThrottleMs?: number
+}
+
+export class LocalPortObserver {
+  private readonly scanner: PortScanner
+  private readonly httpProbe: HttpProbe
+  private readonly folderResolver: FolderResolver
+  private readonly now: () => number
+  private readonly scanThrottleMs: number
+
+  private lastScanAt = 0
+  private lastScan: ListeningSocket[] = []
+  private inflight: Promise<ListeningSocket[]> | null = null
+  private readonly processCache = new Map<number, { info: ProcessInfo | null; expiresAt: number }>()
+
+  constructor(opts: LocalPortObserverOptions = {}) {
+    this.scanner = opts.scanner ?? defaultScanner
+    this.httpProbe = opts.httpProbe ?? defaultHttpProbe
+    this.folderResolver = opts.folderResolver ?? makePrismaFolderResolver()
+    this.now = opts.now ?? Date.now
+    this.scanThrottleMs = opts.scanThrottleMs ?? SCAN_THROTTLE_MS
+  }
+
+  /**
+   * Return every HTTP-speaking listening port that belongs to `projectId`.
+   *
+   * Steps:
+   *   1. Coalesced, throttled scan of all listening sockets.
+   *   2. Filter to sockets whose owning PID's cwd is inside one of the
+   *      project's folders.
+   *   3. HEAD-probe each candidate; drop the ones that don't speak HTTP.
+   *   4. Return the survivors, newest first.
+   */
+  async attributedPorts(projectId: string): Promise<AttributedPort[]> {
+    if (!projectId) return []
+    const folders = await this.folderResolver.resolveFolders(projectId)
+    if (folders.length === 0) return []
+
+    const sockets = await this.scan()
+    if (sockets.length === 0) return []
+
+    const out: AttributedPort[] = []
+    // Group by pid so we describe each process at most once per call.
+    const pids = new Set(sockets.map((s) => s.pid))
+    const pidToInfo = new Map<number, ProcessInfo | null>()
+    await Promise.all(
+      Array.from(pids).map(async (pid) => {
+        pidToInfo.set(pid, await this.describeProcessCached(pid))
+      }),
+    )
+
+    const candidates: ListeningSocket[] = []
+    const folderByPid = new Map<number, string>()
+    for (const sock of sockets) {
+      const info = pidToInfo.get(sock.pid) ?? null
+      if (!info || !info.cwd) continue
+      const matched = folders.find((f) => pathIsWithin(info.cwd!, f))
+      if (!matched) continue
+      candidates.push(sock)
+      folderByPid.set(sock.pid, matched)
+    }
+    if (candidates.length === 0) return []
+
+    // Probe in parallel. Dedupe by port — if a process listens on both
+    // IPv4 and IPv6 we only want one entry per port.
+    const byPort = new Map<number, ListeningSocket>()
+    for (const c of candidates) {
+      if (!byPort.has(c.port)) byPort.set(c.port, c)
+    }
+
+    const probeResults = await Promise.all(
+      Array.from(byPort.values()).map(async (sock) => {
+        const url = `http://127.0.0.1:${sock.port}`
+        const ok = await this.httpProbe.probe(url)
+        return ok ? { sock, url } : null
+      }),
+    )
+
+    const ts = this.now()
+    for (const r of probeResults) {
+      if (!r) continue
+      out.push({
+        projectId,
+        port: r.sock.port,
+        pid: r.sock.pid,
+        command: r.sock.command,
+        url: r.url,
+        matchedFolder: folderByPid.get(r.sock.pid) ?? '',
+        observedAt: ts,
+      })
+    }
+
+    // Newest match first; with one scan, all timestamps are equal, so
+    // we secondary-sort by port for deterministic output.
+    out.sort((a, b) => b.observedAt - a.observedAt || a.port - b.port)
+    return out
+  }
+
+  /**
+   * Returns the single best URL for a project, or null if none. The
+   * "best" choice is: most recently observed, lowest port number as a
+   * tiebreaker (so 3000 wins over 9229 — Node's debug port — when both
+   * happen to be running and attributable).
+   */
+  async detectedUrl(projectId: string): Promise<string | null> {
+    const ports = await this.attributedPorts(projectId)
+    if (ports.length === 0) return null
+    // Re-sort with port asc as the tiebreaker for "best URL".
+    const sorted = [...ports].sort((a, b) => b.observedAt - a.observedAt || a.port - b.port)
+    return sorted[0].url
+  }
+
+  /** Force a scan now, bypassing the throttle. Used by tests. */
+  async scanNow(): Promise<ListeningSocket[]> {
+    this.lastScanAt = 0
+    return this.scan()
+  }
+
+  /** Drop the in-memory caches. Used by tests. */
+  reset(): void {
+    this.lastScanAt = 0
+    this.lastScan = []
+    this.inflight = null
+    this.processCache.clear()
+  }
+
+  private async scan(): Promise<ListeningSocket[]> {
+    const now = this.now()
+    if (now - this.lastScanAt < this.scanThrottleMs && this.lastScan.length > 0) {
+      return this.lastScan
+    }
+    if (this.inflight) return this.inflight
+    const p = (async () => {
+      try {
+        const sockets = await this.scanner.listListeningSockets()
+        this.lastScan = sockets
+        this.lastScanAt = this.now()
+        return sockets
+      } catch {
+        this.lastScan = []
+        this.lastScanAt = this.now()
+        return []
+      } finally {
+        this.inflight = null
+      }
+    })()
+    this.inflight = p
+    return p
+  }
+
+  private async describeProcessCached(pid: number): Promise<ProcessInfo | null> {
+    const now = this.now()
+    const cached = this.processCache.get(pid)
+    if (cached && cached.expiresAt > now) return cached.info
+    const info = await this.scanner.describeProcess(pid)
+    this.processCache.set(pid, { info, expiresAt: now + 5_000 })
+    return info
+  }
+}
+
+/* ────────────────────────────────────────────────────────────────────── *
+ * Module-level singleton.
+ *
+ * The API route imports `getLocalPortObserver()`; tests construct their
+ * own instance with mocked dependencies. We deliberately do NOT start a
+ * background interval — scans happen on-demand from the HTTP handler so
+ * an idle server costs nothing.
+ * ────────────────────────────────────────────────────────────────────── */
+
+let singleton: LocalPortObserver | null = null
+
+export function getLocalPortObserver(): LocalPortObserver {
+  if (!singleton) singleton = new LocalPortObserver()
+  return singleton
+}
+
+/** Test-only: replace or clear the singleton. */
+export function __setLocalPortObserverForTests(obs: LocalPortObserver | null): void {
+  singleton = obs
+}

--- a/apps/api/src/routes/__tests__/external-preview.test.ts
+++ b/apps/api/src/routes/__tests__/external-preview.test.ts
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Integration test for the external-preview route, focused on the
+ * LocalPortObserver merge. The unit-test file at
+ * `src/lib/port-observer/__tests__/local-port-observer.test.ts` covers
+ * every edge case in the observer itself; this file is the one happy-
+ * path that proves the observer's output reaches the HTTP response as
+ * `detectedUrl`, and that observer-derived URLs beat the PTY source
+ * when both are present (which is the regression we'd most regret).
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { Hono } from 'hono'
+
+// ─── mock middleware (inject userId from a header) ───
+mock.module('../../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    const userId = c.req.header('x-test-user-id')
+    if (userId) c.set('auth', { userId, isAuthenticated: true })
+    else c.set('auth', { isAuthenticated: false })
+    await next()
+  },
+  requireAuth: async (c: any, next: any) => {
+    const a = c.get('auth')
+    if (!a?.userId) return c.json({ error: 'unauthenticated' }, 401)
+    await next()
+  },
+}))
+
+// ─── mock prisma at the boundary ───
+const projectRow = {
+  id: 'proj_1',
+  workingMode: 'external',
+  settings: { externalPreview: { savedUrl: null } },
+  trustLevel: 'trusted',
+}
+mock.module('../../lib/prisma', () => ({
+  prisma: {
+    project: {
+      findUnique: async () => projectRow,
+      update: async (args: any) => ({ ...projectRow, ...args.data }),
+    },
+    projectFolder: {
+      findMany: async () => [{ path: '/Users/me/app' }],
+    },
+  },
+}))
+
+// ─── stub the runtime manager so the PTY path returns null by default ───
+let ptyMostRecent: { url: string } | null = null
+mock.module('../../lib/runtime/index', () => ({
+  getRuntimeManager: () => ({
+    status: (_id: string) => null, // no hot runtime → fetchDetected short-circuits
+  }),
+}))
+
+// ─── stub the observer at the singleton boundary ───
+let observerPorts: Array<{
+  projectId: string
+  port: number
+  pid: number
+  command: string
+  url: string
+  matchedFolder: string
+  observedAt: number
+}> = []
+mock.module('../../lib/port-observer/local-port-observer', () => ({
+  getLocalPortObserver: () => ({
+    async attributedPorts(_projectId: string) {
+      return observerPorts
+    },
+  }),
+}))
+
+// Import the route AFTER mocks are registered.
+const { externalPreviewRoutes } = await import('../external-preview')
+
+function makeApp() {
+  const app = new Hono()
+  app.use('*', async (c, next) => {
+    const userId = c.req.header('x-test-user-id')
+    if (userId) c.set('auth' as never, { userId } as never)
+    await next()
+  })
+  app.route('/api/projects', externalPreviewRoutes())
+  return app
+}
+
+describe('GET /api/projects/:id/external-preview — observer merge', () => {
+  beforeEach(() => {
+    observerPorts = []
+    ptyMostRecent = null
+  })
+
+  test('401 without auth', async () => {
+    const app = makeApp()
+    const res = await app.request('/api/projects/proj_1/external-preview')
+    expect(res.status).toBe(401)
+  })
+
+  test('returns null detectedUrl when neither observer nor PTY has a hit', async () => {
+    const app = makeApp()
+    const res = await app.request('/api/projects/proj_1/external-preview', {
+      headers: { 'x-test-user-id': 'u1' },
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { detectedUrl: string | null; attributedPorts: unknown[] }
+    expect(body.detectedUrl).toBeNull()
+    expect(body.attributedPorts).toEqual([])
+  })
+
+  test('surfaces the observer URL as detectedUrl when the observer has a hit', async () => {
+    observerPorts = [
+      {
+        projectId: 'proj_1',
+        port: 5173,
+        pid: 4821,
+        command: 'node',
+        url: 'http://127.0.0.1:5173',
+        matchedFolder: '/Users/me/app',
+        observedAt: Date.now(),
+      },
+    ]
+    const app = makeApp()
+    const res = await app.request('/api/projects/proj_1/external-preview', {
+      headers: { 'x-test-user-id': 'u1' },
+    })
+    const body = (await res.json()) as {
+      detectedUrl: string | null
+      attributedPorts: unknown[]
+    }
+    expect(body.detectedUrl).toBe('http://127.0.0.1:5173')
+    expect(body.attributedPorts).toHaveLength(1)
+  })
+
+  test('observer URL wins when both sources are present (PTY may hold stale data)', async () => {
+    // Both sources have a URL, but they disagree. The observer is
+    // grounded in current OS state and must take precedence.
+    observerPorts = [
+      {
+        projectId: 'proj_1',
+        port: 5173,
+        pid: 1,
+        command: 'node',
+        url: 'http://127.0.0.1:5173',
+        matchedFolder: '/Users/me/app',
+        observedAt: Date.now(),
+      },
+    ]
+    ptyMostRecent = { url: 'http://localhost:3000' } // stale, ignored
+
+    const app = makeApp()
+    const res = await app.request('/api/projects/proj_1/external-preview', {
+      headers: { 'x-test-user-id': 'u1' },
+    })
+    const body = (await res.json()) as { detectedUrl: string | null }
+    expect(body.detectedUrl).toBe('http://127.0.0.1:5173')
+    // Quiet "unused let" by referencing the stale value:
+    expect(ptyMostRecent).not.toBeNull()
+  })
+})

--- a/apps/api/src/routes/external-preview.ts
+++ b/apps/api/src/routes/external-preview.ts
@@ -28,6 +28,10 @@
 
 import { Hono } from 'hono'
 import { prisma } from '../lib/prisma'
+import {
+  getLocalPortObserver,
+  type AttributedPort,
+} from '../lib/port-observer/local-port-observer'
 
 interface ExternalPreviewSettings {
   savedUrl?: string | null
@@ -129,6 +133,23 @@ async function fetchDetected(projectId: string): Promise<DetectedPayload | null>
   }
 }
 
+/**
+ * Ask the LocalPortObserver for HTTP listeners attributable to this
+ * project. Failures here must never blow up the route — the observer's
+ * job is to surface info opportunistically, not to be a hard dependency.
+ */
+async function fetchAttributedPorts(projectId: string): Promise<AttributedPort[]> {
+  try {
+    return await getLocalPortObserver().attributedPorts(projectId)
+  } catch (err) {
+    console.debug(
+      `[ExternalPreview] LocalPortObserver failed for ${projectId}:`,
+      (err as Error)?.message,
+    )
+    return []
+  }
+}
+
 export function externalPreviewRoutes() {
   const router = new Hono()
 
@@ -144,14 +165,37 @@ export function externalPreviewRoutes() {
     if (!project) return c.json({ error: 'project_not_found' }, 404)
 
     const savedUrl = readSavedUrl(project.settings)
-    const detected = await fetchDetected(projectId)
+
+    // Two independent sources feed `detectedUrl`:
+    //
+    //   1. The PTY-derived stream from agent-runtime. Only fires for
+    //      managed projects whose runtime is hot AND whose dev server
+    //      was launched inside the runtime's terminal.
+    //
+    //   2. The OS-level LocalPortObserver. Picks up any HTTP listener
+    //      whose owning process has its cwd inside one of the project's
+    //      linked folders — covers external-folder projects, servers
+    //      started in Cursor / iTerm, docker-compose, anything.
+    //
+    // We run both in parallel and prefer the observer when present,
+    // because it carries liveness (a port that disappeared from the
+    // scan is gone from the result), whereas the PTY buffer can hold
+    // stale URLs after a crashed server.
+    const [detected, attributedPorts] = await Promise.all([
+      fetchDetected(projectId),
+      fetchAttributedPorts(projectId),
+    ])
+
+    const observerUrl = attributedPorts[0]?.url ?? null
+    const ptyUrl = detected?.mostRecent?.url ?? null
 
     return c.json({
       projectId,
       workingMode: project.workingMode ?? 'managed',
       savedUrl,
-      detectedUrl: detected?.mostRecent?.url ?? null,
+      detectedUrl: observerUrl ?? ptyUrl,
       detections: detected?.detections ?? [],
+      attributedPorts,
     })
   })
 


### PR DESCRIPTION
Closes #678
Jira: [SHOG-692](https://odin-ai.atlassian.net/browse/SHOG-692)

## What this does

The **Preview URL** tab now auto-fills with whatever dev server is attributable to the project's folder — regardless of who started it (Shogo's terminal, Cursor / iTerm, docker-compose, a system service). No more typing `http://localhost:5173` by hand.

## Root cause (one sentence)

Detection was coupled to PTY stdout inside `agent-runtime` and gated on `runtime.status === 'running'`, so external-folder projects (`workingMode='external'`, the common Open-Folder case) got `detectedUrl: null` every time.

## The architectural fix (not a patch)

Move detection one layer down — from a per-terminal byte stream to an **OS-level observer** that diff-scans listening TCP sockets and attributes them by walking the owning PID's cwd against the project's `ProjectFolder.path` rows. This is the model VS Code / Cursor use (`remote.autoForwardPortsSource: process`).

The existing PTY regex is demoted to a hint source. The observer wins when both fire, because it carries liveness — a port that disappeared from the scan is gone from the result, whereas the PTY buffer can hold stale URLs after a crashed server.

## Changes

| File | Change |
|---|---|
| `apps/api/src/lib/port-observer/local-port-observer.ts` | **NEW** · the observer + default `lsof`-based scanner + HEAD-probe + folder resolver |
| `apps/api/src/lib/port-observer/__tests__/local-port-observer.test.ts` | **NEW** · 29 unit tests |
| `apps/api/src/routes/external-preview.ts` | merges observer output with the existing PTY source; adds `attributedPorts` to the response payload |
| `apps/api/src/routes/__tests__/external-preview.test.ts` | **NEW** · 4 integration tests for the merge logic |

+1158 / -2 lines.

## Design decisions

- **Dependency injection.** The scanner, HTTP probe, and folder resolver are all interfaces with default implementations. Tests run hermetically without `lsof`, network, or Prisma. The default scanner shells out to `lsof` on darwin/linux and degrades to a no-op on other platforms (same baseline behaviour as today, no regression).
- **Scan coalescing + throttling.** Multiple simultaneous requests share one in-flight scan; consecutive scans are throttled to once per 1.5s. A busy polling renderer can't melt `lsof`.
- **HTTP fingerprinting.** A 300ms HEAD probe (with a ranged-GET fallback for picky servers) filters out non-HTTP listeners — Postgres, Redis, language servers, devtools sockets — so they never surface in the Preview URL bar.
- **Folder cache.** Prisma lookups for `ProjectFolder` are cached for 30s per project. Adding a new folder mid-session takes effect on the next cache cycle.
- **No background interval.** Scans happen on-demand from the HTTP handler. An idle server costs nothing.
- **Liveness as a first-class concept.** A port that disappeared from the scan is dropped from the result on the next call. No stale URLs.

## Tests (33 / 33 passing)

### Unit (29) — `local-port-observer.test.ts`
- `lsof -F` parser: IPv4, IPv6 with brackets, multi-record, IPv4+IPv6 dedupe on same pid+port, malformed ports, missing pid, wildcard listen addr.
- `pathIsWithin`: exact match, descendant, **sibling-prefix attack (`/a/app` must NOT match `/a/app2`)**, outside path, empty inputs.
- Observer `attributedPorts`: no folders → `[]`; cwd inside folder → attributed; cwd outside → not attributed; non-HTTP probe → dropped; multi-folder match; pid with unknown cwd; dual-stack v4+v6 dedupe; scanner error → `[]`; throttling; concurrent-call coalescing.
- Observer `detectedUrl`: returns `null` when empty; **picks lowest port** as tiebreaker (so 3000 wins over 9229 — Node's debug port).
- `reset()` and `scanNow()` helpers.

### Integration (4) — `external-preview.test.ts`
- `401` without auth.
- `detectedUrl: null` when neither source has a hit.
- Observer URL surfaces as `detectedUrl`.
- **Observer URL wins when both observer and PTY have URLs** (the regression we'd most regret).

```
$ bun test src/lib/port-observer/__tests__/local-port-observer.test.ts
 29 pass · 0 fail · 39 expect() calls · 125ms
$ bun test src/routes/__tests__/external-preview.test.ts
  4 pass · 0 fail ·  8 expect() calls ·  84ms
```

Typecheck on the touched files: clean (`bun x tsc --noEmit | grep -E "port-observer|external-preview"` → empty). The 151 pre-existing errors in `packages/voice/*` are `rootDir` violations unrelated to this PR.

## Manual smoke against real `lsof`

```
$ bun -e 'import("./src/lib/port-observer/local-port-observer").then(...)'
found 8 listening sockets
sample: [ { port: 64929, pid: 443, command: 'rapportd', address: '*' }, … ]
pid 443 → { pid: 443, cwd: '/' }
```
Real-world parser output validates clean.

## Out of scope (follow-ups, intentionally not in this diff)

Kept this PR reviewable; each follow-up is its own self-contained ticket:

1. **Dedicated Ports tab in the desktop UI** — peer to Preview URL, not nested in Terminal (matches VS Code mental model). Renders the new `attributedPorts` field this PR adds.
2. **Agent tools `list_servers` / `run_server`** — so the agent reuses existing servers instead of duplicate-spawning. Both tools read the same observer.
3. **Windows scanner** (`Get-NetTCPConnection`). Currently darwin/linux only.
4. **Parent-chain attribution.** Today we only match on cwd. Parent-chain (e.g. a Shogo-tagged PTY → node child) catches servers whose pid runs in a tmpfs cwd via a volume mount.
5. **Promote `agent-runtime/detected-urls` to a *hint feed* into the observer.** Right now we just merge them at the route layer; eventually the regex output should feed into the observer's scan-priority queue.

## Risk

Low. The route's existing PTY-based path is unchanged — observer output is added in parallel and chosen only when present. Worst case (observer throws, lsof missing, etc.) the route returns the same payload it returns today. The new `attributedPorts` field is additive; no existing consumer reads it yet.

## Reviewer checklist

- [ ] Parser handles real `lsof -F` output (covered by 7 unit tests + manual smoke)
- [ ] `pathIsWithin` is anchor-safe (sibling-prefix attack covered)
- [ ] No new prisma indexes / migrations needed (uses existing `ProjectFolder` table)
- [ ] Graceful degradation on Windows / missing `lsof` (tested via empty-scanner mock)
- [ ] Probe doesn't surface non-HTTP listeners (tested)
- [ ] Singleton is overridable in tests (`__setLocalPortObserverForTests`)