### PR TITLE
fix(knative): enable podspec-init-containers feature flag

### DIFF
--- a/terraform/modules/knative-oci/main.tf
+++ b/terraform/modules/knative-oci/main.tf
@@ -186,6 +186,15 @@ resource "null_resource" "knative_config" {
     scale_to_zero_grace_period = var.scale_to_zero_grace_period
     enable_pvc_support         = var.enable_pvc_support
     drain_timeout              = "30s"
+    # Bump this whenever the inline kubectl patches below change. The
+    # other triggers are typed inputs that don't move with patch-string
+    # edits, which is why earlier additions to the config-features patch
+    # (pvc / pv-write etc.) silently failed to re-apply on already-
+    # provisioned clusters and left production drifting. Form is
+    # `<YYYY-MM-DD>-<short-reason>`; only the value matters, not the
+    # shape. See the post-2026-05-26 incident note in
+    # docs/runbooks/deploy-prod.md for context.
+    feature_flags_revision = "2026-05-26-init-containers"
   }
 
   provisioner "local-exec" {
@@ -207,11 +216,17 @@ resource "null_resource" "knative_config" {
 
       # Enable PVC support and scheduling feature flags
       # See: https://knative.dev/docs/serving/configuration/feature-flags/
+      #
+      # `kubernetes.podspec-init-containers` is required by the publish
+      # flow's nginx + S3-sync pod (apps/api/src/lib/knative-project-
+      # manager.ts createPublishedService). Without it, every Studio
+      # Publish 400s at admission with `pod spec support for init-
+      # containers is off, but found 1 init containers`.
       %{if var.enable_pvc_support}
       kubectl patch configmap/config-features \
         --namespace knative-serving \
         --type merge \
-        --patch '{"data":{"kubernetes.podspec-persistent-volume-claim":"enabled","kubernetes.podspec-persistent-volume-write":"enabled","kubernetes.podspec-securitycontext":"enabled","kubernetes.podspec-affinity":"enabled","kubernetes.podspec-fieldref":"enabled"}}'
+        --patch '{"data":{"kubernetes.podspec-persistent-volume-claim":"enabled","kubernetes.podspec-persistent-volume-write":"enabled","kubernetes.podspec-securitycontext":"enabled","kubernetes.podspec-affinity":"enabled","kubernetes.podspec-fieldref":"enabled","kubernetes.podspec-init-containers":"enabled"}}'
       %{endif}
 
       # Enable HTTPS on Kourier (port 8443) using the kourier-tls secret.


### PR DESCRIPTION
## Summary

Studio Publish has been failing for every project since the `/agent/dist-files` namespace fix (commit 07c71e18d) unblocked the prior step. Publishes now reach step 4 (`createPublishedService`) and Knative's admission webhook 400s every request with:

> admission webhook \"validation.webhook.serving.knative.dev\" denied the request: validation failed: must not set the field(s): spec.template.spec.initContainers
> pod spec support for init-containers is off, but found 1 init containers

Root cause: the published-app spec in [`apps/api/src/lib/knative-project-manager.ts:1490`](https://github.com/shogo-labs/shogo-ai/blob/main/apps/api/src/lib/knative-project-manager.ts#L1490) uses an `initContainers` block to `aws s3 sync` the built `dist/` from S3 into an `emptyDir` before nginx serves it. Knative gates that field behind the `kubernetes.podspec-init-containers` feature flag, which was never enabled in `config-features` on any cluster.

## Changes

`terraform/modules/knative-oci/main.tf`:

1. Add `kubernetes.podspec-init-containers: "enabled"` to the existing `config-features` merge patch.
2. Add a `feature_flags_revision` trigger key to `null_resource.knative_config` so the patch actually re-applies on already-provisioned clusters. The existing triggers are typed inputs (`scale_to_zero_grace_period`, `enable_pvc_support`, `drain_timeout`) that don't move when the patch literal changes — which is why earlier additions of `podspec-persistent-volume-claim` and `podspec-persistent-volume-write` to the patch silently never re-applied and left production drifting.

## Pre-applied live

Live patch already applied to all four clusters to unblock in-flight publishes:

```bash
for ctx in oke-production-us oke-production-eu oke-production-india oke-staging; do
  kubectl --context "$ctx" patch configmap/config-features \
    -n knative-serving --type merge \
    --patch '{"data":{"kubernetes.podspec-init-containers":"enabled"}}'
done
```

All four reported `enabled` after the patch. This PR is the durable record so the next `terraform apply` doesn't drift the flag back off.

## Test plan

- [ ] `terraform plan` against staging shows the `null_resource.knative_config` will re-create (trigger bump) and the merge patch picks up the new flag.
- [ ] `terraform apply` against staging — `kubectl get cm -n knative-serving config-features -o jsonpath='{.data.kubernetes\.podspec-init-containers}'` returns `enabled` (no-op, already set live).
- [ ] Smoke-publish a project on staging end-to-end. Expect `publishStatus = live`, no 400 from the admission webhook.
- [ ] Repeat for `production-{us,eu,india}` after staging.

## Drift cleanup (follow-up, NOT this PR)

While we're here it's worth noting that the same trigger-staleness bug means production currently lacks `podspec-persistent-volume-claim` and `podspec-persistent-volume-write` even though terraform claims to set them. The `feature_flags_revision` bump in this PR will reconcile that on next apply (the merge patch now re-runs in full). No code change needed; just `terraform apply` will fix it once this lands.


Made with [Cursor](https://cursor.com)