### PR TITLE
fix(publish): make PUBLISH_BUCKET explicit per-overlay (prod was uploading to staging)

### DIFF
--- a/apps/api/src/routes/publish.ts
+++ b/apps/api/src/routes/publish.ts
@@ -25,8 +25,17 @@ import * as checkpointService from "../services/checkpoint.service"
 // Workspaces directory for checkpoint creation
 const WORKSPACES_DIR = process.env.WORKSPACES_DIR || resolve(import.meta.dir, '../../../../workspaces')
 
-// S3 configuration (CloudFront removed -- published apps route through Kourier ALB)
-const PUBLISH_BUCKET = process.env.PUBLISH_BUCKET || "shogo-published-apps-staging"
+// S3 configuration. `PUBLISH_BUCKET` must be set explicitly in every K8s
+// overlay (k8s/overlays/{staging,production-*}/api-service.yaml) — the
+// fallback below is a deliberately wrong-looking local-dev value so a
+// missing overlay value can't silently route prod uploads to the staging
+// bucket. That happened on 2026-05-26: prod api ksvc had no
+// PUBLISH_BUCKET, the old default `shogo-published-apps-staging` won,
+// and every prod publish wrote to the staging bucket while the
+// Cloudflare Worker for *.shogo.one was reading from
+// `shogo-published-apps-production` — every published app served
+// `ObjectNotFound`. uploadToS3() now also asserts at call time.
+const PUBLISH_BUCKET = process.env.PUBLISH_BUCKET || "shogo-published-apps-LOCAL-DEV"
 const PUBLISH_DOMAIN = process.env.PUBLISH_DOMAIN || "shogo.one"
 const AWS_REGION = process.env.S3_REGION || process.env.AWS_REGION || "us-east-1"
 
@@ -271,6 +280,21 @@ async function downloadDistFiles(projectId: string): Promise<Map<string, Buffer>
  * Upload files to S3 bucket under the subdomain prefix
  */
 async function uploadToS3(subdomain: string, files: Map<string, Buffer>): Promise<void> {
+  // Hard-fail in K8s mode if the overlay forgot to set PUBLISH_BUCKET
+  // — silently uploading to the LOCAL-DEV fallback would land prod
+  // content in a non-existent bucket (or worse, the wrong env's bucket
+  // if the name happened to collide). See the long comment on
+  // PUBLISH_BUCKET above for the 2026-05-26 incident.
+  if (isKubernetes() && !process.env.PUBLISH_BUCKET) {
+    throw new Error(
+      "PUBLISH_BUCKET env var is not set. The api ksvc overlay must set " +
+      "this explicitly to the OCI Object Storage bucket the *.shogo.one " +
+      "Cloudflare Worker reads from " +
+      "(`shogo-published-apps-${environment}` per " +
+      "terraform/modules/publish-hosting-oci). Refusing to upload " +
+      "without it.",
+    )
+  }
   console.log(`[Publish] Uploading ${files.size} files to S3 bucket ${PUBLISH_BUCKET}/${subdomain}/`)
   
   for (const [filePath, content] of files) {

--- a/k8s/overlays/production-eu/api-service.yaml
+++ b/k8s/overlays/production-eu/api-service.yaml
@@ -184,6 +184,13 @@ spec:
                   key: secret-key
             - name: PUBLISH_NAMESPACE
               value: "shogo-production-system"
+            # OCI Object Storage bucket the *.shogo.one Cloudflare Worker
+            # reads from (terraform/modules/publish-hosting-oci). MUST
+            # match `shogo-published-apps-${var.environment}` for the env
+            # this overlay deploys. publish.ts asserts this is set in
+            # K8s mode — see the post-2026-05-26 comment there.
+            - name: PUBLISH_BUCKET
+              value: "shogo-published-apps-production"
             - name: PUBLISH_DOMAIN
               value: "shogo.one"
             - name: BETTER_AUTH_URL

--- a/k8s/overlays/production-india/api-service.yaml
+++ b/k8s/overlays/production-india/api-service.yaml
@@ -184,6 +184,13 @@ spec:
                   key: secret-key
             - name: PUBLISH_NAMESPACE
               value: "shogo-production-system"
+            # OCI Object Storage bucket the *.shogo.one Cloudflare Worker
+            # reads from (terraform/modules/publish-hosting-oci). MUST
+            # match `shogo-published-apps-${var.environment}` for the env
+            # this overlay deploys. publish.ts asserts this is set in
+            # K8s mode — see the post-2026-05-26 comment there.
+            - name: PUBLISH_BUCKET
+              value: "shogo-published-apps-production"
             - name: PUBLISH_DOMAIN
               value: "shogo.one"
             - name: BETTER_AUTH_URL

--- a/k8s/overlays/production-us/api-service.yaml
+++ b/k8s/overlays/production-us/api-service.yaml
@@ -183,6 +183,13 @@ spec:
                   key: secret-key
             - name: PUBLISH_NAMESPACE
               value: "shogo-production-system"
+            # OCI Object Storage bucket the *.shogo.one Cloudflare Worker
+            # reads from (terraform/modules/publish-hosting-oci). MUST
+            # match `shogo-published-apps-${var.environment}` for the env
+            # this overlay deploys. publish.ts asserts this is set in
+            # K8s mode — see the post-2026-05-26 comment there.
+            - name: PUBLISH_BUCKET
+              value: "shogo-published-apps-production"
             - name: PUBLISH_DOMAIN
               value: "shogo.one"
             - name: BETTER_AUTH_URL

--- a/k8s/overlays/production/api-service.yaml
+++ b/k8s/overlays/production/api-service.yaml
@@ -136,6 +136,13 @@ spec:
                   key: secret-key
             - name: PUBLISH_NAMESPACE
               value: "shogo-system"
+            # OCI Object Storage bucket the *.shogo.one Cloudflare Worker
+            # reads from (terraform/modules/publish-hosting-oci). MUST
+            # match `shogo-published-apps-${var.environment}` for the env
+            # this overlay deploys. publish.ts asserts this is set in
+            # K8s mode — see the post-2026-05-26 comment there.
+            - name: PUBLISH_BUCKET
+              value: "shogo-published-apps-production"
             - name: PUBLISH_DOMAIN
               value: "shogo.one"
             - name: BETTER_AUTH_URL

--- a/k8s/overlays/staging/api-service.yaml
+++ b/k8s/overlays/staging/api-service.yaml
@@ -175,6 +175,13 @@ spec:
                   key: secret-key
             - name: PUBLISH_NAMESPACE
               value: "shogo-staging-system"
+            # OCI Object Storage bucket the *.shogo.one Cloudflare Worker
+            # reads from (terraform/modules/publish-hosting-oci). MUST
+            # match `shogo-published-apps-${var.environment}` for the env
+            # this overlay deploys. publish.ts asserts this is set in
+            # K8s mode — see the post-2026-05-26 comment there.
+            - name: PUBLISH_BUCKET
+              value: "shogo-published-apps-staging"
             - name: PUBLISH_DOMAIN
               value: "shogo.one"
             - name: BETTER_AUTH_URL


### PR DESCRIPTION
## Summary

Production publishes have been silently writing to the **staging** bucket because:

- `apps/api/src/routes/publish.ts:29` defaulted `PUBLISH_BUCKET` to `shogo-published-apps-staging` when unset.
- No K8s overlay (staging, production-{us,eu,india}, production) actually set the env var.
- The Cloudflare Worker that serves \`*.shogo.one\` (in [\`terraform/modules/publish-hosting-oci/main.tf\`](https://github.com/shogo-labs/shogo-ai/blob/main/terraform/modules/publish-hosting-oci/main.tf)) reads from \`shogo-published-apps-\${var.environment}\` — i.e. the **production** bucket in prod.

So every prod publish uploaded files to the staging bucket while the prod CDN looked in the production bucket, and every visit to \`{subdomain}.shogo.one\` returned the raw OCI Object Storage error:

\`\`\`json
{
  \"code\": \"ObjectNotFound\",
  \"message\": \"The object '/{subdomain}/index.html' was not found in the bucket 'shogo-published-apps-production'\"
}
\`\`\`

Staging happened to work by coincidence because the old default name happened to match \`var.environment = \"staging\"\`.

## Fix is two-sided

Just adding the env var to the overlays would fix the symptom but leave the same trap waiting to recur. So:

### 1. \`apps/api/src/routes/publish.ts\`
- Change the fallback to a deliberately wrong-looking \`shogo-published-apps-LOCAL-DEV\` so it can never silently collide with a real bucket name.
- Add a hard runtime assert in \`uploadToS3\`: when \`isKubernetes() && !process.env.PUBLISH_BUCKET\`, throw with an actionable message pointing at the overlay file. Local dev (which never reaches the upload path because of the existing \`isKubernetes()\` guard) is unaffected.

### 2. K8s overlays — set \`PUBLISH_BUCKET\` explicitly
| Overlay | Value |
|---|---|
| \`k8s/overlays/staging/api-service.yaml\` | \`shogo-published-apps-staging\` |
| \`k8s/overlays/production-us/api-service.yaml\` | \`shogo-published-apps-production\` |
| \`k8s/overlays/production-eu/api-service.yaml\` | \`shogo-published-apps-production\` |
| \`k8s/overlays/production-india/api-service.yaml\` | \`shogo-published-apps-production\` |
| \`k8s/overlays/production/api-service.yaml\` (legacy) | \`shogo-published-apps-production\` |

## Pre-applied live

Already patched on all four ksvcs to unblock the in-flight publish for project \`3e35447c-c868-43ef-bfae-c857c3402a27\`:

\`\`\`bash
kubectl --context oke-production-us patch ksvc -n shogo-production-system api --type json \\
  -p '[{\"op\":\"add\",\"path\":\"/spec/template/spec/containers/0/env/-\",\"value\":{\"name\":\"PUBLISH_BUCKET\",\"value\":\"shogo-published-apps-production\"}}]'
# (same for production-eu, production-india, oke-staging with the right bucket name)
\`\`\`

This PR is the durable record so the next \`kubectl apply -k\` doesn't reset the var and re-create the bug.

## Test plan

- [ ] Re-publish project \`3e35447c-c868-43ef-bfae-c857c3402a27\` from Studio. Expect \`publishStatus = live\` and \`credits-usage-dashboard.shogo.one\` to serve the app instead of \`ObjectNotFound\`.
- [ ] \`oci os object list -bn shogo-published-apps-production --prefix credits-usage-dashboard/\` confirms files are in the prod bucket.
- [ ] \`kubectl apply -k k8s/overlays/production-us\` (and eu/india/staging) shows \`PUBLISH_BUCKET\` configured and no drift vs the live patch.

## Adjacent observation (NOT this PR)

The architecture comment at \`apps/api/src/routes/publish.ts:9-15\` describes the now-dead Knative+nginx+S3-init-container path. The actual prod path is Cloudflare Worker → OCI Object Storage PAR (per \`terraform/modules/publish-hosting-oci\`). The whole \`createPublishedService\` / \`createPublishedDomainMapping\` machinery in \`apps/api/src/lib/knative-project-manager.ts\` appears to be dead code in production. Worth a follow-up cleanup ticket — and explains why we bothered enabling \`kubernetes.podspec-init-containers\` in #682 for nothing. The init-containers flag is still worth having enabled for other future use cases, but neither it nor the S3-init-container approach is on the actual hot path.


Made with [Cursor](https://cursor.com)