### PR TITLE
fix(publish-hosting-oci): correct double-slash in CF Worker → OCI PAR fetch

### DIFF
--- a/terraform/modules/publish-hosting-oci/main.tf
+++ b/terraform/modules/publish-hosting-oci/main.tf
@@ -138,35 +138,60 @@ resource "cloudflare_worker_script" "subdomain_router" {
   # Worker runtime treats the content as a legacy service-worker script
   # and rejects the file with "Uncaught SyntaxError: Unexpected token
   # 'export'" at deploy time.
-  module  = true
+  module = true
+  # The OCI PAR `access_uri` returned by the provider ends in `/o/`
+  # (verified via OCI CLI on the live PAR; matches OCI docs). The
+  # original implementation built `originUrl = par_base_url + path`
+  # where `path` was `/${subdomain}/index.html`, producing
+  # `…/o//credits-usage-dashboard/index.html` — a literal double
+  # slash. OCI then parses the object name as everything after `/o/`,
+  # i.e. `/credits-usage-dashboard/index.html` (with leading slash),
+  # which does not match the actual stored key
+  # `credits-usage-dashboard/index.html`. Result: 100% of requests
+  # 404'd and the SPA fallback (also broken the same way) returned
+  # the OCI ObjectNotFound JSON wrapped in HTTP 200, masking the
+  # failure as a "successful but bogus" response. Fix here:
+  #   1. Trim trailing slashes from the PAR base before concatenating.
+  #   2. Always normalise the request path to start with exactly one `/`.
+  #   3. If the SPA fallback itself 404s, return the upstream status
+  #      instead of pretending it was 200, so debugging surfaces the
+  #      real problem next time.
   content = <<-JS
+    const ORIGIN_BASE = '${local.par_base_url}'.replace(/\/+$/, '');
+
+    function buildOriginUrl(subdomain, requestPath) {
+      // Ensure path starts with exactly one '/' (no leading-slash
+      // duplication, no missing slash if the URL is malformed).
+      const cleanPath =
+        requestPath === '' || requestPath === '/'
+          ? '/' + subdomain + '/index.html'
+          : '/' + subdomain + (requestPath.startsWith('/') ? '' : '/') + requestPath;
+      return ORIGIN_BASE + cleanPath;
+    }
+
     export default {
       async fetch(request) {
         const url = new URL(request.url);
-        const host = url.hostname;
-        const subdomain = host.split('.')[0];
+        const subdomain = url.hostname.split('.')[0];
 
-        // Rewrite path: /index.html → /subdomain/index.html
-        let path = url.pathname;
-        if (path === '/' || path === '') {
-          path = '/' + subdomain + '/index.html';
-        } else {
-          path = '/' + subdomain + path;
-        }
-
-        // Fetch from OCI Object Storage via pre-authenticated request
-        const originUrl = '${local.par_base_url}' + path;
-
+        const originUrl = buildOriginUrl(subdomain, url.pathname);
         const response = await fetch(originUrl, {
-          headers: {
-            'User-Agent': 'Cloudflare-Worker',
-          },
+          headers: { 'User-Agent': 'Cloudflare-Worker' },
         });
 
         if (response.status === 404 || response.status === 403) {
-          // SPA fallback: serve index.html for client-side routing
-          const fallbackUrl = '${local.par_base_url}/' + subdomain + '/index.html';
+          // SPA client-side routing fallback.
+          const fallbackUrl = buildOriginUrl(subdomain, '/');
           const fallback = await fetch(fallbackUrl);
+          // Surface fallback failures honestly (don't pretend 200
+          // when the index.html itself is missing — that's how the
+          // 2026-05-26 publish bug stayed undiagnosed for hours).
+          if (!fallback.ok) {
+            return new Response(fallback.body, {
+              status: fallback.status,
+              headers: fallback.headers,
+            });
+          }
           return new Response(fallback.body, {
             status: 200,
             headers: fallback.headers,


### PR DESCRIPTION
## Summary

Every visit to a published app at \`*.shogo.one\` returns the OCI Object Storage error JSON (wrapped in HTTP 200, see below). After today's PR #683 fix that gets uploads to the right bucket, this is the next thing in the chain that needs fixing.

### Root cause

The Cloudflare Worker in this module concatenates the OCI PAR base with the request path:

\`\`\`js
const originUrl = '\${local.par_base_url}' + path; // path = \"/credits-usage-dashboard/index.html\"
\`\`\`

The provider's \`oci_objectstorage_preauthrequest.access_uri\` ends in \`/o/\`, so the final URL is:

\`\`\`
https://objectstorage.us-ashburn-1.oraclecloud.com/p/<token>/n/<ns>/b/<bucket>/o//credits-usage-dashboard/index.html
                                                                                ^^ double slash
\`\`\`

OCI parses object name as everything after \`/o/\`, so it looks up \`/credits-usage-dashboard/index.html\` (with a leading slash) — which doesn't match the stored key \`credits-usage-dashboard/index.html\`. Result: 100% of \`*.shogo.one\` requests 404 at origin.

The Worker's SPA fallback is broken the same way **and** unconditionally wrapped the failure in HTTP 200, which is why nothing flagged it for hours:

\`\`\`
$ curl -i https://credits-usage-dashboard.shogo.one/
HTTP/2 200
content-type: application/json

{\"code\":\"ObjectNotFound\",\"message\":\"The object
 '/credits-usage-dashboard/index.html' was not found in the
 bucket 'shogo-published-apps-production'\"}
\`\`\`

### Fix

1. Trim trailing slashes from \`par_base_url\` before concatenating, and centralise the URL build into one helper so the main path and SPA fallback can't drift.
2. SPA fallback now propagates the upstream status when the fallback itself fails — instead of pretending 404 is 200. Cuts off the entire class of \"silent ObjectNotFound wrapped in 200\" failures.

Verified against the live URL — current bug reproduces with \`curl https://credits-usage-dashboard.shogo.one/\` regardless of path (root, \`/index.html\`, or any asset). After deploy, the Worker should fetch \`…/o/credits-usage-dashboard/index.html\` (single slash) and find the 396-byte \`index.html\` already sitting in the production bucket from PR #683's republish.

## Deploy

Affects two envs:

- [ ] **production-us** owns \`*.shogo.one\` → dispatch \`Terraform\` workflow with \`env=production-us, action=apply\` (or \`terraform apply\` from \`terraform/environments/production-us\` locally). Worker redeploy is the only change; no compute or data resources are touched. Plan should show one in-place update on \`module.us.module.publish_hosting[0].cloudflare_worker_script.subdomain_router\`.
- [ ] **staging** owns \`*.staging.shogo.one\` → same workflow with \`env=staging\`. Lower urgency since staging publishes work by accident (its content key has the same leading-slash bug, but no one's depending on a staging publish right now).

## Test plan

- [ ] After production-us apply, hit \`https://credits-usage-dashboard.shogo.one/\` — expect HTML 200 (the 396-byte index.html), not the OCI ObjectNotFound JSON.
- [ ] Hit a known-bad path like \`/does-not-exist\` — expect SPA fallback to serve the same index.html with HTTP 200.
- [ ] Hit a non-existent subdomain like \`https://no-such-app-xyz.shogo.one/\` — expect HTTP 404 propagated honestly (not 200 with an OCI error body).


Made with [Cursor](https://cursor.com)