### PR TITLE
fix(replication): stop poisoning EU/India Prisma state via _prisma_migrations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1402,6 +1402,36 @@ jobs:
           fi
           echo "✓ logical_replicator has SELECT on every public table on US"
 
+      # Install / re-affirm the `_prisma_migrations` REPLICA-trigger that
+      # discards replicated changes. Without it, a `_prisma_migrations` row
+      # from a peer region with `finished_at IS NULL` (because the apply
+      # worker is stuck mid-transaction) makes Prisma here bail with
+      # P3009, blocking every future deploy on this cluster — the
+      # 2026-05-26 incident pattern. Idempotent. See
+      # k8s/cnpg/logical-replication/skip-replicated-migrations.sql.
+      - name: Install _prisma_migrations REPLICA-trigger
+        run: |
+          kubectl exec -i -n ${{ env.NS_SYSTEM }} "$PG_PRIMARY" -c postgres -- \
+            psql -U postgres -d shogo \
+            < k8s/cnpg/logical-replication/skip-replicated-migrations.sql \
+            || { echo "::error::skip-replicated-migrations.sql failed on US"; exit 1; }
+
+      - name: Verify _prisma_migrations REPLICA-trigger
+        run: |
+          set -euo pipefail
+          STATE=$(kubectl exec -n ${{ env.NS_SYSTEM }} "$PG_PRIMARY" -c postgres -- \
+            psql -U postgres -d shogo -tAc "
+              SELECT tgenabled
+              FROM pg_trigger
+              WHERE tgrelid='_prisma_migrations'::regclass
+                AND tgname='skip_replicated_migrations_trg';
+            ")
+          if [ "$STATE" != "R" ]; then
+            echo "::error::skip_replicated_migrations_trg on US is in state '$STATE', expected 'R' (replica-only)"
+            exit 1
+          fi
+          echo "✓ skip_replicated_migrations_trg is REPLICA-mode on US"
+
       - name: Refresh logical replication subscriptions
         run: |
           for SUB in sub_from_eu sub_from_india; do
@@ -1603,6 +1633,15 @@ jobs:
 
       - name: Run Prisma migrations
         if: needs.detect-changes.outputs.api_changed == 'true'
+        # Failure here is fatal. Until 2026-05-26 this used
+        # `|| echo "::warning::..."` and EU/India migration P3009s
+        # silently passed the deploy while the api ksvcs crashlooped on
+        # stale revisions. The 2026-05-26 incident was caused by exactly
+        # this swallowed error: a replicated `_prisma_migrations` row from
+        # US poisoned EU/India's local Prisma state and `migrate deploy`
+        # bailed with P3009 — a fatal exit code that the workflow ignored.
+        # The publication-side fix is in `skip-replicated-migrations.sql`,
+        # but the deploy must also stop pretending failures are warnings.
         run: |
           DB_URL=$(kubectl get secret postgres-credentials -n ${{ env.NS_SYSTEM }} -o jsonpath='{.data.DATABASE_URL}' | base64 -d)
           kubectl run prisma-migrate-eu --rm -i --restart=Never \
@@ -1611,7 +1650,7 @@ jobs:
             --env="DATABASE_URL=${DB_URL}" \
             --env="SKIP_MIGRATIONS=false" \
             --command -- sh -c "cd /app && bunx prisma migrate deploy" \
-            --timeout=120s || echo "::warning::EU migration completed with warnings"
+            --timeout=120s
 
       - name: Verify configured node pool matches running nodes
         run: |
@@ -1684,6 +1723,30 @@ jobs:
             exit 1
           fi
           echo "✓ logical_replicator has SELECT on every public table on EU"
+
+      # See deploy-us for full rationale (2026-05-26 incident).
+      - name: Install _prisma_migrations REPLICA-trigger
+        run: |
+          kubectl exec -i -n ${{ env.NS_SYSTEM }} "$PG_PRIMARY" -c postgres -- \
+            psql -U postgres -d shogo \
+            < k8s/cnpg/logical-replication/skip-replicated-migrations.sql \
+            || { echo "::error::skip-replicated-migrations.sql failed on EU"; exit 1; }
+
+      - name: Verify _prisma_migrations REPLICA-trigger
+        run: |
+          set -euo pipefail
+          STATE=$(kubectl exec -n ${{ env.NS_SYSTEM }} "$PG_PRIMARY" -c postgres -- \
+            psql -U postgres -d shogo -tAc "
+              SELECT tgenabled
+              FROM pg_trigger
+              WHERE tgrelid='_prisma_migrations'::regclass
+                AND tgname='skip_replicated_migrations_trg';
+            ")
+          if [ "$STATE" != "R" ]; then
+            echo "::error::skip_replicated_migrations_trg on EU is in state '$STATE', expected 'R'"
+            exit 1
+          fi
+          echo "✓ skip_replicated_migrations_trg is REPLICA-mode on EU"
 
       - name: Refresh logical replication subscriptions
         run: |
@@ -2011,6 +2074,7 @@ jobs:
       - name: Run Prisma migrations
         if: needs.detect-changes.outputs.api_changed == 'true'
         run: |
+          # Failure here is fatal — see the matching note in deploy-eu.
           DB_URL=$(kubectl get secret postgres-credentials -n ${{ env.NS_SYSTEM }} -o jsonpath='{.data.DATABASE_URL}' | base64 -d)
           kubectl run prisma-migrate-india --rm -i --restart=Never \
             --namespace=${{ env.NS_SYSTEM }} \
@@ -2018,7 +2082,7 @@ jobs:
             --env="DATABASE_URL=${DB_URL}" \
             --env="SKIP_MIGRATIONS=false" \
             --command -- sh -c "cd /app && bunx prisma migrate deploy" \
-            --timeout=120s || echo "::warning::India migration completed with warnings"
+            --timeout=120s
 
       - name: Verify configured node pool matches running nodes
         run: |
@@ -2088,6 +2152,30 @@ jobs:
             exit 1
           fi
           echo "✓ logical_replicator has SELECT on every public table on India"
+
+      # See deploy-us for full rationale (2026-05-26 incident).
+      - name: Install _prisma_migrations REPLICA-trigger
+        run: |
+          kubectl exec -i -n ${{ env.NS_SYSTEM }} "$PG_PRIMARY" -c postgres -- \
+            psql -U postgres -d shogo \
+            < k8s/cnpg/logical-replication/skip-replicated-migrations.sql \
+            || { echo "::error::skip-replicated-migrations.sql failed on India"; exit 1; }
+
+      - name: Verify _prisma_migrations REPLICA-trigger
+        run: |
+          set -euo pipefail
+          STATE=$(kubectl exec -n ${{ env.NS_SYSTEM }} "$PG_PRIMARY" -c postgres -- \
+            psql -U postgres -d shogo -tAc "
+              SELECT tgenabled
+              FROM pg_trigger
+              WHERE tgrelid='_prisma_migrations'::regclass
+                AND tgname='skip_replicated_migrations_trg';
+            ")
+          if [ "$STATE" != "R" ]; then
+            echo "::error::skip_replicated_migrations_trg on India is in state '$STATE', expected 'R'"
+            exit 1
+          fi
+          echo "✓ skip_replicated_migrations_trg is REPLICA-mode on India"
 
       - name: Refresh logical replication subscriptions
         run: |

--- a/k8s/cnpg/logical-replication/RUNBOOK.md
+++ b/k8s/cnpg/logical-replication/RUNBOOK.md
@@ -183,16 +183,59 @@ kubectl --context oke-india apply -f k8s/cnpg/production-india/sub-from-us.yaml
 kubectl --context oke-india apply -f k8s/cnpg/production-india/sub-from-eu.yaml
 ```
 
-### Step 9: Enable PG 18 Conflict Resolution
+### Step 9: Conflict handling
 
-After subscriptions are created and initial sync completes, enable `INSERT_EXISTS_ACTION`:
+PostgreSQL 18.3 mainline does **not** ship automatic per-row conflict
+resolution for logical replication on the subscriber side. The
+`INSERT_EXISTS_ACTION = last_update_wins` parameter that prior versions
+of this runbook recommended does not exist (`ALTER SUBSCRIPTION ... SET
+(insert_exists_action = ...)` returns `unrecognized subscription
+parameter`). When a `conflict=insert_exists`, `update_origin_differs`,
+or `update_exists` row arrives, the apply worker logs `ERROR` and
+exits — Postgres restarts it ~3s later, it hits the same row, exits,
+repeat. This crash-loop pins the slot and stalls every later
+transaction in the WAL behind it (incident 2026-05-26 saw 3 GB of
+backlog accumulate this way over 15 hours). The choices are:
+
+1. **Resolve the underlying duplicate** (preferred when feasible —
+   delete the older/wrong row on the subscriber so the apply succeeds),
+   or
+2. **Skip the offending transaction** with the LSN reported in the
+   error message:
+
+   ```sql
+   -- LSN comes from the "finished at <X/Y>" suffix in the apply
+   -- worker's ERROR log line.
+   ALTER SUBSCRIPTION <sub> SKIP (lsn = '<X/Y>');
+   ```
+
+   Each `SKIP` advances the apply worker past exactly one transaction
+   and discards every change in it. For tables like `storage_usage`
+   where both regions independently write the same workspace ID, this
+   is the documented unblock path.
+
+A fast skip-loop using the most recent LSN from `pg_log` is in the
+2026-05-26 incident notes; do not extract it into a tool until the
+underlying `storage_usage`-style multi-master conflicts are addressed
+at the application layer (mark those tables region-local so they don't
+ride logical replication at all).
+
+`disable_on_error = true` flips the apply worker from "crash-restart
+loop" to "stop on first error and stay disabled until an operator
+runs `ALTER SUBSCRIPTION ... ENABLE`". This is the correct default for
+production: a stopped subscription is loud (the
+`replication-monitor` CronJob alerts on it), a crash-looping one is
+silent. Apply once per subscription:
 
 ```bash
-for ctx in oke-us oke-eu oke-india; do
+for ctx in oke-production-us oke-production-eu oke-production-india; do
+  PRIMARY=$(kubectl --context "$ctx" get pods -n shogo-production-system \
+    -l "cnpg.io/cluster=platform-pg,cnpg.io/instanceRole=primary" \
+    -o jsonpath='{.items[0].metadata.name}')
   for sub in sub_from_us sub_from_eu sub_from_india; do
-    kubectl --context $ctx exec -n shogo-production-system platform-pg-1 -c postgres -- psql -U postgres -d shogo -c "
-      ALTER SUBSCRIPTION $sub SET (INSERT_EXISTS_ACTION = last_update_wins);
-    " 2>/dev/null || true
+    kubectl --context "$ctx" exec -n shogo-production-system "$PRIMARY" \
+      -c postgres -- psql -U postgres -d shogo -c \
+      "ALTER SUBSCRIPTION $sub SET (disable_on_error = true);" 2>/dev/null || true
   done
 done
 ```
@@ -326,11 +369,41 @@ What still has to happen:
 1. `prisma migrate deploy` runs in every region (handled automatically by
    the deploy workflow — US via the API pod entrypoint, EU/India via
    `kubectl run prisma-migrate-*` jobs in `.github/workflows/deploy.yml`).
+   These migrations must succeed in **every** region before any region's API
+   ksvc rolls forward; the deploy workflow now treats EU/India migration
+   failure as a hard error (was a silent `::warning::` until incident
+   2026-05-26).
 2. Each subscriber must `ALTER SUBSCRIPTION <name> REFRESH PUBLICATION`
    once after the publisher has applied the migration, so the new table is
    added to its subscription's table set. The deploy workflow does this
    automatically at the end of each region's deploy job
    (`Refresh logical replication subscriptions`).
+
+### Why migrations cannot be skipped on subscribers
+
+Replicating `_prisma_migrations` would let one region's migration row leak
+to a peer that hasn't applied the DDL locally yet. Two failure modes
+follow:
+
+1. The publisher's seed-DML for the new table (e.g.
+   `INSERT INTO affiliate_commission_tiers VALUES ...`) reaches the
+   subscriber, finds the table missing locally, and crash-loops the apply
+   worker — pinning the slot and stalling every other write in WAL behind
+   it.
+2. Even without seed-DML, the subscriber's own `prisma migrate deploy`
+   sees a `_prisma_migrations` row with `finished_at` filled in (replicated
+   from the publisher's UPDATE) and **skips applying the DDL locally**.
+   The subscriber is then silently a schema behind, with a "successful"
+   tracking row covering it up.
+
+The fix in `k8s/cnpg/logical-replication/skip-replicated-migrations.sql`
+installs a `BEFORE INSERT/UPDATE/DELETE` trigger on `_prisma_migrations`
+in `ENABLE REPLICA TRIGGER` mode. It returns NULL — discarding any change
+that arrives via the apply worker — while leaving local
+`prisma migrate deploy` writes untouched. Each region's
+`_prisma_migrations` then reflects only that region's own migration
+history, which is what Prisma assumes. Applied on every deploy alongside
+`grants.sql`.
 
 If a region's deploy fails between migration and refresh, or two regions'
 parallel deploys race so a refresh runs before the peer's migration, the

--- a/k8s/cnpg/logical-replication/replication-monitor.yaml
+++ b/k8s/cnpg/logical-replication/replication-monitor.yaml
@@ -1,6 +1,22 @@
 # CronJob that checks logical replication health across all subscriptions
-# every 5 minutes. Logs warnings for disabled subscriptions, high conflict
-# counts, inactive replication slots, and replication lag > 10s.
+# every 5 minutes.
+#
+# The job exits non-zero when something is broken so the CronJob shows up
+# as failed in K8s and the alerting hooks (kube-state-metrics
+# `kube_job_status_failed`) fire. Until 2026-05-26 it only printed
+# "WARNING:" / "CRITICAL:" lines and exited 0, so the 2026-05-26 incident
+# (3 GB of WAL backlog and 6 hour-old apply errors) ran for 15 hours
+# without paging anyone. The thresholds below are tuned to surface that
+# kind of incident within one polling interval.
+#
+# Conditions that fail the job:
+#   - any subscription with pid IS NULL (apply worker not streaming)
+#   - any subscription with apply_error_count > 0 (PG 18 conflict log)
+#   - any inactive logical replication slot
+#   - any logical slot with > 100 MB WAL lag (down from 1 GB)
+#   - any table in `public` (other than `_prisma%`) missing from the
+#     publication
+#   - any subscription that trails the local publication by 1+ tables
 #
 # Deploy once per region. The job connects to the local CNPG cluster.
 apiVersion: batch/v1
@@ -49,6 +65,8 @@ spec:
                 - |
                   echo "=== Replication Monitor — $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
 
+                  EXIT_RC=0
+
                   echo "--- Subscription Status ---"
                   psql -X -t -A -F'|' -c "
                     SELECT subname,
@@ -68,7 +86,8 @@ spec:
                   ")
 
                   if [ "$STOPPED" -gt 0 ]; then
-                    echo "WARNING: $STOPPED subscription(s) not streaming!"
+                    echo "CRITICAL: $STOPPED subscription(s) not streaming!"
+                    EXIT_RC=1
                   fi
 
                   echo "--- Conflict Stats (PG 18) ---"
@@ -80,6 +99,33 @@ spec:
                     WHERE subname LIKE 'sub_from_%'
                     ORDER BY subname;
                   " 2>/dev/null || echo "(pg_stat_subscription_stats not available)"
+
+                  # An apply error pins the slot and stalls every later
+                  # transaction in the WAL behind the bad one. Operators
+                  # need a page within the polling interval, not 15 hours
+                  # later (incident 2026-05-26).
+                  APPLY_ERRORS=$(psql -X -t -A -c "
+                    SELECT count(*)
+                    FROM pg_stat_subscription_stats
+                    WHERE subname LIKE 'sub_from_%'
+                      AND apply_error_count > 0;
+                  " 2>/dev/null || echo "0")
+
+                  if [ "$APPLY_ERRORS" -gt 0 ]; then
+                    echo "CRITICAL: $APPLY_ERRORS subscription(s) have apply_error_count > 0!"
+                    psql -X -t -A -F'|' -c "
+                      SELECT subname, apply_error_count, sync_error_count
+                      FROM pg_stat_subscription_stats
+                      WHERE subname LIKE 'sub_from_%'
+                        AND (apply_error_count > 0 OR sync_error_count > 0)
+                      ORDER BY subname;
+                    " 2>/dev/null || true
+                    echo "Check the publisher's pg log for the LSN, then:"
+                    echo "  ALTER SUBSCRIPTION <sub> SKIP (lsn = '<X/Y>');"
+                    echo "or fix the underlying duplicate row. See"
+                    echo "k8s/cnpg/logical-replication/RUNBOOK.md step 9."
+                    EXIT_RC=1
+                  fi
 
                   echo "--- Replication Slots ---"
                   psql -X -t -A -F'|' -c "
@@ -98,18 +144,33 @@ spec:
                   ")
 
                   if [ "$INACTIVE_SLOTS" -gt 0 ]; then
-                    echo "WARNING: $INACTIVE_SLOTS inactive logical replication slot(s)!"
+                    echo "CRITICAL: $INACTIVE_SLOTS inactive logical replication slot(s)!"
+                    EXIT_RC=1
                   fi
 
+                  # 100 MB threshold (was 1 GB). The 2026-05-26 incident
+                  # accumulated 3 GB of backlog over 15 hours; at 100 MB
+                  # the first 5-minute polling interval after a stuck
+                  # apply worker will already trigger a page.
                   WAL_BLOAT=$(psql -X -t -A -c "
                     SELECT count(*)
                     FROM pg_replication_slots
                     WHERE slot_type = 'logical'
-                      AND pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) > 1073741824;
+                      AND pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) > 104857600;
                   ")
 
                   if [ "$WAL_BLOAT" -gt 0 ]; then
-                    echo "CRITICAL: $WAL_BLOAT slot(s) with > 1GB WAL lag!"
+                    echo "CRITICAL: $WAL_BLOAT slot(s) with > 100MB WAL lag!"
+                    psql -X -t -A -F'|' -c "
+                      SELECT slot_name,
+                             active,
+                             pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) AS wal_lag
+                      FROM pg_replication_slots
+                      WHERE slot_type = 'logical'
+                        AND pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) > 104857600
+                      ORDER BY slot_name;
+                    "
+                    EXIT_RC=1
                   fi
 
                   echo "--- Publication Completeness ---"
@@ -131,7 +192,7 @@ spec:
                   ")
 
                   if [ "$UNPUBLISHED" -gt 0 ]; then
-                    echo "WARNING: $UNPUBLISHED table(s) missing from publication!"
+                    echo "CRITICAL: $UNPUBLISHED table(s) missing from publication!"
                     psql -X -t -A -c "
                       SELECT t.tablename
                       FROM pg_tables t
@@ -144,6 +205,7 @@ spec:
                         AND pt.tablename IS NULL
                       ORDER BY t.tablename;
                     "
+                    EXIT_RC=1
                   fi
 
                   echo "--- Subscription Refresh Staleness ---"
@@ -173,12 +235,31 @@ spec:
                   ")
 
                   if [ -n "$STALE_SUBS" ]; then
-                    echo "WARNING: subscription(s) trail the local publication by 1+ tables."
+                    echo "CRITICAL: subscription(s) trail the local publication by 1+ tables."
                     echo "Run: ALTER SUBSCRIPTION <subname> REFRESH PUBLICATION;"
                     echo "$STALE_SUBS"
+                    EXIT_RC=1
                   fi
 
-                  echo "=== Monitor complete ==="
+                  # `_prisma_migrations` REPLICA-trigger contract
+                  # (skip-replicated-migrations.sql). A missing or
+                  # mis-enabled trigger means the next migration
+                  # row from a peer region poisons local Prisma state.
+                  TRIGGER_OK=$(psql -X -t -A -c "
+                    SELECT count(*)
+                    FROM pg_trigger
+                    WHERE tgrelid = '_prisma_migrations'::regclass
+                      AND tgname = 'skip_replicated_migrations_trg'
+                      AND tgenabled = 'R';
+                  " 2>/dev/null || echo "0")
+                  if [ "$TRIGGER_OK" != "1" ]; then
+                    echo "CRITICAL: skip_replicated_migrations_trg missing or not in REPLICA mode."
+                    echo "Reapply k8s/cnpg/logical-replication/skip-replicated-migrations.sql."
+                    EXIT_RC=1
+                  fi
+
+                  echo "=== Monitor complete (exit=$EXIT_RC) ==="
+                  exit "$EXIT_RC"
               resources:
                 requests:
                   memory: "64Mi"

--- a/k8s/cnpg/logical-replication/skip-replicated-migrations.sql
+++ b/k8s/cnpg/logical-replication/skip-replicated-migrations.sql
@@ -1,0 +1,79 @@
+-- ---------------------------------------------------------------------------
+-- Discard replicated writes to `_prisma_migrations`.
+--
+-- Why this file exists
+-- ====================
+-- `shogo_all_pub` uses `FOR TABLES IN SCHEMA public`, which auto-publishes
+-- every table in `public` — including `_prisma_migrations`. CNPG's
+-- Publication CR does not expose row filters, and Postgres does not allow
+-- `ALTER PUBLICATION ... DROP TABLE` against a `FOR TABLES IN SCHEMA`
+-- publication. So we cannot exclude `_prisma_migrations` on the publisher
+-- side.
+--
+-- Replicating `_prisma_migrations` corrupts Prisma's per-database tracking:
+--
+--   1. Prisma is supposed to maintain `_prisma_migrations` independently per
+--      database. Replicating it means every region sees every other region's
+--      migration rows.
+--   2. Logical replication does not replicate DDL. So when US runs
+--      `prisma migrate deploy`, the `_prisma_migrations` INSERT replicates
+--      to EU/India but the new tables it creates do not. Any DML on those
+--      new tables (e.g. seed inserts) then breaks replication on EU/India
+--      with `relation "..." does not exist`, halting the apply worker
+--      entirely and blocking ALL future writes from US.
+--   3. Even when (2) is avoided (no seed DML), Prisma on EU/India queries
+--      `_prisma_migrations`, sees the replicated row with `finished_at`
+--      filled in, and **skips applying the DDL locally**. The subscriber
+--      ends up a schema behind, with a "successful" tracking row covering
+--      it up, until the next time the publisher writes to the missing
+--      table and replication breaks.
+--
+-- Both failure modes were observed in production on 2026-05-26. See
+-- the post-incident notes in this PR.
+--
+-- The fix
+-- =======
+-- Install a `BEFORE INSERT OR UPDATE OR DELETE` trigger on
+-- `_prisma_migrations` that returns NULL — discards the row — and enable
+-- it ONLY for replicated (replica-role) writes via `ENABLE REPLICA TRIGGER`.
+--
+--   * Local `prisma migrate deploy` continues to write to the table normally
+--     (regular trigger semantics: REPLICA-only triggers do not fire on
+--     locally-originated writes).
+--   * Any change that arrives via the logical-replication apply worker is
+--     silently dropped, so each region's `_prisma_migrations` reflects only
+--     that region's own migration history.
+--
+-- The `DISABLE TRIGGER ... ENABLE REPLICA TRIGGER` pair is the canonical
+-- way to express "fire only during replication" — see the Postgres docs
+-- for `ALTER TABLE ... ENABLE/DISABLE TRIGGER` REPLICA mode.
+--
+-- Applied to every cluster (US, EU, India) on every deploy by
+-- `.github/workflows/deploy.yml`. Idempotent.
+--
+-- Run as `postgres` (superuser).
+-- ---------------------------------------------------------------------------
+
+\set ON_ERROR_STOP on
+
+CREATE OR REPLACE FUNCTION skip_replicated_migrations() RETURNS trigger AS $f$
+BEGIN
+  -- Returning NULL from a BEFORE-row trigger discards the operation.
+  -- The apply worker's transaction continues; only this row is dropped.
+  RETURN NULL;
+END;
+$f$ LANGUAGE plpgsql;
+
+-- Recreate the trigger so the binding is fresh on every run, in case the
+-- function signature changes in the future.
+DROP TRIGGER IF EXISTS skip_replicated_migrations_trg ON _prisma_migrations;
+CREATE TRIGGER skip_replicated_migrations_trg
+  BEFORE INSERT OR UPDATE OR DELETE ON _prisma_migrations
+  FOR EACH ROW EXECUTE FUNCTION skip_replicated_migrations();
+
+-- DISABLE for local writes; ENABLE REPLICA for replicated apply-worker writes.
+-- These two statements together set the trigger's `tgenabled` column to 'R'
+-- (replica). 'D' = disabled, 'O' = origin (default = local only),
+-- 'A' = always (both), 'R' = replica only.
+ALTER TABLE _prisma_migrations DISABLE TRIGGER skip_replicated_migrations_trg;
+ALTER TABLE _prisma_migrations ENABLE REPLICA TRIGGER skip_replicated_migrations_trg;

--- a/k8s/cnpg/production-eu-oci/platform-publication.yaml
+++ b/k8s/cnpg/production-eu-oci/platform-publication.yaml
@@ -6,9 +6,18 @@
 # are picked up automatically — no edit to this YAML is required when the
 # schema grows.
 #
-# `_prisma_migrations` is technically published too but is never written by
-# application traffic and is filtered/ignored on the subscriber side. Do not
-# revert to a hand-listed `objects[].table` set: the CI guard
+# `_prisma_migrations` is also published (CNPG's Publication CR doesn't
+# expose row filters, and `ALTER PUBLICATION ... DROP TABLE` doesn't work
+# against `FOR TABLES IN SCHEMA` publications). Replicating it would corrupt
+# Prisma's per-database tracking — incident 2026-05-26 — so each subscriber
+# installs a `BEFORE INSERT/UPDATE/DELETE` trigger on `_prisma_migrations`
+# in `ENABLE REPLICA TRIGGER` mode that returns NULL, silently discarding
+# any replicated change while leaving local `prisma migrate deploy` writes
+# untouched. The trigger is installed by
+# `k8s/cnpg/logical-replication/skip-replicated-migrations.sql`, applied on
+# every deploy via `.github/workflows/deploy.yml`.
+#
+# Do not revert to a hand-listed `objects[].table` set: the CI guard
 # (`bun run check:publication`) will reject any PR that does, and the
 # replication-monitor CronJob warns on drift in production.
 #

--- a/k8s/cnpg/production-india-oci/platform-publication.yaml
+++ b/k8s/cnpg/production-india-oci/platform-publication.yaml
@@ -6,9 +6,18 @@
 # are picked up automatically — no edit to this YAML is required when the
 # schema grows.
 #
-# `_prisma_migrations` is technically published too but is never written by
-# application traffic and is filtered/ignored on the subscriber side. Do not
-# revert to a hand-listed `objects[].table` set: the CI guard
+# `_prisma_migrations` is also published (CNPG's Publication CR doesn't
+# expose row filters, and `ALTER PUBLICATION ... DROP TABLE` doesn't work
+# against `FOR TABLES IN SCHEMA` publications). Replicating it would corrupt
+# Prisma's per-database tracking — incident 2026-05-26 — so each subscriber
+# installs a `BEFORE INSERT/UPDATE/DELETE` trigger on `_prisma_migrations`
+# in `ENABLE REPLICA TRIGGER` mode that returns NULL, silently discarding
+# any replicated change while leaving local `prisma migrate deploy` writes
+# untouched. The trigger is installed by
+# `k8s/cnpg/logical-replication/skip-replicated-migrations.sql`, applied on
+# every deploy via `.github/workflows/deploy.yml`.
+#
+# Do not revert to a hand-listed `objects[].table` set: the CI guard
 # (`bun run check:publication`) will reject any PR that does, and the
 # replication-monitor CronJob warns on drift in production.
 #

--- a/k8s/cnpg/production-us-oci/platform-publication.yaml
+++ b/k8s/cnpg/production-us-oci/platform-publication.yaml
@@ -6,9 +6,18 @@
 # are picked up automatically — no edit to this YAML is required when the
 # schema grows.
 #
-# `_prisma_migrations` is technically published too but is never written by
-# application traffic and is filtered/ignored on the subscriber side. Do not
-# revert to a hand-listed `objects[].table` set: the CI guard
+# `_prisma_migrations` is also published (CNPG's Publication CR doesn't
+# expose row filters, and `ALTER PUBLICATION ... DROP TABLE` doesn't work
+# against `FOR TABLES IN SCHEMA` publications). Replicating it would corrupt
+# Prisma's per-database tracking — incident 2026-05-26 — so each subscriber
+# installs a `BEFORE INSERT/UPDATE/DELETE` trigger on `_prisma_migrations`
+# in `ENABLE REPLICA TRIGGER` mode that returns NULL, silently discarding
+# any replicated change while leaving local `prisma migrate deploy` writes
+# untouched. The trigger is installed by
+# `k8s/cnpg/logical-replication/skip-replicated-migrations.sql`, applied on
+# every deploy via `.github/workflows/deploy.yml`.
+#
+# Do not revert to a hand-listed `objects[].table` set: the CI guard
 # (`bun run check:publication`) will reject any PR that does, and the
 # replication-monitor CronJob warns on drift in production.
 #


### PR DESCRIPTION
## Summary

Closes the multi-master logical-replication trap that broke `prisma migrate deploy` on EU and India for ~6 hours on 2026-05-26 and blocked every API ksvc rollout in both regions.

`shogo_all_pub` uses `FOR TABLES IN SCHEMA public`, so `_prisma_migrations` is replicated bidirectionally between US ⇆ EU ⇆ India. CNPG doesn't expose row filters, and `ALTER PUBLICATION ... DROP TABLE` is a no-op against a `FOR TABLES IN SCHEMA` publication. So we cannot exclude the table on the publisher side. Replicating it corrupts Prisma's per-database tracking — the publisher's seed-DML for a new table arrives before the DDL exists locally and the apply worker crash-loops on a relation-not-exist; even if there's no seed-DML, the subscriber's own `prisma migrate deploy` sees the replicated row with `finished_at` filled in and silently skips the DDL.

## What changed

**`k8s/cnpg/logical-replication/skip-replicated-migrations.sql`** — new file. Installs a `BEFORE INSERT/UPDATE/DELETE` trigger on `_prisma_migrations` that returns NULL, and enables it in REPLICA-only mode (`tgenabled='R'`). Local `prisma migrate deploy` writes pass through; replicated apply-worker writes are silently discarded. Idempotent.

**`.github/workflows/deploy.yml`** — applies the SQL on every region's deploy with a verify step that asserts `tgenabled='R'`. Also makes EU/India `Run Prisma migrations` exit non-zero on failure (was `|| echo "::warning::..."` — that's how the 2026-05-26 P3009 hid for 15 hours).

**`k8s/cnpg/logical-replication/replication-monitor.yaml`** — exits non-zero on apply errors, stopped subs, inactive slots, WAL lag > 100 MB (was 1 GB), missing publication entries, stale subscriptions, or missing REPLICA-trigger. So the K8s job actually goes red and pages instead of just printing `WARNING:`.

**`k8s/cnpg/production-{us,eu,india}-oci/platform-publication.yaml`** — comments updated. The old comment claimed `_prisma_migrations` was "filtered/ignored on the subscriber side" — that wasn't true.

**`k8s/cnpg/logical-replication/RUNBOOK.md`** — step 9 recommended `ALTER SUBSCRIPTION ... SET (INSERT_EXISTS_ACTION = last_update_wins)`, which is not a real PG 18.3 parameter (`unrecognized subscription parameter`). Replaced with the actual playbook: resolve the duplicate row or `ALTER SUBSCRIPTION ... SKIP (lsn = ...)`, plus `disable_on_error = true` so conflicts are loud instead of crash-looping. The "Schema Evolution" section now documents why `_prisma_migrations` cannot be excluded on the publisher side and how the trigger handles it.

## Already applied to live clusters

During the incident I installed the trigger manually on US, EU, and India primaries (verified `tgenabled='R'` on all three) and drained the 3.2 GB WAL backlog by skipping `storage_usage` insert-exists conflicts. After the drain every logical slot was < 5 KB lag, every subscription `active=t`. This PR makes the trigger and verify step durable: any future bootstrap or CNPG restore reapplies them via the deploy workflow.

## Follow-ups (not in this PR)

- `storage_usage` cross-region writes are independent multi-master conflicts (both regions create rows for the same workspaceId; `unique(workspaceId)` makes every replicated INSERT a conflict). The pragmatic fix is to mark this table region-local and not ride logical replication. Filing as a separate ticket — needs a small data-model change in the API.

## Test plan

- [x] Trigger SQL applied to all 3 production primaries; `tgenabled='R'` confirmed on each.
- [x] Replication mesh healthy after drain: every slot < 5 KB lag, every subscription `active=t`.
- [x] Local `prisma migrate deploy` semantics unaffected — REPLICA triggers don't fire on locally-originated writes (covered by trigger semantics; verified manually that `_prisma_migrations` already contains rows for the two affiliate / project_auth_configs migrations after the unblock).
- [ ] Next deploy exercises the new `Install / Verify _prisma_migrations REPLICA-trigger` steps end-to-end on all three regions.
- [ ] Force a synthetic conflict (e.g. drop and rerun `replication-monitor`) and confirm the CronJob shows up as failed in K8s.

Made with [Cursor](https://cursor.com)