### PR TITLE
fix(sdk/ci): isolate hooks-coverage.test.tsx in its own bun process

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -256,8 +256,8 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
-    "test": "NODE_ENV=development bun --no-env-file test src/",
-    "test:coverage": "NODE_ENV=development bun --no-env-file test src/ --coverage",
+    "test": "NODE_ENV=development bun --no-env-file test src/ --path-ignore-patterns '**/hooks-coverage.test.tsx' && NODE_ENV=development bun --no-env-file test src/agent/__tests__/hooks-coverage.test.tsx",
+    "test:coverage": "NODE_ENV=development bun --no-env-file test src/ --path-ignore-patterns '**/hooks-coverage.test.tsx' --coverage && NODE_ENV=development bun --no-env-file test src/agent/__tests__/hooks-coverage.test.tsx --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "verify:license-isolation": "node scripts/verify-license-isolation.mjs"

--- a/packages/sdk/src/agent/__tests__/hooks-coverage.test.tsx
+++ b/packages/sdk/src/agent/__tests__/hooks-coverage.test.tsx
@@ -6,6 +6,19 @@
  * Renders each hook with @testing-library/react under happy-dom and a
  * mocked AgentClient module. Covers all 5 hook bodies + the useClient
  * ref-init helper.
+ *
+ * IMPORTANT: This file MUST be run in its own `bun test` process. The
+ * `mock.module('../client.js', ...)` call below registers a FakeAgentClient
+ * that intentionally implements only the ~8 methods this test exercises
+ * — Bun's module mocks are process-global with no per-file restore, so
+ * if this runs in the same process as `client.test.ts` (which imports the
+ * real AgentClient and calls ~30 methods), every method missing from
+ * FakeAgentClient throws "is not a function" and 50/52 client tests fail.
+ *
+ * `packages/sdk/package.json` enforces the isolation by splitting `test`
+ * into two passes (`bun test src/ --path-ignore-patterns '**\/hooks-coverage.test.tsx'`
+ * then this file alone). Don't merge them back without first making the
+ * mock per-file-scoped, or move hooks to dependency injection.
  */
 import './happy-dom-setup.ts';
 import { describe, it, expect, mock, beforeEach } from 'bun:test';


### PR DESCRIPTION
## Summary

`packages/sdk` tests have been red on every `main` CI run since [`8c6fcd24`](https://github.com/shogo-labs/shogo-ai/commit/8c6fcd24) — 50/52 tests in `src/agent/__tests__/client.test.ts` fail with errors like `c.readFileBlob is not a function`, `c.subscribeToWorkspace is not a function`, etc.

### Root cause

`hooks-coverage.test.tsx` (added in `8c6fcd24`) calls:

```ts
mock.module('../client.js', () => ({
  AgentClient: FakeAgentClient,
  getAgentClient: () => singleton,
}));
```

where `FakeAgentClient` only implements 8 methods (the ones the hooks exercise). The real `AgentClient` has ~30 (`readFileBlob`, `uploadWorkspaceFiles`, `subscribeToWorkspace`, `deleteFile`, `searchFiles`, `mkdirWorkspace`, `readWorkspaceConfigFile`, `writeWorkspaceConfigFile`, `deletePlan`, `listPlans`, …).

Bun's `mock.module()` registers process-globally with no per-file restore. So when `bun test src/` runs both files in the same worker, every method missing from `FakeAgentClient` throws "is not a function" the moment `client.test.ts` imports `'../client'`.

### Repro

```bash
cd packages/sdk
bun test src/agent/__tests__/client.test.ts                                    # 52 pass
bun test src/agent/__tests__/hooks-coverage.test.tsx \
         src/agent/__tests__/client.test.ts                                    # 50 fail
```

### Fix

Split `packages/sdk` `test` (and `test:coverage`) into two bun processes:

1. `bun test src/ --path-ignore-patterns '**/hooks-coverage.test.tsx'`
2. `bun test src/agent/__tests__/hooks-coverage.test.tsx`

Plus a header comment on `hooks-coverage.test.tsx` flagging the constraint so a future refactor doesn't merge them back without first scoping the mock per-file (or moving hooks to dependency injection).

## Test plan

- [x] `bun run test` in `packages/sdk` → 687 pass / 0 fail across 43 files, then 25 pass / 0 fail in the isolated hooks-coverage file
- [ ] Confirm green CI on this PR
- [ ] (Out of scope) `packages/shared-runtime`, `packages/agent-runtime`, `apps/api` still red — separate PRs follow


Made with [Cursor](https://cursor.com)