### PR TITLE
fix(shared-runtime/test): set AI_PROXY_TOKEN with AI_PROXY_URL in deriveApiUrl tests

### DIFF
--- a/packages/shared-runtime/src/__tests__/server-framework.test.ts
+++ b/packages/shared-runtime/src/__tests__/server-framework.test.ts
@@ -872,7 +872,16 @@ describe('deriveApiUrl fallback paths (L311-319)', () => {
 
   test('L312-317: AI_PROXY_URL path — host extracted from proxy URL', async () => {
     const { app } = await buildApp({
-      env: { SHOGO_API_URL: undefined, API_URL: undefined, AI_PROXY_URL: 'http://proxy.internal:8080/v1' },
+      // AI_PROXY_TOKEN must accompany AI_PROXY_URL — configureAIProxy()
+      // throws "no proxy token is available" otherwise, and the
+      // catch in createRuntimeApp does process.exit(1), killing the
+      // whole test process (file would report 0/0/0 → CI red).
+      env: {
+        SHOGO_API_URL: undefined,
+        API_URL: undefined,
+        AI_PROXY_URL: 'http://proxy.internal:8080/v1',
+        AI_PROXY_TOKEN: 'test-proxy-token',
+      },
     })
     fetchImpl = async () => ({
       ok: true, status: 200,
@@ -999,10 +1008,14 @@ describe('pool assignment marker write failure (L646)', () => {
 describe('deriveApiUrl invalid AI_PROXY_URL (L317)', () => {
   test('falls through to namespace fallback when AI_PROXY_URL is not a valid URL', async () => {
     const { app } = await buildApp({
+      // See note above: AI_PROXY_URL without AI_PROXY_TOKEN trips
+      // configureAIProxy → FATAL → process.exit(1) and the whole
+      // test file silently FAILs with 0 pass / 0 fail.
       env: {
         SHOGO_API_URL: undefined,
         API_URL: undefined,
         AI_PROXY_URL: 'not-a-valid-url!!!',
+        AI_PROXY_TOKEN: 'test-proxy-token',
       },
     })
     fetchImpl = async () => ({


### PR DESCRIPTION
## Summary

`packages/shared-runtime/src/__tests__/server-framework.test.ts` was the first failing file in CI's `Test` step, reported as a wholesale `FAIL (0 pass, 0 fail, 0 skip)` because the worker process was killed mid-suite.

### Root cause

Two tests in the `deriveApiUrl` coverage set push `AI_PROXY_URL` into `process.env` via `buildApp({ env: ... })` without also setting `AI_PROXY_TOKEN`:

- L873 `test('L312-317: AI_PROXY_URL path — host extracted from proxy URL')`
- L1005 `test('falls through to namespace fallback when AI_PROXY_URL is not a valid URL')`

`configureAIProxy()` (correctly) throws `"AI_PROXY_URL is set ... but no proxy token is available"` to refuse silent fallback to a raw `ANTHROPIC_API_KEY`, and `createRuntimeApp`'s boot-time catch logs `FATAL` and calls `process.exit(1)`. That kills the `bun test` worker mid-suite, so the runner can't emit pass/fail counts and the file is reported as a wholesale `FAIL`.

### Repro

```bash
bun test packages/shared-runtime/src/__tests__/server-framework.test.ts -t "L312-317"
# → [test-runtime] FATAL: AI_PROXY_URL is set (http://proxy.internal:8080/v1) but no proxy token is available.
# → exit code 1, no pass/fail output
```

### Fix

Add `AI_PROXY_TOKEN: 'test-proxy-token'` to both env overrides + inline comment so the next person doesn't trip the same landmine. Production behavior is unchanged — the strict-token guard is exactly what we want at runtime.

## Test plan

- [x] `bun run test` in `packages/shared-runtime`: 540 pass / 0 fail across 24 files
- [x] Specific file: 62 pass / 0 fail
- [ ] Confirm green CI on this PR


Made with [Cursor](https://cursor.com)