### PR TITLE
fix(agent-runtime/ci): clear the 7 failing files in CI run 26481585808

### DIFF
--- a/packages/agent-runtime/src/__tests__/error-recovery.test.ts
+++ b/packages/agent-runtime/src/__tests__/error-recovery.test.ts
@@ -316,7 +316,9 @@ describe('AgentGateway error recovery', () => {
       write: (chunk: any) => { writtenChunks.push(chunk) },
     }
 
-    await gateway.processChatMessageStream('Hello', mockWriter as any, {})
+    await gateway.processChatMessageStream('Hello', mockWriter as any, {
+      chatSessionId: 'error-recovery-zero-output',
+    })
 
     const errorChunk = writtenChunks.find((c) => c.type === 'error')
     expect(errorChunk).toBeDefined()
@@ -331,9 +333,12 @@ describe('AgentGateway error recovery', () => {
     await gateway.start()
 
     const mockWriter = { write: (_chunk: any) => {} }
-    await gateway.processChatMessageStream('Hello', mockWriter as any, {})
+    const sessionId = 'error-recovery-persists-user'
+    await gateway.processChatMessageStream('Hello', mockWriter as any, {
+      chatSessionId: sessionId,
+    })
 
-    const session = gateway.getSessionManager().get('chat')
+    const session = gateway.getSessionManager().get(sessionId)
     expect(session).toBeDefined()
     expect(session!.messages.length).toBeGreaterThan(0)
 

--- a/packages/agent-runtime/src/__tests__/prepare-bundle-extra.test.ts
+++ b/packages/agent-runtime/src/__tests__/prepare-bundle-extra.test.ts
@@ -581,9 +581,19 @@ describe('prepareVMBundle', () => {
       }
       if (cmd.startsWith('bun add') && cwd) {
         fsState.set(`${cwd}/node_modules`, { type: 'dir' })
-        fsState.set(`${cwd}/node_modules/@prisma`, { type: 'dir' })
-        fsState.set(`${cwd}/node_modules/@prisma/internals`, { type: 'dir' })
-        fsState.set(`${cwd}/node_modules/typescript-language-server`, { type: 'dir' })
+        // Mirror the real bun-add: only create the markers for packages the
+        // command actually installs. The old blanket-create masked the
+        // typescript-language-server install step — prepare-bundle.ts skips
+        // the install when the marker is already present, so the prisma
+        // `bun add` (which used to seed the ts-lsp marker too) made the
+        // ts-lsp install path unreachable from the test.
+        if (cmd.includes('prisma')) {
+          fsState.set(`${cwd}/node_modules/@prisma`, { type: 'dir' })
+          fsState.set(`${cwd}/node_modules/@prisma/internals`, { type: 'dir' })
+        }
+        if (cmd.includes('typescript-language-server')) {
+          fsState.set(`${cwd}/node_modules/typescript-language-server`, { type: 'dir' })
+        }
       }
       if (cmd.startsWith('bun build') && cwd) {
         const outflagIdx = cmd.indexOf('--outfile')

--- a/packages/agent-runtime/src/__tests__/preview-manager-v4.test.ts
+++ b/packages/agent-runtime/src/__tests__/preview-manager-v4.test.ts
@@ -25,6 +25,7 @@ import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } fr
 import { mkdirSync, writeFileSync, rmSync, existsSync, statSync } from 'fs'
 import { join } from 'path'
 
+import { flushAllLogWrites } from '../runtime-log-writer'
 import {
   PreviewManager,
   emitBuildLine,
@@ -277,10 +278,14 @@ describe('emitBuildLine extra branches', () => {
     expect(existsSync(buildLog)).toBe(false)
   })
 
-  test('writes a line with prefix + newline to the build-log file', () => {
+  test('writes a line with prefix + newline to the build-log file', async () => {
     const buildLog = join(TEST_ROOT, 'el-write.log')
     if (existsSync(buildLog)) rmSync(buildLog)
     emitBuildLine(buildLog, '[stdout]', 'hello', 'stdout')
+    // emitBuildLine now delegates to runtime-log-writer.scheduleLogWrite,
+    // which batches via setImmediate to keep /health responsive on Windows
+    // — see runtime-log-writer.ts header. Drain before asserting.
+    await flushAllLogWrites(buildLog)
     expect(existsSync(buildLog)).toBe(true)
     const stat = statSync(buildLog)
     expect(stat.size).toBeGreaterThan(0)
@@ -300,11 +305,12 @@ describe('emitBuildLine extra branches', () => {
     expect(() => emitBuildLine(buildLog, '[stderr]', 'compile error', 'stderr')).not.toThrow()
   })
 
-  test('default stream argument is stdout', () => {
+  test('default stream argument is stdout', async () => {
     const buildLog = join(TEST_ROOT, 'el-default.log')
     if (existsSync(buildLog)) rmSync(buildLog)
     // @ts-expect-error — exercising the default-argument path
     emitBuildLine(buildLog, '[stdout]', 'using default stream')
+    await flushAllLogWrites(buildLog)
     expect(existsSync(buildLog)).toBe(true)
   })
 })

--- a/packages/agent-runtime/src/__tests__/stop-continue-context.test.ts
+++ b/packages/agent-runtime/src/__tests__/stop-continue-context.test.ts
@@ -138,6 +138,7 @@ describe('Fix 1: addMessages persists to session when uiWriter throws', () => {
   })
 
   test('session contains turn messages even when writer throws after text-end', async () => {
+    const SESSION_ID = 'fix1-persist-on-writer-throw'
     const mockStream = createMockStreamFn([
       buildTextResponse('Here is my response about quantum computing.'),
     ])
@@ -148,9 +149,11 @@ describe('Fix 1: addMessages persists to session when uiWriter throws', () => {
 
     const { writer } = createThrowingWriter('text-end')
 
-    await gateway.processChatMessageStream('Explain quantum computing', writer as any, {})
+    await gateway.processChatMessageStream('Explain quantum computing', writer as any, {
+      chatSessionId: SESSION_ID,
+    })
 
-    const session = gateway.getSessionManager().get('chat')
+    const session = gateway.getSessionManager().get(SESSION_ID)
     expect(session).toBeDefined()
     expect(session!.messages.length).toBeGreaterThan(0)
 
@@ -161,6 +164,7 @@ describe('Fix 1: addMessages persists to session when uiWriter throws', () => {
   })
 
   test('"continue" sees interrupted turn context when writer fails mid-stream', async () => {
+    const SESSION_ID = 'fix1-continue-after-writer-fail'
     const mockStreamPhase1 = createMockStreamFn([
       buildTextResponse('Quantum computing uses qubits which...'),
     ])
@@ -170,7 +174,9 @@ describe('Fix 1: addMessages persists to session when uiWriter throws', () => {
     await gateway.start()
 
     const { writer: throwingWriter } = createThrowingWriter('text-end')
-    await gateway.processChatMessageStream('Explain quantum computing', throwingWriter as any, {})
+    await gateway.processChatMessageStream('Explain quantum computing', throwingWriter as any, {
+      chatSessionId: SESSION_ID,
+    })
 
     let messagesSentToLLM: Message[][] = []
     const mockStreamPhase2 = createMockStreamFn(
@@ -180,7 +186,9 @@ describe('Fix 1: addMessages persists to session when uiWriter throws', () => {
     gateway.setStreamFn(mockStreamPhase2)
 
     const { writer: normalWriter } = createCollectingWriter()
-    await gateway.processChatMessageStream('continue', normalWriter as any, {})
+    await gateway.processChatMessageStream('continue', normalWriter as any, {
+      chatSessionId: SESSION_ID,
+    })
 
     expect(messagesSentToLLM).toHaveLength(1)
     const history = messagesSentToLLM[0]
@@ -211,6 +219,7 @@ describe('Fix 2: abortCurrentTurn cancels running turn', () => {
   })
 
   test('abortCurrentTurn returns true for an in-flight turn', async () => {
+    const SESSION_ID = 'fix2-abort-returns-true'
     const mockStream = createDelayedStreamFn(
       [buildTextResponse('This response takes a while...')],
       500,
@@ -221,21 +230,24 @@ describe('Fix 2: abortCurrentTurn cancels running turn', () => {
     await gateway.start()
 
     const { writer } = createCollectingWriter()
-    const turnPromise = gateway.processChatMessageStream('Hello', writer as any, {})
+    const turnPromise = gateway.processChatMessageStream('Hello', writer as any, {
+      chatSessionId: SESSION_ID,
+    })
 
     await new Promise((r) => setTimeout(r, 50))
-    const aborted = gateway.abortCurrentTurn('chat')
+    const aborted = gateway.abortCurrentTurn(SESSION_ID)
     expect(aborted).toBe(true)
 
     await turnPromise
 
-    const session = gateway.getSessionManager().get('chat')
+    const session = gateway.getSessionManager().get(SESSION_ID)
     expect(session).toBeDefined()
     const hasUser = session!.messages.some((m) => m.role === 'user')
     expect(hasUser).toBe(true)
   })
 
   test('abort + continue preserves context (full scenario)', async () => {
+    const SESSION_ID = 'fix2-abort-continue'
     const mockStreamSlow = createDelayedStreamFn(
       [buildTextResponse('Slow partial response content...')],
       500,
@@ -246,10 +258,12 @@ describe('Fix 2: abortCurrentTurn cancels running turn', () => {
     await gateway.start()
 
     const { writer: writer1 } = createCollectingWriter()
-    const turn1 = gateway.processChatMessageStream('Write something complex', writer1 as any, {})
+    const turn1 = gateway.processChatMessageStream('Write something complex', writer1 as any, {
+      chatSessionId: SESSION_ID,
+    })
 
     await new Promise((r) => setTimeout(r, 50))
-    gateway.abortCurrentTurn('chat')
+    gateway.abortCurrentTurn(SESSION_ID)
     await turn1
 
     let messagesSentToLLM: Message[][] = []
@@ -260,7 +274,9 @@ describe('Fix 2: abortCurrentTurn cancels running turn', () => {
     gateway.setStreamFn(mockStreamFast)
 
     const { writer: writer2 } = createCollectingWriter()
-    await gateway.processChatMessageStream('continue', writer2 as any, {})
+    await gateway.processChatMessageStream('continue', writer2 as any, {
+      chatSessionId: SESSION_ID,
+    })
 
     expect(messagesSentToLLM).toHaveLength(1)
     const history = messagesSentToLLM[0]
@@ -320,11 +336,16 @@ describe('Fix 3: concurrent turn waits for previous turn', () => {
     gateway.setStreamFn(mockStream)
     await gateway.start()
 
+    const SESSION_ID = 'fix3-concurrent-shares-history'
     const { writer: w1 } = createCollectingWriter()
     const { writer: w2 } = createCollectingWriter()
 
-    const turn1 = gateway.processChatMessageStream('First message', w1 as any, {})
-    const turn2 = gateway.processChatMessageStream('continue', w2 as any, {})
+    const turn1 = gateway.processChatMessageStream('First message', w1 as any, {
+      chatSessionId: SESSION_ID,
+    })
+    const turn2 = gateway.processChatMessageStream('continue', w2 as any, {
+      chatSessionId: SESSION_ID,
+    })
 
     await Promise.all([turn1, turn2])
 

--- a/packages/agent-runtime/src/__tests__/workspace-defaults-extra.test.ts
+++ b/packages/agent-runtime/src/__tests__/workspace-defaults-extra.test.ts
@@ -9,7 +9,7 @@
 import { describe, test, expect, mock, beforeEach, afterEach, beforeAll, afterAll } from 'bun:test'
 import {
   mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync,
-  readdirSync, symlinkSync,
+  readdirSync, realpathSync, symlinkSync,
 } from 'node:fs'
 import { tmpdir, platform as osPlatform } from 'node:os'
 import { join } from 'node:path'
@@ -335,7 +335,11 @@ describe('getRuntimeTemplatePath / seedRuntimeTemplate', () => {
     const tplDir = makeTmp()
     writeFileSync(join(tplDir, 'package.json'), '{"name":"runtime-template"}')
     process.env.RUNTIME_TEMPLATE_DIR = tplDir
-    expect(wd.getRuntimeTemplatePath()).toBe(tplDir)
+    // getRuntimeTemplatePath canonicalises via realpathSync so cpSync()
+    // doesn't choke on a symlink-to-directory. On macOS /var/folders/...
+    // resolves to /private/var/folders/..., so compare against the
+    // canonical form rather than the raw mkdtempSync output.
+    expect(wd.getRuntimeTemplatePath()).toBe(realpathSync(tplDir))
   })
 
   test('seedRuntimeTemplate returns false when package.json already exists', () => {
@@ -344,12 +348,14 @@ describe('getRuntimeTemplatePath / seedRuntimeTemplate', () => {
     expect(wd.seedRuntimeTemplate(dir)).toBe(false)
   })
 
-  test('seedRuntimeTemplate handles missing env-override gracefully (falls through to other candidates)', () => {
+  test('seedRuntimeTemplate handles missing env-override gracefully (no template available)', () => {
     const dir = makeTmp()
     process.env.RUNTIME_TEMPLATE_DIR = join(tmpdir(), 'definitely-nonexistent-' + Date.now())
-    // Source tree has bundled runtime-template; env override is just first candidate.
-    // We assert the call does not throw — the result depends on the host env.
+    // Explicit env override is exclusive — when the pointed-at dir doesn't
+    // exist getRuntimeTemplatePath returns null and seedRuntimeTemplate is
+    // a no-op (returns false). It must not throw.
     expect(() => wd.seedRuntimeTemplate(dir)).not.toThrow()
+    expect(wd.seedRuntimeTemplate(dir)).toBe(false)
   })
 
   test('seedRuntimeTemplate copies template, excluding node_modules and .shogo and src/generated', () => {

--- a/packages/agent-runtime/src/detected-urls.ts
+++ b/packages/agent-runtime/src/detected-urls.ts
@@ -72,8 +72,17 @@ export interface DetectedUrl {
   sessionId: string
   /** Millisecond epoch when detection fired. */
   detectedAt: number
+  /**
+   * Monotonic per-process sequence used as a tiebreaker when two detections
+   * land in the same `Date.now()` millisecond — without it the sort in
+   * `listAllDetections` is stable-equal and the "newest first" contract
+   * collapses to insertion order, which back-to-back dev-server starts
+   * (and the corresponding test) trip routinely.
+   */
+  seq: number
 }
 
+let detectionSeq = 0
 const detectedBySession = new Map<string, DetectedUrl>()
 let lastAnyDetection: DetectedUrl | null = null
 const listeners = new Set<(d: DetectedUrl) => void>()
@@ -142,6 +151,7 @@ export function ingestChunk(sessionId: string, bytes: Uint8Array | string): Dete
       url,
       sessionId,
       detectedAt: Date.now(),
+      seq: ++detectionSeq,
     }
     detectedBySession.set(sessionId, detection)
     lastAnyDetection = detection
@@ -170,7 +180,9 @@ export function getMostRecentDetection(): DetectedUrl | null {
 }
 
 export function listAllDetections(): DetectedUrl[] {
-  return [...detectedBySession.values()].sort((a, b) => b.detectedAt - a.detectedAt)
+  return [...detectedBySession.values()].sort(
+    (a, b) => b.detectedAt - a.detectedAt || b.seq - a.seq,
+  )
 }
 
 export function clearDetection(sessionId: string): void {
@@ -192,5 +204,6 @@ export function _resetForTests(): void {
   detectedBySession.clear()
   tailBuffer.clear()
   lastAnyDetection = null
+  detectionSeq = 0
   listeners.clear()
 }

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -4577,8 +4577,15 @@ export default {
     // Bun.serve() had already bound the port. This early return skips
     // that path for the smallest possible response.
     if (url.pathname === '/health' && req.method === 'GET') {
+      // The slow path (createRuntimeApp's /health in shared-runtime) reports
+      // `poolMode: IS_POOL_MODE && !state.poolAssigned`. The fast path needs
+      // to match that contract or the warm-pool tests + RuntimeManager
+      // probes can't distinguish an unassigned pool pod from an assigned
+      // project pod. Both checks are sync reads of in-process state, so
+      // they're safe in the hot path.
+      const poolMode = state.isPoolMode && !state.poolAssigned
       return new Response(
-        JSON.stringify({ status: 'ok', projectId: process.env.PROJECT_ID, runtimeType: 'unified', poolMode: false, uptime: 0, fast: true }),
+        JSON.stringify({ status: 'ok', projectId: process.env.PROJECT_ID, runtimeType: 'unified', poolMode, uptime: 0, fast: true }),
         { status: 200, headers: { 'content-type': 'application/json' } },
       )
     }

--- a/packages/agent-runtime/src/workspace-defaults.ts
+++ b/packages/agent-runtime/src/workspace-defaults.ts
@@ -466,6 +466,18 @@ const RUNTIME_TEMPLATE_SKIP = new Set([
  */
 export function getRuntimeTemplatePath(): string | null {
   const envOverride = process.env.RUNTIME_TEMPLATE_DIR
+  // When the operator explicitly points us at a template dir, treat that
+  // choice as exclusive — falling through to the bundled candidates if
+  // their dir doesn't yet exist would silently mask a misconfiguration
+  // (and tests using a sentinel non-existent path to mean "no template
+  // available here" would unexpectedly pick up the repo's checked-in
+  // templates/runtime-template/ instead).
+  if (envOverride !== undefined) {
+    if (existsSync(join(envOverride, 'package.json'))) {
+      try { return realpathSync(envOverride) } catch { return envOverride }
+    }
+    return null
+  }
   let execAdjacent: string | null = null
   try {
     if (process.execPath) {
@@ -473,7 +485,6 @@ export function getRuntimeTemplatePath(): string | null {
     }
   } catch { /* execPath unavailable (e.g. test stub) */ }
   const candidates = [
-    ...(envOverride ? [envOverride] : []),
     ...(execAdjacent ? [execAdjacent] : []),
     join(__dirname, '..', '..', '..', 'templates', 'runtime-template'),
     join(__dirname, 'templates', 'runtime-template'),


### PR DESCRIPTION
## Summary

All seven failing test files in `packages/agent-runtime` had different root causes but accumulated on top of each other because `main` has not gone green in days. Each file is fixed independently below.

### 1. `detected-urls.test.ts` (1 fail)

`listAllDetections` sorts by `detectedAt` desc; back-to-back `ingestChunk` calls landed in the same `Date.now()` millisecond and the stable-sort tiebreaker collapsed to insertion order, so "newest first" returned oldest first. Add a per-process monotonic `seq` field to `DetectedUrl` and use it as the sort tiebreaker. `_resetForTests` resets the counter.

### 2. `error-recovery.test.ts` (2 fails) & 3. `stop-continue-context.test.ts` (5 fails)

`processChatMessageStream` now throws `"chatSessionId is required"` (commit [`20c618bc`](https://github.com/shogo-labs/shogo-ai/commit/20c618bc) fixed the bug where missing id collapsed every no-id turn into a literal `'chat'` bucket). These tests were written pre-20c618bc and called it with `{}` — pass a unique `chatSessionId` per test and update `getSessionManager().get(...)` / `abortCurrentTurn(...)` sites to use that id.

### 4. `prepare-bundle-extra.test.ts` (1 fail)

`primeBunInstallSideEffects()` pre-seeded the `node_modules/typescript-language-server` marker on **every** `bun add` invocation, including the prisma one that runs first. `prepare-bundle.ts` then sees the marker already exists when it gets to the ts-lsp install step and skips it, so `bun add typescript-language-server` was never invoked. Scope the per-package markers to the matching command (`prisma` → `@prisma/*`, `typescript-language-server` → its own).

### 5. `preview-manager-v4.test.ts` (2 fails)

`emitBuildLine()` was migrated to `runtime-log-writer.scheduleLogWrite` (batched + async via `setImmediate`) to keep `/health` responsive on Windows. The two "writes a line to the build-log file" tests still asserted `existsSync` right after the call, before the flush. Make them async and `await flushAllLogWrites(buildLog)` before the assert.

### 6. `warm-pool.test.ts` (2 fails)

`server.ts`'s `/health` fast-path (the route-tree-bypass added for the Windows JIT freeze) hardcoded `poolMode: false`, so warm-pool pods reported the wrong mode. Compute the same value the slow path does: `state.isPoolMode && !state.poolAssigned`. Both reads are sync, safe in the hot path.

### 7. `workspace-defaults-extra.test.ts` (3 fails)

Three `ensureWorkspaceDeps` tests set `RUNTIME_TEMPLATE_DIR` to a non-existent sentinel to mean "no template available", but `getRuntimeTemplatePath` silently fell through to the bundled `templates/runtime-template/` checked into the repo, so the test then copied that template's `node_modules` (3+ seconds of `cpSync`) and returned `didInstall=false`. Make the env override exclusive: when set, the bundled-path fallback is not consulted (matches operator intent and is more correct in production too). Updated the one docstring test that previously asserted the fallback, and made the "respects `RUNTIME_TEMPLATE_DIR` env override" test compare against `realpathSync(tplDir)` so macOS `/var/`-vs-`/private/var/` canonicalisation doesn't trip the assertion.

## Test plan

- [x] `bun test` on the 7 originally-failing files: **206 pass / 0 fail**
- [x] `bun run test` in `packages/agent-runtime`: **2904 pass / 2 fail / 104 skip across 179 files**. The 2 remaining fails (`permission-engine.test.ts` realpathSync-on-broken-symlink and `workspace-seeding.test.ts` `pkg` export) are pre-existing local-only failures (pass in CI) and out of scope.
- [ ] Confirm green CI on this PR.


Made with [Cursor](https://cursor.com)