### PR TITLE
fix(api/ci): unbreak apps/api tests — 27 failing files → all green

### DIFF
--- a/apps/api/src/__tests__/local-projects-v4.test.ts
+++ b/apps/api/src/__tests__/local-projects-v4.test.ts
@@ -1,13 +1,18 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { Hono } from 'hono'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { withPrismaExports } from './helpers/prisma-mock-exports'
 
 process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET || 'test-secret-v4'
 
-const FAKE_HOME = '/tmp/v4-B-home'
-mkdirSync(FAKE_HOME, { recursive: true })
+// macOS hard-links /tmp -> /private/tmp, so `realpathSync('/tmp/x')` returns
+// `/private/tmp/x`. The `/fs/browse` route validates the realpath'd target
+// against `os.homedir()` (a literal string compare), which would fail unless
+// FAKE_HOME *is* the realpath'd form. Canonicalise it at startup so both
+// sides of the isUnderHome() check line up on macOS and Linux alike.
+mkdirSync('/tmp/v4-B-home', { recursive: true })
+const FAKE_HOME = realpathSync('/tmp/v4-B-home')
 
 const realOs = await import('os')
 mock.module('os', () => ({

--- a/apps/api/src/__tests__/preload-sdk-mocks.ts
+++ b/apps/api/src/__tests__/preload-sdk-mocks.ts
@@ -74,17 +74,14 @@ mock.module('@shogo-ai/sdk/ai-client', () => ({
   createAiClient: (_opts?: any) => ({}),
 }))
 
-mock.module('@shogo-ai/sdk/model-catalog', () => ({
-  getModelTier: (_modelId?: string) => 'standard',
-  resolveModelId: (mode?: string) => mode || 'claude-haiku-4-5',
-  MODEL_CATALOG: {},
-  getModelEntry: (_id?: string) => null,
-  MODEL_DOLLAR_COSTS: {} as Record<string, any>,
-  calculateDollarCost: () => 0,
-  getModelBillingModel: (id?: string) => id || '',
-  resolveAgentModeDefault: (mode?: string) => mode || '',
-  getAgentModeOverrides: () => ({}),
-}))
+// `@shogo-ai/sdk/model-catalog` and `@shogo/model-catalog` are NOT mocked
+// here: apps/api's bunfig.toml ships `conditions = ["development"]`, so
+// Bun resolves both to the source `.ts` files (verified with
+// `bun --no-env-file -e "import {...} from '@shogo/model-catalog'"`).
+// Stubbing them out with empty MODEL_DOLLAR_COSTS / resolveModelId broke
+// usage-cost.test.ts and proxy-billing-session.test.ts which legitimately
+// exercise the real catalog (and chat-usage-tracker.test.ts which only
+// needed a non-empty cost row to not crash inside closeSession).
 
 mock.module('@shogo-ai/sdk/stream-buffer', () => {
   class StreamBufferWriter { write() {} close() {} }
@@ -127,21 +124,21 @@ mock.module('@shogo-ai/sdk/cli/pkg', () => ({
   resolveBinInvocation: (cmd: string) => cmd,
 }))
 
-// Intercept workspace package re-export shims that Bun doesn't hoist in static-import context
-mock.module('@shogo/model-catalog', () => ({
-  getModelTier: (_modelId?: string) => 'standard',
-  resolveModelId: (mode?: string) => mode || 'claude-haiku-4-5',
-  MODEL_CATALOG: {},
-  getModelEntry: (_id?: string) => null,
-  MODEL_DOLLAR_COSTS: {} as Record<string, any>,
-  calculateDollarCost: () => 0,
-  getModelBillingModel: (id?: string) => id || '',
-  resolveAgentModeDefault: (mode?: string) => mode || '',
-  getAgentModeOverrides: () => ({}),
-  getMaxOutputTokens: (_id?: string) => 4096,
-  MODEL_ALIASES: {} as Record<string, any>,
-}))
-
+// Intercept workspace package re-export shims that Bun doesn't hoist in
+// static-import context. Keep the symbol union in sync with `import { ... }
+// from '@shogo/model-catalog'` across apps/api/src/** — Bun resolves every
+// named import at module load, so a missing symbol here turns into a
+// "SyntaxError: Export named 'X' not found" the moment a sibling test
+// imports a route that touches it (e.g. ai-proxy.ts pulls in
+// IMAGE_MODEL_CATALOG / AGENT_MODE_DEFAULTS).
+// `@shogo/shared-runtime` is imported in many apps/api code paths
+// (manager.ts, server.ts, project-export-import.ts, marketplace-install,
+// instance-sizes, …). Most tests don't touch shared-runtime behaviour at
+// all, but Bun fully resolves every named import at module load — so
+// every missing symbol here turns into a "SyntaxError: Export named 'X'
+// not found" the moment a sibling import pulls in a file that touches it.
+// Keep this object in sync with the union of `import { ... } from
+// '@shogo/shared-runtime'` across apps/api/src/**.
 mock.module('@shogo/shared-runtime', () => ({
   RUNTIME_CONFIG: {
     apiPort: 4000,
@@ -154,4 +151,39 @@ mock.module('@shogo/shared-runtime', () => ({
     componentLabel: 'runtime',
     containerName: 'runtime',
   },
+  pkg: {
+    version: '0.0.0',
+    name: '@shogo/shared-runtime',
+    isWindows: false,
+    bunBinary: 'bun',
+    // runtime/manager.ts:ensureProjectDirectory calls pkg.installAsync
+    // for projects without a pre-seeded template; mirror the real
+    // installer's contract of "node_modules exists after success" so
+    // the writeFileSync(installSentinel) on the next line doesn't ENOENT.
+    installAsync: async (dir: string, _opts?: any) => {
+      const { mkdirSync } = await import('node:fs')
+      const { join } = await import('node:path')
+      try { mkdirSync(join(dir, 'node_modules'), { recursive: true }) } catch {}
+    },
+  },
+  isMobileTechStack: (stack?: any) =>
+    stack === 'expo-app' || stack === 'expo-three' || stack === 'react-native',
+  // Keep this in sync with `seedsOwnTemplate: true` entries in
+  // packages/core/src/tech-stack-registry.ts. runtime-manager-directory.test.ts
+  // relies on `python-data` returning true to exercise the empty-workspace
+  // skip-install branch in `ensureProjectDirectory`.
+  stackSeedsItself: (stack?: any) =>
+    stack === 'expo-app' ||
+    stack === 'expo-three' ||
+    stack === 'react-native' ||
+    stack === 'python-data' ||
+    stack === 'unity-game' ||
+    stack === 'none',
+  diagnosticsRoutes: () => ({}),
+  createS3SyncForProject: (_projectId?: string, _opts?: any) => ({
+    syncProjectArchive: async () => ({ ok: true }),
+    downloadProjectArchive: async () => null,
+    listProjectArchives: async () => [],
+  }),
+  isMacOSJunkName: (_name: string) => false,
 }))

--- a/apps/api/src/lib/__tests__/local-heartbeat-scheduler.test.ts
+++ b/apps/api/src/lib/__tests__/local-heartbeat-scheduler.test.ts
@@ -17,10 +17,20 @@ function hasLocalSqliteSchema(): boolean {
   try {
     const db = new Database('shogo.db', { readonly: true })
     try {
-      const row = db.query(
+      const workspacesRow = db.query(
         "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'workspaces'",
       ).get()
-      return !!row
+      if (!workspacesRow) return false
+      // Verify the schema is up to date. An older `shogo.db` left over
+      // from a checkout that predates the publish-status columns will
+      // pass the workspaces check but blow up the first time the test
+      // runs `prisma.project.create()` with a P2022 ColumnNotFound.
+      // Skip cleanly in that case instead of failing.
+      const projectsColumns = db
+        .query("PRAGMA table_info('projects')")
+        .all() as Array<{ name: string }>
+      if (!projectsColumns.some((c) => c.name === 'publishStatus')) return false
+      return true
     } finally {
       db.close()
     }

--- a/apps/api/src/routes/__tests__/thumbnail.test.ts
+++ b/apps/api/src/routes/__tests__/thumbnail.test.ts
@@ -72,6 +72,18 @@ mock.module('@aws-sdk/client-s3', () => ({
   },
 }))
 
+// The real `getPreviewUrl` is a pure string-formatter that always returns
+// a URL, so the "no_url" branch in routes/thumbnail.ts (which only fires
+// if the import OR call throws) can't be exercised without a mock. Make
+// it throw so the test can assert the 400 no_url contract.
+let previewUrlThrows = false
+mock.module('../../lib/knative-project-manager', () => ({
+  getPreviewUrl: (projectId: string) => {
+    if (previewUrlThrows) throw new Error('preview url unavailable')
+    return `https://preview--${projectId}.dev.example.com/`
+  },
+}))
+
 const { thumbnailRoutes } = await import('../thumbnail')
 
 let logSpy: any
@@ -86,6 +98,7 @@ beforeEach(() => {
   s3.presignedUrl = 'https://artifacts.example.com/thumbnails/p.png?sig=abc'
   s3.sendCalls = []
   s3.sendThrow = null
+  previewUrlThrows = false
   logSpy = mock(() => {})
   errorSpy = mock(() => {})
   console.log = logSpy as any
@@ -278,9 +291,10 @@ describe('POST /projects/:id/thumbnail/capture (Playwright)', () => {
 
   it('returns 400 (no_url) when no body URL, no publishedSubdomain, and no preview-URL', async () => {
     ps.project = { id: 'p-1', publishedSubdomain: null, type: 'agent' }
-    // The dynamic import of knative-project-manager will fail in the test
-    // runtime (it pulls in @kubernetes/client-node, not mocked here), and
-    // the route catches and returns 400 no_url.
+    // Simulate the preview URL being unavailable so the route's no_url
+    // branch fires (the real `getPreviewUrl` is a pure formatter that
+    // never returns null, so we must throw to reach 400).
+    previewUrlThrows = true
     const res = await makeApp().fetch(captureReq())
     expect(res.status).toBe(400)
     const body = await res.json()

--- a/apps/api/src/services/__tests__/git.service.test.ts
+++ b/apps/api/src/services/__tests__/git.service.test.ts
@@ -10,6 +10,7 @@ import {
   readFileSync,
   rmSync,
   statSync,
+  utimesSync,
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -216,9 +217,12 @@ describe('initRepo — evicts a stale .git/index.lock', () => {
     await svc.initRepo(ws)
     const lockPath = join(ws, '.git', 'index.lock')
     writeFileSync(lockPath, '')
-    // Backdate the lock file by 10 seconds
+    // Backdate the lock file by 10 seconds. `touch -d @<epoch>` is a
+    // GNU-only flag — BSD `touch` (macOS) rejects it with "out of range
+    // or illegal time specification". `utimesSync` is portable and
+    // takes seconds-since-epoch directly.
     const oldTime = (Date.now() - 10_000) / 1000
-    execFileSync('touch', ['-d', `@${oldTime}`, lockPath])
+    utimesSync(lockPath, oldTime, oldTime)
 
     const warns: string[] = []
     const orig = console.warn


### PR DESCRIPTION
## Summary

Final PR in the 4-PR sequence that gets shogo-ai CI back to green for the first time in several days. Goes after #686 (sdk), #687 (shared-runtime), #688 (agent-runtime) — all merged.

Takes `apps/api` from **27 failing test files** to **7242 pass / 0 fail / 42 skip across 380 files**.

Five orthogonal fixes, all in test infrastructure (no production code changes):

### 1. `preload-sdk-mocks.ts` — model-catalog + shared-runtime coverage
- **Drop** the `@shogo-ai/sdk/model-catalog` and `@shogo/model-catalog` mocks entirely. `apps/api`'s `bunfig.toml` ships `conditions = [\"development\"]`, so Bun resolves both to source `.ts` files. Stubbing them with empty `MODEL_DOLLAR_COSTS` / `resolveModelId` broke `usage-cost.test.ts` and `proxy-billing-session.test.ts` (legit catalog users) and crashed `chat-usage-tracker.test.ts` inside `closeSession`.
- **Expand** `@shogo/shared-runtime` to expose `pkg` (with `isWindows` / `bunBinary` / `installAsync`), `isMobileTechStack`, `stackSeedsItself`, `diagnosticsRoutes`, `createS3SyncForProject`, `isMacOSJunkName` — all pulled in transitively by apps/api routes. Bun resolves every named import at module load, so a missing symbol becomes a `SyntaxError: Export named 'X' not found` the moment a sibling test imports a route that touches it.
- `pkg.installAsync` mirrors the real installer's contract (creates `node_modules/`) so `runtime/manager.ts`'s `writeFileSync` of the install-ok sentinel doesn't ENOENT.
- `stackSeedsItself` enumerates the `seedsOwnTemplate: true` entries from `packages/core/src/tech-stack-registry.ts` so `runtime-manager-directory.test.ts` can exercise the `python-data` skip-install branch.

### 2. `local-projects-v4.test.ts` — macOS realpath in `/fs/browse`
The route validates `realpathSync(target)` against `os.homedir()` with a literal string compare. On macOS `/tmp -> /private/tmp`, so the pre-mocked `FAKE_HOME = '/tmp/v4-B-home'` produced a mismatch and six `400 outside_home` responses where the test expected `200`. Run `realpathSync` on `FAKE_HOME` up front so both sides of the `isUnderHome()` check are canonical on macOS and Linux alike.

### 3. `local-heartbeat-scheduler.test.ts` — schema-drift skip
`describe.skipIf(!LOCAL_SQLITE_READY)` only checked for the `workspaces` table. An older `shogo.db` from before the publish columns landed passes that check but blows up the first `prisma.project.create` with P2022 ColumnNotFound on `publishStatus`. Tighten the gate to require the `publishStatus` column on `projects` too.

### 4. `thumbnail.test.ts` — `getPreviewUrl` is a pure formatter
The \"no_url\" test relied on the dynamic import of `knative-project-manager` throwing (because `@kubernetes/client-node` used to be unimportable in test). That stopped holding, so `getPreviewUrl` returned a real URL and Playwright tried to navigate to it and failed with `ERR_NAME_NOT_RESOLVED` → 500 instead of 400. Mock `knative-project-manager` directly and add a per-test `previewUrlThrows` toggle so the no_url branch is exercised deterministically.

### 5. `git.service.test.ts` — `utimesSync` instead of `touch -d @<epoch>`
GNU `touch` accepts `-d @1779844821`, BSD `touch` (macOS) rejects it with \"out of range or illegal time specification\" and the stale-index-lock eviction test never gets to assert. Backdate via `utimesSync` which is portable.

## Test plan

- [x] `cd apps/api && bun run test` → `7242 pass, 0 fail, 42 skip across 380 files`
- [x] Each previously-failing file passes in isolation (`bun test <file>`)
- [ ] CI workflow on this PR is green end-to-end (apps/api job)
- [ ] Verify on Linux runner that the macOS-specific fixes (realpath, utimesSync) don't regress anything


Made with [Cursor](https://cursor.com)