### PR TITLE
fix(trust): route desktop trust refresh to local API

### DIFF
--- a/apps/api/src/__tests__/runtime-manager-proxy-urls.test.ts
+++ b/apps/api/src/__tests__/runtime-manager-proxy-urls.test.ts
@@ -66,4 +66,44 @@ describe('TOOLS_PROXY_URL / AI_PROXY_URL convention', () => {
       expect(src).not.toMatch(/TOOLS_PROXY_URL.*['"]\s*[^'"]*\/api['"]/)
     }
   })
+
+  // ─────────────────────────────────────────────────────────────────
+  // SHOGO_API_URL pin — root-cause regression guard for "Trust folder
+  // still restricted" (post-#670 follow-up).
+  //
+  // The embedded WorkerRuntimeManager defaults SHOGO_API_URL to the
+  // Shogo Cloud URL (right for outbound LLM / Composio proxying, WRONG
+  // for the runtime's own control-plane callbacks). Every manager that
+  // composes runtime env MUST pin SHOGO_API_URL to the local API base
+  // before handing off, otherwise trust resolution, heartbeat reports,
+  // and subagent overrides silently fail in desktop mode.
+  // ─────────────────────────────────────────────────────────────────
+  test('desktop RuntimeManager pins SHOGO_API_URL to the local apiBase', () => {
+    const src = readSource(MANAGER_PATH)
+    // The exact assignment we expect — same `apiBase` the AI proxy URL
+    // is built from, so the two can't drift to different hosts.
+    expect(src).toMatch(/runtimeEnv\.SHOGO_API_URL\s*=\s*apiBase/)
+  })
+
+  test('cloud spawn-env builder pins SHOGO_API_URL to its local apiBase', () => {
+    // Parallel pin on the K8s pod / warm-pool path so the desktop and
+    // cloud pinning live side-by-side in the same regression file.
+    const src = readSource(
+      join(import.meta.dir, '..', 'lib', 'runtime', 'build-project-env.ts'),
+    )
+    expect(src).toMatch(/env\.SHOGO_API_URL\s*=\s*apiBase/)
+  })
+
+  test('no manager hands the cloud URL straight to SHOGO_API_URL', () => {
+    // Catches the original-shape regression: `SHOGO_API_URL: cfg.cloudUrl`
+    // or any literal assignment of the studio.shogo.ai host. The worker
+    // is allowed to default to `cfg.cloudUrl` (that's a sane fallback for
+    // a bare worker call), but every manager that composes env here in
+    // apps/api MUST override it.
+    for (const path of [MANAGER_PATH, KNATIVE_PATH, WARM_POOL_PATH]) {
+      const src = readSource(path)
+      expect(src).not.toMatch(/SHOGO_API_URL\s*[:=]\s*cfg\.cloudUrl/)
+      expect(src).not.toMatch(/SHOGO_API_URL\s*[:=]\s*['"]https:\/\/studio\.shogo/)
+    }
+  })
 })

--- a/apps/api/src/lib/runtime/manager.ts
+++ b/apps/api/src/lib/runtime/manager.ts
@@ -1355,6 +1355,29 @@ export class ShogoErrorBoundary extends Component<Props, State> {
         const proxyUrl = buildAiProxyUrl(apiBase)
         runtimeEnv.AI_PROXY_URL = proxyUrl
 
+        // Pin SHOGO_API_URL to the LOCAL desktop API. Without this, the
+        // embedded WorkerRuntimeManager would default SHOGO_API_URL to
+        // `cfg.cloudUrl` (= https://studio.shogo.ai) — that's the right
+        // value for cloud-forwarded LLM / Composio calls (still on
+        // SHOGO_CLOUD_URL), but it's the WRONG host for the runtime's
+        // internal control-plane callbacks (trust resolution, heartbeat
+        // completion, subagent overrides) which live on the desktop's
+        // own API and authenticate via the local `x-runtime-token`.
+        //
+        // This was the root cause of the "Trust folder still restricted"
+        // regression after #670: the IPC ping POST /internal/refresh-trust
+        // landed correctly on the local runtime, but the refresh handler
+        // then fetched GET /api/internal/projects/:id/trust against
+        // studio.shogo.ai (which rejects the local runtime-token), the
+        // trust-resolver kept its fail-closed `restricted` default, and
+        // assertAllowedPath() kept blocking write/exec tools.
+        //
+        // Mirrors the cloud spawn path in `build-project-env.ts:131`,
+        // which has always pinned this correctly. Goes into `runtimeEnv`
+        // (a.k.a. `extraEnv`), which the worker's buildEnv applies LAST
+        // so it overrides the worker's `cfg.cloudUrl` default.
+        runtimeEnv.SHOGO_API_URL = apiBase
+
         let proxyConfigured = false
         const workspaceId = await this.getProjectWorkspaceId(projectId) || 'local-dev'
         try {

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -2522,7 +2522,7 @@ export default observer(function ProjectLayout() {
                 <ExternalPreviewWebView
                   projectId={projectId!}
                   url={externalSavedUrl ?? externalDetectedUrl ?? null}
-                  visible={effectiveTab === 'external-preview'}
+                  visible={effectiveTab === 'external-preview' && !trustPromptOpen}
                   detectedUrl={externalDetectedUrl}
                   onUrlSubmit={handleSaveExternalPreviewUrl}
                   isTrusted={projectTrustLevel === 'trusted'}

--- a/apps/mobile/components/canvas/ExternalPreviewWebView.tsx
+++ b/apps/mobile/components/canvas/ExternalPreviewWebView.tsx
@@ -236,10 +236,17 @@ export function ExternalPreviewWebView({
             onTrustRequired?.(url)
           }
           setLoadError(res?.error ?? 'open-failed')
+          return
         }
+        // If the parent has hidden this preview (for example while a
+        // React modal is open), re-apply that state after `open` creates
+        // the native Electron view. A prior `setVisible(false)` can be a
+        // no-op when the view does not exist yet.
+        void bridge.setVisible(projectId, visible)
+        if (visible) pushBounds()
       })
     }
-  }, [bridge, projectId, url, isTrusted, onTrustRequired])
+  }, [bridge, projectId, url, isTrusted, onTrustRequired, visible, pushBounds])
 
   useEffect(() => {
     if (!bridge) return


### PR DESCRIPTION

<img width="1512" height="982" alt="Screenshot 2026-05-27 at 11 13 59 AM" src="https://github.com/user-attachments/assets/ec671e34-dca2-4e29-a76b-cda95a88e736" />

<img width="1512" height="982" alt="Screenshot 2026-05-27 at 10 28 38 AM" src="https://github.com/user-attachments/assets/63d5a9a7-e7fa-41c1-b406-df6f7633ddb6" />
<img width="1512" height="982" alt="Screenshot 2026-05-27 at 10 46 34 AM" src="https://github.com/user-attachments/assets/0f77cd4b-e5fb-4d3a-822d-b0022990d01c" />
## Summary
- Fixes desktop external-folder trust refresh by pinning the spawned runtime's `SHOGO_API_URL` to the local desktop API instead of Shogo Cloud.
- Fixes Workspace Trust modal layering by hiding the Electron-owned external preview surface while the modal is open and reapplying hidden state after native preview creation.
- Adds regression coverage for the desktop `SHOGO_API_URL` control-plane host so the post-#670 bug class cannot silently return.

Closes #690.

## Detailed Implementation
### 1. Desktop trust refresh host
The desktop runtime env now sets `runtimeEnv.SHOGO_API_URL = apiBase`, where `apiBase` is the same local API origin already used for `AI_PROXY_URL` and `TOOLS_PROXY_URL`.

```mermaid
flowchart TD
  A[Desktop RuntimeManager] --> B[apiBase = http://localhost:API_PORT]
  B --> C[AI_PROXY_URL = apiBase/api/ai/v1]
  B --> D[TOOLS_PROXY_URL = apiBase/api/tools]
  B --> E[SHOGO_API_URL = apiBase]
  E --> F[extraEnv passed to WorkerRuntimeManager]
  F --> G[Worker buildEnv applies extraEnv last]
  G --> H[Runtime deriveApiUrl resolves local API]
  H --> I[refreshTrust reads local DB-backed trust endpoint]
```

This preserves `SHOGO_CLOUD_URL` for cloud-forwarded functionality while making `SHOGO_API_URL` the runtime control-plane host. That distinction matters because the live trust resolver authenticates to the desktop API with the local `x-runtime-token`.

### 2. Native preview vs React modal layering
The external preview is an Electron `WebContentsView`, not normal DOM. React modal z-index alone cannot cover it. The project layout now marks the preview invisible while `trustPromptOpen` is true, and `ExternalPreviewWebView` reapplies the requested visibility once `bridge.open()` completes.

```mermaid
sequenceDiagram
  participant Layout as Project Layout
  participant Preview as ExternalPreviewWebView
  participant Bridge as Desktop Preview Bridge
  participant Main as Electron Main
  participant Modal as TrustPrompt

  Layout->>Modal: trustPromptOpen = true
  Layout->>Preview: visible = false
  Preview->>Bridge: setVisible(projectId, false)
  Bridge->>Main: hide / zero WebContentsView bounds
  Layout->>Modal: render trust prompt
  Bridge-->>Preview: open() resolves later
  Preview->>Bridge: reapply setVisible(projectId, false)
```

The reapply step closes the race where `setVisible(false)` may have run before Electron main had created the native `WebContentsView`.

## Architecture Diagram
```mermaid
flowchart LR
  subgraph DesktopApp[Desktop App]
    UI[React / RN Web UI]
    Modal[TrustPrompt Modal]
    PreviewController[ExternalPreviewWebView Controller]
  end

  subgraph ElectronMain[Electron Main]
    NativePreview[WebContentsView External Preview]
  end

  subgraph LocalAPI[Local Desktop API]
    TrustRoute[POST /api/local/projects/:id/trust]
    InternalTrust[GET /api/internal/projects/:id/trust]
    RuntimeManager[RuntimeManager env composition]
  end

  subgraph Runtime[Agent Runtime]
    Resolver[trust-resolver refreshTrust]
    Tools[assertAllowedPath write/exec gates]
  end

  UI --> TrustRoute
  TrustRoute --> InternalTrust
  TrustRoute --> Resolver
  RuntimeManager -->|SHOGO_API_URL=http://localhost:API_PORT| Runtime
  Resolver -->|x-runtime-token| InternalTrust
  Resolver --> Tools
  PreviewController --> ElectronMain
  Modal -. hides while open .-> NativePreview
```

## Test Plan
- `cd apps/api && bun test src/__tests__/runtime-manager-proxy-urls.test.ts`
- `cd packages/agent-runtime && bun test src/__tests__/trust-resolver.test.ts src/__tests__/runtime-trust.test.ts`
- `cd apps/api && bun test src/__tests__/trust-resolver-wiring.test.ts`
- IDE diagnostics checked for edited files: no linter errors.

## Notes
Unrelated local edits to `apps/desktop/src/local-server.ts` and `package.json` were intentionally left uncommitted and are not part of this PR.

Made with [Cursor](https://cursor.com)