### PR TITLE
feat(marketplace): add buyer uninstall flow and My Installs UX refresh

### DIFF
--- a/apps/api/src/routes/marketplace.ts
+++ b/apps/api/src/routes/marketplace.ts
@@ -103,6 +103,11 @@ export function marketplaceRoutes() {
       return next()
     }
 
+    // Uninstall works locally (cancel DB record + remove workspace files).
+    if (path.includes('/installs/') && method === 'DELETE') {
+      return next()
+    }
+
     // Everything else (paid checkout, Stripe payout, etc.) → proxy to Cloud.
     const cloudKey = process.env.SHOGO_API_KEY
     if (!cloudKey) {
@@ -425,6 +430,25 @@ export function marketplaceRoutes() {
     } catch (err) {
       console.error('[marketplace] applyUpdate', err)
       return c.json({ error: 'Failed to apply update' }, 500)
+    }
+  })
+
+  app.delete('/installs/:installId', requireMarketplaceFeature, async (c) => {
+    const authCtx = c.get('auth') as AuthContext | undefined
+    if (!authCtx?.isAuthenticated || !authCtx.userId) {
+      return c.json({ error: 'Unauthorized' }, 401)
+    }
+    try {
+      const installId = c.req.param('installId')
+      await installService.uninstallAgent({ installId, userId: authCtx.userId })
+      return c.json({ ok: true })
+    } catch (err: any) {
+      const msg = err?.message || ''
+      if (msg === 'install_not_found') return c.json({ error: msg }, 404)
+      if (msg === 'install_access_denied') return c.json({ error: msg }, 403)
+      if (msg === 'install_not_active') return c.json({ error: msg }, 409)
+      console.error('[marketplace] uninstallAgent', err)
+      return c.json({ error: 'Failed to uninstall agent' }, 500)
     }
   })
 

--- a/apps/api/src/services/__tests__/marketplace-install.service.test.ts
+++ b/apps/api/src/services/__tests__/marketplace-install.service.test.ts
@@ -18,6 +18,7 @@ type Listing = {
   installModel: string
   installCount: number
   projectId: string
+  creatorId: string
   project?: any
 }
 type Install = {
@@ -82,6 +83,11 @@ mock.module('../../lib/prisma', () => ({
         deletedProjects.push(where.id)
         db.projects.delete(where.id)
         return {}
+      },
+      update: async ({ where, data }: any) => {
+        const p = db.projects.get(where.id)
+        if (p) Object.assign(p, data)
+        return p ?? {}
       },
     },
     marketplaceListingVersion: {
@@ -175,11 +181,17 @@ mock.module('../../lib/prisma', () => ({
             db.installs.set(row.id, row)
             return row
           },
+          update: async ({ where, data }: any) => {
+            const i = db.installs.get(where.id)!
+            Object.assign(i, data)
+            return i
+          },
         },
         marketplaceListing: {
           update: async ({ where, data }: any) => {
             const L = db.listings.get(where.id)!
             if (data.installCount?.increment) L.installCount += data.installCount.increment
+            if (data.installCount?.decrement) L.installCount -= data.installCount.decrement
             return L
           },
         },
@@ -211,6 +223,22 @@ mock.module('@shogo/shared-runtime', () => ({
     s3SyncFactoryMock ? s3SyncFactoryMock(projectDir, projectId) : null,
 }))
 
+let cancelledSubscriptions: string[] = []
+
+mock.module('../stripe-connect.service', () => ({
+  cancelMarketplaceSubscription: async (subId: string) => {
+    cancelledSubscriptions.push(subId)
+  },
+}))
+
+let recalculatedCreators: string[] = []
+
+mock.module('../creator-gamification.service', () => ({
+  recalculateCreatorStats: async (creatorId: string) => {
+    recalculatedCreators.push(creatorId)
+  },
+}))
+
 const svc = await import('../marketplace-install.service')
 
 // ─── fs fixtures ─────────────────────────────────────────────────────────────
@@ -236,6 +264,8 @@ beforeEach(() => {
   db.versions.length = 0
   db.agentConfigs.length = 0
   deletedProjects.length = 0
+  cancelledSubscriptions.length = 0
+  recalculatedCreators.length = 0
   workspaceAccessGranted = true
   snapshotExtractMock = null
   computeManifestMock = () => ({})
@@ -281,6 +311,7 @@ function seedListing(overrides: Partial<Listing> & { id?: string } = {}): Listin
     installModel: 'managed',
     installCount: 0,
     projectId: projId,
+    creatorId: overrides.creatorId ?? 'creator_1',
     project: { ...proj, agentConfig: { heartbeatInterval: 1800 } },
     ...overrides,
   }
@@ -1079,5 +1110,68 @@ describe('getInstallsForListing', () => {
     expect(out.page).toBe(2)
     expect(out.limit).toBe(3)
     expect(out.installs).toHaveLength(3)
+  })
+})
+
+// ─── uninstallAgent ───────────────────────────────────────────────────────────
+
+describe('uninstallAgent', () => {
+  it('marks install as cancelled and decrements installCount', async () => {
+    const L = seedListing()
+    L.installCount = 5
+    const inst = seedInstall({ listingId: L.id, userId: 'user_1', projectId: 'proj_x' })
+    makeWorkspaceDir('proj_x', { 'main.ts': 'hello' })
+
+    await svc.uninstallAgent({ installId: inst.id, userId: 'user_1' })
+
+    expect(inst.status).toBe('cancelled')
+    expect(L.installCount).toBe(4)
+    expect(recalculatedCreators).toContain('creator_1')
+  })
+
+  it('removes workspace directory on disk', async () => {
+    const L = seedListing()
+    const inst = seedInstall({ listingId: L.id, userId: 'user_1', projectId: 'proj_disk' })
+    const dir = makeWorkspaceDir('proj_disk', { 'a.txt': 'x' })
+
+    await svc.uninstallAgent({ installId: inst.id, userId: 'user_1' })
+
+    expect(existsSync(dir)).toBe(false)
+  })
+
+  it('cancels Stripe subscription when present', async () => {
+    const L = seedListing()
+    const inst = seedInstall({ listingId: L.id, userId: 'user_1', projectId: 'proj_sub' })
+    ;(inst as any).stripeSubscriptionId = 'sub_test_123'
+    makeWorkspaceDir('proj_sub')
+
+    await svc.uninstallAgent({ installId: inst.id, userId: 'user_1' })
+
+    expect(cancelledSubscriptions).toContain('sub_test_123')
+  })
+
+  it('throws install_not_found for nonexistent install', async () => {
+    await expect(
+      svc.uninstallAgent({ installId: 'nonexistent', userId: 'user_1' }),
+    ).rejects.toThrow('install_not_found')
+  })
+
+  it('throws install_access_denied when userId does not match', async () => {
+    const L = seedListing()
+    const inst = seedInstall({ listingId: L.id, userId: 'user_1', projectId: 'proj_y' })
+
+    await expect(
+      svc.uninstallAgent({ installId: inst.id, userId: 'user_other' }),
+    ).rejects.toThrow('install_access_denied')
+  })
+
+  it('throws install_not_active for already cancelled installs', async () => {
+    const L = seedListing()
+    const inst = seedInstall({ listingId: L.id, userId: 'user_1', projectId: 'proj_z' })
+    inst.status = 'cancelled'
+
+    await expect(
+      svc.uninstallAgent({ installId: inst.id, userId: 'user_1' }),
+    ).rejects.toThrow('install_not_active')
   })
 })

--- a/apps/api/src/services/marketplace-install.service.ts
+++ b/apps/api/src/services/marketplace-install.service.ts
@@ -528,9 +528,64 @@ export async function applyUpdate(
   }
 }
 
+export async function uninstallAgent(params: {
+  installId: string
+  userId: string
+}): Promise<void> {
+  const { installId, userId } = params
+
+  const install = await prisma.marketplaceInstall.findUnique({
+    where: { id: installId },
+    include: {
+      listing: { select: { id: true, creatorId: true } },
+    },
+  })
+
+  if (!install) {
+    throw new Error('install_not_found')
+  }
+  if (install.userId !== userId) {
+    throw new Error('install_access_denied')
+  }
+  if (install.status !== 'active') {
+    throw new Error('install_not_active')
+  }
+
+  if (install.stripeSubscriptionId) {
+    const { cancelMarketplaceSubscription } = await import('./stripe-connect.service')
+    await cancelMarketplaceSubscription(install.stripeSubscriptionId)
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.marketplaceInstall.update({
+      where: { id: installId },
+      data: { status: 'cancelled' },
+    })
+    await tx.marketplaceListing.update({
+      where: { id: install.listing.id },
+      data: { installCount: { decrement: 1 } },
+    })
+  })
+
+  if (install.projectId) {
+    const projectDir = join(getWorkspacesDir(), install.projectId)
+    if (existsSync(projectDir)) {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+
+    await prisma.project.update({
+      where: { id: install.projectId },
+      data: { status: 'archived' },
+    })
+  }
+
+  const { recalculateCreatorStats } = await import('./creator-gamification.service')
+  await recalculateCreatorStats(install.listing.creatorId)
+}
+
 export async function getInstallsForUser(userId: string) {
   return prisma.marketplaceInstall.findMany({
-    where: { userId },
+    where: { userId, status: 'active' },
     include: {
       listing: {
         select: {

--- a/apps/api/src/services/stripe-connect.service.ts
+++ b/apps/api/src/services/stripe-connect.service.ts
@@ -424,6 +424,16 @@ export async function createSubscriptionCheckout(params: {
   return session.url;
 }
 
+export async function cancelMarketplaceSubscription(
+  stripeSubscriptionId: string,
+): Promise<void> {
+  if (!isStripeConfigured()) return;
+  const stripe = getStripe();
+  await stripe.subscriptions.update(stripeSubscriptionId, {
+    cancel_at_period_end: true,
+  });
+}
+
 export async function triggerPayout(
   creatorProfileId: string,
   amountInCents?: number,

--- a/apps/mobile/app/(app)/marketplace/installs.tsx
+++ b/apps/mobile/app/(app)/marketplace/installs.tsx
@@ -1,21 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2026 Shogo Technologies, Inc.
 
-/**
- * Phase 8 — installed marketplace agents screen.
- *
- * Lists every install owned by the current user, with:
- * - Update available badge when listing.currentVersion !== installedVersion
- * - Drift indicator when the on-disk workspace diverges from the
- *   baseline manifest captured at last install/update
- * - "Apply update" button (no-drift path)
- * - "Force update — overwrites your changes" button (drift path)
- *
- * This pairs with the API rewrite in
- * apps/api/src/services/marketplace-install.service.ts (checkForUpdates
- * + applyUpdate({ force })) shipped in Phase 6.
- */
-
 import { useEffect, useState, useCallback, useMemo } from 'react'
 import {
   View,
@@ -26,6 +11,7 @@ import {
   RefreshControl,
   TextInput,
   Image,
+  Modal,
 } from 'react-native'
 import { observer } from 'mobx-react-lite'
 import { useRouter } from 'expo-router'
@@ -36,40 +22,33 @@ import {
   CheckCircle2,
   Package,
   Search,
+  Trash2,
   X,
+  ExternalLink,
+  ArrowUpCircle,
 } from 'lucide-react-native'
 import { useDomainHttp } from '../../../contexts/domain'
 import { cn } from '@shogo/shared-ui/primitives'
 import { getAccentColor, getInitial } from '../../../components/marketplace/accent'
 
-const INSTALL_MODEL_LABELS: Record<'fork' | 'linked', string> = {
-  fork: 'Independent copy',
-  linked: 'Linked to publisher',
-}
-
-function InstallListingIcon({
-  iconUrl,
-  title,
-}: {
-  iconUrl: string | null
-  title: string
-}) {
+function InstallIcon({ iconUrl, title, size = 36 }: { iconUrl: string | null; title: string; size?: number }) {
   const accent = getAccentColor(title)
   if (iconUrl) {
     return (
       <Image
         source={{ uri: iconUrl }}
-        className="w-10 h-10 rounded-xl"
+        className="rounded-lg"
+        style={{ width: size, height: size }}
         resizeMode="cover"
       />
     )
   }
   return (
     <View
-      className="w-10 h-10 rounded-xl items-center justify-center"
-      style={{ backgroundColor: `${accent}33` }}
+      className="rounded-lg items-center justify-center"
+      style={{ width: size, height: size, backgroundColor: `${accent}20` }}
     >
-      <Text style={{ color: accent, fontSize: 16, fontWeight: '700' }}>
+      <Text style={{ color: accent, fontSize: size * 0.4, fontWeight: '700' }}>
         {getInitial(title)}
       </Text>
     </View>
@@ -113,6 +92,8 @@ export default observer(function InstallsScreen() {
   const [refreshing, setRefreshing] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
   const [updateStates, setUpdateStates] = useState<Record<string, UpdateState>>({})
+  const [uninstallTarget, setUninstallTarget] = useState<InstallRow | null>(null)
+  const [uninstalling, setUninstalling] = useState(false)
 
   const loadInstalls = useCallback(async () => {
     setLoadError(null)
@@ -120,9 +101,6 @@ export default observer(function InstallsScreen() {
       const res = await http.get<{ installs: InstallRow[] }>('/api/marketplace/my-installs')
       const items = res.data?.installs ?? []
       setInstalls(items)
-      // Kick off update checks in parallel — they're independent so
-      // we don't need to chain them, and the per-row loading flag
-      // shows a spinner inside the card while we wait.
       const next: Record<string, UpdateState> = {}
       for (const inst of items) {
         next[inst.id] = {
@@ -150,8 +128,6 @@ export default observer(function InstallsScreen() {
       setLoading(false)
       setRefreshing(false)
     }
-    // refreshOne dependency intentionally omitted — declared below
-    // and stable across renders via the http closure.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [http])
 
@@ -218,10 +194,9 @@ export default observer(function InstallsScreen() {
               installedVersion: data.installedVersion ?? prev[installId].installedVersion,
               applying: false,
               drift: null,
-              appliedNotice: 'Update applied.',
+              appliedNotice: 'Updated successfully',
             },
           }))
-          // Re-check after apply so we get a fresh drift baseline.
           refreshOne(installId)
         } else {
           setUpdateStates((prev) => ({
@@ -232,7 +207,7 @@ export default observer(function InstallsScreen() {
               drift: data.diverged ?? prev[installId].drift,
               error:
                 data.error === 'drift_detected'
-                  ? 'You have local changes — use Force update to overwrite them.'
+                  ? 'Local changes detected. Force update to overwrite.'
                   : `Failed: ${data.error}`,
             },
           }))
@@ -247,6 +222,20 @@ export default observer(function InstallsScreen() {
     },
     [http, refreshOne],
   )
+
+  const handleUninstall = useCallback(async () => {
+    if (!uninstallTarget) return
+    setUninstalling(true)
+    try {
+      await http.delete(`/api/marketplace/installs/${uninstallTarget.id}`)
+      setInstalls((prev) => prev.filter((i) => i.id !== uninstallTarget.id))
+      setUninstallTarget(null)
+    } catch (err) {
+      console.error('[installs] uninstall failed', err)
+    } finally {
+      setUninstalling(false)
+    }
+  }, [http, uninstallTarget])
 
   const onRefresh = useCallback(() => {
     setRefreshing(true)
@@ -279,13 +268,6 @@ export default observer(function InstallsScreen() {
     [sortedInstalls, updateStates],
   )
 
-  const openProject = useCallback(
-    (projectId: string) => {
-      router.push(`/(app)/projects/${projectId}` as any)
-    },
-    [router],
-  )
-
   if (loading) {
     return (
       <View className="flex-1 bg-background items-center justify-center">
@@ -296,86 +278,87 @@ export default observer(function InstallsScreen() {
 
   return (
     <View className="flex-1 bg-background">
-      <View className="border-b border-border">
-        <View className="flex-row items-center gap-3 px-5 pt-3 pb-2">
-          <Pressable onPress={() => router.back()} hitSlop={6} className="p-1">
-            <ArrowLeft size={20} color="#71717a" />
+      {/* Header */}
+      <View className="px-5 pt-4 pb-3 gap-3">
+        <View className="flex-row items-center gap-3">
+          <Pressable onPress={() => router.back()} hitSlop={8} className="p-1 -ml-1">
+            <ArrowLeft size={18} color="#a1a1aa" />
           </Pressable>
-          <View className="flex-1 min-w-0">
-            <Text className="text-base font-semibold text-foreground">My installs</Text>
-            {!loadError && sortedInstalls.length > 0 && (
-              <Text className="text-[11px] text-muted-foreground mt-0.5">
-                {sortedInstalls.length} installed
-                {updateCount > 0 ? ` · ${updateCount} update${updateCount === 1 ? '' : 's'} available` : ''}
+          <Text className="text-lg font-semibold text-foreground flex-1">Installed</Text>
+          {updateCount > 0 && (
+            <View className="px-2.5 py-1 rounded-md bg-blue-500/15">
+              <Text className="text-[11px] font-semibold text-blue-500">
+                {updateCount} update{updateCount !== 1 ? 's' : ''}
               </Text>
-            )}
-          </View>
-        </View>
-        {!loadError && sortedInstalls.length > 0 && (
-          <View className="px-5 pb-3">
-            <View className="flex-row items-center bg-card border border-input rounded-xl px-3 h-10">
-              <Search size={16} color="#71717a" />
-              <TextInput
-                className="flex-1 ml-2 text-sm text-foreground web:outline-none no-focus-ring"
-                placeholder="Search installs…"
-                placeholderTextColor="#71717a"
-                value={searchQuery}
-                onChangeText={setSearchQuery}
-                autoCapitalize="none"
-                autoCorrect={false}
-              />
-              {searchQuery.length > 0 && (
-                <Pressable onPress={() => setSearchQuery('')} hitSlop={6}>
-                  <X size={14} color="#71717a" />
-                </Pressable>
-              )}
             </View>
+          )}
+        </View>
+
+        {!loadError && sortedInstalls.length > 0 && (
+          <View className="flex-row items-center bg-muted/50 rounded-lg px-3 h-9">
+            <Search size={14} color="#71717a" />
+            <TextInput
+              className="flex-1 ml-2 text-[13px] text-foreground web:outline-none no-focus-ring"
+              placeholder="Filter installed agents…"
+              placeholderTextColor="#71717a"
+              value={searchQuery}
+              onChangeText={setSearchQuery}
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
+            {searchQuery.length > 0 && (
+              <Pressable onPress={() => setSearchQuery('')} hitSlop={6}>
+                <X size={13} color="#71717a" />
+              </Pressable>
+            )}
           </View>
         )}
       </View>
 
+      <View className="h-px bg-border" />
+
+      {/* Content */}
       <ScrollView
-        contentContainerStyle={{ padding: 16, paddingBottom: 48, gap: 12 }}
+        contentContainerStyle={{ padding: 16, paddingBottom: 48, gap: 10 }}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
       >
         {loadError && (
-          <View className="rounded-2xl border border-destructive/30 bg-destructive/10 px-5 py-6 gap-2">
-            <Text className="text-sm font-semibold text-destructive">Could not load installs</Text>
-            <Text className="text-xs text-foreground/80">{loadError}</Text>
-            <Pressable
-              onPress={onRefresh}
-              className="mt-2 self-start px-3 py-2 rounded-lg bg-primary active:opacity-80"
-            >
-              <Text className="text-xs font-semibold text-primary-foreground">Retry</Text>
+          <View className="rounded-xl bg-destructive/5 border border-destructive/20 px-4 py-5 gap-2">
+            <Text className="text-[13px] font-medium text-destructive">Could not load installs</Text>
+            <Text className="text-xs text-muted-foreground">{loadError}</Text>
+            <Pressable onPress={onRefresh} className="mt-2 self-start px-3 py-1.5 rounded-md bg-primary">
+              <Text className="text-[11px] font-semibold text-primary-foreground">Retry</Text>
             </Pressable>
           </View>
         )}
+
         {!loadError && sortedInstalls.length === 0 && (
-          <View className="rounded-2xl border border-border bg-card px-5 py-10 items-center gap-3">
-            <Package size={28} color="#71717a" />
-            <Text className="text-sm font-semibold text-foreground">No installs yet</Text>
-            <Text className="text-xs text-muted-foreground text-center">
-              Browse the marketplace to install your first agent.
-            </Text>
+          <View className="flex-1 items-center justify-center pt-20 gap-4">
+            <View className="w-14 h-14 rounded-2xl bg-muted/60 items-center justify-center">
+              <Package size={24} color="#71717a" />
+            </View>
+            <View className="items-center gap-1">
+              <Text className="text-sm font-medium text-foreground">No agents installed</Text>
+              <Text className="text-xs text-muted-foreground text-center px-8">
+                Agents you install from the marketplace will appear here.
+              </Text>
+            </View>
             <Pressable
               onPress={() => router.push('/(app)/marketplace' as any)}
-              className="mt-1 px-4 py-2.5 rounded-xl bg-primary active:opacity-80"
+              className="mt-2 px-4 py-2 rounded-lg bg-primary active:opacity-80"
             >
-              <Text className="text-xs font-semibold text-primary-foreground">
-                Browse marketplace
-              </Text>
+              <Text className="text-xs font-semibold text-primary-foreground">Browse marketplace</Text>
             </Pressable>
           </View>
         )}
+
         {!loadError && sortedInstalls.length > 0 && filteredInstalls.length === 0 && (
-          <View className="rounded-2xl border border-border bg-card px-5 py-10 items-center gap-2">
-            <Search size={28} color="#71717a" />
-            <Text className="text-sm font-semibold text-foreground">No matching installs</Text>
-            <Text className="text-xs text-muted-foreground text-center">
-              Try a different search term.
-            </Text>
+          <View className="items-center pt-16 gap-2">
+            <Search size={20} color="#71717a" />
+            <Text className="text-sm text-muted-foreground">No matching agents</Text>
           </View>
         )}
+
         {filteredInstalls.map((inst) => {
           const state = updateStates[inst.id] ?? {
             hasUpdate: false,
@@ -388,115 +371,184 @@ export default observer(function InstallsScreen() {
           const driftCount = drift
             ? drift.added.length + drift.modified.length + drift.deleted.length
             : 0
+
           return (
             <View
               key={inst.id}
-              className="rounded-2xl border border-border bg-card overflow-hidden"
+              className="rounded-xl border border-border bg-card overflow-hidden"
             >
-              <Pressable
-                onPress={() => openProject(inst.projectId)}
-                className="p-4 gap-3 active:opacity-95"
-              >
-              <View className="flex-row items-center gap-3">
-                <InstallListingIcon
-                  iconUrl={inst.listing.iconUrl}
-                  title={inst.listing.title}
-                />
+              {/* Top row: icon + title + badge */}
+              <View className="flex-row items-center px-4 pt-4 pb-2 gap-3">
+                <InstallIcon iconUrl={inst.listing.iconUrl} title={inst.listing.title} />
+
                 <View className="flex-1 min-w-0">
-                  <Text className="text-sm font-semibold text-foreground" numberOfLines={1}>
+                  <Text className="text-[13px] font-semibold text-foreground" numberOfLines={1}>
                     {inst.listing.title}
                   </Text>
-                  <Text className="text-[11px] text-muted-foreground">
+                  <Text className="text-[11px] text-muted-foreground mt-0.5">
                     v{state.installedVersion}
-                    {state.hasUpdate ? ` → v${state.currentVersion}` : ''}
-                    {' · '}
-                    {INSTALL_MODEL_LABELS[inst.installModel]}
+                    {inst.installModel === 'linked' ? ' · Linked' : ''}
                   </Text>
                 </View>
-                {state.hasUpdate && (
-                  <View className="px-2 py-1 rounded-full bg-amber-500/15">
-                    <Text className="text-[10px] font-semibold text-amber-600 dark:text-amber-400">
-                      Update available
-                    </Text>
+
+                {/* Status badge with text */}
+                {state.loading && (
+                  <View className="flex-row items-center gap-1.5 px-2 py-1 rounded-md bg-muted/50">
+                    <ActivityIndicator size={10} />
+                    <Text className="text-[10px] text-muted-foreground">Checking</Text>
                   </View>
                 )}
-                {!state.hasUpdate && !state.loading && driftCount === 0 && (
-                  <CheckCircle2 size={14} color="#16a34a" />
+                {!state.loading && state.hasUpdate && (
+                  <View className="flex-row items-center gap-1.5 px-2 py-1 rounded-md bg-blue-500/10">
+                    <ArrowUpCircle size={12} color="#3b82f6" />
+                    <Text className="text-[10px] font-semibold text-blue-500">Update available</Text>
+                  </View>
+                )}
+                {!state.loading && !state.hasUpdate && driftCount > 0 && (
+                  <View className="flex-row items-center gap-1.5 px-2 py-1 rounded-md bg-amber-500/10">
+                    <AlertTriangle size={12} color="#d97706" />
+                    <Text className="text-[10px] font-semibold text-amber-600 dark:text-amber-400">Modified</Text>
+                  </View>
+                )}
+                {!state.loading && !state.hasUpdate && driftCount === 0 && (
+                  <View className="flex-row items-center gap-1.5 px-2 py-1 rounded-md bg-emerald-500/10">
+                    <CheckCircle2 size={12} color="#22c55e" />
+                    <Text className="text-[10px] font-semibold text-emerald-600 dark:text-emerald-400">Up to date</Text>
+                  </View>
                 )}
               </View>
 
-              {state.changelog && (
-                <View className="rounded-xl bg-muted/30 px-3 py-2">
-                  <Text className="text-[10px] uppercase font-semibold text-muted-foreground mb-1">
-                    Changelog
+              {/* Changelog (shown when update available) */}
+              {state.changelog && state.hasUpdate && (
+                <View className="mx-4 mb-2 rounded-md bg-muted/30 px-3 py-2">
+                  <Text className="text-[10px] uppercase font-semibold text-muted-foreground tracking-wide">
+                    What's new
                   </Text>
-                  <Text className="text-xs text-foreground/80">{state.changelog}</Text>
+                  <Text className="text-[11px] text-foreground/80 mt-1 leading-4">
+                    {state.changelog}
+                  </Text>
                 </View>
               )}
 
+              {/* Drift details */}
               {driftCount > 0 && (
-                <View className="rounded-xl border border-amber-300/40 bg-amber-50/40 dark:bg-amber-900/10 px-3 py-2 flex-row gap-2">
-                  <AlertTriangle size={12} color="#d97706" style={{ marginTop: 2 }} />
-                  <View className="flex-1">
-                    <Text className="text-[11px] font-semibold text-foreground">
-                      You've modified this install
-                    </Text>
-                    <Text className="text-[11px] text-foreground/80 mt-0.5">
-                      {drift!.modified.length} modified · {drift!.added.length} added ·{' '}
-                      {drift!.deleted.length} deleted
-                    </Text>
-                  </View>
+                <View className="mx-4 mb-2 flex-row items-center gap-2 rounded-md bg-amber-500/5 border border-amber-500/15 px-3 py-2">
+                  <AlertTriangle size={11} color="#d97706" />
+                  <Text className="text-[11px] text-muted-foreground flex-1">
+                    {drift!.modified.length} modified · {drift!.added.length} added · {drift!.deleted.length} removed
+                  </Text>
                 </View>
               )}
 
+              {/* Error / success messages */}
               {state.error && (
-                <Text className="text-[11px] text-destructive">{state.error}</Text>
+                <Text className="text-[11px] text-destructive px-4 mb-2">{state.error}</Text>
               )}
               {state.appliedNotice && (
-                <Text className="text-[11px] text-emerald-600">{state.appliedNotice}</Text>
+                <View className="flex-row items-center gap-1.5 px-4 mb-2">
+                  <CheckCircle2 size={11} color="#16a34a" />
+                  <Text className="text-[11px] text-emerald-600">{state.appliedNotice}</Text>
+                </View>
               )}
-              </Pressable>
 
-              {state.hasUpdate && (
-                <View className="flex-row gap-2 px-4 pb-4">
+              {/* Actions bar */}
+              <View className="flex-row items-center px-4 py-3 border-t border-border/50 gap-2">
+                {state.hasUpdate && (
                   <Pressable
                     onPress={() => handleApply(inst.id, false)}
                     disabled={state.applying}
                     className={cn(
-                      'flex-1 flex-row items-center justify-center gap-2 py-2.5 rounded-xl',
-                      state.applying ? 'bg-primary/40' : 'bg-primary active:opacity-80',
+                      'flex-row items-center gap-1.5 px-3 py-1.5 rounded-md',
+                      state.applying ? 'bg-primary/30' : 'bg-primary active:opacity-80',
                     )}
                   >
                     {state.applying ? (
-                      <ActivityIndicator size="small" color="#fff" />
+                      <ActivityIndicator size={10} color="#fff" />
                     ) : (
-                      <RefreshCw size={12} color="#fff" />
+                      <RefreshCw size={11} color="#fff" />
                     )}
-                    <Text className="text-xs font-semibold text-primary-foreground">
-                      Apply update
-                    </Text>
+                    <Text className="text-[11px] font-semibold text-primary-foreground">Update</Text>
                   </Pressable>
-                  {driftCount > 0 && (
-                    <Pressable
-                      onPress={() => handleApply(inst.id, true)}
-                      disabled={state.applying}
-                      className={cn(
-                        'flex-1 flex-row items-center justify-center gap-2 py-2.5 rounded-xl',
-                        state.applying ? 'bg-destructive/40' : 'bg-destructive/15 active:opacity-80',
-                      )}
-                    >
-                      <AlertTriangle size={12} color="#dc2626" />
-                      <Text className="text-xs font-semibold text-destructive">
-                        Force update (overwrite)
-                      </Text>
-                    </Pressable>
-                  )}
-                </View>
-              )}
+                )}
+                {state.hasUpdate && driftCount > 0 && (
+                  <Pressable
+                    onPress={() => handleApply(inst.id, true)}
+                    disabled={state.applying}
+                    className="flex-row items-center gap-1.5 px-3 py-1.5 rounded-md border border-amber-500/30 active:opacity-80"
+                  >
+                    <AlertTriangle size={10} color="#d97706" />
+                    <Text className="text-[11px] font-medium text-amber-700 dark:text-amber-400">Force update</Text>
+                  </Pressable>
+                )}
+                <Pressable
+                  onPress={() => router.push(`/(app)/projects/${inst.projectId}` as any)}
+                  className="flex-row items-center gap-1.5 px-3 py-1.5 rounded-md border border-border active:opacity-80"
+                >
+                  <ExternalLink size={10} color="#71717a" />
+                  <Text className="text-[11px] font-medium text-muted-foreground">Open</Text>
+                </Pressable>
+                <View className="flex-1" />
+                <Pressable
+                  onPress={() => setUninstallTarget(inst)}
+                  hitSlop={6}
+                  className="flex-row items-center gap-1.5 px-2.5 py-1.5 rounded-md active:bg-destructive/10"
+                >
+                  <Trash2 size={12} color="#dc2626" />
+                  <Text className="text-[11px] font-medium text-destructive">Uninstall</Text>
+                </Pressable>
+              </View>
             </View>
           )
         })}
       </ScrollView>
+
+      {/* Uninstall confirmation modal */}
+      <Modal
+        visible={!!uninstallTarget}
+        transparent
+        animationType="fade"
+        onRequestClose={() => !uninstalling && setUninstallTarget(null)}
+      >
+        <Pressable
+          onPress={() => !uninstalling && setUninstallTarget(null)}
+          className="flex-1 bg-black/60 items-center justify-center px-6"
+        >
+          <Pressable className="w-full max-w-sm rounded-xl bg-card border border-border overflow-hidden">
+            <View className="p-5 gap-3">
+              <View className="flex-row items-center gap-3">
+                {uninstallTarget && (
+                  <InstallIcon iconUrl={uninstallTarget.listing.iconUrl} title={uninstallTarget.listing.title} size={32} />
+                )}
+                <Text className="text-[15px] font-semibold text-foreground flex-1">
+                  Uninstall {uninstallTarget?.listing.title}?
+                </Text>
+              </View>
+              <Text className="text-[13px] text-muted-foreground leading-5">
+                This will permanently delete the project files. If you have a subscription, it will cancel at the end of the current billing period.
+              </Text>
+            </View>
+            <View className="flex-row border-t border-border">
+              <Pressable
+                onPress={() => setUninstallTarget(null)}
+                disabled={uninstalling}
+                className="flex-1 items-center py-3 active:bg-muted/40 border-r border-border"
+              >
+                <Text className="text-[13px] font-medium text-muted-foreground">Cancel</Text>
+              </Pressable>
+              <Pressable
+                onPress={handleUninstall}
+                disabled={uninstalling}
+                className="flex-1 flex-row items-center justify-center gap-2 py-3 active:bg-destructive/10"
+              >
+                {uninstalling && <ActivityIndicator size={12} color="#dc2626" />}
+                <Text className="text-[13px] font-medium text-destructive">
+                  {uninstalling ? 'Removing…' : 'Uninstall'}
+                </Text>
+              </Pressable>
+            </View>
+          </Pressable>
+        </Pressable>
+      </Modal>
     </View>
   )
 })


### PR DESCRIPTION
## Summary

- Add a complete buyer uninstall flow for marketplace installs: a new `DELETE /api/marketplace/installs/:installId` route, backend uninstall service logic, and Stripe subscription cancellation at period end when a `stripeSubscriptionId` exists.
- Make uninstall local-mode compatible by allowing `DELETE /installs/:id` through the local marketplace write-path guard when `SHOGO_LOCAL_MODE=true` (same pattern used for local install/review/update paths).
- Refresh the mobile **My Installs** UX into card-based rows with always-visible detail sections, text status badges (not icon-only), and a destructive uninstall action + confirmation modal.
- Ensure only active installs are returned in `getInstallsForUser`, so cancelled installs do not remain visible in the installs list after uninstall.
- Add uninstall-focused unit coverage for success and error paths (`install_not_found`, access denied, and not-active conflict).
<img width="1595" height="797" alt="image" src="https://github.com/user-attachments/assets/1395dced-023b-422c-98d8-98ee57d25ae4" />
<img width="1607" height="776" alt="image" src="https://github.com/user-attachments/assets/c6abcc51-2608-4d74-b5d6-9b4ccde291c5" />


## Why this change

- Users could install but had no supported way to remove an installed agent from **My Installs**.
- Local-mode users were blocked by `cloud_signin_required` because uninstall `DELETE` requests were incorrectly routed through Cloud-proxy enforcement.
- The prior list UI made status and uninstall actions less explicit, and status indicators relied too heavily on icon-only semantics.

## Key implementation notes

- `cancelMarketplaceSubscription()` uses Stripe `cancel_at_period_end: true` to avoid abrupt mid-cycle cutoff.
- `uninstallAgent()` validates ownership and state, updates install/listing counters in a transaction, removes local workspace files, archives the project, and recalculates creator stats.
- Route-level error mapping returns:
  - `404` for `install_not_found`
  - `403` for `install_access_denied`
  - `409` for `install_not_active`
  - `500` fallback for unexpected failures

## Test plan

- [x] User-facing manual validation: install cards render with text badges and destructive uninstall action.
- [x] Manual uninstall flow validation in local mode (`SHOGO_LOCAL_MODE=true`) now reaches local API and no longer fails with `cloud_signin_required`.
- [x] Added service unit tests for uninstall happy/error paths in:
  `apps/api/src/services/__tests__/marketplace-install.service.test.ts`
- [x] Existing test suite behavior unchanged outside this feature scope (known pre-existing Windows-specific failures remain unrelated).

