### PR TITLE
fix(mobile): upgrade Sentry iOS SDK for launch crash

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -215,6 +215,8 @@ jobs:
           "
 
       - name: Build workspace packages
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
         run: bun run build
 
       - name: Setup EAS
@@ -406,6 +408,8 @@ jobs:
         run: bun install
 
       - name: Build workspace packages
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
         run: bun run build
 
       - name: App Store compliance pre-flight

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Shogo",
     "slug": "shogo",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "orientation": "default",
     "icon": "./assets/ic_shogo_legacy.png",
     "scheme": "shogo",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Shogo",
     "slug": "shogo",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "orientation": "default",
     "icon": "./assets/ic_shogo_legacy.png",
     "scheme": "shogo",

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -53,6 +53,7 @@ import { useAuth } from '../../../../contexts/auth'
 import { useDomainHttp } from '../../../../contexts/domain'
 import { authClient } from '../../../../lib/auth-client'
 import { API_URL, api } from '../../../../lib/api'
+import { openWebAppSession } from '../../../../lib/openWebAppSession'
 import { workspaceProjectFilter } from '../../../../lib/project-load'
 import { getActiveWorkspaceId } from '../../../../lib/workspace-store'
 import { usePlatformConfig } from '../../../../lib/platform-config'
@@ -612,6 +613,9 @@ export default observer(function ProjectLayout() {
     previewUrl,
     canvasBaseUrl,
     ready: runtimeReady,
+    error: runtimeError,
+    stalled: runtimeStalled,
+    lastStatus: runtimeLastStatus,
   } = useAgentUrl(API_URL!, projectId, {
     credentials: Platform.OS === 'web' ? 'include' : 'omit',
     headers: nativeHeaders,
@@ -1907,14 +1911,57 @@ export default observer(function ProjectLayout() {
   // surfaces for the host/VM/K8s paths).
   if (isLoading || !project || (!remoteProjectAgentBaseUrl && !runtimeReady)) {
     const stillBootingRuntime = !isLoading && project && !remoteProjectAgentBaseUrl && !runtimeReady
+    // After ~30s of polling, or on a 4xx/5xx response, surface what's
+    // happening and offer the user a way out — going back, opening on
+    // web, or retrying — instead of leaving them on an infinite
+    // "Starting your project…" spinner like the v1.0.8 TestFlight build
+    // (where the project runtime endpoint kept returning ready:false
+    // after the worklets stub crash + cold ASC subscription state).
+    const showStalledRecovery = stillBootingRuntime && (runtimeStalled || !!runtimeError)
     return (
       <>
         <Stack.Screen options={HIDDEN_HEADER_OPTIONS} />
-        <View className="flex-1 bg-background items-center justify-center">
-          <ActivityIndicator size="large" />
-          <Text className="text-muted-foreground mt-3 text-sm">
-            {stillBootingRuntime ? 'Starting your project…' : 'Loading project...'}
-          </Text>
+        <View className="flex-1 bg-background items-center justify-center px-6">
+          {!showStalledRecovery && (
+            <>
+              <ActivityIndicator size="large" />
+              <Text className="text-muted-foreground mt-3 text-sm">
+                {stillBootingRuntime ? 'Starting your project…' : 'Loading project...'}
+              </Text>
+            </>
+          )}
+          {showStalledRecovery && (
+            <View className="w-full max-w-sm gap-3 items-center">
+              <Text className="text-foreground text-base font-semibold text-center">
+                This is taking longer than expected
+              </Text>
+              <Text className="text-muted-foreground text-sm text-center">
+                {runtimeError
+                  ? `We couldn't reach your project's runtime${runtimeLastStatus ? ` (${runtimeLastStatus})` : ''}. Check your connection or open this project on the web.`
+                  : 'Your project runtime is still warming up. You can keep waiting or open it on the web.'}
+              </Text>
+              <View className="flex-row gap-2 mt-2">
+                <Pressable
+                  onPress={() => (router.canGoBack() ? router.back() : router.replace('/(app)'))}
+                  className="px-4 py-2 rounded-md border border-border active:bg-muted"
+                  accessibilityLabel="Go back to projects list"
+                >
+                  <Text className="text-foreground text-sm font-medium">Go back</Text>
+                </Pressable>
+                <Pressable
+                  onPress={() => {
+                    void openWebAppSession(`/projects/${projectId}`).catch((err) =>
+                      console.warn('[ProjectLayout] open-on-web failed:', err),
+                    )
+                  }}
+                  className="px-4 py-2 rounded-md bg-primary active:bg-primary/80"
+                  accessibilityLabel="Open this project on the web"
+                >
+                  <Text className="text-primary-foreground text-sm font-medium">Open on web</Text>
+                </Pressable>
+              </View>
+            </View>
+          )}
         </View>
       </>
     )

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -616,6 +616,7 @@ export default observer(function ProjectLayout() {
     error: runtimeError,
     stalled: runtimeStalled,
     lastStatus: runtimeLastStatus,
+    retry: retryAgentUrl,
   } = useAgentUrl(API_URL!, projectId, {
     credentials: Platform.OS === 'web' ? 'include' : 'omit',
     headers: nativeHeaders,
@@ -1911,12 +1912,13 @@ export default observer(function ProjectLayout() {
   // surfaces for the host/VM/K8s paths).
   if (isLoading || !project || (!remoteProjectAgentBaseUrl && !runtimeReady)) {
     const stillBootingRuntime = !isLoading && project && !remoteProjectAgentBaseUrl && !runtimeReady
-    // After ~30s of polling, or on a 4xx/5xx response, surface what's
-    // happening and offer the user a way out — going back, opening on
-    // web, or retrying — instead of leaving them on an infinite
-    // "Starting your project…" spinner like the v1.0.8 TestFlight build
-    // (where the project runtime endpoint kept returning ready:false
-    // after the worklets stub crash + cold ASC subscription state).
+    // After STALL_THRESHOLD_MS (~45s) of polling, or on a 4xx/5xx
+    // response, surface what's happening and offer the user a way out —
+    // retrying in place, going back, or opening on web — instead of
+    // leaving them on an infinite "Starting your project…" spinner like
+    // the v1.0.8 TestFlight build (where the project runtime endpoint
+    // kept returning ready:false after the worklets stub crash + cold
+    // ASC subscription state).
     const showStalledRecovery = stillBootingRuntime && (runtimeStalled || !!runtimeError)
     return (
       <>
@@ -1932,15 +1934,28 @@ export default observer(function ProjectLayout() {
           )}
           {showStalledRecovery && (
             <View className="w-full max-w-sm gap-3 items-center">
+              {/* Keep an indicator visible — polling continues in the
+                  background, and the recovery card on its own (no spinner,
+                  no progress) made the app look stuck even though
+                  useAgentUrl was still retrying. See iPad screenshot in
+                  PR #(fix/ios-sentry-launch-crash). */}
+              <ActivityIndicator size="small" />
               <Text className="text-foreground text-base font-semibold text-center">
                 This is taking longer than expected
               </Text>
               <Text className="text-muted-foreground text-sm text-center">
                 {runtimeError
-                  ? `We couldn't reach your project's runtime${runtimeLastStatus ? ` (${runtimeLastStatus})` : ''}. Check your connection or open this project on the web.`
-                  : 'Your project runtime is still warming up. You can keep waiting or open it on the web.'}
+                  ? `We couldn't reach your project's runtime${runtimeLastStatus ? ` (${runtimeLastStatus})` : ''}. Check your connection or try again.`
+                  : 'Your project runtime is still warming up. You can keep waiting, retry, or open it on the web.'}
               </Text>
-              <View className="flex-row gap-2 mt-2">
+              <View className="flex-row flex-wrap gap-2 mt-2 justify-center">
+                <Pressable
+                  onPress={() => retryAgentUrl()}
+                  className="px-4 py-2 rounded-md border border-border active:bg-muted"
+                  accessibilityLabel="Retry connecting to your project"
+                >
+                  <Text className="text-foreground text-sm font-medium">Try again</Text>
+                </Pressable>
                 <Pressable
                   onPress={() => (router.canGoBack() ? router.back() : router.replace('/(app)'))}
                   className="px-4 py-2 rounded-md border border-border active:bg-muted"

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -82,22 +82,6 @@ Sentry.init({
   release: process.env.EXPO_PUBLIC_BUILD_HASH || 'dev',
   tracesSampleRate: 0.2,
   enabled: !!sentryDsn,
-  // sentry-cocoa 8.5x (bundled with @sentry/react-native@7.11.0) has an open
-  // race in `_SentryDispatchQueueWrapperInternal`: its UIViewController
-  // tracker can enqueue a cleanup block holding a stale controller pointer.
-  // On iPadOS 26 cold launch this matches App Review's EXC_BAD_ACCESS at 0x10
-  // crashes. Tracking upstream: getsentry/sentry-cocoa#7815. The React Native
-  // fix ships in @sentry/react-native@8.7.0+, but that bump is too broad for
-  // the App Store hotfix.
-  //
-  // Until we can land that bump in a separate PR, switch off every native
-  // auto-instrumentation that funnels through the racy dispatch wrapper.
-  // Crash + JS error capture still works (those go through the unaffected
-  // SentryHub event pipeline); we only lose UIViewController/native-frames
-  // performance spans, which we weren't actually using yet.
-  enableAutoPerformanceTracing: false,
-  enableNativeFramesTracking: false,
-  enableUserInteractionTracing: false,
   // Drop unhandled promise rejections whose "reason" was a non-Error value
   // (e.g. `Promise.reject(new Event(...))` from third-party libs, or string
   // rejections from Stripe / posthog). They show up in Sentry as a single

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -82,6 +82,22 @@ Sentry.init({
   release: process.env.EXPO_PUBLIC_BUILD_HASH || 'dev',
   tracesSampleRate: 0.2,
   enabled: !!sentryDsn,
+  // sentry-cocoa 8.5x (bundled with @sentry/react-native@7.11.0) has an open
+  // race in `_SentryDispatchQueueWrapperInternal`: its UIViewController
+  // tracker can enqueue a cleanup block holding a stale controller pointer.
+  // On iPadOS 26 cold launch this matches App Review's EXC_BAD_ACCESS at 0x10
+  // crashes. Tracking upstream: getsentry/sentry-cocoa#7815. The React Native
+  // fix ships in @sentry/react-native@8.7.0+, but that bump is too broad for
+  // the App Store hotfix.
+  //
+  // Until we can land that bump in a separate PR, switch off every native
+  // auto-instrumentation that funnels through the racy dispatch wrapper.
+  // Crash + JS error capture still works (those go through the unaffected
+  // SentryHub event pipeline); we only lose UIViewController/native-frames
+  // performance spans, which we weren't actually using yet.
+  enableAutoPerformanceTracing: false,
+  enableNativeFramesTracking: false,
+  enableUserInteractionTracing: false,
   // Drop unhandled promise rejections whose "reason" was a non-Error value
   // (e.g. `Promise.reject(new Event(...))` from third-party libs, or string
   // rejections from Stripe / posthog). They show up in Sentry as a single

--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -16,11 +16,22 @@ module.exports = function (api) {
           },
         },
       ],
-      // MUST be last. Without this, react-native-worklets cannot initialize
-      // its native binding and any screen that uses Reanimated (chat composer,
-      // gestures, animations) throws "Native part of Worklets doesn't seem to
-      // be initialized" on first render — which was crashing the in-project
-      // chat flow on iPad.
+      // MUST be last. Pairs with the Metro stubs of
+      // `react-native-reanimated` / `react-native-worklets` in
+      // `metro.config.js` (see banner there) — together they keep the
+      // worklets pipeline self-consistent without the native pod.
+      //
+      // The babel plugin is what auto-workletizes gesture-handler and
+      // reanimated callbacks. With the plugin enabled, the autoworkletized
+      // code requires JS-only worklets helpers (`createSerializable`,
+      // `runOnJS`, …) from `react-native-worklets`; Metro then redirects
+      // those requires to our stub and the helpers become no-ops.
+      //
+      // Without the plugin, the same callbacks were left referencing the
+      // native worklets runtime, which doesn't ship in this binary, and
+      // the iPad chat composer threw "Native part of Worklets doesn't seem
+      // to be initialized" on first render. Removing this line is only
+      // safe in tandem with adding back the real worklets pod.
       'react-native-worklets/plugin',
     ],
   }

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -74,6 +74,87 @@ for (const pkg of SINGLETON_PACKAGES) {
   } catch {}
 }
 
+// =====================================================================
+// Reanimated / Worklets stub aliases (App Review hotfix — May 2026)
+// =====================================================================
+// The iOS Podfile (and Android autolinking) deliberately omit
+// `react-native-reanimated` and `react-native-worklets`:
+//
+//     // apps/mobile/package.json
+//     "expo": { "autolinking": { "exclude": [
+//        "react-native-reanimated", "react-native-worklets"
+//     ] } }
+//
+// + `app.json` has `newArchEnabled: false`, which Reanimated 4 / Worklets
+// require. The native binding does not ship in the production binary.
+//
+// However NativeWind ⇒ `react-native-css-interop@0.2.x` issues an
+// unconditional `require('react-native-reanimated')` whenever any styled
+// component carries a `transition-*` / `animate-*` / `duration-*` class
+// (hundreds of components do — chat composer, billing cards, project
+// shell, etc.). Without a real module to resolve to, the destructured
+// top-level statement
+//
+//     const { makeMutable, withTiming, … } = require('react-native-reanimated')
+//
+// resolved to `undefined` inside the Hermes/iOS bundle and the renderer
+// crashed with `TypeError: Cannot read property 'makeMutable' of
+// undefined`. This is exactly the App Store / TestFlight crash users
+// reported on build 1.0.8 (run id 26500877669).
+//
+// Aliasing both packages to JS-only no-op shims in `./stubs/` keeps the
+// `require()` resolvable, returns safe no-op exports for every entry
+// point css-interop / gesture-handler / screens probe at runtime, and
+// — critically — adds no native dependency. Animations become instant
+// (acceptable for non-essential UI flair), nothing crashes, and we keep
+// the binary footprint and architecture posture we shipped with.
+//
+// If/when we want real Reanimated, the fix is bigger than removing this
+// alias: flip `newArchEnabled` to true, install both packages as direct
+// deps of apps/mobile, drop them from `autolinking.exclude`, regenerate
+// the Podfile/manifest, and run the full RN-newarch migration. Until
+// then, this alias is the canonical path.
+const REANIMATED_STUB = path.resolve(__dirname, 'stubs/react-native-reanimated.js')
+const WORKLETS_STUB = path.resolve(__dirname, 'stubs/react-native-worklets.js')
+const EXPO_MODULES_CORE_JS_LOGGER_STUB = path.resolve(
+  __dirname,
+  'stubs/expo-modules-core-native-js-logger.js',
+)
+
+function resolveStubFor(context, moduleName) {
+  if (moduleName === 'react-native-reanimated') return REANIMATED_STUB
+  if (moduleName === 'react-native-worklets') return WORKLETS_STUB
+  // Subpath imports like `react-native-reanimated/lib/...` — fall through
+  // to the stub for parity, since we want every reanimated re-export to
+  // hit the same noop surface.
+  if (moduleName.startsWith('react-native-reanimated/')) return REANIMATED_STUB
+  if (moduleName.startsWith('react-native-worklets/')) {
+    // Two carve-outs to leave intact:
+    //
+    // 1. `react-native-worklets/plugin` — the Babel transform; pulled in
+    //    from `babel.config.js` via Node's `require()` at *build* time.
+    //    Metro never sees it, but for completeness don't stub it either.
+    // 2. `react-native-worklets/__generatedWorklets/<hash>.js` — factory
+    //    files the Babel plugin emits to disk inside the worklets package
+    //    when it autoworkletizes a function. If we redirected these to
+    //    the stub, the generated `default(...)` factory call would land
+    //    on a plain object and throw. Letting them resolve normally is
+    //    safe because each generated factory only imports JS-side helpers
+    //    from `react-native-worklets`, which themselves go through this
+    //    alias and end up at the stub.
+    if (moduleName === 'react-native-worklets/plugin') return null
+    if (moduleName.startsWith('react-native-worklets/__generatedWorklets/')) return null
+    return WORKLETS_STUB
+  }
+  if (
+    moduleName === './NativeJSLogger' &&
+    context?.originModulePath?.includes(`${path.sep}expo-modules-core${path.sep}src${path.sep}sweet${path.sep}`)
+  ) {
+    return EXPO_MODULES_CORE_JS_LOGGER_STUB
+  }
+  return null
+}
+
 // Shogo source files use `.js` extensions in their relative imports
 // (e.g. `import './foo.js'` from a `.ts` file) — that's the standard
 // TypeScript NodeNext pattern so the emitted `dist/*.js` references
@@ -119,6 +200,12 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
       moduleName,
       platform,
     )
+  }
+  // Redirect Reanimated / Worklets requires to JS-only stubs since the
+  // native pods aren't part of this build (see banner above).
+  const stub = resolveStubFor(context, moduleName)
+  if (stub) {
+    return { type: 'sourceFile', filePath: stub }
   }
   const sdkSrcMatch = resolveSdkSourceJsAsTs(context, moduleName, platform)
   if (sdkSrcMatch) return sdkSrcMatch

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -37,7 +37,7 @@
     "@legendapp/motion": "^2.3.0",
     "@monaco-editor/react": "^4.7.0",
     "@react-native-async-storage/async-storage": "2.2.0",
-    "@sentry/react-native": "~7.11.0",
+    "@sentry/react-native": "^8.12.0",
     "@shogo-ai/sdk": "workspace:*",
     "@shogo/domain-stores": "workspace:*",
     "@shogo/model-catalog": "workspace:*",

--- a/apps/mobile/stubs/__tests__/reanimated-stub.test.ts
+++ b/apps/mobile/stubs/__tests__/reanimated-stub.test.ts
@@ -55,6 +55,7 @@ describe('react-native-reanimated stub', () => {
 
   test('makeMutable returns a mutable value object', () => {
     const sv = (Reanimated as any).makeMutable(7)
+    expect(sv._isReanimatedSharedValue).toBe(true)
     expect(sv.value).toBe(7)
     sv.value = 12
     expect(sv.value).toBe(12)
@@ -102,6 +103,23 @@ describe('react-native-reanimated stub', () => {
     expect((Reanimated as any).useAnimatedStyle(() => ({ opacity: 0.5 }))).toEqual({ opacity: 0.5 })
     expect(typeof (Reanimated as any).useAnimatedProps).toBe('function')
     expect(typeof (Reanimated as any).useDerivedValue).toBe('function')
+  })
+
+  test('normalizes animated transform angles for react-native-svg', () => {
+    const sv = (Reanimated as any).makeMutable(180)
+    const style = (Reanimated as any).useAnimatedStyle(() => ({
+      transform: [
+        { rotate: 360 },
+        { rotateZ: sv },
+        { scale: 1 },
+      ],
+    }))
+
+    expect(style.transform).toEqual([
+      { rotate: '360deg' },
+      { rotateZ: '180deg' },
+      { scale: 1 },
+    ])
   })
 
   test('introspection helpers return safe negative values', () => {

--- a/apps/mobile/stubs/__tests__/reanimated-stub.test.ts
+++ b/apps/mobile/stubs/__tests__/reanimated-stub.test.ts
@@ -95,6 +95,15 @@ describe('react-native-reanimated stub', () => {
     expect((Reanimated as any).useSharedValue).toBeUndefined()
   })
 
+  test('exports JS-only animated hooks required by css-interop', () => {
+    // NativeWind's react-native-css-interop calls `useAnimatedStyle` when
+    // rendering animate/transition classes such as `animate-spin`.
+    expect(typeof (Reanimated as any).useAnimatedStyle).toBe('function')
+    expect((Reanimated as any).useAnimatedStyle(() => ({ opacity: 0.5 }))).toEqual({ opacity: 0.5 })
+    expect(typeof (Reanimated as any).useAnimatedProps).toBe('function')
+    expect(typeof (Reanimated as any).useDerivedValue).toBe('function')
+  })
+
   test('introspection helpers return safe negative values', () => {
     expect((Reanimated as any).isReanimated3()).toBe(false)
     expect((Reanimated as any).isConfigured()).toBe(false)

--- a/apps/mobile/stubs/__tests__/reanimated-stub.test.ts
+++ b/apps/mobile/stubs/__tests__/reanimated-stub.test.ts
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Pins the shape of the `react-native-reanimated` / `react-native-worklets`
+ * no-op shims that Metro aliases into the production bundle (see
+ * `apps/mobile/metro.config.js` and the banners on each stub file).
+ *
+ * Why this exists
+ * ---------------
+ * The TestFlight v1.0.8 / App Review build crashed on every project entry
+ * with `Cannot read property 'makeMutable' of undefined` because
+ * `react-native-css-interop` (under NativeWind) does an unconditional
+ * top-level destructure:
+ *
+ *     const { makeMutable, withTiming, withDelay, withRepeat, withSequence,
+ *             Easing, cancelAnimation } =
+ *       require("react-native-reanimated") as typeof import(...)
+ *
+ * and we ship the binary with Reanimated + Worklets autolink-excluded
+ * (no native pod, no new architecture). The Metro alias points those
+ * imports at our stubs instead so the destructure resolves to no-op
+ * functions instead of `undefined`.
+ *
+ * This test locks the contract — if anyone removes a member from the
+ * stub, css-interop crashes the renderer in production again. We also
+ * lock the surfaces a couple of other libraries probe (`isReanimated3`
+ * exists; `useSharedValue` deliberately does NOT exist so
+ * gesture-handler picks its JS fallback path; etc.).
+ *
+ * Run: bun test apps/mobile/stubs/__tests__/reanimated-stub.test.ts
+ */
+
+import { describe, test, expect } from 'bun:test'
+
+import * as Reanimated from '../react-native-reanimated.js'
+import * as Worklets from '../react-native-worklets.js'
+
+describe('react-native-reanimated stub', () => {
+  test('exports the exact surface css-interop destructures', () => {
+    // Locked by react-native-css-interop@0.2.x at
+    //   src/runtime/native/native-interop.ts (lines ~556, ~701, ~741)
+    const required = [
+      'makeMutable',
+      'withTiming',
+      'withDelay',
+      'withRepeat',
+      'withSequence',
+      'cancelAnimation',
+      'Easing',
+    ] as const
+    for (const name of required) {
+      expect(typeof (Reanimated as any)[name]).not.toBe('undefined')
+    }
+  })
+
+  test('makeMutable returns a mutable value object', () => {
+    const sv = (Reanimated as any).makeMutable(7)
+    expect(sv.value).toBe(7)
+    sv.value = 12
+    expect(sv.value).toBe(12)
+    expect(typeof sv.addListener).toBe('function')
+    expect(typeof sv.modify).toBe('function')
+  })
+
+  test('animation primitives resolve to final value synchronously', () => {
+    expect((Reanimated as any).withTiming(100)).toBe(100)
+    expect((Reanimated as any).withSpring(50)).toBe(50)
+    expect((Reanimated as any).withSequence('a', 'b', 'c')).toBe('c')
+    expect((Reanimated as any).withDelay(500, 42)).toBe(42)
+    expect((Reanimated as any).withRepeat(99)).toBe(99)
+  })
+
+  test('animation callbacks fire with finished=true', () => {
+    let timingFinished: unknown = null
+    ;(Reanimated as any).withTiming(0, undefined, (ok: boolean) => {
+      timingFinished = ok
+    })
+    expect(timingFinished).toBe(true)
+  })
+
+  test('Easing functions exist and are callable', () => {
+    const E = (Reanimated as any).Easing
+    expect(typeof E.linear).toBe('function')
+    expect(typeof E.ease).toBe('function')
+    expect(typeof E.bezier).toBe('function')
+    const cubic = E.bezier(0.2, 0.8, 0.2, 1)
+    expect(typeof cubic).toBe('function')
+    expect(cubic(0.5)).toBe(0.5)
+  })
+
+  test('useSharedValue is INTENTIONALLY missing — gesture-handler fallback', () => {
+    // react-native-gesture-handler's `reanimatedWrapper.js` resets
+    // `Reanimated = undefined` when `useSharedValue` isn't present, which
+    // routes gestures through the pure-JS path. We must preserve that.
+    expect((Reanimated as any).useSharedValue).toBeUndefined()
+  })
+
+  test('introspection helpers return safe negative values', () => {
+    expect((Reanimated as any).isReanimated3()).toBe(false)
+    expect((Reanimated as any).isConfigured()).toBe(false)
+  })
+
+  test('cancelAnimation does not throw on a shared value or unknown input', () => {
+    const sv = (Reanimated as any).makeMutable(3)
+    expect(() => (Reanimated as any).cancelAnimation(sv)).not.toThrow()
+    expect(() => (Reanimated as any).cancelAnimation(null)).not.toThrow()
+    expect(() => (Reanimated as any).cancelAnimation(undefined)).not.toThrow()
+  })
+})
+
+describe('react-native-worklets stub', () => {
+  test('exports the helpers reanimated 4 internals require()', () => {
+    // Reanimated 4's `lib/module/core.js` does
+    //   `import { createSerializable } from 'react-native-worklets'`
+    // and worklet-transformed callbacks reach for `runOnJS` / `runOnUI`.
+    expect(typeof (Worklets as any).createSerializable).toBe('function')
+    expect(typeof (Worklets as any).runOnJS).toBe('function')
+    expect(typeof (Worklets as any).runOnUI).toBe('function')
+  })
+
+  test('worklet wrappers invoke the underlying function', () => {
+    let calls = 0
+    const fn = () => { calls += 1 }
+    ;(Worklets as any).runOnJS(fn)()
+    ;(Worklets as any).runOnUI(fn)()
+    expect(calls).toBe(2)
+  })
+
+  test('createSerializable is identity', () => {
+    const obj = { a: 1 }
+    expect((Worklets as any).createSerializable(obj)).toBe(obj)
+  })
+
+  test('isWorkletFunction always reports false (no real worklet runtime)', () => {
+    expect((Worklets as any).isWorkletFunction()).toBe(false)
+  })
+})

--- a/apps/mobile/stubs/expo-modules-core-native-js-logger.js
+++ b/apps/mobile/stubs/expo-modules-core-native-js-logger.js
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+//
+// Dev-client compatibility shim.
+//
+// Expo Modules Core 3 imports `./sweet/NativeJSLogger` from
+// `setUpJsLogger.fx.ts` in development and expects the native module to
+// expose `addListener`. On this local simulator build the optional native
+// module exists but doesn't provide that event-emitter method, which aborts
+// module evaluation before AppRegistry registers the app:
+//
+//   NativeJSLogger.default.addListener is not a function
+//
+// Production bundles don't execute this path (`__DEV__` only), but simulator
+// testing does. Metro aliases the NativeJSLogger import to this no-op emitter
+// so the dev logger setup can't break app launch.
+
+const logger = {
+  addListener() {
+    return { remove() {} }
+  },
+  removeListeners() {},
+}
+
+module.exports = {
+  __esModule: true,
+  default: logger,
+  ...logger,
+}

--- a/apps/mobile/stubs/react-native-reanimated.js
+++ b/apps/mobile/stubs/react-native-reanimated.js
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+//
+// react-native-reanimated NoOp shim
+// =================================
+//
+// Why this file exists
+// --------------------
+// We ship the mobile app without the Reanimated 4 native binding (the iOS
+// project's autolinking `exclude` list — apps/mobile/package.json — pulls
+// both `react-native-reanimated` and `react-native-worklets` out of the
+// CocoaPods install, and `newArchEnabled: false` in app.json forbids the
+// Fabric/Turbo runtime Reanimated 4 needs). Reanimated and the worklets
+// runtime are deliberately not part of this build's surface area.
+//
+// However NativeWind's underlying interop package (`react-native-css-interop`
+// 0.2.x) lazy-`require()`s `react-native-reanimated` whenever any styled
+// element has a `transition-*` / `animate-*` / `duration-*` class — which is
+// hundreds of components in this codebase. Without a Reanimated module to
+// load, the destructured top-level statement
+//
+//     const { makeMutable, withTiming, … } = require("react-native-reanimated")
+//
+// resolved to `undefined` in the production iOS bundle and crashed the
+// renderer with "Cannot read property 'makeMutable' of undefined" — that's
+// the App Review / TestFlight error users see on the project entry screen.
+//
+// What this shim does
+// -------------------
+// Provides a self-contained, dependency-free JS module that exports the same
+// surface css-interop (and a handful of other libs that probe Reanimated at
+// runtime) destructures. Mutables become a plain `{ value }` object and
+// every animation primitive (`withTiming`, `withDelay`, `withRepeat`,
+// `withSequence`, `withSpring`, `withDecay`, `cancelAnimation`) returns the
+// final value synchronously — i.e. animations land at their end-state
+// instantly instead of throwing. Easing matches the runtime's named-table
+// shape with identity bezier functions so a `cubicBezier(...)` lookup on
+// the stub still returns a callable.
+//
+// Metro is wired to alias both `react-native-reanimated` and
+// `react-native-worklets` to this directory in `metro.config.js`; that's
+// the only place these stubs are reachable from. Removing the alias (or
+// installing the real Reanimated/Worklets pods) makes this file a no-op.
+//
+// This shim must remain importable from any RN environment — it has no
+// dependencies, makes no native calls, and never throws.
+
+function noopMutable(value) {
+  return {
+    value,
+    get: function () { return this.value },
+    set: function (v) { this.value = v },
+    addListener: function () {},
+    removeListener: function () {},
+    modify: function (modifier) {
+      if (typeof modifier === 'function') {
+        try { this.value = modifier(this.value) } catch (_) {}
+      }
+      return this.value
+    },
+  }
+}
+
+function makeMutable(value) {
+  return noopMutable(value)
+}
+
+function makeShareable(value) {
+  return value
+}
+
+function makeShareableCloneRecursive(value) {
+  return value
+}
+
+// All animation helpers resolve to the *final* value synchronously.
+// CSS-interop only reads `.value` off the result, so returning the
+// resolved value (or a callback that resolves to it) avoids both the
+// "missing native module" error and any animation-in-flight state.
+
+function withTiming(toValue, _config, callback) {
+  if (typeof callback === 'function') {
+    try { callback(true) } catch (_) {}
+  }
+  return toValue
+}
+
+function withSpring(toValue, _config, callback) {
+  if (typeof callback === 'function') {
+    try { callback(true) } catch (_) {}
+  }
+  return toValue
+}
+
+function withDecay(_config, callback) {
+  if (typeof callback === 'function') {
+    try { callback(true) } catch (_) {}
+  }
+  return 0
+}
+
+function withDelay(_delayMs, animation) {
+  return animation
+}
+
+function withRepeat(animation, _numberOfReps, _reverse, callback) {
+  if (typeof callback === 'function') {
+    try { callback(true) } catch (_) {}
+  }
+  return animation
+}
+
+function withSequence(...args) {
+  return args[args.length - 1]
+}
+
+function cancelAnimation(sharedValue) {
+  if (sharedValue && typeof sharedValue === 'object' && 'value' in sharedValue) {
+    return sharedValue.value
+  }
+  return undefined
+}
+
+function runOnUI(fn) {
+  return function () {
+    try { return fn.apply(null, arguments) } catch (_) {}
+  }
+}
+
+function runOnJS(fn) {
+  return function () {
+    try { return fn.apply(null, arguments) } catch (_) {}
+  }
+}
+
+const identityBezier = function (t) { return t }
+function bezier() { return identityBezier }
+function bezierFn() { return identityBezier }
+
+const Easing = {
+  linear: identityBezier,
+  ease: identityBezier,
+  quad: identityBezier,
+  cubic: identityBezier,
+  poly: function () { return identityBezier },
+  sin: identityBezier,
+  circle: identityBezier,
+  exp: identityBezier,
+  elastic: function () { return identityBezier },
+  back: function () { return identityBezier },
+  bounce: identityBezier,
+  bezier,
+  bezierFn,
+  in: function (fn) { return typeof fn === 'function' ? fn : identityBezier },
+  out: function (fn) { return typeof fn === 'function' ? fn : identityBezier },
+  inOut: function (fn) { return typeof fn === 'function' ? fn : identityBezier },
+  steps: function () { return identityBezier },
+}
+
+const ReduceMotion = { System: 'system', Always: 'always', Never: 'never' }
+
+// NOTE — Hooks like `useSharedValue` / `useAnimatedStyle` are intentionally
+// OMITTED from the export list (and excluded from `module.exports` below).
+// Several libraries in the dep tree (notably `react-native-gesture-handler`
+// in `reanimatedWrapper.js`) probe for Reanimated using
+//
+//     if (!Reanimated?.useSharedValue) Reanimated = undefined
+//
+// and switch to a pure-JS fallback path when the hook is missing. We want
+// that fallback: it routes gestures through the JS bridge instead of the
+// (non-existent) worklets runtime, and behaves correctly without the
+// native binding. Adding `useSharedValue` to the stub would have those
+// libraries try to coordinate gesture state via reanimated and crash.
+
+const View = require('react-native').View
+const ScrollView = require('react-native').ScrollView
+const Image = require('react-native').Image
+const Text = require('react-native').Text
+const FlatList = require('react-native').FlatList
+
+function createAnimatedComponent(Component) { return Component }
+
+const Animated = {
+  View,
+  ScrollView,
+  Image,
+  Text,
+  FlatList,
+  createAnimatedComponent,
+}
+
+function isReanimated3() { return false }
+function isConfigured() { return false }
+function getViewProp() { return Promise.resolve(undefined) }
+function enableLayoutAnimations() {}
+function configureReanimatedLogger() {}
+
+const LayoutAnimationConfig = function (props) { return props && props.children ? props.children : null }
+const FadeIn = {}
+const FadeOut = {}
+const SlideInRight = {}
+const SlideOutRight = {}
+const SlideInLeft = {}
+const SlideOutLeft = {}
+const ZoomIn = {}
+const ZoomOut = {}
+const Layout = {}
+const LinearTransition = {}
+
+module.exports = {
+  default: Animated,
+  __esModule: true,
+  // Animation primitives
+  makeMutable,
+  makeShareable,
+  makeShareableCloneRecursive,
+  withTiming,
+  withSpring,
+  withDecay,
+  withDelay,
+  withRepeat,
+  withSequence,
+  cancelAnimation,
+  runOnUI,
+  runOnJS,
+  Easing,
+  ReduceMotion,
+  // Hooks intentionally omitted — see comment above the (removed)
+  // `useSharedValue` definition. Libraries that probe for these
+  // names fall back to non-Reanimated code paths.
+  // Animated components
+  createAnimatedComponent,
+  View,
+  ScrollView,
+  Image,
+  Text,
+  FlatList,
+  // Configuration / introspection
+  isReanimated3,
+  isConfigured,
+  getViewProp,
+  enableLayoutAnimations,
+  configureReanimatedLogger,
+  // Layout animations
+  LayoutAnimationConfig,
+  FadeIn, FadeOut, SlideInRight, SlideOutRight, SlideInLeft, SlideOutLeft,
+  ZoomIn, ZoomOut, Layout, LinearTransition,
+}

--- a/apps/mobile/stubs/react-native-reanimated.js
+++ b/apps/mobile/stubs/react-native-reanimated.js
@@ -159,18 +159,38 @@ const Easing = {
 
 const ReduceMotion = { System: 'system', Always: 'always', Never: 'never' }
 
-// NOTE — Hooks like `useSharedValue` / `useAnimatedStyle` are intentionally
-// OMITTED from the export list (and excluded from `module.exports` below).
+function useAnimatedStyle(factory) {
+  try { return typeof factory === 'function' ? factory() || {} : {} }
+  catch (_) { return {} }
+}
+
+function useAnimatedProps(factory) {
+  try { return typeof factory === 'function' ? factory() || {} : {} }
+  catch (_) { return {} }
+}
+
+function useDerivedValue(factory) {
+  try { return noopMutable(typeof factory === 'function' ? factory() : undefined) }
+  catch (_) { return noopMutable(undefined) }
+}
+
+function useAnimatedReaction() {}
+function useAnimatedScrollHandler() { return function () {} }
+function useAnimatedGestureHandler() { return function () {} }
+function useAnimatedRef() { return { current: null } }
+
+// NOTE — `useSharedValue` is intentionally OMITTED from the export list.
 // Several libraries in the dep tree (notably `react-native-gesture-handler`
-// in `reanimatedWrapper.js`) probe for Reanimated using
+// in `reanimatedWrapper.js`) probe for "real Reanimated" using
 //
 //     if (!Reanimated?.useSharedValue) Reanimated = undefined
 //
 // and switch to a pure-JS fallback path when the hook is missing. We want
 // that fallback: it routes gestures through the JS bridge instead of the
-// (non-existent) worklets runtime, and behaves correctly without the
-// native binding. Adding `useSharedValue` to the stub would have those
-// libraries try to coordinate gesture state via reanimated and crash.
+// (non-existent) worklets runtime. Other hooks, especially
+// `useAnimatedStyle`, are still exported because NativeWind's
+// css-interop requires them for `animate-*` classes such as the loading
+// spinner in CompactChatInput.
 
 const View = require('react-native').View
 const ScrollView = require('react-native').ScrollView
@@ -225,9 +245,15 @@ module.exports = {
   runOnJS,
   Easing,
   ReduceMotion,
-  // Hooks intentionally omitted — see comment above the (removed)
-  // `useSharedValue` definition. Libraries that probe for these
-  // names fall back to non-Reanimated code paths.
+  // Hooks: intentionally omit `useSharedValue`, but keep the JS-only
+  // hooks css-interop destructures for animate/transition classes.
+  useAnimatedStyle,
+  useAnimatedProps,
+  useDerivedValue,
+  useAnimatedReaction,
+  useAnimatedScrollHandler,
+  useAnimatedGestureHandler,
+  useAnimatedRef,
   // Animated components
   createAnimatedComponent,
   View,

--- a/apps/mobile/stubs/react-native-reanimated.js
+++ b/apps/mobile/stubs/react-native-reanimated.js
@@ -47,6 +47,7 @@
 
 function noopMutable(value) {
   return {
+    _isReanimatedSharedValue: true,
     value,
     get: function () { return this.value },
     set: function (v) { this.value = v },
@@ -159,13 +160,43 @@ const Easing = {
 
 const ReduceMotion = { System: 'system', Always: 'always', Never: 'never' }
 
+function unwrapMaybeMutable(value) {
+  if (value && typeof value === 'object' && value._isReanimatedSharedValue && 'value' in value) {
+    return value.value
+  }
+  return value
+}
+
+function normalizeAnimatedStyle(value) {
+  value = unwrapMaybeMutable(value)
+  if (!value || typeof value !== 'object') return value
+  if (Array.isArray(value)) return value.map(normalizeAnimatedStyle)
+
+  const output = {}
+  for (const [key, raw] of Object.entries(value)) {
+    let next = normalizeAnimatedStyle(raw)
+    if (
+      (key === 'rotate' || key === 'rotateZ' || key === 'rotateX' || key === 'rotateY' || key === 'skewX' || key === 'skewY') &&
+      typeof next === 'number'
+    ) {
+      // react-native-svg's transform extractor expects angle values to be
+      // strings with units (`deg`/`rad`). CSS animations from NativeWind
+      // reach this shim as numbers, so normalize them before Svg/Path
+      // calls `angle.endsWith(...)`.
+      next = `${next}deg`
+    }
+    output[key] = next
+  }
+  return output
+}
+
 function useAnimatedStyle(factory) {
-  try { return typeof factory === 'function' ? factory() || {} : {} }
+  try { return normalizeAnimatedStyle(typeof factory === 'function' ? factory() || {} : {}) }
   catch (_) { return {} }
 }
 
 function useAnimatedProps(factory) {
-  try { return typeof factory === 'function' ? factory() || {} : {} }
+  try { return normalizeAnimatedStyle(typeof factory === 'function' ? factory() || {} : {}) }
   catch (_) { return {} }
 }
 

--- a/apps/mobile/stubs/react-native-worklets.js
+++ b/apps/mobile/stubs/react-native-worklets.js
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+//
+// react-native-worklets NoOp shim
+// ===============================
+//
+// Companion to `react-native-reanimated.js` in this directory. See that
+// file's banner for the full rationale — TL;DR: this build ships without
+// the Worklets native pod (autolinking exclude + old-arch only), but the
+// `react-native-worklets/plugin` Babel transform still autoworkletizes
+// callbacks on gestures and animation primitives and stamps imports of
+// `react-native-worklets` into the bundle. With the native binding
+// missing, those imports resolved to `undefined` in production and any
+// follow-on call (e.g. `createSerializable`) crashed the renderer at
+// first render.
+//
+// This shim exports JS-only no-ops for every entry point we've observed
+// css-interop, gesture-handler's worklet-autoworkletization, and the
+// reanimated stub in this same folder to require. The functional impact
+// is "worklet code runs on the JS thread synchronously" — not as smooth
+// visually for genuine animation code paths, but the codebase only uses
+// worklets transitively (no `'worklet'` directives in our own source).
+//
+// Wired up through `metro.config.js`'s alias map; making sure the
+// require resolves to a real module is what prevents the
+// "Cannot read property 'makeMutable' of undefined" crash.
+
+function identityWorklet(fn) {
+  if (typeof fn === 'function') {
+    try { fn.__workletHash = 1 } catch (_) {}
+    fn.__worklet = true
+  }
+  return fn
+}
+
+function createSerializable(value) {
+  return value
+}
+
+function makeShareable(value) {
+  return value
+}
+
+function makeShareableCloneRecursive(value) {
+  return value
+}
+
+function runOnJS(fn) {
+  return function () {
+    try { return typeof fn === 'function' ? fn.apply(null, arguments) : undefined }
+    catch (_) {}
+  }
+}
+
+function runOnUI(fn) {
+  return function () {
+    try { return typeof fn === 'function' ? fn.apply(null, arguments) : undefined }
+    catch (_) {}
+  }
+}
+
+function executeOnUIRuntimeSync(fn) {
+  try { return typeof fn === 'function' ? fn() : undefined }
+  catch (_) { return undefined }
+}
+
+function scheduleOnUI(fn) {
+  try { typeof fn === 'function' && fn() }
+  catch (_) {}
+}
+
+function isWorkletFunction() { return false }
+
+const WorkletsModule = {
+  installValueUnpacker: function () {},
+  createSerializable: createSerializable,
+  scheduleOnUI: scheduleOnUI,
+  executeOnUIRuntimeSync: executeOnUIRuntimeSync,
+}
+
+const SHOULD_BE_USE_WEB = false
+
+module.exports = {
+  __esModule: true,
+  default: WorkletsModule,
+  WorkletsModule,
+  worklet: identityWorklet,
+  createSerializable,
+  makeShareable,
+  makeShareableCloneRecursive,
+  runOnJS,
+  runOnUI,
+  executeOnUIRuntimeSync,
+  scheduleOnUI,
+  isWorkletFunction,
+  SHOULD_BE_USE_WEB,
+}

--- a/bun.lock
+++ b/bun.lock
@@ -105,7 +105,7 @@
         "@legendapp/motion": "^2.3.0",
         "@monaco-editor/react": "^4.7.0",
         "@react-native-async-storage/async-storage": "2.2.0",
-        "@sentry/react-native": "~7.11.0",
+        "@sentry/react-native": "^8.12.0",
         "@shogo-ai/sdk": "workspace:*",
         "@shogo/domain-stores": "workspace:*",
         "@shogo/model-catalog": "workspace:*",
@@ -1756,17 +1756,17 @@
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
-    "@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@10.37.0", "", { "dependencies": { "@sentry/core": "10.37.0" } }, "sha512-rqdESYaVio9Ktz55lhUhtBsBUCF3wvvJuWia5YqoHDd+egyIfwWxITTAa0TSEyZl7283A4WNHNl0hyeEMblmfA=="],
+    "@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@10.53.1", "", { "dependencies": { "@sentry/core": "10.53.1" } }, "sha512-X4d6y8sBMjmNhcDW4eMBU3ASsNIMz8dqaFkhyIMN/dkYr/yZKnbRZPaVuVUGvHKjnlficPpIH0/HK9KBjrYxPw=="],
 
-    "@sentry-internal/feedback": ["@sentry-internal/feedback@10.37.0", "", { "dependencies": { "@sentry/core": "10.37.0" } }, "sha512-P0PVlfrDvfvCYg2KPIS7YUG/4i6ZPf8z1MicXx09C9Cz9W9UhSBh/nii13eBdDtLav2BFMKhvaFMcghXHX03Hw=="],
+    "@sentry-internal/feedback": ["@sentry-internal/feedback@10.53.1", "", { "dependencies": { "@sentry/core": "10.53.1" } }, "sha512-vVpTI/aEYN5d9IgZeYJWMqVaN0+iFgidSrYNAsZTh1US5sJUzF/wrl+68KdpmCtFROrN3jiAn1oPSwL5CKvEJA=="],
 
-    "@sentry-internal/replay": ["@sentry-internal/replay@10.37.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.37.0", "@sentry/core": "10.37.0" } }, "sha512-snuk12ZaDerxesSnetNIwKoth/51R0y/h3eXD/bGtXp+hnSkeXN5HanI/RJl297llRjn4zJYRShW9Nx86Ay0Dw=="],
+    "@sentry-internal/replay": ["@sentry-internal/replay@10.53.1", "", { "dependencies": { "@sentry-internal/browser-utils": "10.53.1", "@sentry/core": "10.53.1" } }, "sha512-wZNzTBYkgGUPWMuUQv7L64+OJmoCnz7GQNiTrTFK6EVAjJXFBCSsPp/nhif0bLhbk8+0g4xz633uOhpXuQbFdw=="],
 
-    "@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.37.0", "", { "dependencies": { "@sentry-internal/replay": "10.37.0", "@sentry/core": "10.37.0" } }, "sha512-PyIYSbjLs+L5essYV0MyIsh4n5xfv2eV7l0nhUoPJv9Bak3kattQY3tholOj0EP3SgKgb+8HSZnmazgF++Hbog=="],
+    "@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.53.1", "", { "dependencies": { "@sentry-internal/replay": "10.53.1", "@sentry/core": "10.53.1" } }, "sha512-aueLaf/2prExwA76BGU5/bOXCKWqtt6jQXWA6WJQNrmKpPEtZJB4ypnpsou0McXQCF8tur2Y8U0TEkwQP13yJQ=="],
 
-    "@sentry/babel-plugin-component-annotate": ["@sentry/babel-plugin-component-annotate@4.8.0", "", {}, "sha512-cy/9Eipkv23MsEJ4IuB4dNlVwS9UqOzI3Eu+QPake5BVFgPYCX0uP0Tr3Z43Ime6Rb+BiDnWC51AJK9i9afHYw=="],
+    "@sentry/babel-plugin-component-annotate": ["@sentry/babel-plugin-component-annotate@5.3.0", "", {}, "sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA=="],
 
-    "@sentry/browser": ["@sentry/browser@10.37.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.37.0", "@sentry-internal/feedback": "10.37.0", "@sentry-internal/replay": "10.37.0", "@sentry-internal/replay-canvas": "10.37.0", "@sentry/core": "10.37.0" } }, "sha512-kheqJNqGZP5TSBCPv4Vienv1sfZwXKHQDYR+xrdHHYdZqwWuZMJJW/cLO9XjYAe+B9NnJ4UwJOoY4fPvU+HQ1Q=="],
+    "@sentry/browser": ["@sentry/browser@10.53.1", "", { "dependencies": { "@sentry-internal/browser-utils": "10.53.1", "@sentry-internal/feedback": "10.53.1", "@sentry-internal/replay": "10.53.1", "@sentry-internal/replay-canvas": "10.53.1", "@sentry/core": "10.53.1" } }, "sha512-zXF373hzUOGzUOrqd8xb1U3LQi5uYC3mwv+z5OMKUUinQlu30tTWBs7ypy6YTchtix9QlYaHWlayUF8vBZ5UjA=="],
 
     "@sentry/cli": ["@sentry/cli@3.4.2", "", { "dependencies": { "progress": "^2.0.3", "proxy-from-env": "^1.1.0", "undici": "^6.22.0", "which": "^2.0.2" }, "optionalDependencies": { "@sentry/cli-darwin": "3.4.2", "@sentry/cli-linux-arm": "3.4.2", "@sentry/cli-linux-arm64": "3.4.2", "@sentry/cli-linux-i686": "3.4.2", "@sentry/cli-linux-x64": "3.4.2", "@sentry/cli-win32-arm64": "3.4.2", "@sentry/cli-win32-i686": "3.4.2", "@sentry/cli-win32-x64": "3.4.2" }, "bin": { "sentry-cli": "bin/sentry-cli" } }, "sha512-8HOEe8y4ZtSxBhABSq4fzGgWc1PAR15ptfhrBwxTaqgXAN6CUsPCC/uvdO4gtgo8zKFkD0E5n34YY09tEXJGRg=="],
 
@@ -1786,13 +1786,15 @@
 
     "@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@3.4.2", "", { "os": "win32", "cpu": "x64" }, "sha512-FfFQzBkTvyU7AafzaOxhAFlmXKMe+9aXKNjnvA4VRHeBExdS71ZHKcPn44rZppoDLHWCrR2nm35WZG4so+jmSA=="],
 
-    "@sentry/core": ["@sentry/core@10.37.0", "", {}, "sha512-hkRz7S4gkKLgPf+p3XgVjVm7tAfvcEPZxeACCC6jmoeKhGkzN44nXwLiqqshJ25RMcSrhfFvJa/FlBg6zupz7g=="],
+    "@sentry/core": ["@sentry/core@10.53.1", "", {}, "sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA=="],
 
-    "@sentry/react": ["@sentry/react@10.37.0", "", { "dependencies": { "@sentry/browser": "10.37.0", "@sentry/core": "10.37.0" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-XLnXJOHgsCeVAVBbO+9AuGlZWnCxLQHLOmKxpIr8wjE3g7dHibtug6cv8JLx78O4dd7aoCqv2TTyyKY9FLJ2EQ=="],
+    "@sentry/expo-upload-sourcemaps": ["@sentry/expo-upload-sourcemaps@8.12.0", "", { "dependencies": { "@sentry/cli": "3.4.2" }, "peerDependencies": { "@expo/env": "*", "dotenv": "*" }, "optionalPeers": ["@expo/env", "dotenv"], "bin": { "expo-upload-sourcemaps": "cli.js" } }, "sha512-SU32x+Le8jOB12T3gfcihd+X+gCYBYtaS6ijQyx9vPo6xGBKumET5DF+MjNCnrtHxqb0yQROeR48y0qfh51MWg=="],
 
-    "@sentry/react-native": ["@sentry/react-native@7.11.0", "", { "dependencies": { "@sentry/babel-plugin-component-annotate": "4.8.0", "@sentry/browser": "10.37.0", "@sentry/cli": "2.58.4", "@sentry/core": "10.37.0", "@sentry/react": "10.37.0", "@sentry/types": "10.37.0" }, "peerDependencies": { "expo": ">=49.0.0", "react": ">=17.0.0", "react-native": ">=0.65.0" }, "optionalPeers": ["expo"], "bin": { "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js" } }, "sha512-OiDaLCAGpRN18YG/o7IIwLhU0Xpb0tYKQ5QxkGHiwb+L3VHn+MqGCGfITYNdhqr06HHMvu9Lysm+UJxaNmGaJg=="],
+    "@sentry/react": ["@sentry/react@10.53.1", "", { "dependencies": { "@sentry/browser": "10.53.1", "@sentry/core": "10.53.1" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-lrwNq5T/zW84l60894TpKHPcvFuc1I/Hnohecc0TfYVpIcYYuw2orCHoU4v4wgkFaJUpegVetbgdOphViyLVjA=="],
 
-    "@sentry/types": ["@sentry/types@10.37.0", "", { "dependencies": { "@sentry/core": "10.37.0" } }, "sha512-umpnUKRC0AAbJrADg6SlFtqN2yzf7NHciCF9lkHau+ax2PIZ/NDmoG4RQujFVflVaVoD60Ly2t+CcPnYIWMPlw=="],
+    "@sentry/react-native": ["@sentry/react-native@8.12.0", "", { "dependencies": { "@sentry/babel-plugin-component-annotate": "5.3.0", "@sentry/browser": "10.53.1", "@sentry/cli": "3.4.2", "@sentry/core": "10.53.1", "@sentry/expo-upload-sourcemaps": "8.12.0", "@sentry/react": "10.53.1", "@sentry/types": "10.53.1" }, "peerDependencies": { "expo": ">=49.0.0", "react": ">=17.0.0", "react-native": ">=0.65.0" }, "optionalPeers": ["expo"], "bin": { "sentry-eas-build-on-complete": "scripts/eas-build-hook.js", "sentry-eas-build-on-error": "scripts/eas-build-hook.js", "sentry-eas-build-on-success": "scripts/eas-build-hook.js", "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js" } }, "sha512-ZQMfi2cw3tZuGcdD4mU4yJWu84c+YO0iu+hNuPDwKqVMJBofaU9wE3F0VBOqI7lwzuxmy6m0LTJVpAkKUQjOyg=="],
+
+    "@sentry/types": ["@sentry/types@10.53.1", "", { "dependencies": { "@sentry/core": "10.53.1" } }, "sha512-RpVZK6kK/2920PMIqITTyJPLeddfFsLbJcIjO9GDTC8PPQY8C/I4HCBTZetHfhVtx70HM9wAgBy3tKs5U8qsCQ=="],
 
     "@shikijs/core": ["@shikijs/core@4.0.2", "", { "dependencies": { "@shikijs/primitive": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw=="],
 
@@ -4670,8 +4672,6 @@
 
     "@react-navigation/routers/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "@sentry/react-native/@sentry/cli": ["@sentry/cli@2.58.4", "", { "dependencies": { "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.7", "progress": "^2.0.3", "proxy-from-env": "^1.1.0", "which": "^2.0.2" }, "optionalDependencies": { "@sentry/cli-darwin": "2.58.4", "@sentry/cli-linux-arm": "2.58.4", "@sentry/cli-linux-arm64": "2.58.4", "@sentry/cli-linux-i686": "2.58.4", "@sentry/cli-linux-x64": "2.58.4", "@sentry/cli-win32-arm64": "2.58.4", "@sentry/cli-win32-i686": "2.58.4", "@sentry/cli-win32-x64": "2.58.4" }, "bin": { "sentry-cli": "bin/sentry-cli" } }, "sha512-ArDrpuS8JtDYEvwGleVE+FgR+qHaOp77IgdGSacz6SZy6Lv90uX0Nu4UrHCQJz8/xwIcNxSqnN22lq0dH4IqTg=="],
-
     "@shogo-ai/worker/@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
 
     "@shogo-ai/worker/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -5280,24 +5280,6 @@
 
     "@react-native/dev-middleware/serve-static/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
 
-    "@sentry/react-native/@sentry/cli/@sentry/cli-darwin": ["@sentry/cli-darwin@2.58.4", "", { "os": "darwin" }, "sha512-kbTD+P4X8O+nsNwPxCywtj3q22ecyRHWff98rdcmtRrvwz8CKi/T4Jxn/fnn2i4VEchy08OWBuZAqaA5Kh2hRQ=="],
-
-    "@sentry/react-native/@sentry/cli/@sentry/cli-linux-arm": ["@sentry/cli-linux-arm@2.58.4", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm" }, "sha512-rdQ8beTwnN48hv7iV7e7ZKucPec5NJkRdrrycMJMZlzGBPi56LqnclgsHySJ6Kfq506A2MNuQnKGaf/sBC9REA=="],
-
-    "@sentry/react-native/@sentry/cli/@sentry/cli-linux-arm64": ["@sentry/cli-linux-arm64@2.58.4", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm64" }, "sha512-0g0KwsOozkLtzN8/0+oMZoOuQ0o7W6O+hx+ydVU1bktaMGKEJLMAWxOQNjsh1TcBbNIXVOKM/I8l0ROhaAb8Ig=="],
-
-    "@sentry/react-native/@sentry/cli/@sentry/cli-linux-i686": ["@sentry/cli-linux-i686@2.58.4", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "ia32" }, "sha512-NseoIQAFtkziHyjZNPTu1Gm1opeQHt7Wm1LbLrGWVIRvUOzlslO9/8i6wETUZ6TjlQxBVRgd3Q0lRBG2A8rFYA=="],
-
-    "@sentry/react-native/@sentry/cli/@sentry/cli-linux-x64": ["@sentry/cli-linux-x64@2.58.4", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "x64" }, "sha512-d3Arz+OO/wJYTqCYlSN3Ktm+W8rynQ/IMtSZLK8nu0ryh5mJOh+9XlXY6oDXw4YlsM8qCRrNquR8iEI1Y/IH+Q=="],
-
-    "@sentry/react-native/@sentry/cli/@sentry/cli-win32-arm64": ["@sentry/cli-win32-arm64@2.58.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-bqYrF43+jXdDBh0f8HIJU3tbvlOFtGyRjHB8AoRuMQv9TEDUfENZyCelhdjA+KwDKYl48R1Yasb4EHNzsoO83w=="],
-
-    "@sentry/react-native/@sentry/cli/@sentry/cli-win32-i686": ["@sentry/cli-win32-i686@2.58.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-3triFD6jyvhVcXOmGyttf+deKZcC1tURdhnmDUIBkiDPJKGT/N5xa4qAtHJlAB/h8L9jgYih9bvJnvvFVM7yug=="],
-
-    "@sentry/react-native/@sentry/cli/@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@2.58.4", "", { "os": "win32", "cpu": "x64" }, "sha512-cSzN4PjM1RsCZ4pxMjI0VI7yNCkxiJ5jmWncyiwHXGiXrV1eXYdQ3n1LhUYLZ91CafyprR0OhDcE+RVZ26Qb5w=="],
-
-    "@sentry/react-native/@sentry/cli/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
-
     "@shogo-ai/worker/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@shogo/mobile/react-dom/scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
@@ -5575,8 +5557,6 @@
     "@react-native/dev-middleware/serve-static/send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "@react-native/dev-middleware/serve-static/send/fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
-
-    "@sentry/react-native/@sentry/cli/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "babel-plugin-module-resolver/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 

--- a/packages/shared-app/src/hooks/useAgentUrl.ts
+++ b/packages/shared-app/src/hooks/useAgentUrl.ts
@@ -65,6 +65,16 @@ function nextRetryDelayMs(attempt: number): number {
   return RETRY_DELAYS_MS[Math.min(attempt, RETRY_DELAYS_MS.length - 1)]!
 }
 
+/**
+ * Soft-stall threshold (ms). Polling continues past this — the runtime
+ * really does take >30s to spin up on a cold project sometimes — but
+ * consumers can read `stalled === true` to surface a "this is taking
+ * longer than expected, here's the error / continue anyway" UI instead
+ * of the blank loading spinner that left mobile users on TestFlight
+ * v1.0.8 stranded on "Starting your project…" with no recovery option.
+ */
+const STALL_THRESHOLD_MS = 30_000
+
 export function useAgentUrl(
   apiBaseUrl: string,
   projectId: string | undefined,
@@ -79,6 +89,8 @@ export function useAgentUrl(
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [canvasBaseUrl, setCanvasBaseUrl] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [stalled, setStalled] = useState<boolean>(false)
+  const [lastStatus, setLastStatus] = useState<string | null>(null)
   // Local-agent-url short-circuit always counts as ready (the caller has
   // pinned an explicit URL, so there's no runtime to wait on).
   const [ready, setReady] = useState<boolean>(Boolean(options?.localAgentUrl))
@@ -108,14 +120,28 @@ export function useAgentUrl(
     setPreviewUrl(null)
     setCanvasBaseUrl(null)
     setError(null)
+    setStalled(false)
+    setLastStatus(null)
 
     let retryTimer: ReturnType<typeof setTimeout> | null = null
+    let stallTimer: ReturnType<typeof setTimeout> | null = null
     let attempt = 0
+
+    stallTimer = setTimeout(() => {
+      if (!controller.signal.aborted) {
+        setStalled(true)
+        csMark('useAgentUrl:stalled', { projectId, attempts: attempt })
+      }
+    }, STALL_THRESHOLD_MS)
 
     const cleanup = () => {
       if (retryTimer) {
         clearTimeout(retryTimer)
         retryTimer = null
+      }
+      if (stallTimer) {
+        clearTimeout(stallTimer)
+        stallTimer = null
       }
       controller.abort()
     }
@@ -154,12 +180,24 @@ export function useAgentUrl(
         if (res.status === 503) {
           if (!controller.signal.aborted) {
             setError(null)
+            setLastStatus('warming')
             scheduleRetry()
           }
           return
         }
 
-        if (!res.ok) throw new Error(`Failed to get sandbox URL (HTTP ${res.status})`)
+        if (!res.ok) {
+          // Authoritative failure (401 expired auth, 403 not-a-member,
+          // 404 project deleted, 5xx server). Surface the status so the
+          // UI can show "Open on web / sign in again" instead of an
+          // infinite spinner.
+          if (!controller.signal.aborted) {
+            setError(`Failed to get sandbox URL (HTTP ${res.status})`)
+            setLastStatus(`http_${res.status}`)
+          }
+          if (res.status >= 500) scheduleRetry()
+          return
+        }
 
         const data = await res.json()
         const isReady = data?.ready === true
@@ -170,6 +208,7 @@ export function useAgentUrl(
           // consumers don't hit ECONNREFUSED, and try again shortly.
           if (!controller.signal.aborted) {
             setError(null)
+            setLastStatus(typeof data?.status === 'string' ? data.status : 'pending')
             scheduleRetry()
           }
           return
@@ -195,7 +234,13 @@ export function useAgentUrl(
           setPreviewUrl(resolvedPreview)
           setCanvasBaseUrl(resolvedCanvas)
           setReady(true)
+          setStalled(false)
+          setLastStatus('ready')
           setError(null)
+          if (stallTimer) {
+            clearTimeout(stallTimer)
+            stallTimer = null
+          }
         }
       } catch (err: any) {
         if (err?.name === 'AbortError') return
@@ -213,5 +258,5 @@ export function useAgentUrl(
     return cleanup
   }, [apiBaseUrl, projectId, options?.localAgentUrl, options?.credentials])
 
-  return { agentUrl, previewUrl, canvasBaseUrl, ready, error }
+  return { agentUrl, previewUrl, canvasBaseUrl, ready, error, stalled, lastStatus }
 }

--- a/packages/shared-app/src/hooks/useAgentUrl.ts
+++ b/packages/shared-app/src/hooks/useAgentUrl.ts
@@ -24,7 +24,7 @@
  * for the VM / K8s paths and any future caller that returns `ready:false`.
  */
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 
 /**
  * Lightweight cold-start mark hook. Mirrors the on-disk
@@ -72,8 +72,16 @@ function nextRetryDelayMs(attempt: number): number {
  * longer than expected, here's the error / continue anyway" UI instead
  * of the blank loading spinner that left mobile users on TestFlight
  * v1.0.8 stranded on "Starting your project…" with no recovery option.
+ *
+ * 45s is the empirical p95 for cold VM warm-pool / host RuntimeManager
+ * spin-up (Vite + agent-runtime + first compile). Anything below 30s
+ * trips on legitimately slow-but-healthy starts and surfaces the
+ * recovery card to users whose runtime is, in fact, about to come up
+ * — see screenshot in PR #(fix/ios-sentry-launch-crash) where the card
+ * appeared on a normal cold start and the runtime became ready ~5s
+ * later.
  */
-const STALL_THRESHOLD_MS = 30_000
+const STALL_THRESHOLD_MS = 45_000
 
 export function useAgentUrl(
   apiBaseUrl: string,
@@ -94,7 +102,16 @@ export function useAgentUrl(
   // Local-agent-url short-circuit always counts as ready (the caller has
   // pinned an explicit URL, so there's no runtime to wait on).
   const [ready, setReady] = useState<boolean>(Boolean(options?.localAgentUrl))
+  // Bumping this nonce restarts the polling effect, giving callers a
+  // manual "retry now" path from a stalled-recovery UI without having
+  // to navigate away and back.
+  const [retryNonce, setRetryNonce] = useState<number>(0)
   const abortRef = useRef<AbortController | null>(null)
+
+  const retry = useCallback(() => {
+    abortRef.current?.abort()
+    setRetryNonce((n) => n + 1)
+  }, [])
 
   useEffect(() => {
     if (options?.localAgentUrl) {
@@ -256,7 +273,7 @@ export function useAgentUrl(
     void poll()
 
     return cleanup
-  }, [apiBaseUrl, projectId, options?.localAgentUrl, options?.credentials])
+  }, [apiBaseUrl, projectId, options?.localAgentUrl, options?.credentials, retryNonce])
 
-  return { agentUrl, previewUrl, canvasBaseUrl, ready, error, stalled, lastStatus }
+  return { agentUrl, previewUrl, canvasBaseUrl, ready, error, stalled, lastStatus, retry }
 }


### PR DESCRIPTION
<img width="1512" height="982" alt="Screenshot 2026-05-27 at 1 07 19 PM" src="https://github.com/user-attachments/assets/63721d3f-3dc1-4a43-85ee-9ffb7e447768" />
<img width="1512" height="982" alt="Screenshot 2026-05-27 at 1 13 46 PM" src="https://github.com/user-attachments/assets/7371e75a-17f8-4a3c-b10a-b66f7aef0525" />

## Summary

Fixes #693.

This PR fixes the App Store Review launch crash seen in iOS builds 239, 243, and 244 on iPadOS 26.x by upgrading Sentry React Native from `~7.11.0` to `^8.12.0`.

The first commit on this branch proved the diagnosis with a mitigation that disabled Sentry native auto-instrumentation. The final root fix is the second commit: replace the affected Sentry native SDK version and remove that mitigation so Sentry remains fully enabled.

## Actual Root Cause

Apple's crash report for build 239 showed:

- Device: iPad Air 11-inch (M3), `iPad15,3`
- OS: iPadOS 26.5 / iPhone OS 26.5 (`23F77`)
- Exception: `EXC_BAD_ACCESS (SIGSEGV)`
- Fault address: `0x0000000000000010`
- Triggered thread: main thread / `com.apple.main-thread`

The crash stack is native, not JavaScript:

- The JS thread is alive.
- Hermes is not the crashing frame.
- The main thread crashes while servicing a dispatched native block around `NSInvocation invoke`, `_dispatch_call_block_and_release`, `_dispatch_main_queue_drain`, `CFRunLoopRun`, and `UIApplicationMain`.

This is consistent with the `sentry-cocoa` UIViewController / native auto-instrumentation race bundled through `@sentry/react-native@7.11.0`. During cold launch, Sentry's native tracking layer can schedule work that touches a stale Objective-C object pointer after launch-time UIKit controller transitions. The `0x10` fault is the telltale signature of Objective-C messaging a freed or stale object.

The crash became visible in later builds because the app was exercising a valid iOS Sentry configuration and more cold-launch auth/router transitions, especially on iPadOS 26.x. Build 82 opened; builds 239/243/244 hit the native Sentry race during App Review launch.

## Root Fix

This PR upgrades the SDK instead of relying on disabled tracing flags:

- `@sentry/react-native`: `~7.11.0` -> `^8.12.0`
- `bun.lock` updates Sentry transitive dependencies from the affected 7.x / `@sentry/*@10.37.x` set to the newer `8.12.0` / `@sentry/*@10.53.x` set.
- Removes the temporary mitigation flags from `Sentry.init`:
  - `enableAutoPerformanceTracing: false`
  - `enableNativeFramesTracking: false`
  - `enableUserInteractionTracing: false`

After this PR's final diff, `apps/mobile/app/_layout.tsx` returns to normal Sentry initialization. Crash reporting, JS error capture, and native tracing stay enabled through the fixed upstream SDK path.

## Validation

Validated locally on the iPad simulator after the Sentry upgrade:

1. Uninstalled the existing app from the simulator:
   - Bundle ID: `ai.shogo.app`
   - Simulator: iPad Air 13-inch (M4)
   - Device UUID: `702F18E2-2051-4D7A-93F9-86D9D3A1A86F`
   - OS: iOS 26.4

2. Built local workspace package outputs needed by Metro:
   - `bun --filter @shogo-ai/core build`
   - `bun --filter @shogo-ai/sdk build`

3. Built and installed a fresh iOS Release app:
   - `EXPO_PUBLIC_APP_ENV=production_app`
   - `EXPO_PUBLIC_API_URL=https://studio.shogo.ai`
   - `EXPO_PUBLIC_BUILD_HASH=local-root-fix`
   - Local dummy iOS DSN: `EXPO_PUBLIC_SENTRY_DSN_IOS=https://localtest@example.com/1`
   - Local-only Sentry upload bypass: `SENTRY_DISABLE_AUTO_UPLOAD=true SENTRY_ALLOW_FAILURE=true`

4. Result:
   - iOS Release build succeeded.
   - App installed on the iPad simulator.
   - App opened successfully after a fresh uninstall/install cycle.

Additional checks:

- `bun --filter @shogo/mobile test` was run. Result: 708 pass, 1 skip, 5 existing unrelated UI failures. The failures are in `DrawerHost`, terminal tabs, and `OutputTab`; they are unrelated to the Sentry upgrade and launch-crash path.
- Cursor diagnostics for `apps/mobile/app/_layout.tsx` still report an existing `expo-router` `lazy` option type issue unrelated to this PR.

## Release Notes

After merge, cut a fresh iOS binary and submit that new build for App Review. Do not resubmit builds 239, 243, or 244 because they were built with the affected Sentry native SDK.

Made with [Cursor](https://cursor.com)