### PR TITLE
fix(deploy): make RUNTIME_IMAGE pin loud-fail on EU/India

### DIFF
--- a/.github/scripts/sync-api-env.sh
+++ b/.github/scripts/sync-api-env.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# .github/scripts/sync-api-env.sh
+#
+# Idempotently set a single env var on the `api` Knative Service in a
+# given namespace. The value is verified after patching; the step fails
+# loudly if the post-patch value does not match the expected value.
+#
+# Background — the 2026-05-27 502 incident:
+#
+# The previous inline implementation in deploy.yml looked like:
+#
+#   IDX=$(kubectl get ksvc api ... | python3 -c "..." 2>/dev/null) || IDX="-1"
+#   if [ -n "$IDX" ] && [ "$IDX" != "-1" ]; then
+#     CURRENT=$(kubectl get ksvc api ...)
+#     if [ "$CURRENT" != "$RUNTIME_IMAGE" ]; then
+#       kubectl patch ksvc api ...
+#     fi
+#   fi
+#
+# Two ways this silently passed under `bash -eo pipefail` (the GH Actions
+# default) while doing nothing useful:
+#
+#   (a) Any non-zero from kubectl or python3 was swallowed by the
+#       `2>/dev/null` + `|| IDX="-1"` pair, dropping straight into the
+#       no-op branch.
+#   (b) A successful `kubectl patch` with no post-patch verification meant
+#       even a webhook-rejected patch (or an entirely missing patch) was
+#       indistinguishable from success at the workflow level.
+#
+# The end result on EU and India during the v1.8.13 deploy was that
+# RUNTIME_IMAGE on the api ksvc kept the kustomize overlay placeholder
+# `:production-bootstrap`, the warm-pool controller minted pods with
+# that non-existent image, every warm pod went ImagePullBackOff, and
+# once the existing warm pool drained the cluster threw 502s for new
+# project requests.
+#
+# This script replaces that pattern with:
+#   * `set -euo pipefail` — non-zero from any command fails the step
+#   * jq for JSON parsing — no `2>/dev/null` muting of real errors
+#   * ADD if missing — instead of silently skipping when the env var
+#     was never declared on the ksvc spec
+#   * post-patch verify via a fresh `kubectl get` — fails the step if
+#     the value didn't actually land
+#   * a guardrail that rejects RUNTIME_IMAGE values containing
+#     "bootstrap" (the overlay placeholder), so we never re-enter the
+#     ImagePullBackOff state via a misconfigured runtime-tag step
+#
+# Usage:
+#   .github/scripts/sync-api-env.sh <namespace> <env-name> <expected-value>
+
+set -euo pipefail
+
+NS="${1:?namespace required}"
+NAME="${2:?env name required}"
+EXPECTED="${3?expected value required (pass empty string explicitly if intended)}"
+
+# Defense-in-depth against the 2026-05-27 footgun: every kustomize overlay
+# ships RUNTIME_IMAGE pointing at the placeholder `:<env>-bootstrap` tag,
+# which exists in no OCIR. If the runtime-tag step ever resolves back to
+# that placeholder (e.g. because of a misread configmap or a broken
+# variable interpolation), refuse to apply it rather than re-arm the bug.
+if [[ "$NAME" == "RUNTIME_IMAGE" && "$EXPECTED" == *bootstrap* ]]; then
+  echo "::error::sync-api-env: refusing to pin RUNTIME_IMAGE to placeholder value '$EXPECTED'"
+  exit 1
+fi
+
+echo "Syncing env $NAME on ksvc/api in namespace $NS"
+echo "  expected: $EXPECTED"
+
+get_idx() {
+  kubectl get ksvc api -n "$NS" -o json \
+    | jq -r --arg name "$NAME" '
+        (.spec.template.spec.containers[0].env // [])
+        | map(.name)
+        | index($name) // -1
+      '
+}
+
+get_current_value() {
+  kubectl get ksvc api -n "$NS" -o json \
+    | jq -r --arg name "$NAME" '
+        ((.spec.template.spec.containers[0].env // [])
+         | map(select(.name == $name))
+         | first
+        ).value // ""
+      '
+}
+
+apply_patch() {
+  local idx
+  idx=$(get_idx)
+  if [[ "$idx" == "-1" ]]; then
+    echo "  $NAME missing on ksvc/api — adding"
+    kubectl patch ksvc api -n "$NS" --type='json' -p="[
+      {\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/env/-\", \"value\": {\"name\": \"$NAME\", \"value\": \"$EXPECTED\"}}
+    ]"
+    return
+  fi
+
+  local current
+  current=$(get_current_value)
+  if [[ "$current" == "$EXPECTED" ]]; then
+    echo "  $NAME already correct — no patch"
+    return
+  fi
+  echo "  Updating $NAME: '$current' -> '$EXPECTED'"
+  kubectl patch ksvc api -n "$NS" --type='json' -p="[
+    {\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/env/${idx}/value\", \"value\": \"$EXPECTED\"}
+  ]"
+}
+
+apply_patch
+
+# Re-read the ksvc and assert the value actually landed. The Knative
+# admission webhook serializes spec mutations through etcd, so a brief
+# retry absorbs webhook settle latency without masking real failures.
+attempts=0
+while true; do
+  current=$(get_current_value)
+  if [[ "$current" == "$EXPECTED" ]]; then
+    echo "  ✓ verified: $NAME = $EXPECTED"
+    break
+  fi
+  attempts=$((attempts + 1))
+  if [[ "$attempts" -ge 5 ]]; then
+    echo "::error::sync-api-env: post-patch verify failed for $NAME on ksvc/api in $NS — got '$current', want '$EXPECTED'"
+    exit 1
+  fi
+  sleep 2
+done

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -874,31 +874,23 @@ jobs:
       - name: Sync API environment variables
         env:
           RUNTIME_IMAGE: ${{ steps.runtime-tag.outputs.image }}
+        # The previous inline implementation here used `python3 -c ...
+        # 2>/dev/null) || IDX="-1"` which silently swallowed every
+        # failure mode (kubectl flake, json parse error, missing env
+        # var) and continued the deploy with the kustomize overlay
+        # placeholder still in place. See `.github/scripts/sync-api-env.sh`
+        # for the full postmortem. The script `set -euo pipefail`s,
+        # ADDs missing env vars instead of skipping, and verifies the
+        # post-patch value via a fresh `kubectl get`.
         run: |
-          patch_env() {
-            local var_name="$1" expected="$2"
-            IDX=$(kubectl get ksvc api -n ${{ env.NS_SYSTEM }} -o json | \
-              python3 -c "import sys,json; envs=json.load(sys.stdin)['spec']['template']['spec']['containers'][0]['env']; print(next((i for i,e in enumerate(envs) if e['name']=='${var_name}'), -1))" 2>/dev/null) || IDX="-1"
-            if [ -z "$IDX" ] || [ "$IDX" = "-1" ]; then
-              echo "  $var_name not found in api ksvc env — skipping"
-              return
-            fi
-            CURRENT=$(kubectl get ksvc api -n ${{ env.NS_SYSTEM }} -o jsonpath="{.spec.template.spec.containers[0].env[${IDX}].value}")
-            if [ "$CURRENT" != "$expected" ]; then
-              echo "  Updating $var_name: $CURRENT -> $expected"
-              kubectl patch ksvc api -n ${{ env.NS_SYSTEM }} --type='json' -p="[
-                {\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/env/${IDX}/value\", \"value\": \"${expected}\"}
-              ]"
-            else
-              echo "  $var_name already correct"
-            fi
-          }
-          patch_env BETTER_AUTH_URL "https://${{ env.DOMAIN }}"
-          # Pin RUNTIME_IMAGE to the immutable SHA-tagged build resolved above.
-          # This is what the warm-pool controller uses for newly minted ksvc;
-          # see the staging incident postmortem (2026-05-04) for why we no
-          # longer use the mutable `:${env}-latest` tag here.
-          patch_env RUNTIME_IMAGE "$RUNTIME_IMAGE"
+          .github/scripts/sync-api-env.sh "${{ env.NS_SYSTEM }}" BETTER_AUTH_URL "https://${{ env.DOMAIN }}"
+          # RUNTIME_IMAGE is what the warm-pool controller bakes into newly
+          # minted agent ksvc. Pin it to the immutable :${env}-<sha> tag
+          # resolved by the runtime-tag step. The 2026-05-04 staging
+          # incident covered why the mutable `:${env}-latest` tag is
+          # unsafe here; the 2026-05-27 production incident covered why
+          # silent-skip-on-error is even worse.
+          .github/scripts/sync-api-env.sh "${{ env.NS_SYSTEM }}" RUNTIME_IMAGE "$RUNTIME_IMAGE"
 
       - name: Wait for rollout
         run: |
@@ -1241,17 +1233,20 @@ jobs:
           patch_ksvc api "${{ env.NS_SYSTEM }}" shogo-api "$API_CHANGED" "$PREV_API_IMAGE"
           patch_ksvc docs "${{ env.NS_SYSTEM }}" shogo-docs "$DOCS_CHANGED" "$PREV_DOCS_IMAGE"
 
-          # Pin RUNTIME_IMAGE on api ksvc to the immutable SHA tag
-          IDX=$(kubectl get ksvc api -n ${{ env.NS_SYSTEM }} -o json | \
-            python3 -c "import sys,json; envs=json.load(sys.stdin)['spec']['template']['spec']['containers'][0]['env']; print(next((i for i,e in enumerate(envs) if e['name']=='RUNTIME_IMAGE'), -1))" 2>/dev/null) || IDX="-1"
-          if [ -n "$IDX" ] && [ "$IDX" != "-1" ]; then
-            CURRENT=$(kubectl get ksvc api -n ${{ env.NS_SYSTEM }} -o jsonpath="{.spec.template.spec.containers[0].env[${IDX}].value}")
-            if [ "$CURRENT" != "$RUNTIME_IMAGE" ]; then
-              kubectl patch ksvc api -n ${{ env.NS_SYSTEM }} --type='json' -p="[
-                {\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/env/${IDX}/value\", \"value\": \"${RUNTIME_IMAGE}\"}
-              ]"
-            fi
-          fi
+      # The inline `python3 ... 2>/dev/null) || IDX="-1"` block that used
+      # to live at the bottom of `Deploy Knative services` silently
+      # skipped on every error path (the kubectl pipefail, the python
+      # parse, the patch itself), let the kustomize overlay placeholder
+      # `:production-bootstrap` survive the deploy on EU/India during
+      # v1.8.13, and triggered the 2026-05-27 502 incident once the
+      # warm-pool controller tried to mint pods with a non-existent
+      # image. The shared script `set -euo pipefail`s, ADDs missing env
+      # vars, and verifies the post-patch value via a fresh `kubectl get`.
+      - name: Sync API environment variables
+        env:
+          RUNTIME_IMAGE: ${{ steps.runtime-tag.outputs.image }}
+        run: |
+          .github/scripts/sync-api-env.sh "${{ env.NS_SYSTEM }}" RUNTIME_IMAGE "$RUNTIME_IMAGE"
 
       - name: Wait for rollout and health check
         run: |
@@ -1825,17 +1820,20 @@ jobs:
           patch_ksvc api "${{ env.NS_SYSTEM }}" shogo-api "$API_CHANGED" "$PREV_API_IMAGE"
           patch_ksvc docs "${{ env.NS_SYSTEM }}" shogo-docs "$DOCS_CHANGED" "$PREV_DOCS_IMAGE"
 
-          # Pin RUNTIME_IMAGE on api ksvc to the immutable SHA tag
-          IDX=$(kubectl get ksvc api -n ${{ env.NS_SYSTEM }} -o json | \
-            python3 -c "import sys,json; envs=json.load(sys.stdin)['spec']['template']['spec']['containers'][0]['env']; print(next((i for i,e in enumerate(envs) if e['name']=='RUNTIME_IMAGE'), -1))" 2>/dev/null) || IDX="-1"
-          if [ -n "$IDX" ] && [ "$IDX" != "-1" ]; then
-            CURRENT=$(kubectl get ksvc api -n ${{ env.NS_SYSTEM }} -o jsonpath="{.spec.template.spec.containers[0].env[${IDX}].value}")
-            if [ "$CURRENT" != "$RUNTIME_IMAGE" ]; then
-              kubectl patch ksvc api -n ${{ env.NS_SYSTEM }} --type='json' -p="[
-                {\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/env/${IDX}/value\", \"value\": \"${RUNTIME_IMAGE}\"}
-              ]"
-            fi
-          fi
+      # The inline `python3 ... 2>/dev/null) || IDX="-1"` block that used
+      # to live at the bottom of `Deploy Knative services` silently
+      # skipped on every error path (the kubectl pipefail, the python
+      # parse, the patch itself), let the kustomize overlay placeholder
+      # `:production-bootstrap` survive the deploy on EU/India during
+      # v1.8.13, and triggered the 2026-05-27 502 incident once the
+      # warm-pool controller tried to mint pods with a non-existent
+      # image. The shared script `set -euo pipefail`s, ADDs missing env
+      # vars, and verifies the post-patch value via a fresh `kubectl get`.
+      - name: Sync API environment variables
+        env:
+          RUNTIME_IMAGE: ${{ steps.runtime-tag.outputs.image }}
+        run: |
+          .github/scripts/sync-api-env.sh "${{ env.NS_SYSTEM }}" RUNTIME_IMAGE "$RUNTIME_IMAGE"
 
       - name: Wait for rollout and health check
         run: |
@@ -2254,17 +2252,20 @@ jobs:
           patch_ksvc api "${{ env.NS_SYSTEM }}" shogo-api "$API_CHANGED" "$PREV_API_IMAGE"
           patch_ksvc docs "${{ env.NS_SYSTEM }}" shogo-docs "$DOCS_CHANGED" "$PREV_DOCS_IMAGE"
 
-          # Pin RUNTIME_IMAGE on api ksvc to the immutable SHA tag
-          IDX=$(kubectl get ksvc api -n ${{ env.NS_SYSTEM }} -o json | \
-            python3 -c "import sys,json; envs=json.load(sys.stdin)['spec']['template']['spec']['containers'][0]['env']; print(next((i for i,e in enumerate(envs) if e['name']=='RUNTIME_IMAGE'), -1))" 2>/dev/null) || IDX="-1"
-          if [ -n "$IDX" ] && [ "$IDX" != "-1" ]; then
-            CURRENT=$(kubectl get ksvc api -n ${{ env.NS_SYSTEM }} -o jsonpath="{.spec.template.spec.containers[0].env[${IDX}].value}")
-            if [ "$CURRENT" != "$RUNTIME_IMAGE" ]; then
-              kubectl patch ksvc api -n ${{ env.NS_SYSTEM }} --type='json' -p="[
-                {\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/env/${IDX}/value\", \"value\": \"${RUNTIME_IMAGE}\"}
-              ]"
-            fi
-          fi
+      # The inline `python3 ... 2>/dev/null) || IDX="-1"` block that used
+      # to live at the bottom of `Deploy Knative services` silently
+      # skipped on every error path (the kubectl pipefail, the python
+      # parse, the patch itself), let the kustomize overlay placeholder
+      # `:production-bootstrap` survive the deploy on EU/India during
+      # v1.8.13, and triggered the 2026-05-27 502 incident once the
+      # warm-pool controller tried to mint pods with a non-existent
+      # image. The shared script `set -euo pipefail`s, ADDs missing env
+      # vars, and verifies the post-patch value via a fresh `kubectl get`.
+      - name: Sync API environment variables
+        env:
+          RUNTIME_IMAGE: ${{ steps.runtime-tag.outputs.image }}
+        run: |
+          .github/scripts/sync-api-env.sh "${{ env.NS_SYSTEM }}" RUNTIME_IMAGE "$RUNTIME_IMAGE"
 
       - name: Wait for rollout and health check
         run: |


### PR DESCRIPTION
## Summary

Root cause of the **2026-05-27 production 502 incident**: the inline `Pin RUNTIME_IMAGE` step at the end of every `Deploy Knative services` block in `.github/workflows/deploy.yml` used:

```bash
IDX=$(kubectl get ksvc api ... | python3 -c "..." 2>/dev/null) || IDX="-1"
if [ -n "$IDX" ] && [ "$IDX" != "-1" ]; then ...; fi
```

Under `bash -eo pipefail` (the GH Actions default), every error path silently dropped into the no-op branch:
- any non-zero from kubectl was eaten by `2>/dev/null` + `|| IDX="-1"`
- any python parse error did the same
- a successful `kubectl patch` with no post-patch verification meant a webhook-rejected patch was indistinguishable from success

During the v1.8.13 deploy this silently left `RUNTIME_IMAGE` on the EU/India `api` ksvc pinned to the kustomize overlay placeholder `:production-bootstrap`. The warm-pool controller minted agent ksvc pointing at that non-existent image, every warm pod went `ImagePullBackOff`, and once the existing warm pool drained the cluster threw 502s for new project requests.

## Changes

- **New shared script `.github/scripts/sync-api-env.sh`**:
  - `set -euo pipefail` and `jq` instead of `python3 ... 2>/dev/null`
  - **ADDs** missing env vars instead of silently skipping
  - **Verifies** the post-patch value via a fresh `kubectl get` and fails the step if the patch did not actually land (with a small retry to absorb webhook settle latency)
  - **Hard-rejects** any `RUNTIME_IMAGE` value containing `bootstrap`, so a misconfigured `runtime-tag` step can never re-arm the placeholder footgun
- **`.github/workflows/deploy.yml`**: replace the inline patch in all four blocks (staging, production-us, production-eu, production-india) with a uniform `Sync API environment variables` step that calls the shared script. Staging continues to also sync `BETTER_AUTH_URL` through the same path.

## Why this matters

Regressions like the 2026-05-27 incident now **fail the deploy workflow** instead of completing green while leaving the cluster broken. A deploy that cannot pin `RUNTIME_IMAGE` to a real image is a deploy that should fail, not one that should ship with the warm pool already broken.

## Test plan

- [x] Shellcheck passes on `.github/scripts/sync-api-env.sh`
- [x] `python3 -c yaml.safe_load` parses the modified `deploy.yml`
- [x] `actionlint` reports no new issues in the changed regions
- [x] Smoke-tested arg validation (missing namespace -> error, missing name -> error)
- [x] Smoke-tested placeholder rejection: `sync-api-env.sh foo RUNTIME_IMAGE 'us-ashburn-1.ocir.io/x/shogo-runtime:production-bootstrap'` exits 1 with the expected `::error::` line
- [x] Verified jq queries return correct values against the **real production-eu `api` ksvc** (`index = 6`, current value matches the SHA-tagged image manually pinned during the incident)
- [x] Verified jq returns `-1` for a missing env name (so the ADD branch fires correctly when an overlay never declared the var)
- [ ] Watch the staging deploy turn green on this branch
- [ ] After staging: tag, watch the production deploy, and confirm the new step actually runs (look for `✓ verified: RUNTIME_IMAGE = ...` in each region's logs)