### PR TITLE
feat(deploy): warm-pool health gate, revision GC, continuous monitor

### DIFF
--- a/.github/scripts/check-warm-pool-health.sh
+++ b/.github/scripts/check-warm-pool-health.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# .github/scripts/check-warm-pool-health.sh
+#
+# Deploy-time gate that catches the 2026-05-27 incident class: api ksvc
+# rolled out cleanly but the warm-pool controller can't actually mint
+# healthy pods because RUNTIME_IMAGE points at a non-existent tag.
+#
+# Without this gate, the deploy completed green, the warm pool kept
+# serving from the previous revision's pods (still warm in the OS layer),
+# and 502s only started flowing into user traffic ~24 hours later when
+# those pods scaled to zero or expired the warm-pool TTL.
+#
+# This script samples warm-pool state in the workspaces namespace AFTER
+# the api ksvc is Ready (the warm-pool controller runs inside the api
+# pod), and fails the deploy if:
+#
+#   * any warm-pool pod is in ImagePullBackOff / ErrImagePull /
+#     CrashLoopBackOff (the canonical "image is broken" / "container
+#     crashes on boot" failure modes for warm-pool minting)
+#   * warm-pool ksvcs exist but 0 are Ready (controller is alive but
+#     every pod is broken — same incident shape, slightly later state)
+#
+# Zero warm-pool ksvcs is treated as a warning, not an error: a fresh
+# bootstrap or a deploy immediately after a `kubectl delete ksvc -l
+# shogo.io/warm-pool=true` (incident remediation) will land here briefly.
+#
+# Usage:
+#   .github/scripts/check-warm-pool-health.sh <api-ns> <workspaces-ns> [wait-seconds]
+
+set -euo pipefail
+
+API_NS="${1:?api namespace required}"
+WP_NS="${2:?workspaces namespace required}"
+WAIT_BEFORE_CHECK="${3:-90}"
+
+# A second-line guard against the same regression PR #697 fixed in
+# sync-api-env.sh: refuse to ship if any api ksvc env value still
+# contains the kustomize overlay placeholder. Cheap (~1 kubectl get)
+# and catches a regression class even if a future change to the sync
+# step accidentally re-introduces silent-skip semantics.
+echo "Auditing api ksvc env values in $API_NS for placeholder leaks..."
+bad_envs=$(kubectl get ksvc api -n "$API_NS" -o json | jq -r '
+  .spec.template.spec.containers[0].env // []
+  | map(select((.value? // "") | type == "string" and contains("bootstrap")))
+  | map("\(.name)=\(.value)")
+  | join("; ")
+')
+if [[ -n "$bad_envs" ]]; then
+  echo "::error::check-warm-pool-health: api ksvc has placeholder env value(s): $bad_envs"
+  exit 1
+fi
+
+# The warm-pool controller's reconcile interval is 30s by default. A pod
+# that fails to pull its image is classified as ImagePullBackOff by the
+# kubelet within ~10s of creation. Wait long enough for at least one
+# reconcile cycle plus image-pull headroom on a cold node, otherwise we
+# risk a false-pass on a controller that simply hasn't started filling
+# the pool yet.
+echo "Sleeping ${WAIT_BEFORE_CHECK}s to let warm-pool controller reconcile..."
+sleep "$WAIT_BEFORE_CHECK"
+
+echo "Checking warm-pool health in $WP_NS"
+
+ksvc_json=$(kubectl get ksvc -n "$WP_NS" -l "shogo.io/warm-pool=true" -o json)
+total_count=$(echo "$ksvc_json" | jq '.items | length')
+ready_count=$(echo "$ksvc_json" | jq '
+  [.items[]
+    | select(.status.conditions[]? | select(.type == "Ready" and .status == "True"))
+  ] | length
+')
+echo "  warm-pool ksvcs: $ready_count Ready / $total_count total"
+
+# Knative does not propagate the `shogo.io/warm-pool=true` label down to
+# pods, but it does propagate `serving.knative.dev/service`. So we list
+# all pods in the workspaces ns and filter by that label prefix.
+broken=$(kubectl get pods -n "$WP_NS" -o json | jq -r '
+  .items[]
+  | select(.metadata.labels["serving.knative.dev/service"] // "" | startswith("warm-pool-"))
+  | (
+      ((.status.containerStatuses // []) + (.status.initContainerStatuses // []))
+      | map(.state.waiting.reason? // "")
+      | map(select(. == "ImagePullBackOff" or . == "ErrImagePull" or . == "CrashLoopBackOff"))
+    ) as $bad
+  | select(($bad | length) > 0)
+  | "\(.metadata.name) [\($bad | join(","))]"
+')
+if [[ -n "$broken" ]]; then
+  echo "::error::check-warm-pool-health: warm-pool pod(s) in BackOff state:"
+  echo "$broken" | awk '{print "  " $0}'
+  echo "::group::warm-pool pods (most recent 30)"
+  kubectl get pods -n "$WP_NS" -o wide --sort-by=.metadata.creationTimestamp 2>&1 | tail -30 || true
+  echo "::endgroup::"
+  exit 1
+fi
+
+if [[ "$total_count" -eq 0 ]]; then
+  echo "::warning::no warm-pool ksvcs exist yet — controller may still be reconciling, or pool was just wiped"
+  exit 0
+fi
+
+if [[ "$ready_count" -lt 1 ]]; then
+  echo "::error::check-warm-pool-health: $total_count warm-pool ksvcs exist but 0 are Ready"
+  echo "::group::warm-pool ksvcs"
+  kubectl get ksvc -n "$WP_NS" -l "shogo.io/warm-pool=true" 2>&1 || true
+  echo "::endgroup::"
+  exit 1
+fi
+
+echo "✓ warm pool healthy ($ready_count/$total_count ksvcs Ready, no broken pods)"

--- a/.github/scripts/gc-old-api-revisions.sh
+++ b/.github/scripts/gc-old-api-revisions.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# .github/scripts/gc-old-api-revisions.sh
+#
+# Knative keeps obsolete revisions around indefinitely under
+# config-gc's default retention policy. With `min-scale: 2` on the api
+# ksvc, those obsolete revisions also keep pods alive — and each api pod
+# runs an independent warm-pool controller. The result is a multi-
+# reconciler race where every revision's controller deletes warm-pool
+# pods created by the others. This was the US half of the 2026-05-27
+# 502 incident: api-00202 (production-bootstrap config) was still
+# running pods alongside api-00205 (correct config), each tearing down
+# the other's warm-pool work, churning the pool until it ran dry.
+#
+# At the end of every successful deploy, prune all api revisions except
+# the latestReadyRevisionName (currently serving traffic) and the
+# latestCreatedRevisionName (in case a roll is mid-flight). Knative's
+# revision controller GCs the underlying Deployment + ReplicaSet + pods
+# when the Revision object is deleted.
+#
+# This script is intentionally idempotent and safe to re-run: if there
+# are no old revisions, it's a no-op.
+#
+# Usage:
+#   .github/scripts/gc-old-api-revisions.sh <namespace>
+
+set -euo pipefail
+
+NS="${1:?namespace required}"
+
+LATEST_READY=$(kubectl get ksvc api -n "$NS" -o jsonpath='{.status.latestReadyRevisionName}')
+LATEST_CREATED=$(kubectl get ksvc api -n "$NS" -o jsonpath='{.status.latestCreatedRevisionName}')
+
+# Refuse to GC if the ksvc has no Ready revision yet — that shape means
+# the deploy is broken (Wait for rollout should have caught it). Better
+# to leave the cluster alone than to delete the only pods serving
+# traffic.
+if [[ -z "$LATEST_READY" ]]; then
+  echo "::error::gc-old-api-revisions: api ksvc in $NS has no latestReadyRevisionName — refusing to GC"
+  exit 1
+fi
+
+if [[ -n "$LATEST_CREATED" && "$LATEST_CREATED" != "$LATEST_READY" ]]; then
+  echo "Keeping api revisions: $LATEST_READY (Ready), $LATEST_CREATED (latestCreated)"
+else
+  echo "Keeping api revision: $LATEST_READY (Ready)"
+fi
+
+deleted=0
+while read -r rev; do
+  [[ -z "$rev" ]] && continue
+  if [[ "$rev" == "$LATEST_READY" || "$rev" == "$LATEST_CREATED" ]]; then
+    continue
+  fi
+  echo "  deleting obsolete revision $rev"
+  kubectl delete revision -n "$NS" "$rev" --wait=false
+  deleted=$((deleted + 1))
+done < <(kubectl get revision -n "$NS" -l "serving.knative.dev/service=api" \
+          -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+
+echo "✓ api revision GC complete in $NS ($deleted obsolete revision(s) deleted)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -842,6 +842,18 @@ jobs:
               k8s/base/image-prepuller.yaml | kubectl apply -f -
           kubectl get daemonset image-prepuller -n ${{ env.NS_SYSTEM }}
 
+      # See the matching production step for context — a 5-minute
+      # CronJob that catches the 2026-05-27 incident classes (placeholder
+      # env leak, BackOff warm-pool pod, zero-Ready ksvcs) and fails the
+      # K8s job to fire the existing alerting hook. Same monitor, same
+      # base manifest, sed-substituted to the staging namespaces.
+      - name: Deploy warm-pool monitor
+        run: |
+          sed -e "s|namespace: shogo-staging-system|namespace: ${{ env.NS_SYSTEM }}|g" \
+              -e "s|value: shogo-staging-system|value: ${{ env.NS_SYSTEM }}|g" \
+              -e "s|value: shogo-staging-workspaces|value: ${{ env.NS_WORKSPACES }}|g" \
+              k8s/base/warm-pool-monitor.yaml | kubectl apply -f -
+
       - name: Deploy Knative services
         env:
           OCIR_REGISTRY: ${{ needs.resolve-config.outputs.ocir_registry }}
@@ -941,6 +953,25 @@ jobs:
           for s in studio api docs; do
             wait_ksvc_ready "$s" "${{ env.NS_SYSTEM }}" 600
           done
+
+      # Deploy-time gate against the 2026-05-27 incident class. After api
+      # ksvc is Ready, give the warm-pool controller time to reconcile,
+      # then verify it actually mints healthy pods. This is the second
+      # line of defense after sync-api-env.sh — it catches a deploy that
+      # somehow shipped a broken RUNTIME_IMAGE config without going
+      # through the placeholder-rejection guardrail.
+      - name: Check warm-pool health
+        run: |
+          .github/scripts/check-warm-pool-health.sh "${{ env.NS_SYSTEM }}" "${{ env.NS_WORKSPACES }}"
+
+      # Prevent the multi-reconciler race that amplified the 2026-05-27
+      # US incident: an obsolete api-* revision kept pods alive (min-scale=2)
+      # and its warm-pool controller fought the new revision's controller,
+      # each tearing down the other's warm pods. GC obsolete revisions so
+      # only the latest controller is reconciling.
+      - name: Garbage-collect old api revisions
+        run: |
+          .github/scripts/gc-old-api-revisions.sh "${{ env.NS_SYSTEM }}"
 
       - name: Restart image prepuller
         if: needs.detect-changes.outputs.runtime_changed == 'true'
@@ -1214,6 +1245,18 @@ jobs:
               -e "s|namespace: shogo-staging-system|namespace: ${{ env.NS_SYSTEM }}|g" \
               k8s/base/image-prepuller.yaml | kubectl apply -f -
 
+      # Continuous warm-pool health monitor: a 5-minute CronJob that fails
+      # the K8s job (and pages via the existing kube_job_status_failed
+      # alert) on any of the 2026-05-27 incident classes — placeholder env
+      # leak on api ksvc, ImagePullBackOff/CrashLoopBackOff on a warm-pool
+      # pod, or zero-Ready warm-pool ksvcs. See k8s/base/warm-pool-monitor.yaml.
+      - name: Deploy warm-pool monitor
+        run: |
+          sed -e "s|namespace: shogo-staging-system|namespace: ${{ env.NS_SYSTEM }}|g" \
+              -e "s|value: shogo-staging-system|value: ${{ env.NS_SYSTEM }}|g" \
+              -e "s|value: shogo-staging-workspaces|value: ${{ env.NS_WORKSPACES }}|g" \
+              k8s/base/warm-pool-monitor.yaml | kubectl apply -f -
+
       - name: Deploy Knative services
         env:
           OCIR_REGISTRY: ${{ needs.resolve-config.outputs.ocir_registry }}
@@ -1307,6 +1350,18 @@ jobs:
             echo "::error::US API health check did not return 200 after 20 attempts"
             exit 1
           fi
+
+      # See the staging block for context on these two gates. Tier 1 of
+      # the 2026-05-27 prevention: warm-pool sanity. Tier 4: prune
+      # obsolete api revisions to kill the multi-reconciler race that
+      # amplified the US half of the incident.
+      - name: Check warm-pool health
+        run: |
+          .github/scripts/check-warm-pool-health.sh "${{ env.NS_SYSTEM }}" "${{ env.NS_WORKSPACES }}"
+
+      - name: Garbage-collect old api revisions
+        run: |
+          .github/scripts/gc-old-api-revisions.sh "${{ env.NS_SYSTEM }}"
 
       # ----------------------------------------------------------------------
       # Logical replication: keep the cross-region publication in sync.
@@ -1798,6 +1853,18 @@ jobs:
               -e "s|namespace: shogo-staging-system|namespace: ${{ env.NS_SYSTEM }}|g" \
               k8s/base/image-prepuller.yaml | kubectl apply -f -
 
+      # Continuous warm-pool health monitor: a 5-minute CronJob that fails
+      # the K8s job (and pages via the existing kube_job_status_failed
+      # alert) on any of the 2026-05-27 incident classes — placeholder env
+      # leak on api ksvc, ImagePullBackOff/CrashLoopBackOff on a warm-pool
+      # pod, or zero-Ready warm-pool ksvcs. See k8s/base/warm-pool-monitor.yaml.
+      - name: Deploy warm-pool monitor
+        run: |
+          sed -e "s|namespace: shogo-staging-system|namespace: ${{ env.NS_SYSTEM }}|g" \
+              -e "s|value: shogo-staging-system|value: ${{ env.NS_SYSTEM }}|g" \
+              -e "s|value: shogo-staging-workspaces|value: ${{ env.NS_WORKSPACES }}|g" \
+              k8s/base/warm-pool-monitor.yaml | kubectl apply -f -
+
       - name: Deploy Knative services
         env:
           OCIR_REGISTRY: ${{ vars.OCI_REGION }}.ocir.io/${{ vars.OCI_TENANCY_NAMESPACE }}
@@ -1882,6 +1949,18 @@ jobs:
             echo "::error::EU /api/health returned HTTP $STATUS (expected 200) via Kourier ${KOURIER_IP}"
             exit 1
           fi
+
+      # See the staging block for context on these two gates. Tier 1 of
+      # the 2026-05-27 prevention: warm-pool sanity. Tier 4: prune
+      # obsolete api revisions to kill the multi-reconciler race that
+      # amplified the US half of the incident.
+      - name: Check warm-pool health
+        run: |
+          .github/scripts/check-warm-pool-health.sh "${{ env.NS_SYSTEM }}" "${{ env.NS_WORKSPACES }}"
+
+      - name: Garbage-collect old api revisions
+        run: |
+          .github/scripts/gc-old-api-revisions.sh "${{ env.NS_SYSTEM }}"
 
       - name: Summary
         run: |
@@ -2227,6 +2306,18 @@ jobs:
               -e "s|namespace: shogo-staging-system|namespace: ${{ env.NS_SYSTEM }}|g" \
               k8s/base/image-prepuller.yaml | kubectl apply -f -
 
+      # Continuous warm-pool health monitor: a 5-minute CronJob that fails
+      # the K8s job (and pages via the existing kube_job_status_failed
+      # alert) on any of the 2026-05-27 incident classes — placeholder env
+      # leak on api ksvc, ImagePullBackOff/CrashLoopBackOff on a warm-pool
+      # pod, or zero-Ready warm-pool ksvcs. See k8s/base/warm-pool-monitor.yaml.
+      - name: Deploy warm-pool monitor
+        run: |
+          sed -e "s|namespace: shogo-staging-system|namespace: ${{ env.NS_SYSTEM }}|g" \
+              -e "s|value: shogo-staging-system|value: ${{ env.NS_SYSTEM }}|g" \
+              -e "s|value: shogo-staging-workspaces|value: ${{ env.NS_WORKSPACES }}|g" \
+              k8s/base/warm-pool-monitor.yaml | kubectl apply -f -
+
       - name: Deploy Knative services
         env:
           OCIR_REGISTRY: ${{ vars.OCI_REGION }}.ocir.io/${{ vars.OCI_TENANCY_NAMESPACE }}
@@ -2317,6 +2408,18 @@ jobs:
             echo "::error::India /api/health returned HTTP $STATUS (expected 200) via Kourier ${KOURIER_IP}"
             exit 1
           fi
+
+      # See the staging block for context on these two gates. Tier 1 of
+      # the 2026-05-27 prevention: warm-pool sanity. Tier 4: prune
+      # obsolete api revisions to kill the multi-reconciler race that
+      # amplified the US half of the incident.
+      - name: Check warm-pool health
+        run: |
+          .github/scripts/check-warm-pool-health.sh "${{ env.NS_SYSTEM }}" "${{ env.NS_WORKSPACES }}"
+
+      - name: Garbage-collect old api revisions
+        run: |
+          .github/scripts/gc-old-api-revisions.sh "${{ env.NS_SYSTEM }}"
 
       - name: Summary
         run: |

--- a/k8s/base/warm-pool-monitor.yaml
+++ b/k8s/base/warm-pool-monitor.yaml
@@ -1,0 +1,173 @@
+# =============================================================================
+# Warm-Pool Monitor CronJob
+# =============================================================================
+# Continuous health check for the agent-runtime warm pool, paired with the
+# deploy-time gate in `.github/scripts/check-warm-pool-health.sh`.
+#
+# The deploy-time gate catches "your new deploy broke the warm pool".
+# This CronJob catches "the warm pool broke at runtime" — image deleted
+# from OCIR, controller crashlooping, RUNTIME_IMAGE quietly mutated by a
+# stray kubectl, etc. — and pages within ~5 minutes via the existing
+# `kube_state_metrics` -> `kube_job_status_failed` alerting hook.
+#
+# Failure conditions (any => exit 1, K8s job fails, page fires):
+#   * api ksvc has any env value containing "bootstrap"
+#       — kustomize overlay placeholder leaked through, deploy regression.
+#         This was the entire 2026-05-27 incident root cause.
+#   * any warm-pool pod is in ImagePullBackOff / ErrImagePull /
+#     CrashLoopBackOff at sample time
+#       — same incident class, runtime variant.
+#   * warm-pool ksvcs exist but 0 are Ready
+#       — controller alive but every pod broken.
+#
+# Modeled after k8s/cnpg/logical-replication/replication-monitor.yaml
+# (deliberately the same structure/operator-experience).
+#
+# Deployed once per region by the matching `Deploy Warm-Pool Monitor`
+# step in .github/workflows/deploy.yml, which sed-substitutes the
+# `shogo-staging-system` / `shogo-staging-workspaces` placeholders to
+# the real per-region namespaces.
+# =============================================================================
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: warm-pool-monitor
+  namespace: shogo-staging-system
+  labels:
+    app.kubernetes.io/part-of: shogo
+    app.kubernetes.io/component: warm-pool-monitor
+---
+# Read-only across the system + workspaces namespaces. We use a
+# ClusterRole because the monitor reads from two namespaces (api ksvc
+# in -system, warm-pool ksvc + pods in -workspaces) and a single
+# ClusterRoleBinding is simpler than two namespaced bindings.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: shogo-warm-pool-monitor
+  labels:
+    app.kubernetes.io/part-of: shogo
+    app.kubernetes.io/component: warm-pool-monitor
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: ["serving.knative.dev"]
+    resources: ["services", "revisions"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: shogo-warm-pool-monitor
+subjects:
+  - kind: ServiceAccount
+    name: warm-pool-monitor
+    namespace: shogo-staging-system
+roleRef:
+  kind: ClusterRole
+  name: shogo-warm-pool-monitor
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: warm-pool-monitor
+  namespace: shogo-staging-system
+  labels:
+    app.kubernetes.io/part-of: shogo
+    app.kubernetes.io/component: warm-pool-monitor
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 120
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: warm-pool-monitor
+          containers:
+            - name: monitor
+              # alpine/k8s ships kubectl + jq + a posix shell in a small
+              # multi-arch image. Pinned to a specific patch so a
+              # registry-side mutation can't change behavior under us.
+              image: alpine/k8s:1.31.5
+              env:
+                - name: API_NS
+                  value: shogo-staging-system
+                - name: WP_NS
+                  value: shogo-staging-workspaces
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  echo "=== Warm-Pool Monitor — $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+                  EXIT_RC=0
+
+                  # 1) Bootstrap placeholder leak on api ksvc.
+                  # Mirrors the guardrail in
+                  # `.github/scripts/sync-api-env.sh`: a 'bootstrap'
+                  # substring on any api env value indicates the
+                  # kustomize overlay placeholder survived past the
+                  # Sync API environment variables step. RUNTIME_IMAGE
+                  # is the obvious case; we check every env value for
+                  # cheap defense-in-depth.
+                  echo "--- api ksvc env audit ---"
+                  BAD_ENVS=$(kubectl get ksvc api -n "$API_NS" -o json | jq -r '
+                    .spec.template.spec.containers[0].env // []
+                    | map(select((.value? // "") | type == "string" and contains("bootstrap")))
+                    | map("\(.name)=\(.value)")
+                    | join("; ")
+                  ')
+                  if [ -n "$BAD_ENVS" ]; then
+                    echo "CRITICAL: api ksvc has placeholder env value(s): $BAD_ENVS"
+                    EXIT_RC=1
+                  fi
+
+                  # 2) Warm-pool pods stuck on image pull or crashlooping.
+                  echo "--- warm-pool pod health ---"
+                  BROKEN=$(kubectl get pods -n "$WP_NS" -o json | jq -r '
+                    [.items[]
+                      | select(.metadata.labels["serving.knative.dev/service"] // "" | startswith("warm-pool-"))
+                      | (
+                          ((.status.containerStatuses // []) + (.status.initContainerStatuses // []))
+                          | map(.state.waiting.reason? // "")
+                          | map(select(. == "ImagePullBackOff" or . == "ErrImagePull" or . == "CrashLoopBackOff"))
+                        ) as $bad
+                      | select(($bad | length) > 0)
+                      | "\(.metadata.name) [\($bad | join(\",\"))]"
+                    ] | join("; ")
+                  ')
+                  if [ -n "$BROKEN" ]; then
+                    echo "CRITICAL: warm-pool pods stuck: $BROKEN"
+                    EXIT_RC=1
+                  fi
+
+                  # 3) Warm-pool readiness.
+                  # Zero ksvcs is OK (post-incident wipe, fresh
+                  # bootstrap); zero ready out of N existing is not.
+                  echo "--- warm-pool ksvc readiness ---"
+                  KSVC_JSON=$(kubectl get ksvc -n "$WP_NS" -l "shogo.io/warm-pool=true" -o json)
+                  TOTAL=$(echo "$KSVC_JSON" | jq '.items | length')
+                  READY=$(echo "$KSVC_JSON" | jq '
+                    [.items[] | select(.status.conditions[]? | select(.type == "Ready" and .status == "True"))] | length
+                  ')
+                  echo "  total=$TOTAL  ready=$READY"
+                  if [ "$TOTAL" -gt 0 ] && [ "$READY" -eq 0 ]; then
+                    echo "CRITICAL: $TOTAL warm-pool ksvcs but 0 are Ready"
+                    EXIT_RC=1
+                  fi
+
+                  echo "=== Monitor complete (exit=$EXIT_RC) ==="
+                  exit "$EXIT_RC"
+              resources:
+                requests:
+                  memory: "64Mi"
+                  cpu: "50m"
+                limits:
+                  memory: "128Mi"
+                  cpu: "100m"


### PR DESCRIPTION
## Summary

Three layered controls to prevent the 2026-05-27 502 incident class from reaching user traffic again. PR #697 closed the silent-skip bug in `Sync API environment variables`; **this PR adds the defense-in-depth controls that would have caught the same incident even with #697's bug still in place.**

### Tier 1 — deploy-time warm-pool gate (`.github/scripts/check-warm-pool-health.sh`)

After api ksvc rolls out, give the warm-pool controller one reconcile cycle, then verify it's actually minting healthy pods. Fails the deploy job if:

- any api ksvc env value contains the kustomize overlay placeholder `bootstrap` (second-line guard against a `sync-api-env.sh` regression)
- any warm-pool pod is in `ImagePullBackOff` / `ErrImagePull` / `CrashLoopBackOff`
- warm-pool ksvcs exist but 0 are Ready

This gate alone would have **failed the v1.8.13 EU/India deploys in real time** instead of silently leaving them in the broken state that the warm pool drained into ~24 hours later.

### Tier 3 — continuous warm-pool monitor (`k8s/base/warm-pool-monitor.yaml`)

A CronJob that runs every 5 minutes per region and fails the K8s job (which fires the existing `kube_job_status_failed` alert) on any of the same three conditions as the deploy-time gate. Modeled exactly on the existing `replication-monitor`: same RBAC pattern, same exit-non-zero-on-failure semantics, same `alpine/k8s` container.

Catches in-flight regressions that the deploy-time gate can't see — image deleted from OCIR, `RUNTIME_IMAGE` quietly mutated by a stray kubectl, controller crashlooping, etc.

### Tier 4 — multi-reconciler race prevention (`.github/scripts/gc-old-api-revisions.sh`)

At the end of every successful deploy, prune all api revisions except the latest Ready and the latest Created. With `min-scale: 2` on the api ksvc, obsolete revisions keep their pods alive — and each api pod runs an independent warm-pool controller. The result was a **multi-reconciler race** where every revision's controller deleted warm pods created by the others. This was the US half of the 2026-05-27 incident: `api-00202` (production-bootstrap config) raced `api-00205` (correct config), churning the pool until it ran dry.

## deploy.yml integration

All four blocks (staging + production-us/eu/india) get three new steps:

- **Deploy warm-pool monitor** — sed-substitutes the base manifest's namespace placeholders and applies. Idempotent.
- **Check warm-pool health** — runs after `Wait for rollout`, gates the deploy.
- **Garbage-collect old api revisions** — runs after the warm-pool gate, only on successful rollout.

## Verification

- [x] `shellcheck` clean on both new scripts
- [x] YAML + `actionlint` clean on the modified workflow (no new issues in changed regions)
- [x] Both scripts smoke-tested against real `production-us/eu/india` clusters — env audit passes, warm-pool reports 8/8 / 5/5 / 5/5 ksvcs Ready, GC correctly identifies a no-op state on a single-revision ksvc
- [x] sed substitutions on `warm-pool-monitor.yaml` render 4 valid K8s resources (SA, ClusterRole, ClusterRoleBinding, CronJob) with correct namespace targeting
- [x] Server-side `kubectl apply --dry-run=server` accepts the rendered manifest on the live EU cluster
- [ ] Watch the staging deploy turn green on this branch
- [ ] After staging: tag, watch the production deploy, confirm three new steps run per region and the warm-pool monitor CronJob is created
- [ ] After 5+ min on production: confirm the first warm-pool monitor run completes successfully (and that it would page on regression — verifiable by `kubectl get jobs -n shogo-production-system -l app.kubernetes.io/component=warm-pool-monitor`)

## Out of scope (potential follow-up PRs)

- **Tier 2** — drop the `RUNTIME_IMAGE` placeholder from the kustomize overlays entirely (and have `sync-api-env.sh` `add` the env on first deploy). Higher leverage but more surgery; deserves its own PR.
- **Tier 5** — postmortem doc under `docs/postmortems/2026-05-27-warm-pool-runtime-image.md`. Pure documentation, no code change.

Stack note: independent of #697 — branched off main, no file overlap, both PRs land cleanly.