### PR TITLE
ci(desktop-macos): assert out/Shogo.app exists after electron-forge package

### DIFF
--- a/.github/workflows/desktop-release-macos.yml
+++ b/.github/workflows/desktop-release-macos.yml
@@ -364,6 +364,34 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SKIP_MOBILE_BUILD: '1'
 
+      - name: Verify packager produced Shogo.app
+        # electron-forge has been observed to exit 0 from
+        # `package --arch=arm64` while silently producing no `out/`
+        # directory (see v1.8.15 macOS arm64 leg — the packager
+        # printed "Copying files / Preparing native dependencies /
+        # Finalizing package" within ~30 ms and returned without
+        # writing anything). When that happens the next step
+        # (Codesign) is where the failure surfaces, with a confusing
+        # `find: out: No such file or directory` and no pointer to
+        # the actual culprit. This assertion fails IN this step so
+        # the bad job is identified as a packager problem and a
+        # `gh run rerun --failed` actually re-runs the right step.
+        working-directory: apps/desktop
+        run: |
+          set -euo pipefail
+          EXPECTED="out/Shogo-darwin-${{ matrix.arch }}/Shogo.app"
+          if [ ! -d "$EXPECTED" ]; then
+            echo "::error::electron-forge package exited 0 but $EXPECTED does not exist."
+            echo "out/ contents:"
+            ls -la out/ 2>&1 || echo "  (out/ does not exist)"
+            if [ -d out ]; then
+              echo "out/* contents (one level deeper):"
+              ls -la out/*/ 2>&1 || true
+            fi
+            exit 1
+          fi
+          echo "Packager produced: $EXPECTED"
+
       - name: Codesign app bundle
         if: env.SIGNING_KEYCHAIN != ''
         working-directory: apps/desktop


### PR DESCRIPTION
## Summary

In the v1.8.15 macOS arm64 desktop release leg ([run 26549478173](https://github.com/shogo-labs/shogo-ai/actions/runs/26549478173)), \`npx electron-forge package --arch=arm64\` exited 0 within ~30 ms after printing its \"Copying files / Preparing native dependencies / Finalizing package\" progress lines, but produced no \`out/\` directory. The failure surfaced one step later in **Codesign app bundle** as \`find: out: No such file or directory\` with no pointer to the actual culprit, and \`gh run rerun --failed\` therefore re-runs Codesign instead of the packager.

This adds a small assertion step immediately after the packager:

- Fails IN the right step (\`::error::\` annotation, plus \`ls -la out/\` + \`out/*/\` for diagnosis).
- Lets \`gh run rerun --failed\` rerun the actual packager.
- Decouples Codesign from \"does out/ exist\" sanity checking.

Drive-by: the existing \"Codesign app bundle\" step already has its own \`if [ -z \"\$APP_PATH\" ]\` guard; leaving it intact because it's still a useful defense-in-depth and adds zero runtime cost.

## Test plan

- [ ] CI green on this branch (both macOS arch legs hit the new assertion successfully).
- [ ] Next macOS desktop release (v1.8.16+): if a packager flake recurs, the failed step is \"Verify packager produced Shogo.app\", not \"Codesign app bundle\".

Made with [Cursor](https://cursor.com)