### PR TITLE
ci(desktop-release): bundle pty-host alongside main (fixes packaging gap from #704)

### DIFF
--- a/.github/workflows/desktop-release-macos.yml
+++ b/.github/workflows/desktop-release-macos.yml
@@ -267,7 +267,15 @@ jobs:
         # get inlined; tsc on its own can't resolve them because
         # apps/desktop is npm-installed, not a bun workspace member.
         # See apps/desktop/scripts/bundle-main.mjs for details.
-        run: npx tsc && npm run bundle:main
+        #
+        # `bundle:pty-host` is the matching step for the PTY utility
+        # process. pty-host-client.ts forks `dist/pty-host.js` at the
+        # flat dist root (not dist/pty-host/pty-host.js where tsc would
+        # put it), AND inlines `@shogo/pty-core` which tsc cannot
+        # resolve. Without this step, the packaged desktop terminal
+        # fails at runtime with MODULE_NOT_FOUND on first spawn.
+        # See apps/desktop/scripts/bundle-pty-host.mjs for details.
+        run: npx tsc && npm run bundle:main && npm run bundle:pty-host
         env:
           # Baked into dist/main.js via `--define` in bundle-main.mjs
           # so the packaged app reports main-process crashes without

--- a/.github/workflows/desktop-release-windows.yml
+++ b/.github/workflows/desktop-release-windows.yml
@@ -238,7 +238,15 @@ jobs:
         # get inlined; tsc on its own can't resolve them because
         # apps/desktop is npm-installed, not a bun workspace member.
         # See apps/desktop/scripts/bundle-main.mjs for details.
-        run: npx tsc && npm run bundle:main
+        #
+        # `bundle:pty-host` is the matching step for the PTY utility
+        # process. pty-host-client.ts forks `dist/pty-host.js` at the
+        # flat dist root (not dist/pty-host/pty-host.js where tsc would
+        # put it), AND inlines `@shogo/pty-core` which tsc cannot
+        # resolve. Without this step, the packaged desktop terminal
+        # fails at runtime with MODULE_NOT_FOUND on first spawn.
+        # See apps/desktop/scripts/bundle-pty-host.mjs for details.
+        run: npx tsc && npm run bundle:main && npm run bundle:pty-host
         env:
           # Baked into dist/main.js via `--define` in bundle-main.mjs
           # so the packaged app reports main-process crashes without


### PR DESCRIPTION
# ci(desktop-release): bundle pty-host alongside main

Adds the missing `npm run bundle:pty-host` step to the **macOS** and **Windows** desktop release workflows. Without it, packaged release builds ship without `dist/pty-host.js` and the desktop terminal fails at first session spawn with `MODULE_NOT_FOUND`.

> ⚠️ This is a release-blocker for any CI-built artifact that includes the PTY host work from #704. Local builds are unaffected.

---

## 1. The bug

`pty-host-client.ts` forks a flat-path entry in the packaged app:

```ts
// apps/desktop/src/pty-host-client.ts:79
const entry = path.join(app.getAppPath(), 'dist', 'pty-host.js')
const child = utilityProcess.fork(entry, …)
```

Both release workflows produced everything **except** that file:

```yaml
# .github/workflows/desktop-release-macos.yml:270  (before)
# .github/workflows/desktop-release-windows.yml:241 (before)
run: npx tsc && npm run bundle:main
```

`tsc` alone cannot satisfy that fork path for two independent reasons.

### Reason A — output path mismatch

The source lives at `src/pty-host/pty-host.ts`. `tsc` with the existing `outDir: dist` config emits:

```text
dist/pty-host/pty-host.js          ← NESTED, not what runtime forks
dist/pty-host/pty-host.js.map
```

The runtime forks `dist/pty-host.js` (flat). Proven empirically:

```text
$ cd apps/desktop && rm -rf dist && bun x tsc
$ find dist -name "pty-host*"
  dist/pty-host-client.js
  dist/pty-host/pty-host.js          ← nested
  dist/pty-host/pty-host.js.map
$ ls dist/pty-host.js
  ls: dist/pty-host.js: No such file or directory
```

### Reason B — workspace import isn't inlined

`pty-host.ts` imports `@shogo/pty-core` (shared decoder, ring buffer, protocol). `tsc` leaves that as a runtime `require('@shogo/pty-core')`. `apps/desktop` is `npm`-installed (not a bun workspace member), so the **packaged** app has no sibling `node_modules/@shogo/pty-core` to resolve. Even if we worked around (A) by moving the file or rewriting the runtime path, this would still crash.

### Why local dev didn't catch it

`apps/desktop/package.json`'s `build` script already chains all three steps:

```json
"build": "tsc && bun run bundle:main && bun run bundle:pty-host"
```

Local `bun run dev`, `bun run build`, and the developer-laptop preview path go through that script and produce `dist/pty-host.js` correctly. The release workflows hand-rolled the first two commands and skipped the third. **Only CI-built notarized installers were broken.**

---

## 2. The fix

Both workflows now run all three steps:

```yaml
run: npx tsc && npm run bundle:main && npm run bundle:pty-host
```

`bundle:pty-host` (`apps/desktop/scripts/bundle-pty-host.mjs`) does what's needed in one shot:

```bash
bun build apps/desktop/src/pty-host/pty-host.ts \
  --target node \
  --format cjs \
  --outfile apps/desktop/dist/pty-host.js \
  --external node-pty \
  --external electron \
  --external xterm-headless
```

- Emits a single CJS file at the flat path the runtime expects.
- Inlines `@shogo/pty-core` so there's no runtime resolve.
- Keeps `node-pty` / `electron` / `xterm-headless` external (they're native or runtime-provided modules that must NOT be bundled).

Verified empirically:

```text
$ bun run bundle:pty-host
  Bundled 11 modules in 3ms
  pty-host.js  43.16 KB  (entry point)

$ ls -la dist/pty-host.js
  -rw-r--r--  43155 bytes   ← flat path, ready to fork

$ grep -c "require.*@shogo/pty-core" dist/pty-host.js
  0   ← workspace import inlined, no runtime resolve needed
```

---

## 3. Files changed

```text
.github/workflows/desktop-release-macos.yml     |  9 ++++++++-
.github/workflows/desktop-release-windows.yml   |  9 ++++++++-
2 files changed, 18 insertions(+), 2 deletions(-)
```

Both edits are identical in shape — added a comment block mirroring the existing `bundle:main` rationale comment, plus the `&& npm run bundle:pty-host` chain on the run step.

```diff
         # `npx tsc` emits dist/{main,preload,...}.js. The follow-up
         # `bundle:main` step re-bundles dist/main.js with `bun build` so
         # workspace TS imports (notably @shogo-ai/worker/cloud-login)
         # get inlined; tsc on its own can't resolve them because
         # apps/desktop is npm-installed, not a bun workspace member.
         # See apps/desktop/scripts/bundle-main.mjs for details.
+        #
+        # `bundle:pty-host` is the matching step for the PTY utility
+        # process. pty-host-client.ts forks `dist/pty-host.js` at the
+        # flat dist root (not dist/pty-host/pty-host.js where tsc would
+        # put it), AND inlines `@shogo/pty-core` which tsc cannot
+        # resolve. Without this step, the packaged desktop terminal
+        # fails at runtime with MODULE_NOT_FOUND on first spawn.
+        # See apps/desktop/scripts/bundle-pty-host.mjs for details.
-        run: npx tsc && npm run bundle:main
+        run: npx tsc && npm run bundle:main && npm run bundle:pty-host
```

The comment block is intentional: it explains the constraint so a future contributor doesn't trim the chain back to `tsc && bundle:main` thinking the third step is redundant.

---

## 4. Why a separate PR

This branch is cut from `feat/desktop-terminal-enhancement` and targets it — not `main`. Reasoning:

- The PTY host code that needs this bundling step only exists on `feat/desktop-terminal-enhancement` (commits `34123b03`, `a856defe`, `ab262aaa`). The fix has no value on `main` until that branch lands.
- Keeping CI-config changes in a separate, narrowly-scoped PR makes them easy to review in isolation and easy to cherry-pick to other release branches if needed.
- The feature PR (#704) stays focused on terminal behavior; this one stays focused on packaging.

When `feat/desktop-terminal-enhancement` merges to `main`, this PR's diff goes with it.

---

## 5. Risk + rollout

- **No runtime code changes**, just CI YAML.
- **No new dependencies**, no new tools, no new GitHub Actions.
- `bundle:pty-host` already exists and is exercised by every local build via the package.json `build` script — this PR just teaches CI to run it too.
- Worst case if reverted: we're back to today's broken state, where packaged releases lack `dist/pty-host.js`. Not destructive.

After merge:

1. The next release workflow run (macOS or Windows) will produce `dist/pty-host.js` inside the packaged app's resources.
2. Desktop terminal sessions will spawn correctly on packaged builds.
3. We should also run a smoke test by downloading the next nightly DMG / NSIS installer and opening a terminal to confirm.

---

## 6. Verification done in this branch

| step | result |
|---|---|
| `cd apps/desktop && bun x tsc` (no bundle) → look for `dist/pty-host.js` | ❌ does not exist (only `dist/pty-host/pty-host.js`) |
| `bun run bundle:pty-host` → look for `dist/pty-host.js` | ✅ exists, 43.16 KB, flat path |
| `grep -c "require.*@shogo/pty-core" dist/pty-host.js` after bundle | `0` — workspace import inlined |
| `python3 -c "import yaml; yaml.safe_load(open('…'))"` on both workflows | both parse clean |
| `git diff --stat` | exactly 2 files, +18 / −2 |

---

## 7. Follow-ups (not in this PR)

- Worth considering: collapse the workflow run-step into `cd apps/desktop && npm run build`, which already chains all three. That removes the temptation to hand-roll the three commands and makes future build-pipeline changes a one-line edit. Out of scope here because the existing workflows split tsc / bundle steps for caching + log-readability reasons; changing that touches more than just this gap.
- A guard test (`scripts/check-dist-pty-host.mjs` that fails CI if `dist/pty-host.js` is missing after the build step) would make this kind of gap impossible to reintroduce. Out of scope for this PR.
