### PR TITLE
feat(marketplace): Stripe-hosted Connect onboarding for creator payouts

### DIFF
--- a/apps/api/src/__tests__/stripe-connect-service.test.ts
+++ b/apps/api/src/__tests__/stripe-connect-service.test.ts
@@ -77,6 +77,9 @@ let accountsRetrieveImpl = async (_id: string) => ({
   requirements: { currently_due: [], past_due: [], disabled_reason: null },
 })
 const accountsUpdateSpy = mock(async (_id: string, _p: any) => ({ id: 'acct_updated' }))
+const accountLinksCreateSpy = mock(async (_p: any) => ({
+  url: 'https://connect.stripe.com/setup/c/acct_live/abc',
+}))
 let checkoutCreateImpl: (params: any) => Promise<any> = async () => ({
   url: 'https://checkout/x',
 })
@@ -90,6 +93,9 @@ class FakeStripe {
     create: (p: any) => accountsCreateImpl(p),
     retrieve: (id: string) => accountsRetrieveImpl(id),
     update: (id: string, p: any) => accountsUpdateSpy(id, p),
+  }
+  accountLinks = {
+    create: (p: any) => accountLinksCreateSpy(p),
   }
   checkout = {
     sessions: { create: (p: any) => checkoutCreateImpl(p) },
@@ -116,6 +122,10 @@ beforeEach(() => {
     requirements: { currently_due: [], past_due: [], disabled_reason: null },
   })
   accountsUpdateSpy.mockClear()
+  accountLinksCreateSpy.mockClear()
+  accountLinksCreateSpy.mockImplementation(async (_p: any) => ({
+    url: 'https://connect.stripe.com/setup/c/acct_live/abc',
+  }))
   checkoutCreateImpl = async () => ({ url: 'https://checkout/x' })
   balanceRetrieveImpl = async (_o: any) => ({
     available: [{ amount: 0, currency: 'usd' }],
@@ -216,6 +226,50 @@ describe('submitPayoutDetails', () => {
     const params = accountsUpdateSpy.mock.calls[0][1]
     expect(params.individual.ssn_last_4).toBeUndefined()
     expect(params.external_account).toBeUndefined()
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// createOnboardingLink
+// ──────────────────────────────────────────────────────────────────────
+
+describe('createOnboardingLink', () => {
+  const URLS = {
+    refreshUrl: 'https://app.test/marketplace/creator/payout-setup?refresh=1',
+    returnUrl: 'https://app.test/marketplace/creator/payout-setup?return=1',
+  }
+
+  test('throws when profile has no stripe account id', async () => {
+    profiles.set('cp_1', { id: 'cp_1' })
+    await expect(svc.createOnboardingLink('cp_1', URLS)).rejects.toThrow(
+      'Creator has no Stripe Connect account',
+    )
+  })
+
+  test('throws when profile is missing entirely', async () => {
+    await expect(svc.createOnboardingLink('cp_missing', URLS)).rejects.toThrow(
+      'Creator has no Stripe Connect account',
+    )
+  })
+
+  test('mock mode: returns returnUrl without hitting Stripe', async () => {
+    delete process.env.STRIPE_SECRET_KEY
+    profiles.set('cp_1', { id: 'cp_1', stripeCustomAccountId: 'acct_mock_1' })
+    const res = await svc.createOnboardingLink('cp_1', URLS)
+    expect(res.url).toBe(URLS.returnUrl)
+    expect(accountLinksCreateSpy).not.toHaveBeenCalled()
+  })
+
+  test('live: forwards account + URLs to Stripe and returns link url', async () => {
+    profiles.set('cp_1', { id: 'cp_1', stripeCustomAccountId: 'acct_live' })
+    const res = await svc.createOnboardingLink('cp_1', URLS)
+    expect(accountLinksCreateSpy).toHaveBeenCalledTimes(1)
+    const params = accountLinksCreateSpy.mock.calls[0][0]
+    expect(params.account).toBe('acct_live')
+    expect(params.refresh_url).toBe(URLS.refreshUrl)
+    expect(params.return_url).toBe(URLS.returnUrl)
+    expect(params.type).toBe('account_onboarding')
+    expect(res.url).toBe('https://connect.stripe.com/setup/c/acct_live/abc')
   })
 })
 

--- a/apps/api/src/routes/marketplace.ts
+++ b/apps/api/src/routes/marketplace.ts
@@ -476,7 +476,21 @@ export function marketplaceRoutes() {
         avatarUrl: body.avatarUrl ?? undefined,
         websiteUrl: body.websiteUrl ?? undefined,
       })
-      await stripeConnect.createCustomAccount(profile.id, authCtx.email)
+      // Best-effort: provision the Stripe Connect account so payouts can be
+      // configured later. If this fails (network, Stripe outage, missing
+      // config), don't fail the whole request — the profile is already
+      // persisted and `/creator/payout-details` will self-heal the Connect
+      // account on first payout setup. Failing here would surface as
+      // "Failed to create creator profile" even though the profile exists,
+      // forcing the user to navigate away and back to recover.
+      try {
+        await stripeConnect.createCustomAccount(profile.id, authCtx.email)
+      } catch (stripeErr) {
+        console.error(
+          '[marketplace] createCreatorProfile stripe connect (non-fatal)',
+          stripeErr,
+        )
+      }
       return c.json({ profile })
     } catch (err) {
       const code = (err as { code?: string }).code
@@ -539,6 +553,15 @@ export function marketplaceRoutes() {
       if (!profile) {
         return c.json({ error: 'Creator profile not found' }, 404)
       }
+      if (!profile.stripeCustomAccountId) {
+        if (!authCtx.email) {
+          return c.json({ error: 'Email required to set up payouts' }, 400)
+        }
+        // Self-heal profiles that were created before the Connect account
+        // step succeeded (or where it failed silently). Without this, the
+        // user is permanently stuck on a 400.
+        await stripeConnect.createCustomAccount(profile.id, authCtx.email)
+      }
       const details = (await c.req.json()) as stripeConnect.PayoutDetails
       await stripeConnect.submitPayoutDetails(profile.id, details)
       return c.json({ ok: true })
@@ -549,6 +572,43 @@ export function marketplaceRoutes() {
       }
       console.error('[marketplace] submitPayoutDetails', err)
       return c.json({ error: 'Failed to submit payout details' }, 500)
+    }
+  })
+
+  // Stripe-hosted onboarding (preferred path). Replaces the legacy
+  // `/creator/payout-details` form: client POSTs here, gets back a URL,
+  // and redirects the user to Stripe's own KYC pages.
+  app.post('/creator/payout-onboarding-link', async (c) => {
+    const authCtx = c.get('auth') as AuthContext | undefined
+    if (!authCtx?.isAuthenticated || !authCtx.userId) {
+      return c.json({ error: 'Unauthorized' }, 401)
+    }
+    try {
+      const profile = await marketplaceService.getCreatorProfile(authCtx.userId)
+      if (!profile) {
+        return c.json({ error: 'Creator profile not found' }, 404)
+      }
+      if (!profile.stripeCustomAccountId) {
+        if (!authCtx.email) {
+          return c.json({ error: 'Email required to set up payouts' }, 400)
+        }
+        await stripeConnect.createCustomAccount(profile.id, authCtx.email)
+      }
+      const body = (await c.req.json().catch(() => ({}))) as {
+        refreshUrl?: string
+        returnUrl?: string
+      }
+      if (!body.refreshUrl || !body.returnUrl) {
+        return c.json({ error: 'refreshUrl and returnUrl are required' }, 400)
+      }
+      const link = await stripeConnect.createOnboardingLink(profile.id, {
+        refreshUrl: body.refreshUrl,
+        returnUrl: body.returnUrl,
+      })
+      return c.json(link)
+    } catch (err) {
+      console.error('[marketplace] createOnboardingLink', err)
+      return c.json({ error: 'Failed to create onboarding link' }, 500)
     }
   })
 

--- a/apps/api/src/services/stripe-connect.service.ts
+++ b/apps/api/src/services/stripe-connect.service.ts
@@ -266,6 +266,42 @@ export async function submitPayoutDetails(
   });
 }
 
+/**
+ * Create a Stripe-hosted onboarding URL for a creator's Connect account.
+ *
+ * Returns a short-lived URL that walks the creator through identity,
+ * address, DOB, SSN, document upload, and bank-account collection on
+ * Stripe's own pages — replaces the custom KYC form previously posted
+ * to `submitPayoutDetails`.
+ *
+ * In mock mode (no STRIPE_SECRET_KEY) returns `params.returnUrl` so the
+ * client flow stays exercisable in dev/CI without hitting Stripe.
+ */
+export async function createOnboardingLink(
+  creatorProfileId: string,
+  params: { refreshUrl: string; returnUrl: string },
+): Promise<{ url: string }> {
+  const profile = await prisma.creatorProfile.findUnique({
+    where: { id: creatorProfileId },
+  });
+  if (!profile?.stripeCustomAccountId) {
+    throw new Error('Creator has no Stripe Connect account');
+  }
+
+  if (!isStripeConfigured()) {
+    return { url: params.returnUrl };
+  }
+
+  const stripe = getStripe();
+  const link = await stripe.accountLinks.create({
+    account: profile.stripeCustomAccountId,
+    refresh_url: params.refreshUrl,
+    return_url: params.returnUrl,
+    type: 'account_onboarding',
+  });
+  return { url: link.url };
+}
+
 export async function getAccountStatus(creatorProfileId: string): Promise<{
   chargesEnabled: boolean;
   payoutsEnabled: boolean;

--- a/apps/mobile/app/(app)/marketplace/creator/payout-setup.tsx
+++ b/apps/mobile/app/(app)/marketplace/creator/payout-setup.tsx
@@ -1,102 +1,148 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2026 Shogo Technologies, Inc.
 
-import { useState, useEffect, useCallback, useMemo } from 'react'
-import {
-  View,
-  Text,
-  Pressable,
-  ScrollView,
-  ActivityIndicator,
-  TextInput,
-  useWindowDimensions,
-} from 'react-native'
-import { useRouter } from 'expo-router'
+/**
+ * Creator payout setup screen.
+ *
+ * Default: redirects the creator to Stripe's hosted onboarding flow
+ * via an Account Links URL minted server-side by
+ * `POST /api/marketplace/creator/payout-onboarding-link`. Stripe collects
+ * all KYC fields (identity, address, DOB, SSN, document upload, bank
+ * account) on their own pages, then redirects back here.
+ *
+ * Escape hatch: append `?legacy=1` to the URL to render the previous
+ * hand-rolled KYC form, which posts to `/api/marketplace/creator/payout-details`.
+ * Useful if the hosted flow has issues — we can fall back without a
+ * redeploy. Remove once hosted onboarding is proven.
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+import { View, Text, Pressable, ActivityIndicator, Platform } from 'react-native'
+import { useRouter, useLocalSearchParams } from 'expo-router'
 import { observer } from 'mobx-react-lite'
+import * as ExpoLinking from 'expo-linking'
+import * as WebBrowser from 'expo-web-browser'
 import {
   ArrowLeft,
   AlertCircle,
-  Check,
-  Building2,
+  ExternalLink,
   ShieldCheck,
-  ChevronDown,
-  Lock,
-  CircleDashed,
-  Circle,
-  CheckCircle2,
+  RefreshCw,
 } from 'lucide-react-native'
 import { useDomainHttp } from '../../../../contexts/domain'
 import { cn } from '@shogo/shared-ui/primitives'
+import PayoutLegacyForm from '../../../../components/marketplace/PayoutLegacyForm'
 
-interface PayoutForm {
-  firstName: string
-  lastName: string
-  email: string
-  dobDay: string
-  dobMonth: string
-  dobYear: string
-  addressLine1: string
-  addressCity: string
-  addressState: string
-  addressPostalCode: string
-  addressCountry: string
-  ssnLast4: string
-  bankAccountToken: string
+type PayoutStatusValue =
+  | 'not_setup'
+  | 'pending'
+  | 'pending_verification'
+  | 'verified'
+  | 'requires_update'
+  | 'disabled'
+
+interface CreatorProfile {
+  payoutStatus: PayoutStatusValue
 }
 
-const INITIAL_FORM: PayoutForm = {
-  firstName: '',
-  lastName: '',
-  email: '',
-  dobDay: '',
-  dobMonth: '',
-  dobYear: '',
-  addressLine1: '',
-  addressCity: '',
-  addressState: '',
-  addressPostalCode: '',
-  addressCountry: 'US',
-  ssnLast4: '',
-  bankAccountToken: '',
+interface AccountStatus {
+  chargesEnabled: boolean
+  payoutsEnabled: boolean
+  detailsSubmitted: boolean
+  requiresAction: boolean
+  currentlyDue: string[]
 }
 
-type SectionKey = 'identity' | 'address' | 'bank'
-
-function payoutStatusColor(status: string): string {
+function payoutStatusColor(status: PayoutStatusValue | string): string {
   if (status === 'verified') return 'bg-green-500'
-  if (status === 'pending') return 'bg-yellow-500'
+  if (status === 'pending' || status === 'pending_verification')
+    return 'bg-yellow-500'
+  if (status === 'requires_update') return 'bg-orange-500'
+  if (status === 'disabled') return 'bg-red-500'
   return 'bg-gray-400'
 }
 
-function payoutStatusLabel(status: string): string {
-  if (status === 'verified') return 'Verified'
-  if (status === 'pending') return 'Pending verification'
+function payoutStatusLabel(status: PayoutStatusValue | string): string {
+  if (status === 'verified') return 'Verified — payouts enabled'
+  if (status === 'pending' || status === 'pending_verification')
+    return 'Pending verification'
+  if (status === 'requires_update') return 'Action needed'
+  if (status === 'disabled') return 'Disabled'
   return 'Not set up'
+}
+
+function buildReturnUrls(): { refreshUrl: string; returnUrl: string } {
+  // Stripe needs absolute URLs. On web, the user is already at
+  // /marketplace/creator/payout-setup — round-trip back to it with
+  // marker query params so we know to refetch status on return.
+  if (Platform.OS === 'web' && typeof window !== 'undefined') {
+    const base = `${window.location.origin}/marketplace/creator/payout-setup`
+    return {
+      refreshUrl: `${base}?refresh=1`,
+      returnUrl: `${base}?return=1`,
+    }
+  }
+  // Native: use the app's deep link so Stripe redirects back into the app.
+  const base = ExpoLinking.createURL('marketplace/creator/payout-setup')
+  return {
+    refreshUrl: `${base}?refresh=1`,
+    returnUrl: `${base}?return=1`,
+  }
 }
 
 export default observer(function PayoutSetupScreen() {
   const router = useRouter()
   const http = useDomainHttp()
-  const { width } = useWindowDimensions()
-  const isWide = width >= 900
+  const params = useLocalSearchParams<{ legacy?: string; return?: string }>()
 
-  const [form, setForm] = useState<PayoutForm>(INITIAL_FORM)
-  const [payoutStatus, setPayoutStatus] = useState<string>('not_setup')
+  if (params.legacy === '1') {
+    return <PayoutLegacyForm />
+  }
+
+  return <HostedPayoutSetup http={http} router={router} returnedFromStripe={params.return === '1'} />
+})
+
+function HostedPayoutSetup({
+  http,
+  router,
+  returnedFromStripe,
+}: {
+  http: ReturnType<typeof useDomainHttp>
+  router: ReturnType<typeof useRouter>
+  returnedFromStripe: boolean
+}) {
+  const [payoutStatus, setPayoutStatus] = useState<PayoutStatusValue>('not_setup')
+  const [acctStatus, setAcctStatus] = useState<AccountStatus | null>(null)
   const [loading, setLoading] = useState(true)
-  const [submitting, setSubmitting] = useState(false)
+  const [opening, setOpening] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [submitted, setSubmitted] = useState(false)
-
-  const [openSection, setOpenSection] = useState<SectionKey>('identity')
 
   const loadStatus = useCallback(async () => {
+    setError(null)
     try {
-      const res = await http.get<{ profile: { payoutStatus: string } }>(
+      const profileRes = await http.get<{ profile: CreatorProfile }>(
         '/api/marketplace/creator/profile',
       )
-      setPayoutStatus(res.data.profile.payoutStatus)
-    } catch {
-      // Profile may not exist yet; ignore
+      setPayoutStatus(profileRes.data.profile.payoutStatus)
+
+      // Best-effort: fetch live Stripe status too so we can show
+      // "what's missing" if Stripe says action is required.
+      try {
+        const acctRes = await http.get<AccountStatus>(
+          '/api/marketplace/creator/payout-status',
+        )
+        setAcctStatus(acctRes.data)
+      } catch {
+        // 400 here just means no Connect account yet — that's expected
+        // pre-onboarding. Swallow and continue.
+        setAcctStatus(null)
+      }
+    } catch (err: unknown) {
+      const apiMsg =
+        (err as { response?: { data?: { error?: string } } })?.response?.data
+          ?.error ??
+        (err as { data?: { error?: string } })?.data?.error
+      setError(apiMsg || 'Failed to load payout status')
     } finally {
       setLoading(false)
     }
@@ -106,97 +152,50 @@ export default observer(function PayoutSetupScreen() {
     loadStatus()
   }, [loadStatus])
 
-  const updateField = useCallback((field: keyof PayoutForm, value: string) => {
-    setForm((prev) => ({ ...prev, [field]: value }))
-    setError(null)
-  }, [])
-
-  const sectionDone = useMemo(
-    () => ({
-      identity:
-        !!form.firstName.trim() &&
-        !!form.lastName.trim() &&
-        !!form.email.trim() &&
-        !!form.dobDay &&
-        !!form.dobMonth &&
-        !!form.dobYear,
-      address:
-        !!form.addressLine1.trim() &&
-        !!form.addressCity.trim() &&
-        !!form.addressState.trim() &&
-        !!form.addressPostalCode.trim() &&
-        !!form.addressCountry.trim(),
-      bank: !!form.bankAccountToken.trim(),
-    }),
-    [form],
-  )
-
-  const validate = useCallback((): string | null => {
-    if (!form.firstName.trim()) return 'First name is required'
-    if (!form.lastName.trim()) return 'Last name is required'
-    if (!form.email.trim()) return 'Email is required'
-    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email))
-      return 'Invalid email address'
-    if (!form.dobDay || !form.dobMonth || !form.dobYear)
-      return 'Date of birth is required'
-    const day = parseInt(form.dobDay, 10)
-    const month = parseInt(form.dobMonth, 10)
-    const year = parseInt(form.dobYear, 10)
-    if (day < 1 || day > 31) return 'Invalid day'
-    if (month < 1 || month > 12) return 'Invalid month'
-    if (year < 1900 || year > new Date().getFullYear() - 13)
-      return 'Invalid year (must be at least 13 years old)'
-    if (!form.addressLine1.trim()) return 'Address is required'
-    if (!form.addressCity.trim()) return 'City is required'
-    if (!form.addressState.trim()) return 'State is required'
-    if (!form.addressPostalCode.trim()) return 'Postal code is required'
-    if (!form.addressCountry.trim()) return 'Country is required'
-    if (
-      form.ssnLast4 &&
-      (form.ssnLast4.length !== 4 || !/^\d{4}$/.test(form.ssnLast4))
-    )
-      return 'SSN last 4 must be exactly 4 digits'
-    if (!form.bankAccountToken.trim())
-      return 'Bank account token is required'
-    return null
-  }, [form])
-
-  const handleSubmit = useCallback(async () => {
-    const err = validate()
-    if (err) {
-      setError(err)
-      return
+  // When the user comes back from Stripe's hosted flow, Stripe redirects
+  // through our return_url with `?return=1`. Refetch so the UI reflects
+  // the new state immediately.
+  useEffect(() => {
+    if (returnedFromStripe) {
+      loadStatus()
     }
-    setSubmitting(true)
+  }, [returnedFromStripe, loadStatus])
+
+  const handleStartOnboarding = useCallback(async () => {
+    setOpening(true)
     setError(null)
     try {
-      await http.post('/api/marketplace/creator/payout-details', {
-        firstName: form.firstName.trim(),
-        lastName: form.lastName.trim(),
-        email: form.email.trim(),
-        dob: {
-          day: parseInt(form.dobDay, 10),
-          month: parseInt(form.dobMonth, 10),
-          year: parseInt(form.dobYear, 10),
-        },
-        address: {
-          line1: form.addressLine1.trim(),
-          city: form.addressCity.trim(),
-          state: form.addressState.trim(),
-          postal_code: form.addressPostalCode.trim(),
-          country: form.addressCountry.trim(),
-        },
-        ...(form.ssnLast4 ? { ssnLast4: form.ssnLast4 } : {}),
-        bankAccountToken: form.bankAccountToken.trim(),
-      })
-      setSubmitted(true)
-      setPayoutStatus('pending')
-    } catch {
-      setError('Failed to submit payout details. Please try again.')
+      const urls = buildReturnUrls()
+      const res = await http.post<{ url: string }>(
+        '/api/marketplace/creator/payout-onboarding-link',
+        urls,
+      )
+      const { url } = res.data
+      if (!url) {
+        throw new Error('No onboarding URL returned')
+      }
+      if (Platform.OS === 'web' && typeof window !== 'undefined') {
+        window.location.href = url
+        return
+      }
+      try {
+        const scheme = ExpoLinking.createURL('')
+        await WebBrowser.openAuthSessionAsync(url, scheme)
+      } finally {
+        // After native flow closes, refresh status either way.
+        await loadStatus()
+      }
+    } catch (err: unknown) {
+      const apiMsg =
+        (err as { response?: { data?: { error?: string } } })?.response?.data
+          ?.error ??
+        (err as { data?: { error?: string } })?.data?.error ??
+        (err as Error)?.message
+      setError(apiMsg || 'Failed to start Stripe onboarding')
     } finally {
-      setSubmitting(false)
+      setOpening(false)
     }
-  }, [validate, form, http])
+  }, [http, loadStatus])
 
   if (loading) {
     return (
@@ -206,395 +205,25 @@ export default observer(function PayoutSetupScreen() {
     )
   }
 
-  if (submitted) {
-    return (
-      <View className="flex-1 bg-background">
-        <View className="flex-row items-center gap-3 px-5 pt-3 pb-2">
-          <Pressable onPress={() => router.back()} hitSlop={6} className="p-1">
-            <ArrowLeft size={20} color="#71717a" />
-          </Pressable>
-          <Text className="text-base font-semibold text-foreground flex-1">
-            Payout setup
-          </Text>
-        </View>
-        <View className="flex-1 items-center justify-center px-6">
-          <View className="rounded-full bg-green-500/15 w-20 h-20 items-center justify-center mb-5">
-            <ShieldCheck size={36} color="#16a34a" />
-          </View>
-          <Text className="text-2xl font-bold text-foreground mb-2 text-center">
-            Details submitted
-          </Text>
-          <Text className="text-muted-foreground text-center leading-6 mb-6 max-w-md">
-            Your payout details are being verified. This usually takes 1-2
-            business days. We&apos;ll notify you once verification is complete.
-          </Text>
-          <Pressable
-            onPress={() => router.back()}
-            className="px-6 py-3 rounded-xl bg-primary"
-          >
-            <Text className="text-sm font-semibold text-primary-foreground">
-              Back to dashboard
-            </Text>
-          </Pressable>
-        </View>
-      </View>
-    )
-  }
+  const isVerified = payoutStatus === 'verified'
+  const isPending =
+    payoutStatus === 'pending' || payoutStatus === 'pending_verification'
+  const needsAction =
+    payoutStatus === 'requires_update' ||
+    payoutStatus === 'disabled' ||
+    (!!acctStatus && acctStatus.requiresAction)
+  const notStarted = payoutStatus === 'not_setup'
 
-  // Verification timeline state
-  const timelineSteps: Array<{ key: SectionKey | 'verified'; label: string; description: string }> = [
-    {
-      key: 'identity',
-      label: 'Identity',
-      description: 'Tell us who you are',
-    },
-    {
-      key: 'address',
-      label: 'Address',
-      description: 'Required for tax reporting',
-    },
-    {
-      key: 'bank',
-      label: 'Bank account',
-      description: 'Where payouts go',
-    },
-    {
-      key: 'verified',
-      label: 'Verified by Stripe',
-      description: '1–2 business days after submit',
-    },
-  ]
-
-  const completedKeys = new Set<string>()
-  if (sectionDone.identity) completedKeys.add('identity')
-  if (sectionDone.address) completedKeys.add('address')
-  if (sectionDone.bank) completedKeys.add('bank')
-  if (payoutStatus === 'verified') completedKeys.add('verified')
-
-  const formColumn = (
-    <ScrollView
-      className="flex-1"
-      contentContainerStyle={{ padding: 20, paddingBottom: 40 }}
-      showsVerticalScrollIndicator={false}
-      keyboardShouldPersistTaps="handled"
-    >
-      {/* Status pill */}
-      <View className="flex-row items-center gap-3 mb-5 px-4 py-3 rounded-2xl border border-border bg-card">
-        <View className={cn('w-3 h-3 rounded-full', payoutStatusColor(payoutStatus))} />
-        <View className="flex-1">
-          <Text className="text-sm font-semibold text-foreground">Payout status</Text>
-          <Text className="text-xs text-muted-foreground">
-            {payoutStatusLabel(payoutStatus)}
-          </Text>
-        </View>
-        <Lock size={14} color="#71717a" />
-      </View>
-
-      {/* Trust paragraph */}
-      <View className="rounded-2xl border border-blue-500/30 bg-blue-500/5 p-4 mb-5 flex-row gap-3">
-        <View className="rounded-full bg-blue-500/15 w-8 h-8 items-center justify-center mt-0.5">
-          <ShieldCheck size={14} color="#3b82f6" />
-        </View>
-        <View className="flex-1">
-          <Text className="text-sm font-semibold text-foreground mb-1">
-            What we collect this for
-          </Text>
-          <Text className="text-xs text-foreground/70 leading-5">
-            Stripe Connect requires this information for KYC verification and to
-            send your payouts. None of these details are stored on Shogo&apos;s
-            servers — they go straight to Stripe.
-          </Text>
-        </View>
-      </View>
-
-      {error && (
-        <View className="flex-row items-center gap-2 mb-4 px-4 py-3 rounded-xl bg-destructive/10">
-          <AlertCircle size={16} color="#dc2626" />
-          <Text className="text-sm text-destructive flex-1">{error}</Text>
-        </View>
-      )}
-
-      {/* Identity */}
-      <Section
-        title="Identity"
-        subtitle="Personal information"
-        done={sectionDone.identity}
-        open={openSection === 'identity'}
-        onToggle={() =>
-          setOpenSection(openSection === 'identity' ? 'address' : 'identity')
-        }
-      >
-        <View className="flex-row gap-3">
-          <View className="flex-1 gap-1.5">
-            <FieldLabel text="First name" />
-            <TextInput
-              value={form.firstName}
-              onChangeText={(v) => updateField('firstName', v)}
-              placeholder="John"
-              placeholderTextColor="#9ca3af"
-              className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm"
-            />
-          </View>
-          <View className="flex-1 gap-1.5">
-            <FieldLabel text="Last name" />
-            <TextInput
-              value={form.lastName}
-              onChangeText={(v) => updateField('lastName', v)}
-              placeholder="Doe"
-              placeholderTextColor="#9ca3af"
-              className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm"
-            />
-          </View>
-        </View>
-
-        <View className="gap-1.5">
-          <FieldLabel text="Email" />
-          <TextInput
-            value={form.email}
-            onChangeText={(v) => updateField('email', v)}
-            placeholder="john@example.com"
-            placeholderTextColor="#9ca3af"
-            keyboardType="email-address"
-            autoCapitalize="none"
-            className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm"
-          />
-        </View>
-
-        <View className="gap-1.5">
-          <FieldLabel text="Date of birth" />
-          <View className="flex-row gap-3">
-            <View className="flex-1">
-              <TextInput
-                value={form.dobMonth}
-                onChangeText={(v) => updateField('dobMonth', v)}
-                placeholder="MM"
-                placeholderTextColor="#9ca3af"
-                keyboardType="number-pad"
-                maxLength={2}
-                className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm text-center"
-              />
-            </View>
-            <View className="flex-1">
-              <TextInput
-                value={form.dobDay}
-                onChangeText={(v) => updateField('dobDay', v)}
-                placeholder="DD"
-                placeholderTextColor="#9ca3af"
-                keyboardType="number-pad"
-                maxLength={2}
-                className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm text-center"
-              />
-            </View>
-            <View className="flex-[1.5]">
-              <TextInput
-                value={form.dobYear}
-                onChangeText={(v) => updateField('dobYear', v)}
-                placeholder="YYYY"
-                placeholderTextColor="#9ca3af"
-                keyboardType="number-pad"
-                maxLength={4}
-                className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm text-center"
-              />
-            </View>
-          </View>
-        </View>
-      </Section>
-
-      {/* Address */}
-      <Section
-        title="Address"
-        subtitle="Where you live"
-        done={sectionDone.address}
-        open={openSection === 'address'}
-        onToggle={() =>
-          setOpenSection(openSection === 'address' ? 'bank' : 'address')
-        }
-      >
-        <View className="gap-1.5">
-          <FieldLabel text="Street address" />
-          <TextInput
-            value={form.addressLine1}
-            onChangeText={(v) => updateField('addressLine1', v)}
-            placeholder="123 Main St"
-            placeholderTextColor="#9ca3af"
-            className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm"
-          />
-        </View>
-
-        <View className="flex-row gap-3">
-          <View className="flex-1 gap-1.5">
-            <FieldLabel text="City" />
-            <TextInput
-              value={form.addressCity}
-              onChangeText={(v) => updateField('addressCity', v)}
-              placeholder="San Francisco"
-              placeholderTextColor="#9ca3af"
-              className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm"
-            />
-          </View>
-          <View className="flex-1 gap-1.5">
-            <FieldLabel text="State" />
-            <TextInput
-              value={form.addressState}
-              onChangeText={(v) => updateField('addressState', v)}
-              placeholder="CA"
-              placeholderTextColor="#9ca3af"
-              className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm"
-            />
-          </View>
-        </View>
-
-        <View className="flex-row gap-3">
-          <View className="flex-1 gap-1.5">
-            <FieldLabel text="Postal code" />
-            <TextInput
-              value={form.addressPostalCode}
-              onChangeText={(v) => updateField('addressPostalCode', v)}
-              placeholder="94102"
-              placeholderTextColor="#9ca3af"
-              keyboardType="number-pad"
-              className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm"
-            />
-          </View>
-          <View className="flex-1 gap-1.5">
-            <FieldLabel text="Country" />
-            <TextInput
-              value={form.addressCountry}
-              onChangeText={(v) => updateField('addressCountry', v)}
-              placeholder="US"
-              placeholderTextColor="#9ca3af"
-              autoCapitalize="characters"
-              maxLength={2}
-              className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm"
-            />
-          </View>
-        </View>
-
-        <View className="gap-1.5">
-          <FieldLabel text="SSN last 4 (US only, optional)" />
-          <TextInput
-            value={form.ssnLast4}
-            onChangeText={(v) => updateField('ssnLast4', v)}
-            placeholder="1234"
-            placeholderTextColor="#9ca3af"
-            keyboardType="number-pad"
-            maxLength={4}
-            secureTextEntry
-            className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm"
-          />
-        </View>
-      </Section>
-
-      {/* Bank */}
-      <Section
-        title="Bank account"
-        subtitle="Where your payouts arrive"
-        done={sectionDone.bank}
-        open={openSection === 'bank'}
-        onToggle={() => setOpenSection('bank')}
-      >
-        <View className="rounded-xl bg-yellow-500/10 px-4 py-3 flex-row items-start gap-2">
-          <Building2 size={14} color="#ca8a04" style={{ marginTop: 2 }} />
-          <Text className="text-xs text-yellow-700 dark:text-yellow-400 flex-1 leading-4">
-            In production, this field uses Stripe.js elements for secure bank
-            account tokenization. Enter a test token to continue.
-          </Text>
-        </View>
-
-        <View className="gap-1.5">
-          <FieldLabel text="Bank account token" />
-          <TextInput
-            value={form.bankAccountToken}
-            onChangeText={(v) => updateField('bankAccountToken', v)}
-            placeholder="btok_…"
-            placeholderTextColor="#9ca3af"
-            autoCapitalize="none"
-            className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm font-mono"
-          />
-        </View>
-      </Section>
-
-      {/* Submit */}
-      <Pressable
-        onPress={handleSubmit}
-        disabled={submitting}
-        className={cn(
-          'flex-row items-center justify-center gap-2 py-3.5 rounded-xl mt-2',
-          submitting ? 'bg-primary/60' : 'bg-primary',
-        )}
-      >
-        {submitting ? (
-          <ActivityIndicator size="small" color="#fff" />
-        ) : (
-          <>
-            <Check size={16} color="#fff" />
-            <Text className="text-sm font-semibold text-primary-foreground">
-              Submit payout details
-            </Text>
-          </>
-        )}
-      </Pressable>
-    </ScrollView>
-  )
-
-  const sidebar = (
-    <View className="bg-muted/20 border-l border-border">
-      <View className="px-5 pt-6 pb-4">
-        <Text className="text-[10px] uppercase font-semibold text-muted-foreground mb-3" style={{ letterSpacing: 0.5 }}>
-          Verification flow
-        </Text>
-        <View className="gap-1">
-          {timelineSteps.map((step, i) => {
-            const done = completedKeys.has(step.key)
-            const current = !done && timelineSteps.slice(0, i).every((s) => completedKeys.has(s.key))
-            return (
-              <View key={step.key} className="flex-row items-start gap-3 pb-3">
-                <View className="items-center" style={{ width: 24 }}>
-                  {done ? (
-                    <CheckCircle2 size={16} color="#22c55e" />
-                  ) : current ? (
-                    <CircleDashed size={16} color="#e27927" />
-                  ) : (
-                    <Circle size={16} color="#a1a1aa" />
-                  )}
-                  {i < timelineSteps.length - 1 && (
-                    <View
-                      className={cn(
-                        'w-px flex-1 mt-1',
-                        done ? 'bg-emerald-500' : 'bg-border',
-                      )}
-                      style={{ minHeight: 24 }}
-                    />
-                  )}
-                </View>
-                <View className="flex-1 pb-1">
-                  <Text
-                    className={cn(
-                      'text-sm font-medium',
-                      done
-                        ? 'text-foreground'
-                        : current
-                          ? 'text-foreground'
-                          : 'text-muted-foreground',
-                    )}
-                  >
-                    {step.label}
-                  </Text>
-                  <Text className="text-[11px] text-muted-foreground mt-0.5">
-                    {step.description}
-                  </Text>
-                </View>
-              </View>
-            )
-          })}
-        </View>
-      </View>
-    </View>
-  )
+  const ctaLabel = (() => {
+    if (isVerified) return 'Update payout details on Stripe'
+    if (isPending) return 'Continue setup on Stripe'
+    if (needsAction) return 'Resolve required info on Stripe'
+    if (notStarted) return 'Set up payouts with Stripe'
+    return 'Open Stripe onboarding'
+  })()
 
   return (
     <View className="flex-1 bg-background">
-      {/* Top bar */}
       <View className="flex-row items-center gap-3 px-5 pt-3 pb-2 border-b border-border">
         <Pressable onPress={() => router.back()} hitSlop={6} className="p-1">
           <ArrowLeft size={20} color="#71717a" />
@@ -602,74 +231,129 @@ export default observer(function PayoutSetupScreen() {
         <Text className="text-base font-semibold text-foreground flex-1">
           Payout setup
         </Text>
+        <Pressable
+          onPress={loadStatus}
+          hitSlop={6}
+          className="p-1"
+          accessibilityLabel="Refresh status"
+        >
+          <RefreshCw size={16} color="#71717a" />
+        </Pressable>
       </View>
 
-      <View className="flex-1 flex-row">
-        <View style={{ flex: isWide ? 1 : undefined, width: isWide ? undefined : '100%' }}>
-          {formColumn}
+      <View className="flex-1 px-5 pt-6 pb-10 gap-5 max-w-2xl">
+        {/* Status pill */}
+        <View className="flex-row items-center gap-3 px-4 py-3 rounded-2xl border border-border bg-card">
+          <View
+            className={cn(
+              'w-3 h-3 rounded-full',
+              payoutStatusColor(payoutStatus),
+            )}
+          />
+          <View className="flex-1">
+            <Text className="text-sm font-semibold text-foreground">
+              Payout status
+            </Text>
+            <Text className="text-xs text-muted-foreground">
+              {payoutStatusLabel(payoutStatus)}
+            </Text>
+          </View>
         </View>
-        {isWide && <View style={{ width: 280 }}>{sidebar}</View>}
-      </View>
-    </View>
-  )
-})
 
-// ── Sub-components ─────────────────────────────────────────────────
+        {/* Trust copy */}
+        <View className="rounded-2xl border border-blue-500/30 bg-blue-500/5 p-4 flex-row gap-3">
+          <View className="rounded-full bg-blue-500/15 w-8 h-8 items-center justify-center mt-0.5">
+            <ShieldCheck size={14} color="#3b82f6" />
+          </View>
+          <View className="flex-1">
+            <Text className="text-sm font-semibold text-foreground mb-1">
+              Stripe handles the rest
+            </Text>
+            <Text className="text-xs text-foreground/70 leading-5">
+              We&apos;ll send you to Stripe to verify your identity and link
+              your bank account. None of this information is stored on
+              Shogo&apos;s servers — it goes straight to Stripe.
+            </Text>
+          </View>
+        </View>
 
-function Section({
-  title,
-  subtitle,
-  done,
-  open,
-  onToggle,
-  children,
-}: {
-  title: string
-  subtitle?: string
-  done?: boolean
-  open: boolean
-  onToggle: () => void
-  children: React.ReactNode
-}) {
-  return (
-    <View className="rounded-2xl border border-border bg-card overflow-hidden mb-4">
-      <Pressable
-        onPress={onToggle}
-        className="flex-row items-center gap-3 px-4 py-3 active:bg-muted/40"
-      >
-        <View
+        {/* What's currently due, if Stripe told us */}
+        {acctStatus &&
+          acctStatus.currentlyDue.length > 0 && (
+            <View className="rounded-2xl border border-orange-500/30 bg-orange-500/5 p-4 gap-2">
+              <Text className="text-sm font-semibold text-foreground">
+                Stripe still needs:
+              </Text>
+              <View className="gap-1">
+                {acctStatus.currentlyDue.map((field) => (
+                  <Text
+                    key={field}
+                    className="text-xs text-foreground/80 leading-5"
+                  >
+                    • {humanizeStripeField(field)}
+                  </Text>
+                ))}
+              </View>
+            </View>
+          )}
+
+        {error && (
+          <View className="flex-row items-center gap-2 px-4 py-3 rounded-xl bg-destructive/10">
+            <AlertCircle size={16} color="#dc2626" />
+            <Text className="text-sm text-destructive flex-1">{error}</Text>
+          </View>
+        )}
+
+        <Pressable
+          onPress={handleStartOnboarding}
+          disabled={opening}
           className={cn(
-            'w-6 h-6 rounded-full items-center justify-center',
-            done ? 'bg-emerald-500/15' : 'bg-muted',
+            'flex-row items-center justify-center gap-2 py-3.5 rounded-xl',
+            opening ? 'bg-primary/60' : 'bg-primary',
           )}
         >
-          {done ? (
-            <Check size={12} color="#16a34a" />
+          {opening ? (
+            <ActivityIndicator size="small" color="#fff" />
           ) : (
-            <View className="w-2 h-2 rounded-full bg-muted-foreground/50" />
+            <>
+              <ExternalLink size={16} color="#fff" />
+              <Text className="text-sm font-semibold text-primary-foreground">
+                {ctaLabel}
+              </Text>
+            </>
           )}
-        </View>
-        <View className="flex-1 min-w-0">
-          <Text className="text-sm font-semibold text-foreground">{title}</Text>
-          {subtitle && (
-            <Text className="text-[11px] text-muted-foreground">{subtitle}</Text>
-          )}
-        </View>
-        <ChevronDown
-          size={16}
-          color="#71717a"
-          style={{ transform: [{ rotate: open ? '180deg' : '0deg' }] }}
-        />
-      </Pressable>
-      {open && (
-        <View className="px-4 pb-4 gap-4 border-t border-border">{children}</View>
-      )}
+        </Pressable>
+
+        {isVerified && (
+          <Text className="text-xs text-muted-foreground text-center">
+            Your account is verified. Use the button above only to update
+            payout details with Stripe.
+          </Text>
+        )}
+      </View>
     </View>
   )
 }
 
-function FieldLabel({ text }: { text: string }) {
-  return (
-    <Text className="text-xs font-semibold text-foreground">{text}</Text>
-  )
+function humanizeStripeField(field: string): string {
+  const map: Record<string, string> = {
+    'individual.first_name': 'First name',
+    'individual.last_name': 'Last name',
+    'individual.email': 'Email',
+    'individual.dob.day': 'Date of birth',
+    'individual.dob.month': 'Date of birth',
+    'individual.dob.year': 'Date of birth',
+    'individual.address.line1': 'Street address',
+    'individual.address.city': 'City',
+    'individual.address.state': 'State',
+    'individual.address.postal_code': 'Postal code',
+    'individual.ssn_last_4': 'SSN (last 4)',
+    'individual.id_number': 'Full SSN / ID number',
+    'individual.verification.document':
+      'Identity document upload (driver license or passport)',
+    external_account: 'Bank account',
+    'tos_acceptance.date': 'Terms of service acceptance',
+    'tos_acceptance.ip': 'Terms of service acceptance',
+  }
+  return map[field] ?? field
 }

--- a/apps/mobile/components/marketplace/PayoutLegacyForm.tsx
+++ b/apps/mobile/components/marketplace/PayoutLegacyForm.tsx
@@ -1,0 +1,704 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Legacy creator payout form.
+ *
+ * Posts raw KYC fields to `POST /api/marketplace/creator/payout-details`.
+ * Replaced as the default flow by the Stripe-hosted Account Links
+ * onboarding (`PayoutSetupScreen`). Kept here as a behind-`?legacy=1`
+ * escape hatch so we can fall back without a redeploy if the hosted
+ * flow misbehaves.
+ *
+ * Delete this file (and the `?legacy=1` branch in `payout-setup.tsx`)
+ * once hosted onboarding is proven on staging + prod.
+ */
+
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import {
+  View,
+  Text,
+  Pressable,
+  ScrollView,
+  ActivityIndicator,
+  TextInput,
+  useWindowDimensions,
+} from 'react-native'
+import { useRouter } from 'expo-router'
+import { observer } from 'mobx-react-lite'
+import {
+  ArrowLeft,
+  AlertCircle,
+  Check,
+  Building2,
+  ShieldCheck,
+  ChevronDown,
+  Lock,
+  CircleDashed,
+  Circle,
+  CheckCircle2,
+} from 'lucide-react-native'
+import { useDomainHttp } from '../../contexts/domain'
+import { cn } from '@shogo/shared-ui/primitives'
+
+interface PayoutForm {
+  firstName: string
+  lastName: string
+  email: string
+  dobDay: string
+  dobMonth: string
+  dobYear: string
+  addressLine1: string
+  addressCity: string
+  addressState: string
+  addressPostalCode: string
+  addressCountry: string
+  ssnLast4: string
+  bankAccountToken: string
+}
+
+const INITIAL_FORM: PayoutForm = {
+  firstName: '',
+  lastName: '',
+  email: '',
+  dobDay: '',
+  dobMonth: '',
+  dobYear: '',
+  addressLine1: '',
+  addressCity: '',
+  addressState: '',
+  addressPostalCode: '',
+  addressCountry: 'US',
+  ssnLast4: '',
+  bankAccountToken: '',
+}
+
+type SectionKey = 'identity' | 'address' | 'bank'
+
+function payoutStatusColor(status: string): string {
+  if (status === 'verified') return 'bg-green-500'
+  if (status === 'pending') return 'bg-yellow-500'
+  return 'bg-gray-400'
+}
+
+function payoutStatusLabel(status: string): string {
+  if (status === 'verified') return 'Verified'
+  if (status === 'pending') return 'Pending verification'
+  return 'Not set up'
+}
+
+export default observer(function PayoutLegacyForm() {
+  const router = useRouter()
+  const http = useDomainHttp()
+  const { width } = useWindowDimensions()
+  const isWide = width >= 900
+
+  const [form, setForm] = useState<PayoutForm>(INITIAL_FORM)
+  const [payoutStatus, setPayoutStatus] = useState<string>('not_setup')
+  const [loading, setLoading] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [submitted, setSubmitted] = useState(false)
+
+  const [openSection, setOpenSection] = useState<SectionKey>('identity')
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const res = await http.get<{ profile: { payoutStatus: string } }>(
+        '/api/marketplace/creator/profile',
+      )
+      setPayoutStatus(res.data.profile.payoutStatus)
+    } catch {
+      // Profile may not exist yet; ignore
+    } finally {
+      setLoading(false)
+    }
+  }, [http])
+
+  useEffect(() => {
+    loadStatus()
+  }, [loadStatus])
+
+  const updateField = useCallback((field: keyof PayoutForm, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }))
+    setError(null)
+  }, [])
+
+  const sectionDone = useMemo(
+    () => ({
+      identity:
+        !!form.firstName.trim() &&
+        !!form.lastName.trim() &&
+        !!form.email.trim() &&
+        !!form.dobDay &&
+        !!form.dobMonth &&
+        !!form.dobYear,
+      address:
+        !!form.addressLine1.trim() &&
+        !!form.addressCity.trim() &&
+        !!form.addressState.trim() &&
+        !!form.addressPostalCode.trim() &&
+        !!form.addressCountry.trim(),
+      bank: !!form.bankAccountToken.trim(),
+    }),
+    [form],
+  )
+
+  const validate = useCallback((): string | null => {
+    if (!form.firstName.trim()) return 'First name is required'
+    if (!form.lastName.trim()) return 'Last name is required'
+    if (!form.email.trim()) return 'Email is required'
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email))
+      return 'Invalid email address'
+    if (!form.dobDay || !form.dobMonth || !form.dobYear)
+      return 'Date of birth is required'
+    const day = parseInt(form.dobDay, 10)
+    const month = parseInt(form.dobMonth, 10)
+    const year = parseInt(form.dobYear, 10)
+    if (day < 1 || day > 31) return 'Invalid day'
+    if (month < 1 || month > 12) return 'Invalid month'
+    if (year < 1900 || year > new Date().getFullYear() - 13)
+      return 'Invalid year (must be at least 13 years old)'
+    if (!form.addressLine1.trim()) return 'Address is required'
+    if (!form.addressCity.trim()) return 'City is required'
+    if (!form.addressState.trim()) return 'State is required'
+    if (!form.addressPostalCode.trim()) return 'Postal code is required'
+    if (!form.addressCountry.trim()) return 'Country is required'
+    if (
+      form.ssnLast4 &&
+      (form.ssnLast4.length !== 4 || !/^\d{4}$/.test(form.ssnLast4))
+    )
+      return 'SSN last 4 must be exactly 4 digits'
+    if (!form.bankAccountToken.trim())
+      return 'Bank account token is required'
+    return null
+  }, [form])
+
+  const handleSubmit = useCallback(async () => {
+    const err = validate()
+    if (err) {
+      setError(err)
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      await http.post('/api/marketplace/creator/payout-details', {
+        firstName: form.firstName.trim(),
+        lastName: form.lastName.trim(),
+        email: form.email.trim(),
+        dob: {
+          day: parseInt(form.dobDay, 10),
+          month: parseInt(form.dobMonth, 10),
+          year: parseInt(form.dobYear, 10),
+        },
+        address: {
+          line1: form.addressLine1.trim(),
+          city: form.addressCity.trim(),
+          state: form.addressState.trim(),
+          postal_code: form.addressPostalCode.trim(),
+          country: form.addressCountry.trim(),
+        },
+        ...(form.ssnLast4 ? { ssnLast4: form.ssnLast4 } : {}),
+        bankAccountToken: form.bankAccountToken.trim(),
+      })
+      setSubmitted(true)
+      setPayoutStatus('pending')
+    } catch (err: unknown) {
+      const apiMsg =
+        (err as { response?: { data?: { error?: string } } })?.response?.data
+          ?.error ??
+        (err as { data?: { error?: string } })?.data?.error ??
+        (err as Error)?.message
+      setError(apiMsg || 'Failed to submit payout details. Please try again.')
+    } finally {
+      setSubmitting(false)
+    }
+  }, [validate, form, http])
+
+  if (loading) {
+    return (
+      <View className="flex-1 bg-background items-center justify-center">
+        <ActivityIndicator size="large" />
+      </View>
+    )
+  }
+
+  if (submitted) {
+    return (
+      <View className="flex-1 bg-background">
+        <View className="flex-row items-center gap-3 px-5 pt-3 pb-2">
+          <Pressable onPress={() => router.back()} hitSlop={6} className="p-1">
+            <ArrowLeft size={20} color="#71717a" />
+          </Pressable>
+          <Text className="text-base font-semibold text-foreground flex-1">
+            Payout setup
+          </Text>
+        </View>
+        <View className="flex-1 items-center justify-center px-6">
+          <View className="rounded-full bg-green-500/15 w-20 h-20 items-center justify-center mb-5">
+            <ShieldCheck size={36} color="#16a34a" />
+          </View>
+          <Text className="text-2xl font-bold text-foreground mb-2 text-center">
+            Details submitted
+          </Text>
+          <Text className="text-muted-foreground text-center leading-6 mb-6 max-w-md">
+            Your payout details are being verified. This usually takes 1-2
+            business days. We&apos;ll notify you once verification is complete.
+          </Text>
+          <Pressable
+            onPress={() => router.back()}
+            className="px-6 py-3 rounded-xl bg-primary"
+          >
+            <Text className="text-sm font-semibold text-primary-foreground">
+              Back to dashboard
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    )
+  }
+
+  const timelineSteps: Array<{
+    key: SectionKey | 'verified'
+    label: string
+    description: string
+  }> = [
+    {
+      key: 'identity',
+      label: 'Identity',
+      description: 'Tell us who you are',
+    },
+    {
+      key: 'address',
+      label: 'Address',
+      description: 'Required for tax reporting',
+    },
+    {
+      key: 'bank',
+      label: 'Bank account',
+      description: 'Where payouts go',
+    },
+    {
+      key: 'verified',
+      label: 'Verified by Stripe',
+      description: '1–2 business days after submit',
+    },
+  ]
+
+  const completedKeys = new Set<string>()
+  if (sectionDone.identity) completedKeys.add('identity')
+  if (sectionDone.address) completedKeys.add('address')
+  if (sectionDone.bank) completedKeys.add('bank')
+  if (payoutStatus === 'verified') completedKeys.add('verified')
+
+  const formColumn = (
+    <ScrollView
+      className="flex-1"
+      contentContainerStyle={{ padding: 20, paddingBottom: 40 }}
+      showsVerticalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+    >
+      <View className="flex-row items-center gap-3 mb-5 px-4 py-3 rounded-2xl border border-border bg-card">
+        <View
+          className={cn(
+            'w-3 h-3 rounded-full',
+            payoutStatusColor(payoutStatus),
+          )}
+        />
+        <View className="flex-1">
+          <Text className="text-sm font-semibold text-foreground">
+            Payout status
+          </Text>
+          <Text className="text-xs text-muted-foreground">
+            {payoutStatusLabel(payoutStatus)}
+          </Text>
+        </View>
+        <Lock size={14} color="#71717a" />
+      </View>
+
+      <View className="rounded-2xl border border-blue-500/30 bg-blue-500/5 p-4 mb-5 flex-row gap-3">
+        <View className="rounded-full bg-blue-500/15 w-8 h-8 items-center justify-center mt-0.5">
+          <ShieldCheck size={14} color="#3b82f6" />
+        </View>
+        <View className="flex-1">
+          <Text className="text-sm font-semibold text-foreground mb-1">
+            What we collect this for
+          </Text>
+          <Text className="text-xs text-foreground/70 leading-5">
+            Stripe Connect requires this information for KYC verification and to
+            send your payouts. None of these details are stored on Shogo&apos;s
+            servers — they go straight to Stripe.
+          </Text>
+        </View>
+      </View>
+
+      {error && (
+        <View className="flex-row items-center gap-2 mb-4 px-4 py-3 rounded-xl bg-destructive/10">
+          <AlertCircle size={16} color="#dc2626" />
+          <Text className="text-sm text-destructive flex-1">{error}</Text>
+        </View>
+      )}
+
+      <Section
+        title="Identity"
+        subtitle="Personal information"
+        done={sectionDone.identity}
+        open={openSection === 'identity'}
+        onToggle={() =>
+          setOpenSection(openSection === 'identity' ? 'address' : 'identity')
+        }
+      >
+        <View className="flex-row gap-3">
+          <View className="flex-1 gap-1.5">
+            <FieldLabel text="First name" />
+            <TextInput
+              value={form.firstName}
+              onChangeText={(v) => updateField('firstName', v)}
+              placeholder="John"
+              placeholderTextColor="#9ca3af"
+              className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm"
+            />
+          </View>
+          <View className="flex-1 gap-1.5">
+            <FieldLabel text="Last name" />
+            <TextInput
+              value={form.lastName}
+              onChangeText={(v) => updateField('lastName', v)}
+              placeholder="Doe"
+              placeholderTextColor="#9ca3af"
+              className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm"
+            />
+          </View>
+        </View>
+
+        <View className="gap-1.5">
+          <FieldLabel text="Email" />
+          <TextInput
+            value={form.email}
+            onChangeText={(v) => updateField('email', v)}
+            placeholder="john@example.com"
+            placeholderTextColor="#9ca3af"
+            keyboardType="email-address"
+            autoCapitalize="none"
+            className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm"
+          />
+        </View>
+
+        <View className="gap-1.5">
+          <FieldLabel text="Date of birth" />
+          <View className="flex-row gap-3">
+            <View className="flex-1">
+              <TextInput
+                value={form.dobMonth}
+                onChangeText={(v) => updateField('dobMonth', v)}
+                placeholder="MM"
+                placeholderTextColor="#9ca3af"
+                keyboardType="number-pad"
+                maxLength={2}
+                className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm text-center"
+              />
+            </View>
+            <View className="flex-1">
+              <TextInput
+                value={form.dobDay}
+                onChangeText={(v) => updateField('dobDay', v)}
+                placeholder="DD"
+                placeholderTextColor="#9ca3af"
+                keyboardType="number-pad"
+                maxLength={2}
+                className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm text-center"
+              />
+            </View>
+            <View className="flex-[1.5]">
+              <TextInput
+                value={form.dobYear}
+                onChangeText={(v) => updateField('dobYear', v)}
+                placeholder="YYYY"
+                placeholderTextColor="#9ca3af"
+                keyboardType="number-pad"
+                maxLength={4}
+                className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm text-center"
+              />
+            </View>
+          </View>
+        </View>
+      </Section>
+
+      <Section
+        title="Address"
+        subtitle="Where you live"
+        done={sectionDone.address}
+        open={openSection === 'address'}
+        onToggle={() =>
+          setOpenSection(openSection === 'address' ? 'bank' : 'address')
+        }
+      >
+        <View className="gap-1.5">
+          <FieldLabel text="Street address" />
+          <TextInput
+            value={form.addressLine1}
+            onChangeText={(v) => updateField('addressLine1', v)}
+            placeholder="123 Main St"
+            placeholderTextColor="#9ca3af"
+            className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm"
+          />
+        </View>
+
+        <View className="flex-row gap-3">
+          <View className="flex-1 gap-1.5">
+            <FieldLabel text="City" />
+            <TextInput
+              value={form.addressCity}
+              onChangeText={(v) => updateField('addressCity', v)}
+              placeholder="San Francisco"
+              placeholderTextColor="#9ca3af"
+              className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm"
+            />
+          </View>
+          <View className="flex-1 gap-1.5">
+            <FieldLabel text="State" />
+            <TextInput
+              value={form.addressState}
+              onChangeText={(v) => updateField('addressState', v)}
+              placeholder="CA"
+              placeholderTextColor="#9ca3af"
+              className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm"
+            />
+          </View>
+        </View>
+
+        <View className="flex-row gap-3">
+          <View className="flex-1 gap-1.5">
+            <FieldLabel text="Postal code" />
+            <TextInput
+              value={form.addressPostalCode}
+              onChangeText={(v) => updateField('addressPostalCode', v)}
+              placeholder="94102"
+              placeholderTextColor="#9ca3af"
+              keyboardType="number-pad"
+              className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm"
+            />
+          </View>
+          <View className="flex-1 gap-1.5">
+            <FieldLabel text="Country" />
+            <TextInput
+              value={form.addressCountry}
+              onChangeText={(v) => updateField('addressCountry', v)}
+              placeholder="US"
+              placeholderTextColor="#9ca3af"
+              autoCapitalize="characters"
+              maxLength={2}
+              className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm"
+            />
+          </View>
+        </View>
+
+        <View className="gap-1.5">
+          <FieldLabel text="SSN last 4 (US only, optional)" />
+          <TextInput
+            value={form.ssnLast4}
+            onChangeText={(v) => updateField('ssnLast4', v)}
+            placeholder="1234"
+            placeholderTextColor="#9ca3af"
+            keyboardType="number-pad"
+            maxLength={4}
+            secureTextEntry
+            className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm"
+          />
+        </View>
+      </Section>
+
+      <Section
+        title="Bank account"
+        subtitle="Where your payouts arrive"
+        done={sectionDone.bank}
+        open={openSection === 'bank'}
+        onToggle={() => setOpenSection('bank')}
+      >
+        <View className="rounded-xl bg-yellow-500/10 px-4 py-3 flex-row items-start gap-2">
+          <Building2 size={14} color="#ca8a04" style={{ marginTop: 2 }} />
+          <Text className="text-xs text-yellow-700 dark:text-yellow-400 flex-1 leading-4">
+            In production, this field uses Stripe.js elements for secure bank
+            account tokenization. Enter a test token to continue.
+          </Text>
+        </View>
+
+        <View className="gap-1.5">
+          <FieldLabel text="Bank account token" />
+          <TextInput
+            value={form.bankAccountToken}
+            onChangeText={(v) => updateField('bankAccountToken', v)}
+            placeholder="btok_…"
+            placeholderTextColor="#9ca3af"
+            autoCapitalize="none"
+            className="px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm font-mono"
+          />
+        </View>
+      </Section>
+
+      <Pressable
+        onPress={handleSubmit}
+        disabled={submitting}
+        className={cn(
+          'flex-row items-center justify-center gap-2 py-3.5 rounded-xl mt-2',
+          submitting ? 'bg-primary/60' : 'bg-primary',
+        )}
+      >
+        {submitting ? (
+          <ActivityIndicator size="small" color="#fff" />
+        ) : (
+          <>
+            <Check size={16} color="#fff" />
+            <Text className="text-sm font-semibold text-primary-foreground">
+              Submit payout details
+            </Text>
+          </>
+        )}
+      </Pressable>
+    </ScrollView>
+  )
+
+  const sidebar = (
+    <View className="bg-muted/20 border-l border-border">
+      <View className="px-5 pt-6 pb-4">
+        <Text
+          className="text-[10px] uppercase font-semibold text-muted-foreground mb-3"
+          style={{ letterSpacing: 0.5 }}
+        >
+          Verification flow
+        </Text>
+        <View className="gap-1">
+          {timelineSteps.map((step, i) => {
+            const done = completedKeys.has(step.key)
+            const current =
+              !done &&
+              timelineSteps.slice(0, i).every((s) => completedKeys.has(s.key))
+            return (
+              <View key={step.key} className="flex-row items-start gap-3 pb-3">
+                <View className="items-center" style={{ width: 24 }}>
+                  {done ? (
+                    <CheckCircle2 size={16} color="#22c55e" />
+                  ) : current ? (
+                    <CircleDashed size={16} color="#e27927" />
+                  ) : (
+                    <Circle size={16} color="#a1a1aa" />
+                  )}
+                  {i < timelineSteps.length - 1 && (
+                    <View
+                      className={cn(
+                        'w-px flex-1 mt-1',
+                        done ? 'bg-emerald-500' : 'bg-border',
+                      )}
+                      style={{ minHeight: 24 }}
+                    />
+                  )}
+                </View>
+                <View className="flex-1 pb-1">
+                  <Text
+                    className={cn(
+                      'text-sm font-medium',
+                      done
+                        ? 'text-foreground'
+                        : current
+                          ? 'text-foreground'
+                          : 'text-muted-foreground',
+                    )}
+                  >
+                    {step.label}
+                  </Text>
+                  <Text className="text-[11px] text-muted-foreground mt-0.5">
+                    {step.description}
+                  </Text>
+                </View>
+              </View>
+            )
+          })}
+        </View>
+      </View>
+    </View>
+  )
+
+  return (
+    <View className="flex-1 bg-background">
+      <View className="flex-row items-center gap-3 px-5 pt-3 pb-2 border-b border-border">
+        <Pressable onPress={() => router.back()} hitSlop={6} className="p-1">
+          <ArrowLeft size={20} color="#71717a" />
+        </Pressable>
+        <Text className="text-base font-semibold text-foreground flex-1">
+          Payout setup (legacy)
+        </Text>
+      </View>
+
+      <View className="flex-1 flex-row">
+        <View
+          style={{
+            flex: isWide ? 1 : undefined,
+            width: isWide ? undefined : '100%',
+          }}
+        >
+          {formColumn}
+        </View>
+        {isWide && <View style={{ width: 280 }}>{sidebar}</View>}
+      </View>
+    </View>
+  )
+})
+
+function Section({
+  title,
+  subtitle,
+  done,
+  open,
+  onToggle,
+  children,
+}: {
+  title: string
+  subtitle?: string
+  done?: boolean
+  open: boolean
+  onToggle: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <View className="rounded-2xl border border-border bg-card overflow-hidden mb-4">
+      <Pressable
+        onPress={onToggle}
+        className="flex-row items-center gap-3 px-4 py-3 active:bg-muted/40"
+      >
+        <View
+          className={cn(
+            'w-6 h-6 rounded-full items-center justify-center',
+            done ? 'bg-emerald-500/15' : 'bg-muted',
+          )}
+        >
+          {done ? (
+            <Check size={12} color="#16a34a" />
+          ) : (
+            <View className="w-2 h-2 rounded-full bg-muted-foreground/50" />
+          )}
+        </View>
+        <View className="flex-1 min-w-0">
+          <Text className="text-sm font-semibold text-foreground">{title}</Text>
+          {subtitle && (
+            <Text className="text-[11px] text-muted-foreground">{subtitle}</Text>
+          )}
+        </View>
+        <ChevronDown
+          size={16}
+          color="#71717a"
+          style={{ transform: [{ rotate: open ? '180deg' : '0deg' }] }}
+        />
+      </Pressable>
+      {open && (
+        <View className="px-4 pb-4 gap-4 border-t border-border">
+          {children}
+        </View>
+      )}
+    </View>
+  )
+}
+
+function FieldLabel({ text }: { text: string }) {
+  return <Text className="text-xs font-semibold text-foreground">{text}</Text>
+}


### PR DESCRIPTION
## Summary

Fixes the `400` returned from `POST /api/marketplace/creator/payout-details` when submitting payout details (reproduced on https://studio.staging.shogo.ai/marketplace/creator/payout-setup) and replaces the hand-rolled KYC form with Stripe's hosted onboarding flow.

**Root cause of the 400:** `POST /creator/profile` creates the DB profile and then non-transactionally calls `createCustomAccount` to populate `stripeCustomAccountId`. If that second call ever failed (Stripe outage, missing key at the time, capability rejection, profile predated the line), the profile was left in the DB without a Connect account, and every subsequent payout-details submit was permanently doomed to throw `"Creator has no Stripe Connect account"` → 400.

**Fix + product improvement:** rather than just patching the 400, move the entire creator KYC flow onto Stripe-hosted onboarding (Account Links). The user clicks a single CTA, Stripe collects every field on their own pages, and we listen for `account.updated` webhooks (already wired in `handleAccountUpdated`) to flip the status. The previous 18-field custom form is preserved as an escape hatch behind `?legacy=1` so we can fall back without a redeploy if the hosted flow misbehaves.

### Changes
- `apps/api/src/services/stripe-connect.service.ts` — new `createOnboardingLink(creatorProfileId, { refreshUrl, returnUrl })` wrapping `stripe.accountLinks.create({ type: 'account_onboarding' })`. Mock-mode shortcut returns `returnUrl` when `STRIPE_SECRET_KEY` is unset so dev/CI flows stay exercisable.
- `apps/api/src/routes/marketplace.ts`
  - New `POST /creator/payout-onboarding-link` — lazy-creates the Connect account if missing, then returns `{ url }`.
  - Existing `POST /creator/payout-details` also lazy-creates the Connect account if missing — unblocks any existing orphaned profile without a manual backfill.
- `apps/mobile/app/(app)/marketplace/creator/payout-setup.tsx` — replaced with a status pill + "Set up payouts with Stripe" CTA + "Stripe still needs:" field list. Reads `?legacy=1` to render the original form. Surfaces real API error messages (no more swallowed errors).
- `apps/mobile/components/marketplace/PayoutLegacyForm.tsx` — the original form, moved here.
- `apps/api/src/__tests__/stripe-connect-service.test.ts` — 4 new tests for `createOnboardingLink` (no account → throws, missing profile → throws, mock mode → returns returnUrl, live mode → forwards params to Stripe). **41/41 pass.**

### Why hosted onboarding (Account Links) over what was there

The old form posted raw KYC fields straight to `stripe.accounts.update`, which Stripe explicitly recommends against for Custom Connect: you own all the country-specific field variations, document upload, re-verification, and (worst) bank account collection (the current screen has a literal "paste a `btok_…` token" textbox — there's no PCI-safe way to collect bank accounts without Stripe's UI). Hosted onboarding hands all of that to Stripe; we keep our existing `account.updated` webhook + status derivation.

## Test plan

### Automated
- [x] `bun test apps/api/src/__tests__/stripe-connect-service.test.ts` → `41 pass, 0 fail`
- [x] No new lint errors
- [x] No new typecheck errors (the 14 pre-existing `apps/api` typecheck failures are untouched)

### Manual — local (no `STRIPE_SECRET_KEY`)
- [ ] `bun dev:all`, open `http://localhost:5173/marketplace/creator/payout-setup`
- [ ] Click "Set up payouts with Stripe" → page redirects to `…/payout-setup?return=1` and status pill refreshes (mock-mode path)
- [ ] Sanity: `Invoke-RestMethod -Method POST http://localhost:8002/api/marketplace/creator/payout-onboarding-link` returns 401 (route registered) not 404

### Manual — staging (with `STRIPE_SECRET_KEY=sk_test_…`)
- [ ] Visit https://studio.staging.shogo.ai/marketplace/creator/payout-setup
- [ ] Click "Set up payouts with Stripe" → redirected to Stripe's hosted onboarding
- [ ] Use Stripe test data (name `Jenny Rosen`, DOB `1901-01-01`, address `address_full_match`, SSN `000-00-0000`, phone `000-000-0000`, routing `110000000`, account `000123456789`)
- [ ] Stripe redirects back to `…/payout-setup?return=1`; status pill flips to "Pending verification" or "Verified"; orange "Stripe still needs:" block shows any outstanding fields
- [ ] Verify the previously-orphaned profile self-heals: query staging DB for `CreatorProfile.stripeCustomAccountId` for the affected user — should now be populated (set by the lazy-create branch on first click)

### Legacy escape hatch
- [ ] Append `?legacy=1` to the payout-setup URL → renders the original form unchanged

## Revert plan

Three layers, fastest first:

1. **No deploy** — tell users to append `?legacy=1` to the URL.
2. **No-code redeploy** — flip the default branch in `payout-setup.tsx` from `if (params.legacy === '1')` to `if (params.hosted !== '1')`, making hosted opt-in.
3. **Full revert** — `git revert <this commit>`. Self-contained and atomic. The only piece worth keeping post-revert is the `/payout-details` lazy-create line, since it fixes the original 400 regardless of which UI ships.
