### PR TITLE
fix(api): use getFrontendUrl() for email links instead of localhost fallback

### DIFF
--- a/apps/api/src/__tests__/cloud-urls.test.ts
+++ b/apps/api/src/__tests__/cloud-urls.test.ts
@@ -221,4 +221,29 @@ describe('getFrontendUrl — defensive edges', () => {
     delete process.env.VITE_PORT
     expect(getFrontendUrl()).toBe('http://localhost:3000')
   })
+
+  // Regression: production emails (welcome, invites, billing, member-joined)
+  // build links from getFrontendUrl(). With the k8s production overlay
+  // (APP_URL set to the studio domain, ALLOWED_ORIGINS listing the studio
+  // domains) the result MUST be the public studio URL and never localhost.
+  test('production overlay config resolves to studio.shogo.ai (never localhost)', () => {
+    process.env.APP_URL = 'https://studio.shogo.ai'
+    process.env.ALLOWED_ORIGINS =
+      'https://studio.shogo.ai,https://shogo.ai,https://eu.studio.shogo.ai,https://india.studio.shogo.ai'
+    const url = getFrontendUrl()
+    expect(url).toBe('https://studio.shogo.ai')
+    expect(url).not.toContain('localhost')
+  })
+
+  // Even if APP_URL were dropped from the deploy, the first ALLOWED_ORIGINS
+  // entry keeps prod links off localhost — the property the old inline
+  // `|| 'http://localhost:3001'` fallbacks violated.
+  test('falls back to first ALLOWED_ORIGINS entry (not localhost) when APP_URL is dropped in prod', () => {
+    delete process.env.APP_URL
+    process.env.ALLOWED_ORIGINS =
+      'https://studio.shogo.ai,https://eu.studio.shogo.ai,https://india.studio.shogo.ai'
+    const url = getFrontendUrl()
+    expect(url).toBe('https://studio.shogo.ai')
+    expect(url).not.toContain('localhost')
+  })
 })

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -22,6 +22,7 @@ import { sendWelcomeEmail, sendPasswordResetEmail, sendEmailVerificationEmail } 
 import { resolveAttributionForUser } from "./services/affiliate.service"
 import { evaluateAllowlist, recordSignIn } from "./services/project-auth-config.service"
 import { prisma } from "./lib/prisma"
+import { getFrontendUrl } from "./lib/cloud-urls"
 
 const isLocalMode = process.env.SHOGO_LOCAL_MODE === 'true'
 const LOAD_TEST_SECRET = process.env.LOAD_TEST_SECRET
@@ -511,7 +512,7 @@ export const auth = betterAuth({
           }
 
           // FIRE-AND-FORGET: Send welcome email (non-blocking)
-          const baseUrl = process.env.APP_URL || process.env.BETTER_AUTH_URL || 'http://localhost:3001'
+          const baseUrl = getFrontendUrl()
           sendWelcomeEmail({
             to: user.email,
             name: user.name || 'User',

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -6310,7 +6310,7 @@ app.post('/api/webhooks/stripe', async (c) => {
               const ownerEmail = workspace?.members?.[0]?.user?.email
               if (ownerEmail) {
                 const planLabel = planId.charAt(0).toUpperCase() + planId.slice(1)
-                const baseUrl = process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3001'
+                const baseUrl = getFrontendUrl()
                 const includedUsd = (await import('./config/usage-plans')).getMonthlyIncludedForPlan(planId, checkoutSeats)
                 sendPlanUpgradedEmail({
                   to: ownerEmail,
@@ -6422,7 +6422,7 @@ app.post('/api/webhooks/stripe', async (c) => {
               const ownerEmail = workspace?.members?.[0]?.user?.email
               if (ownerEmail) {
                 const planLabel = (sub.metadata?.planId || 'Pro').charAt(0).toUpperCase() + (sub.metadata?.planId || 'pro').slice(1)
-                const baseUrl = process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3001'
+                const baseUrl = getFrontendUrl()
                 sendPaymentFailedEmail({
                   to: ownerEmail,
                   workspaceName: workspace!.name,
@@ -6838,7 +6838,7 @@ app.post('/api/invite-links', async (c) => {
 
   const inviteeEmail = body.email as string | undefined
   if (inviteeEmail) {
-    const baseUrl = process.env.BETTER_AUTH_URL || process.env.APP_URL || ''
+    const baseUrl = getFrontendUrl()
     const acceptUrl = `${baseUrl}/invite/${link.token}`
     const [inviter, workspace] = await Promise.all([
       prisma.user.findUnique({ where: { id: userId }, select: { name: true } }),
@@ -6993,7 +6993,7 @@ app.post('/api/invite-links/:token/accept', async (c) => {
   }
 
   // Send notification emails (non-blocking — errors are logged internally)
-  const baseUrl = process.env.BETTER_AUTH_URL || process.env.APP_URL || ''
+  const baseUrl = getFrontendUrl()
   const resolvedWorkspaceId = memberData.workspaceId
   const [acceptingUser, workspace, project] = await Promise.all([
     prisma.user.findUnique({ where: { id: userId }, select: { name: true, email: true } }),

--- a/k8s/overlays/production-eu/api-service.yaml
+++ b/k8s/overlays/production-eu/api-service.yaml
@@ -195,6 +195,12 @@ spec:
               value: "shogo.one"
             - name: BETTER_AUTH_URL
               value: "https://studio.shogo.ai"
+            # User-browser-reachable frontend URL used to build links in
+            # transactional emails (welcome, invites, billing, member-joined).
+            # Resolved by getFrontendUrl() in apps/api/src/lib/cloud-urls.ts;
+            # set explicitly so links never fall back to localhost.
+            - name: APP_URL
+              value: "https://studio.shogo.ai"
             - name: SHOGO_PUBLIC_API_URL
               value: "https://studio.shogo.ai"
             - name: ALLOWED_ORIGINS

--- a/k8s/overlays/production-india/api-service.yaml
+++ b/k8s/overlays/production-india/api-service.yaml
@@ -195,6 +195,12 @@ spec:
               value: "shogo.one"
             - name: BETTER_AUTH_URL
               value: "https://studio.shogo.ai"
+            # User-browser-reachable frontend URL used to build links in
+            # transactional emails (welcome, invites, billing, member-joined).
+            # Resolved by getFrontendUrl() in apps/api/src/lib/cloud-urls.ts;
+            # set explicitly so links never fall back to localhost.
+            - name: APP_URL
+              value: "https://studio.shogo.ai"
             - name: SHOGO_PUBLIC_API_URL
               value: "https://studio.shogo.ai"
             - name: ALLOWED_ORIGINS

--- a/k8s/overlays/production-us/api-service.yaml
+++ b/k8s/overlays/production-us/api-service.yaml
@@ -194,6 +194,12 @@ spec:
               value: "shogo.one"
             - name: BETTER_AUTH_URL
               value: "https://studio.shogo.ai"
+            # User-browser-reachable frontend URL used to build links in
+            # transactional emails (welcome, invites, billing, member-joined).
+            # Resolved by getFrontendUrl() in apps/api/src/lib/cloud-urls.ts;
+            # set explicitly so links never fall back to localhost.
+            - name: APP_URL
+              value: "https://studio.shogo.ai"
             - name: SHOGO_PUBLIC_API_URL
               value: "https://studio.shogo.ai"
             - name: ALLOWED_ORIGINS

--- a/k8s/overlays/production/api-service.yaml
+++ b/k8s/overlays/production/api-service.yaml
@@ -147,6 +147,12 @@ spec:
               value: "shogo.one"
             - name: BETTER_AUTH_URL
               value: "https://studio.shogo.ai"
+            # User-browser-reachable frontend URL used to build links in
+            # transactional emails (welcome, invites, billing, member-joined).
+            # Resolved by getFrontendUrl() in apps/api/src/lib/cloud-urls.ts;
+            # set explicitly so links never fall back to localhost.
+            - name: APP_URL
+              value: "https://studio.shogo.ai"
             - name: SHOGO_PUBLIC_API_URL
               value: "https://studio.shogo.ai"
             - name: ALLOWED_ORIGINS


### PR DESCRIPTION
## Summary

Production emails (e.g. the "New Team Member" / "View Team" notification) were linking to `http://localhost:3001`. The email-sending code built link base URLs ad-hoc in 5 places, several with a hardcoded `http://localhost:3001` fallback when `APP_URL`/`NEXT_PUBLIC_APP_URL` were unset. The production k8s overlays do not set `APP_URL`, so those paths fell straight through to the localhost default.

This routes every email link through the existing `getFrontendUrl()` helper (`apps/api/src/lib/cloud-urls.ts`), which resolves `APP_URL` -> first `ALLOWED_ORIGINS` entry -> localhost dev default. `server.ts` already uses this helper for Stripe checkout return URLs; the email paths were just never migrated.

### Changes
- `apps/api/src/auth.ts` (welcome email) and `apps/api/src/server.ts` (plan-upgraded, payment-failed, invite-link, invite-accepted + member-joined emails): replace inline `process.env.*` base-URL resolution with `getFrontendUrl()`, removing all `http://localhost:3001` / `''` fallbacks.
- `k8s/overlays/production{,-us,-eu,-india}/api-service.yaml`: set `APP_URL: "https://studio.shogo.ai"` explicitly so link resolution is deterministic and never depends on `ALLOWED_ORIGINS` ordering.
- `apps/api/src/__tests__/cloud-urls.test.ts`: add regression tests pinning the production config (resolves to `studio.shogo.ai`, never `localhost`).

### Notes / out of scope
- Email link paths were left unchanged (`/billing`, `/login`, `/invite/:token`, root for "View Team"). While auditing I noticed the Expo Router app (`apps/mobile`) has no `/login` or `/invite/:token` route (auth screens are `/sign-in`, `/sign-up`, etc.), so the welcome/invite links may point at non-existent paths. That is a pre-existing issue independent of the localhost bug and is not addressed here.
- A redeploy is required for the `APP_URL` env change to take effect.

## Test plan
- [x] `bun test apps/api/src/__tests__/cloud-urls.test.ts apps/api/src/lib/__tests__/cloud-urls.test.ts` (47 pass)
- [x] Email service unit tests pass per-file (`run-tests-isolated.ts`)
- [ ] After deploy: trigger a member-joined email in staging/prod and confirm "View Team" links to `https://studio.shogo.ai`

Made with [Cursor](https://cursor.com)