### PR TITLE
fix(docker): include packages/pty-core in API, runtime, and swe-overlay images

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -50,6 +50,12 @@ RUN groupadd -g 1001 appgroup && useradd -u 1001 -g appgroup -m -s /bin/bash app
 # appuser), so COPY preserves ownership without a --chown traversal.
 COPY --from=workspace /app/node_modules ./node_modules
 COPY --from=workspace /app/packages/agent-runtime ./packages/agent-runtime
+# pty-core (34123b03 "feat(desktop): add cursor-parity terminal") holds the
+# shared PTY protocol primitives. packages/agent-runtime/src/pty-protocol.ts
+# re-exports from `@shogo/pty-core`, which apps/api/src/server.ts pulls in at
+# boot via pty-ws-handler — without the source dir the API crashes with
+# `Cannot find module '@shogo/pty-core'`. Same omission pattern as 27619a00.
+COPY --from=workspace /app/packages/pty-core ./packages/pty-core
 COPY --from=workspace /app/packages/shared-runtime ./packages/shared-runtime
 COPY --from=workspace /app/packages/sdk ./packages/sdk
 COPY --from=workspace /app/packages/model-catalog ./packages/model-catalog

--- a/packages/agent-runtime/Dockerfile
+++ b/packages/agent-runtime/Dockerfile
@@ -35,6 +35,12 @@ WORKDIR /app
 COPY --from=workspace /app/node_modules ./node_modules
 COPY --from=workspace /app/packages/shared-runtime ./packages/shared-runtime
 COPY --from=workspace /app/packages/agent-runtime ./packages/agent-runtime
+# pty-core (34123b03 "feat(desktop): add cursor-parity terminal") holds the
+# shared PTY protocol primitives. packages/agent-runtime/src/pty-protocol.ts
+# re-exports from `@shogo/pty-core` and agent-runtime's server.ts imports the
+# PTY WS handler at boot — without the source dir the runtime crashes with
+# `Cannot find module '@shogo/pty-core'`. Same omission pattern as 27619a00.
+COPY --from=workspace /app/packages/pty-core ./packages/pty-core
 COPY --from=workspace /app/packages/model-catalog ./packages/model-catalog
 COPY --from=workspace /app/packages/sdk ./packages/sdk
 COPY --from=workspace /app/packages/shogo-worker ./packages/shogo-worker

--- a/packages/agent-runtime/Dockerfile.swe-overlay
+++ b/packages/agent-runtime/Dockerfile.swe-overlay
@@ -43,6 +43,10 @@ RUN --mount=type=cache,target=/root/.bun/install/cache \
 
 COPY packages/shared-runtime ./packages/shared-runtime
 COPY packages/agent-runtime ./packages/agent-runtime
+# agent-runtime re-exports PTY protocol primitives from `@shogo/pty-core`
+# (34123b03); without the source dir, loading pty-protocol crashes with
+# `Cannot find module '@shogo/pty-core'`.
+COPY packages/pty-core ./packages/pty-core
 COPY templates/runtime-template ./templates/runtime-template
 
 # Pre-install runtime-template dependencies so workspaces get node_modules instantly
@@ -99,6 +103,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=builder /app/packages/shared-runtime ./packages/shared-runtime
 COPY --from=builder /app/packages/agent-runtime ./packages/agent-runtime
+COPY --from=builder /app/packages/pty-core ./packages/pty-core
 COPY --from=builder /app/templates/runtime-template ./templates/runtime-template
 COPY --from=builder /app/package.json ./
 COPY --from=builder /app/bun.lock ./


### PR DESCRIPTION
## Summary

Production deploys to **production-us** have been failing since the introduction of `@shogo/pty-core`: new Knative revisions crash-loop at startup and traffic is stuck on the last healthy revision (`api-00214`; `api-00216`/`api-00217` also failed).

Root cause: commit `34123b03` lifted the PTY protocol primitives into a new workspace package `packages/pty-core` (`@shogo/pty-core`) and made `packages/agent-runtime/src/pty-protocol.ts` re-export from it. The API boots through `server.ts` -> `pty-ws-handler` -> `pty-protocol` -> `@shogo/pty-core`.

The production image Dockerfiles selectively `COPY --from=workspace` only the workspace packages they know about, and `packages/pty-core` was never added. The package's stub `package.json` is glob-copied (`COPY --parents packages/*/package.json`), but its `src/` tree is not, so Bun can't resolve the module and the process exits:

```
error: Cannot find module '@shogo/pty-core' from '/app/packages/agent-runtime/src/pty-protocol.ts'
```

This is the same omission pattern fixed for the SDK split-out packages in `27619a00` (and the 2026-05-14 staging incident).

## Changes

Add the missing `pty-core` COPY to all three images that ship agent-runtime:
- `apps/api/Dockerfile`
- `packages/agent-runtime/Dockerfile` (runtime pods would hit the same crash at project boot)
- `packages/agent-runtime/Dockerfile.swe-overlay` (builder + final stage)

`pty-core` is pure TypeScript (no build output, no native module), so a source COPY is sufficient; the existing `bun install --ignore-scripts` recreates the workspace symlink. `docker/workspace-deps/Dockerfile` already copies all of `packages/`, so the source is present in the `workspace` stage.

## Test plan
- [ ] CI builds the `shogo-api` and runtime images and the new revision reaches `Ready` (no `Cannot find module '@shogo/pty-core'`)
- [ ] Deploy to production-us; confirm a new `api-0021x` revision goes Ready and takes 100% traffic
- [ ] `grep -rn "COPY .*pty-core" apps/api/Dockerfile packages/agent-runtime/Dockerfile*` shows the new lines

## Context
Discovered while patching `APP_URL` onto the prod clusters for the email-link fix (#707) — that env change is in the US desired spec but can't roll out until this image fix lands.

Made with [Cursor](https://cursor.com)