### PR TITLE
Fix chat image copy and download actions

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1108,12 +1108,22 @@ function setupSessionHandlers(): void {
   ses.webRequest.onHeadersReceived((details, callback) => {
     const headers = { ...details.responseHeaders }
 
-    if (details.url.startsWith(apiOrigin)) {
+    const isApiOrigin = details.url.startsWith(apiOrigin)
+    // Direct agent-runtime ports (e.g. http://localhost:<agentPort>/agent/
+    // workspace/download/...) echo back `ALLOWED_ORIGINS[0]` (http://localhost:3000)
+    // for our `shogo://app` origin, so credentialed fetches — chat image
+    // copy/download — are CORS-blocked even though the <img> renders fine.
+    // Rewrite the CORS headers here so those fetches succeed regardless of the
+    // runtime's own CORS config.
+    const isLocalAgent =
+      !isApiOrigin && /^https?:\/\/(localhost|127\.0\.0\.1):\d+/i.test(details.url)
+
+    if (isApiOrigin || isLocalAgent) {
       headers['Access-Control-Allow-Origin'] = [appOrigin]
       headers['Access-Control-Allow-Credentials'] = ['true']
       headers['Access-Control-Allow-Methods'] = ['GET,POST,PUT,PATCH,DELETE,OPTIONS']
 
-      // Preserve the API server's `Access-Control-Allow-Headers` when present:
+      // Preserve the server's `Access-Control-Allow-Headers` when present:
       // Hono's `cors()` middleware reflects the request's
       // `Access-Control-Request-Headers`, so the API already echoes back any
       // custom header the renderer sends (`X-Chat-Session-Id`, `X-Session-Id`,
@@ -1127,7 +1137,9 @@ function setupSessionHandlers(): void {
       if (!hasAllowHeaders) {
         headers['Access-Control-Allow-Headers'] = ['Content-Type,Authorization,X-Requested-With']
       }
+    }
 
+    if (isApiOrigin) {
       const setCookies = headers['Set-Cookie'] || headers['set-cookie']
       if (setCookies) {
         const rewritten = setCookies.map((cookie: string) => {

--- a/apps/mobile/components/chat/ImagePreviewModal.tsx
+++ b/apps/mobile/components/chat/ImagePreviewModal.tsx
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * ImagePreviewModal
+ *
+ * Full-size chat image viewer with clipboard support. On web/desktop we copy
+ * an actual PNG image blob when the platform clipboard supports it.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  ActivityIndicator,
+  Image,
+  Platform,
+  Pressable,
+  Text,
+  useWindowDimensions,
+  View,
+} from "react-native"
+import { Check, ImageIcon, X } from "lucide-react-native"
+import { cn } from "@shogo/shared-ui/primitives"
+import {
+  Modal,
+  ModalBackdrop,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+} from "@/components/ui/modal"
+import {
+  type CopyState,
+  copyImageToClipboard,
+  isShogoDesktop,
+} from "./chatImageActions"
+
+export interface ImagePreviewModalProps {
+  visible: boolean
+  onClose: () => void
+  url: string
+  mediaType?: string
+  title?: string
+  alt?: string
+}
+
+// The image right-click menu only exists in the Shogo desktop app. On web we
+// leave right-click to the browser's native context menu.
+export function ChatImageContextMenu({
+  x,
+  y,
+  onDownload,
+  onClose,
+}: {
+  x: number
+  y: number
+  onDownload: () => void
+  onClose: () => void
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (Platform.OS !== "web") return
+    const onDown = (event: MouseEvent) => {
+      if (!ref.current?.contains(event.target as Node)) onClose()
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose()
+    }
+    window.addEventListener("mousedown", onDown)
+    window.addEventListener("keydown", onKeyDown)
+    window.addEventListener("blur", onClose)
+    return () => {
+      window.removeEventListener("mousedown", onDown)
+      window.removeEventListener("keydown", onKeyDown)
+      window.removeEventListener("blur", onClose)
+    }
+  }, [onClose])
+
+  if (!isShogoDesktop() || typeof window === "undefined") return null
+
+  const left = Math.max(8, Math.min(x, window.innerWidth - 220))
+  const top = Math.max(8, Math.min(y, window.innerHeight - 78))
+
+  return (
+    <div
+      ref={ref}
+      role="menu"
+      style={{ left, top }}
+      className="fixed z-50 min-w-[200px] rounded-xl border border-border bg-background/95 p-1.5 shadow-2xl backdrop-blur"
+    >
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onDownload()
+          onClose()
+        }}
+        className="block w-full rounded-lg px-3 py-1.5 text-left text-sm text-foreground hover:bg-primary hover:text-primary-foreground"
+      >
+        Download Image
+      </button>
+    </div>
+  )
+}
+
+export function ImagePreviewModal({
+  visible,
+  onClose,
+  url,
+  mediaType,
+  title = "Image preview",
+  alt = "Image attachment",
+}: ImagePreviewModalProps) {
+  const [copyState, setCopyState] = useState<CopyState>("idle")
+  const [loadState, setLoadState] = useState<"loading" | "loaded" | "failed">(
+    "loading",
+  )
+  const resetCopyStateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  )
+  const { width, height } = useWindowDimensions()
+  const showCopy = !isShogoDesktop()
+
+  const panelMaxWidth = Math.min(Math.max(width - 32, 280), 960)
+  const panelMaxHeight = Math.min(Math.max(height * 0.86, 320), 760)
+  const imageMaxHeight = Math.max(240, panelMaxHeight - 112)
+
+  useEffect(() => {
+    return () => {
+      if (resetCopyStateTimerRef.current) {
+        clearTimeout(resetCopyStateTimerRef.current)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!visible) return
+    if (resetCopyStateTimerRef.current) {
+      clearTimeout(resetCopyStateTimerRef.current)
+      resetCopyStateTimerRef.current = null
+    }
+    setCopyState("idle")
+    setLoadState("loading")
+  }, [visible, url])
+
+  const statusLabel = useMemo(() => {
+    switch (copyState) {
+      case "copying":
+        return "Copying..."
+      case "copied":
+        return "Copied image"
+      case "failed":
+        return "Copy failed"
+      default:
+        return "Copy image"
+    }
+  }, [copyState])
+
+  const handleCopy = useCallback(async () => {
+    if (!url || copyState === "copying") return
+    setCopyState("copying")
+    const result = await copyImageToClipboard(url, mediaType)
+    setCopyState(result)
+    if (resetCopyStateTimerRef.current) {
+      clearTimeout(resetCopyStateTimerRef.current)
+    }
+    resetCopyStateTimerRef.current = setTimeout(() => {
+      setCopyState("idle")
+      resetCopyStateTimerRef.current = null
+    }, 2200)
+  }, [copyState, mediaType, url])
+
+  return (
+    <Modal isOpen={visible} onClose={onClose} size="full">
+      <ModalBackdrop />
+      <ModalContent
+        className="bg-background m-4 overflow-hidden rounded-xl border border-border p-0"
+        style={{ maxWidth: panelMaxWidth, maxHeight: panelMaxHeight }}
+      >
+        <ModalHeader className="flex-row items-center justify-between border-b border-border px-4 py-3">
+          <View className="min-w-0 flex-1 flex-row items-center gap-2">
+            <ImageIcon size={15} className="text-muted-foreground" />
+            <Text className="text-sm font-semibold text-foreground" numberOfLines={1}>
+              {title}
+            </Text>
+          </View>
+          <View className="flex-row items-center gap-2">
+            {showCopy ? (
+              <Pressable
+                onPress={handleCopy}
+                disabled={copyState === "copying"}
+                accessibilityRole="button"
+                accessibilityLabel={statusLabel}
+                className={cn(
+                  "h-8 flex-row items-center gap-1.5 rounded-md px-2.5",
+                  Platform.OS === "web" && "hover:bg-muted/60",
+                  copyState === "failed" && "bg-destructive/10",
+                )}
+              >
+                {copyState === "copying" ? (
+                  <ActivityIndicator size="small" />
+                ) : copyState === "copied" ? (
+                  <Check size={16} className="text-green-500" />
+                ) : null}
+                <Text
+                  className={cn(
+                    "text-xs font-medium",
+                    copyState === "failed"
+                      ? "text-destructive"
+                      : "text-muted-foreground",
+                  )}
+                >
+                  {statusLabel}
+                </Text>
+              </Pressable>
+            ) : null}
+            <ModalCloseButton className="h-8 w-8 items-center justify-center rounded-md">
+              <X size={16} className="text-muted-foreground" />
+            </ModalCloseButton>
+          </View>
+        </ModalHeader>
+
+        <ModalBody className="m-0 p-0">
+          <View
+            className="items-center justify-center bg-muted/20 p-3"
+            style={{ maxHeight: imageMaxHeight }}
+          >
+            {loadState === "loading" ? (
+              <View className="absolute inset-0 items-center justify-center">
+                <ActivityIndicator size="large" />
+              </View>
+            ) : null}
+            {loadState === "failed" ? (
+              <View className="items-center justify-center gap-2 rounded-lg border border-border bg-background p-8">
+                <ImageIcon size={28} className="text-muted-foreground" />
+                <Text className="text-sm font-medium text-foreground">
+                  Could not load this image
+                </Text>
+                <Text className="max-w-[320px] text-center text-xs text-muted-foreground">
+                  The original may have moved or the browser blocked access.
+                </Text>
+              </View>
+            ) : (
+              <Image
+                source={{ uri: url }}
+                resizeMode="contain"
+                accessibilityLabel={alt}
+                onLoad={() => setLoadState("loaded")}
+                onError={() => setLoadState("failed")}
+                style={{
+                  width: panelMaxWidth - 24,
+                  height: imageMaxHeight,
+                  opacity: loadState === "loaded" ? 1 : 0,
+                }}
+              />
+            )}
+          </View>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export default ImagePreviewModal

--- a/apps/mobile/components/chat/__tests__/chatImageActions.test.ts
+++ b/apps/mobile/components/chat/__tests__/chatImageActions.test.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Unit tests for chat image copy/download actions.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import {
+  copyImageToClipboard,
+  downloadImage,
+} from "../chatImageActions"
+
+// `agentFetch` is replaced by the test preload (apps/mobile/test/testing-library.ts)
+// with a façade that delegates to `globalThis.__shogoAgentFetchHandler`. Image
+// actions go through `agentFetch` so the session cookie travels with the
+// request, so we drive that handler here rather than stubbing global fetch.
+type AgentFetchHandler = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const globalAny = globalThis as any
+const originalAgentFetchHandler = globalAny.__shogoAgentFetchHandler
+const originalClipboardItem = globalThis.ClipboardItem
+const originalCreateObjectUrl = URL.createObjectURL
+const originalRevokeObjectUrl = URL.revokeObjectURL
+const originalAnchorClick = HTMLAnchorElement.prototype.click
+
+function setAgentFetch(handler: AgentFetchHandler): void {
+  globalAny.__shogoAgentFetchHandler = handler
+}
+
+function setClipboard(clipboard: Partial<Clipboard>): void {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: clipboard,
+  })
+}
+
+beforeEach(() => {
+  setClipboard({})
+  setAgentFetch(async () => (
+    new Response(new Blob(["png"], { type: "image/png" }), { status: 200 })
+  ))
+})
+
+afterEach(() => {
+  globalAny.__shogoAgentFetchHandler = originalAgentFetchHandler
+  globalThis.ClipboardItem = originalClipboardItem
+  URL.createObjectURL = originalCreateObjectUrl
+  URL.revokeObjectURL = originalRevokeObjectUrl
+  HTMLAnchorElement.prototype.click = originalAnchorClick
+  setClipboard({})
+  mock.restore()
+})
+
+describe("copyImageToClipboard", () => {
+  test("writes an image blob fetched via the credentialed agent fetch", async () => {
+    const agentFetchSpy = mock(async () => (
+      new Response(new Blob(["png"], { type: "image/png" }), { status: 200 })
+    ))
+    setAgentFetch(agentFetchSpy as unknown as AgentFetchHandler)
+
+    const write = mock(async () => undefined)
+    setClipboard({ write } as unknown as Clipboard)
+
+    class TestClipboardItem {
+      constructor(public readonly items: Record<string, Blob | Promise<Blob>>) {}
+    }
+    globalThis.ClipboardItem = TestClipboardItem as unknown as typeof ClipboardItem
+
+    await expect(copyImageToClipboard("https://api.test/agent/workspace/download/x.png", "image/png"))
+      .resolves.toBe("copied")
+
+    // Root-cause guard: image bytes must be retrieved through the
+    // credential-aware agent fetch, not a bare unauthenticated fetch.
+    expect(agentFetchSpy).toHaveBeenCalledTimes(1)
+    expect(write).toHaveBeenCalledTimes(1)
+    const item = (write.mock.calls[0]?.[0] as TestClipboardItem[])[0]
+    expect(Object.keys(item.items)).toEqual(["image/png"])
+    // Electron-safety guard: the clipboard value must be a resolved Blob,
+    // not a Promise (Electron's Chromium fails to write promise-valued
+    // image clipboard items). `await` on a Blob yields the Blob itself.
+    const value = item.items["image/png"]
+    expect(value).toBeInstanceOf(Blob)
+    expect(value instanceof Promise).toBe(false)
+  })
+
+  test("decodes data: URLs locally instead of fetching them", async () => {
+    // Root-cause guard: routing a `data:` URL through fetch/agentFetch is
+    // refused by the desktop CSP `connect-src` rule, so pasted screenshots
+    // must be decoded directly without touching the network.
+    const agentFetchSpy = mock(async () => (
+      new Response(new Blob(["should-not-run"], { type: "image/png" }), { status: 200 })
+    ))
+    setAgentFetch(agentFetchSpy as unknown as AgentFetchHandler)
+
+    const write = mock(async () => undefined)
+    setClipboard({ write } as unknown as Clipboard)
+
+    class TestClipboardItem {
+      constructor(public readonly items: Record<string, Blob | Promise<Blob>>) {}
+    }
+    globalThis.ClipboardItem = TestClipboardItem as unknown as typeof ClipboardItem
+
+    // 1x1 transparent PNG.
+    const dataUrl =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMCAQDFI6cVAAAAAElFTkSuQmCC"
+
+    await expect(copyImageToClipboard(dataUrl, "image/png")).resolves.toBe("copied")
+
+    expect(agentFetchSpy).not.toHaveBeenCalled()
+    expect(write).toHaveBeenCalledTimes(1)
+    const item = (write.mock.calls[0]?.[0] as TestClipboardItem[])[0]
+    expect(item.items["image/png"]).toBeInstanceOf(Blob)
+  })
+
+  test("does not fall back to copying image URLs as text", async () => {
+    const write = mock(async () => {
+      throw new Error("clipboard image write failed")
+    })
+    const writeText = mock(async () => undefined)
+    setClipboard({ write, writeText } as unknown as Clipboard)
+
+    class TestClipboardItem {
+      constructor(public readonly items: Record<string, Blob | Promise<Blob>>) {}
+    }
+    globalThis.ClipboardItem = TestClipboardItem as unknown as typeof ClipboardItem
+
+    await expect(copyImageToClipboard("https://example.test/image.png", "image/png"))
+      .resolves.toBe("failed")
+
+    expect(write).toHaveBeenCalledTimes(1)
+    expect(writeText).not.toHaveBeenCalled()
+  })
+})
+
+describe("downloadImage", () => {
+  test("downloads fetched image blobs with the image filename", async () => {
+    let clickedAnchor: HTMLAnchorElement | null = null
+    const click = mock(function (this: HTMLAnchorElement) {
+      clickedAnchor = this
+    })
+    const createObjectURL = mock(() => "blob:download-url")
+    const revokeObjectURL = mock(() => undefined)
+    HTMLAnchorElement.prototype.click = click as unknown as typeof HTMLAnchorElement.prototype.click
+    URL.createObjectURL = createObjectURL as unknown as typeof URL.createObjectURL
+    URL.revokeObjectURL = revokeObjectURL as unknown as typeof URL.revokeObjectURL
+
+    await downloadImage("https://example.test/generated/result.png", "generated-image", "image/png")
+
+    expect(click).toHaveBeenCalledTimes(1)
+    expect(clickedAnchor?.href).toBe("blob:download-url")
+    expect(clickedAnchor?.download).toBe("result.png")
+    expect(document.querySelector("a")).toBeNull()
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    expect(revokeObjectURL).not.toHaveBeenCalled()
+  })
+})

--- a/apps/mobile/components/chat/chatImageActions.ts
+++ b/apps/mobile/components/chat/chatImageActions.ts
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Shared image actions for chat image previews and thumbnail context menus.
+ */
+
+import { Platform } from "react-native"
+import * as Clipboard from "expo-clipboard"
+import { agentFetch } from "../../lib/agent-fetch"
+
+export type CopyState = "idle" | "copying" | "copied" | "failed"
+
+/**
+ * True when running inside the Shogo desktop (Electron) shell, detected via the
+ * preload-injected `shogoDesktop` global. The desktop app renders the web
+ * bundle, so this lets shared components branch on the desktop runtime (e.g. the
+ * image right-click menu only exists on desktop).
+ */
+export function isShogoDesktop(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    !!(window as { shogoDesktop?: { isDesktop?: boolean } }).shogoDesktop?.isDesktop
+  )
+}
+
+function inferImageMimeType(url: string, mediaType?: string): string {
+  if (mediaType?.startsWith("image/")) return mediaType
+  const dataMatch = /^data:([^;,]+)[;,]/.exec(url)
+  if (dataMatch?.[1]?.startsWith("image/")) return dataMatch[1]
+  if (/\.jpe?g($|[?#])/i.test(url)) return "image/jpeg"
+  if (/\.webp($|[?#])/i.test(url)) return "image/webp"
+  if (/\.gif($|[?#])/i.test(url)) return "image/gif"
+  return "image/png"
+}
+
+function dataUrlToBlob(dataUrl: string, mediaType?: string): Blob {
+  const commaIndex = dataUrl.indexOf(",")
+  const meta = commaIndex >= 0 ? dataUrl.slice(0, commaIndex) : ""
+  const payload = commaIndex >= 0 ? dataUrl.slice(commaIndex + 1) : ""
+  const type = inferImageMimeType(dataUrl, mediaType)
+  if (/;base64/i.test(meta)) {
+    const binary = atob(payload)
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i)
+    return new Blob([bytes], { type })
+  }
+  return new Blob([decodeURIComponent(payload)], { type })
+}
+
+async function fetchImageBlob(url: string, mediaType?: string): Promise<Blob> {
+  // `data:` URLs (e.g. pasted screenshots) must be decoded locally. Routing
+  // them through `fetch`/`agentFetch` trips the desktop app's Content-Security-
+  // Policy `connect-src` rule, which doesn't allow the `data:` scheme — so the
+  // request is refused and "Copy failed" appears even though the inline `<img>`
+  // renders fine via `img-src`. Decoding the bytes directly avoids the network.
+  if (url.startsWith("data:")) {
+    return dataUrlToBlob(url, mediaType)
+  }
+  // Chat images (especially generated images) are served from the
+  // agent proxy at `${agentUrl}/agent/workspace/download/...`, which is
+  // cross-origin to the web app and gated behind the session cookie.
+  // A bare `fetch` omits credentials and gets a 401/403 even though the
+  // `<img>` tag renders fine — so go through `agentFetch`, which sends
+  // the cookie on web and a `Cookie` header on native.
+  const response = await agentFetch(url)
+  if (!response.ok) {
+    throw new Error(`Image request failed with ${response.status}`)
+  }
+  const blob = await response.blob()
+  if (blob.type) return blob
+  return new Blob([blob], { type: inferImageMimeType(url, mediaType) })
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result))
+    reader.onerror = () => reject(reader.error ?? new Error("Failed to read image"))
+    reader.readAsDataURL(blob)
+  })
+}
+
+async function blobToPng(blob: Blob): Promise<Blob> {
+  if (blob.type === "image/png") return blob
+  if (
+    Platform.OS !== "web" ||
+    typeof window === "undefined" ||
+    typeof document === "undefined"
+  ) {
+    return blob
+  }
+
+  const objectUrl = URL.createObjectURL(blob)
+  try {
+    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const image = new window.Image()
+      image.onload = () => resolve(image)
+      image.onerror = () => reject(new Error("Failed to decode image"))
+      image.src = objectUrl
+    })
+    const canvas = document.createElement("canvas")
+    canvas.width = Math.max(1, img.naturalWidth || img.width)
+    canvas.height = Math.max(1, img.naturalHeight || img.height)
+    const context = canvas.getContext("2d")
+    if (!context) throw new Error("Canvas is unavailable")
+    context.drawImage(img, 0, 0)
+    return await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob((pngBlob) => {
+        if (pngBlob) resolve(pngBlob)
+        else reject(new Error("Failed to encode image"))
+      }, "image/png")
+    })
+  } finally {
+    URL.revokeObjectURL(objectUrl)
+  }
+}
+
+export async function copyImageToClipboard(
+  url: string,
+  mediaType?: string,
+): Promise<Exclude<CopyState, "idle" | "copying">> {
+  if (Platform.OS === "web") {
+    const clipboard = typeof navigator !== "undefined" ? navigator.clipboard : null
+    const ClipboardItemCtor =
+      typeof ClipboardItem !== "undefined" ? ClipboardItem : undefined
+    if (clipboard?.write && ClipboardItemCtor) {
+      try {
+        // Resolve the PNG bytes BEFORE constructing the ClipboardItem.
+        // Passing a `Promise<Blob>` to `ClipboardItem` is spec-valid but
+        // Electron's Chromium fails to write image data that way, so the
+        // desktop app reported "Copy failed" even though the fetch
+        // succeeded. The originating click keeps transient activation
+        // alive across the (fast, local) agent fetch, so writing the
+        // already-resolved blob is reliable on both web and desktop.
+        const pngBlob = await blobToPng(await fetchImageBlob(url, mediaType))
+        await clipboard.write([
+          new ClipboardItemCtor({ "image/png": pngBlob }),
+        ])
+        return "copied"
+      } catch {
+        return "failed"
+      }
+    }
+    return "failed"
+  }
+
+  try {
+    const setImageAsync = (Clipboard as typeof Clipboard & {
+      setImageAsync?: (base64Image: string) => Promise<void>
+    }).setImageAsync
+    if (setImageAsync) {
+      const blob = await fetchImageBlob(url, mediaType)
+      const dataUrl = await blobToDataUrl(blob)
+      const base64 = dataUrl.split(",")[1]
+      if (base64) {
+        await setImageAsync(base64)
+        return "copied"
+      }
+    }
+  } catch {
+    return "failed"
+  }
+  return "failed"
+}
+
+function inferImageFilename(url: string, fallbackTitle?: string): string {
+  const cleanTitle = fallbackTitle
+    ?.trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  const fallback = cleanTitle || "image"
+
+  try {
+    const pathname = new URL(url, window.location.href).pathname
+    const basename = pathname.split("/").filter(Boolean).pop()
+    if (basename && /\.[a-z0-9]+$/i.test(basename)) return basename
+  } catch {
+    // data URLs and malformed remote URLs fall back to the title-based name.
+  }
+
+  return `${fallback}.png`
+}
+
+function clickDownloadLink(href: string, filename: string): void {
+  const anchor = document.createElement("a")
+  anchor.href = href
+  anchor.download = filename
+  anchor.rel = "noopener noreferrer"
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+}
+
+export async function downloadImage(
+  url: string,
+  fallbackTitle?: string,
+  mediaType?: string,
+): Promise<void> {
+  if (Platform.OS !== "web" || typeof document === "undefined") return
+  const filename = inferImageFilename(url, fallbackTitle)
+  try {
+    const blob = await fetchImageBlob(url, mediaType)
+    const objectUrl = URL.createObjectURL(blob)
+    clickDownloadLink(objectUrl, filename)
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 1000)
+  } catch {
+    clickDownloadLink(url, filename)
+  }
+}

--- a/apps/mobile/components/chat/turns/AssistantContent.tsx
+++ b/apps/mobile/components/chat/turns/AssistantContent.tsx
@@ -8,7 +8,7 @@
  */
 
 import { memo, useState, useCallback, useMemo, useRef, useEffect } from "react"
-import { View, Text, Image, Pressable, Linking } from "react-native"
+import { View, Text, Image, Pressable, Linking, Platform } from "react-native"
 import { cn } from "@shogo/shared-ui/primitives"
 import { FileText } from "lucide-react-native"
 import type { UIMessage } from "@ai-sdk/react"
@@ -45,6 +45,8 @@ import { subagentStreamStore } from "../../../lib/subagent-stream-store"
 import { useTodoStateStore, parseTodos as parseTodosForStore } from "../../../lib/todo-state-store"
 import { logScreencast } from "../../../lib/screencast-debug"
 import { FileViewerModal } from "../FileViewerModal"
+import { ChatImageContextMenu, ImagePreviewModal } from "../ImagePreviewModal"
+import { downloadImage, isShogoDesktop } from "../chatImageActions"
 
 /**
  * Throttle a streaming value so heavy downstream work (markdown parsing, part
@@ -430,6 +432,7 @@ const ExplorationGroupSlot = memo(function ExplorationGroupSlot({
 
 function ImageThumbnail({
   url,
+  mediaType,
   index,
 }: {
   url: string
@@ -437,10 +440,29 @@ function ImageThumbnail({
   index: number
 }) {
   const [hasError, setHasError] = useState(false)
+  const [showModal, setShowModal] = useState(false)
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null)
 
   const handlePress = useCallback(() => {
-    Linking.openURL(url)
-  }, [url])
+    setShowModal(true)
+  }, [])
+
+  const handleContextMenu = useCallback((event: any) => {
+    // The custom right-click menu is desktop-only; on web we let the browser
+    // show its native context menu.
+    if (!isShogoDesktop()) return
+    event.preventDefault?.()
+    event.stopPropagation?.()
+    const nativeEvent = event.nativeEvent ?? event
+    setContextMenu({
+      x: nativeEvent.clientX ?? 0,
+      y: nativeEvent.clientY ?? 0,
+    })
+  }, [])
+
+  const handleDownloadImage = useCallback(() => {
+    void downloadImage(url, `image-attachment-${index + 1}`, mediaType)
+  }, [index, mediaType, url])
 
   if (hasError) {
     return (
@@ -453,16 +475,42 @@ function ImageThumbnail({
   }
 
   return (
-    <Pressable onPress={handlePress} testID="image-thumbnail">
-      <Image
-        source={{ uri: url }}
-        className="max-w-[280px] rounded-md"
-        resizeMode="contain"
-        accessibilityLabel={`Image attachment ${index + 1}`}
-        onError={() => setHasError(true)}
-        style={{ width: 280, aspectRatio: 4 / 3 }}
+    <>
+      <Pressable
+        onPress={handlePress}
+        {...(Platform.OS === "web" ? { onContextMenu: handleContextMenu } as any : {})}
+        testID="image-thumbnail"
+        accessibilityRole="button"
+        accessibilityLabel={`Open image attachment ${index + 1}`}
+        accessibilityHint="Opens a larger preview."
+        className={Platform.OS === "web" ? "cursor-zoom-in" : undefined}
+      >
+        <Image
+          source={{ uri: url }}
+          className="max-w-[280px] rounded-md"
+          resizeMode="contain"
+          accessibilityLabel={`Image attachment ${index + 1}`}
+          onError={() => setHasError(true)}
+          style={{ width: 280, aspectRatio: 4 / 3 }}
+        />
+      </Pressable>
+      <ImagePreviewModal
+        visible={showModal}
+        onClose={() => setShowModal(false)}
+        url={url}
+        mediaType={mediaType}
+        title={`Image attachment ${index + 1}`}
+        alt={`Image attachment ${index + 1}`}
       />
-    </Pressable>
+      {contextMenu ? (
+        <ChatImageContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          onDownload={handleDownloadImage}
+          onClose={() => setContextMenu(null)}
+        />
+      ) : null}
+    </>
   )
 }
 

--- a/apps/mobile/components/chat/turns/GenerateImageWidget.tsx
+++ b/apps/mobile/components/chat/turns/GenerateImageWidget.tsx
@@ -9,11 +9,13 @@
  */
 
 import { useState, useCallback, useMemo } from "react"
-import { View, Text, Image, Pressable, Linking, ActivityIndicator } from "react-native"
+import { View, Text, Image, Pressable, ActivityIndicator, Platform } from "react-native"
 import { cn } from "@shogo/shared-ui/primitives"
 import { ImageIcon, Pencil } from "lucide-react-native"
 import type { ToolCallData } from "../tools/types"
 import { useChatContextSafe } from "../ChatContext"
+import { ChatImageContextMenu, ImagePreviewModal } from "../ImagePreviewModal"
+import { downloadImage, isShogoDesktop } from "../chatImageActions"
 
 export interface GenerateImageWidgetProps {
   tool: ToolCallData
@@ -46,6 +48,8 @@ export function GenerateImageWidget({ tool }: GenerateImageWidgetProps) {
   const chatContext = useChatContextSafe()
   const [hasError, setHasError] = useState(false)
   const [isLoaded, setIsLoaded] = useState(false)
+  const [showPreview, setShowPreview] = useState(false)
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null)
 
   const result = useMemo(() => parseResult(tool.result), [tool.result])
 
@@ -55,7 +59,24 @@ export function GenerateImageWidget({ tool }: GenerateImageWidgetProps) {
   }, [result?.path, chatContext?.agentUrl])
 
   const handlePress = useCallback(() => {
-    if (imageUrl) Linking.openURL(imageUrl)
+    if (imageUrl) setShowPreview(true)
+  }, [imageUrl])
+
+  const handleContextMenu = useCallback((event: any) => {
+    // The custom right-click menu is desktop-only; on web we let the browser
+    // show its native context menu.
+    if (!isShogoDesktop() || !imageUrl) return
+    event.preventDefault?.()
+    event.stopPropagation?.()
+    const nativeEvent = event.nativeEvent ?? event
+    setContextMenu({
+      x: nativeEvent.clientX ?? 0,
+      y: nativeEvent.clientY ?? 0,
+    })
+  }, [imageUrl])
+
+  const handleDownloadImage = useCallback(() => {
+    if (imageUrl) void downloadImage(imageUrl, "generated-image", "image/png")
   }, [imageUrl])
 
   if (tool.state === "streaming") {
@@ -94,7 +115,17 @@ export function GenerateImageWidget({ tool }: GenerateImageWidgetProps) {
 
   return (
     <View className="mx-3 my-1.5">
-      <Pressable onPress={handlePress} className="rounded-lg overflow-hidden border border-border">
+      <Pressable
+        onPress={handlePress}
+        {...(Platform.OS === "web" ? { onContextMenu: handleContextMenu } as any : {})}
+        className={cn(
+          "rounded-lg overflow-hidden border border-border",
+          Platform.OS === "web" && "cursor-zoom-in",
+        )}
+        accessibilityRole="button"
+        accessibilityLabel="Open generated image preview"
+        accessibilityHint="Opens a larger preview."
+      >
         {!isLoaded && !hasError && (
           <View className="w-[280px] bg-muted/50 items-center justify-center" style={{ aspectRatio: 1 }}>
             <ActivityIndicator size="small" />
@@ -139,6 +170,22 @@ export function GenerateImageWidget({ tool }: GenerateImageWidgetProps) {
           </Text>
         )}
       </View>
+      <ImagePreviewModal
+        visible={showPreview}
+        onClose={() => setShowPreview(false)}
+        url={imageUrl}
+        mediaType="image/png"
+        title="Generated image"
+        alt={`Generated image: ${result.revised_prompt || "AI generated"}`}
+      />
+      {contextMenu ? (
+        <ChatImageContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          onDownload={handleDownloadImage}
+          onClose={() => setContextMenu(null)}
+        />
+      ) : null}
     </View>
   )
 }

--- a/apps/mobile/components/chat/turns/MessageContent.tsx
+++ b/apps/mobile/components/chat/turns/MessageContent.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useState, useCallback } from "react"
-import { View, Text, Image, Pressable, Linking } from "react-native"
+import { View, Text, Image, Pressable, Linking, Platform } from "react-native"
 import { cn } from "@shogo/shared-ui/primitives"
 import { FileText } from "lucide-react-native"
 import type { UIMessage } from "@ai-sdk/react"
@@ -18,6 +18,8 @@ import { MarkdownText } from "../MarkdownText"
 import { analyzeContent } from "../long-text-utils"
 import { LongTextPreviewCard } from "../LongTextPreviewCard"
 import { FileViewerModal } from "../FileViewerModal"
+import { ChatImageContextMenu, ImagePreviewModal } from "../ImagePreviewModal"
+import { downloadImage, isShogoDesktop } from "../chatImageActions"
 
 export interface MessageContentProps {
   message: UIMessage
@@ -104,6 +106,7 @@ function extractFileParts(message: UIMessage): FilePart[] {
 
 function ImageThumbnail({
   url,
+  mediaType,
   index,
 }: {
   url: string
@@ -111,10 +114,29 @@ function ImageThumbnail({
   index: number
 }) {
   const [hasError, setHasError] = useState(false)
+  const [showModal, setShowModal] = useState(false)
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null)
 
   const handlePress = useCallback(() => {
-    Linking.openURL(url)
-  }, [url])
+    setShowModal(true)
+  }, [])
+
+  const handleContextMenu = useCallback((event: any) => {
+    // The custom right-click menu is desktop-only; on web we let the browser
+    // show its native context menu.
+    if (!isShogoDesktop()) return
+    event.preventDefault?.()
+    event.stopPropagation?.()
+    const nativeEvent = event.nativeEvent ?? event
+    setContextMenu({
+      x: nativeEvent.clientX ?? 0,
+      y: nativeEvent.clientY ?? 0,
+    })
+  }, [])
+
+  const handleDownloadImage = useCallback(() => {
+    void downloadImage(url, `image-attachment-${index + 1}`, mediaType)
+  }, [index, mediaType, url])
 
   if (hasError) {
     return (
@@ -127,16 +149,42 @@ function ImageThumbnail({
   }
 
   return (
-    <Pressable onPress={handlePress} testID="image-thumbnail">
-      <Image
-        source={{ uri: url }}
-        className="max-w-[280px] rounded-md"
-        resizeMode="contain"
-        accessibilityLabel={`Image attachment ${index + 1}`}
-        onError={() => setHasError(true)}
-        style={{ width: 280, aspectRatio: 4 / 3 }}
+    <>
+      <Pressable
+        onPress={handlePress}
+        {...(Platform.OS === "web" ? { onContextMenu: handleContextMenu } as any : {})}
+        testID="image-thumbnail"
+        accessibilityRole="button"
+        accessibilityLabel={`Open image attachment ${index + 1}`}
+        accessibilityHint="Opens a larger preview."
+        className={Platform.OS === "web" ? "cursor-zoom-in" : undefined}
+      >
+        <Image
+          source={{ uri: url }}
+          className="max-w-[280px] rounded-md"
+          resizeMode="contain"
+          accessibilityLabel={`Image attachment ${index + 1}`}
+          onError={() => setHasError(true)}
+          style={{ width: 280, aspectRatio: 4 / 3 }}
+        />
+      </Pressable>
+      <ImagePreviewModal
+        visible={showModal}
+        onClose={() => setShowModal(false)}
+        url={url}
+        mediaType={mediaType}
+        title={`Image attachment ${index + 1}`}
+        alt={`Image attachment ${index + 1}`}
       />
-    </Pressable>
+      {contextMenu ? (
+        <ChatImageContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          onDownload={handleDownloadImage}
+          onClose={() => setContextMenu(null)}
+        />
+      ) : null}
+    </>
   )
 }
 

--- a/apps/mobile/components/ui/modal/index.tsx
+++ b/apps/mobile/components/ui/modal/index.tsx
@@ -160,7 +160,7 @@ const ModalBackdrop = React.forwardRef<
 const ModalContent = React.forwardRef<
   React.ComponentRef<typeof UIModal.Content>,
   IModalContentProps
->(function ModalContent({ className, size, ...props }, ref) {
+>(function ModalContent({ className, size, style, ...props }, ref) {
   const { size: parentSize } = useStyleContext(SCOPE);
 
   return (
@@ -194,7 +194,7 @@ const ModalContent = React.forwardRef<
         size,
         class: className,
       })}
-      style={{ pointerEvents: 'auto' }}
+      style={[style, { pointerEvents: 'auto' }]}
     />
   );
 });

--- a/packages/shared-runtime/src/__tests__/server-framework.test.ts
+++ b/packages/shared-runtime/src/__tests__/server-framework.test.ts
@@ -761,6 +761,19 @@ describe('CORS middleware', () => {
     })
     expect(res.headers.get('access-control-allow-origin')).toBe('http://127.0.0.1:5173')
   })
+
+  test('echoes the shogo:// desktop origin instead of the ALLOWED_ORIGINS fallback', async () => {
+    // The desktop app renders from `shogo://app` and fetches workspace assets
+    // directly from this runtime. Without an explicit allowance it falls through
+    // to `ALLOWED_ORIGINS[0]`, blocking credentialed image copy/download fetches.
+    const { app } = await buildApp({
+      env: { ALLOWED_ORIGINS: 'http://localhost:3000' },
+    })
+    const res = await app.request('/health', {
+      headers: { origin: 'shogo://app' },
+    })
+    expect(res.headers.get('access-control-allow-origin')).toBe('shogo://app')
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/shared-runtime/src/server-framework.ts
+++ b/packages/shared-runtime/src/server-framework.ts
@@ -276,6 +276,10 @@ export async function createRuntimeApp(config: RuntimeAppConfig): Promise<Runtim
       if (allowed.length > 0 && allowed.includes(origin)) return origin
       if (origin.startsWith('http://localhost:') || origin.startsWith('https://localhost:')) return origin
       if (origin.startsWith('http://127.0.0.1:') || origin.startsWith('https://127.0.0.1:')) return origin
+      // The desktop app renders from the custom `shogo://app` origin and fetches
+      // workspace assets (e.g. chat image copy/download) directly from this
+      // runtime port. Echo it back so those credentialed fetches aren't blocked.
+      if (origin.startsWith('shogo://')) return origin
       return allowed[0] || origin
     },
     allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],


### PR DESCRIPTION
<img width="1512" height="982" alt="Screenshot 2026-05-29 at 4 42 42 PM" src="https://github.com/user-attachments/assets/bda30345-ec9e-4764-8954-568346e77279" />

## Summary
- Adds a shared chat image action layer (`chatImageActions.ts`) used by generated-image widgets, user/assistant image attachments, and the full-size preview modal.
- **Copy image** is available on web/native only and is intentionally removed from the Shogo desktop app. It writes a real PNG `ClipboardItem` via the web Clipboard API (no URL/text fallback).
- **Right-click menu** is desktop-only and offers **Download Image** only. On web, right-click falls through to the browser's native context menu.
- **Download image** fetches the image and saves it with the source filename when available.
- Fixes the preview modal sizing and the desktop image-fetch failures (CSP + CORS).

## Behavior matrix
| Surface | Web / mobile | Desktop app |
| --- | --- | --- |
| Right-click image | Native browser menu | Custom menu — **Download only** |
| Preview modal copy button | Shown | Hidden |
| Download | Yes | Yes |

## Problem
- Generated images and image attachments used different interaction paths.
- Copy could silently fall back to copying URL/text instead of image bytes.
- On desktop, copy failed: pasted `data:` images were blocked by the CSP `connect-src` rule, generated/agent images were blocked by CORS (the `shogo://app` origin was not allowed), and Electron could not write a promise-valued `ClipboardItem`.
- The preview modal ignored its `maxWidth`/`maxHeight` and rendered oversized/mispositioned.

## Implementation
- `chatImageActions.ts`: shared `copyImageToClipboard` / `downloadImage` plus an `isShogoDesktop()` runtime check.
  - `data:` URLs are decoded locally (avoids the desktop CSP `connect-src` block).
  - The PNG blob is resolved before constructing the `ClipboardItem` (Electron clipboard safety).
  - Agent-proxy images are fetched with credentials via `agentFetch`.
  - No URL/text clipboard fallback on failure.
- `ChatImageContextMenu` renders only in the desktop app and shows **Download Image** only; the three image surfaces gate right-click on `isShogoDesktop()`.
- `ImagePreviewModal` shows the copy action on web/native and hides it on desktop; `ModalContent` now forwards `style` so the modal honors `maxWidth`/`maxHeight`.
- Agent-runtime CORS (`shared-runtime`) allows the `shogo://` origin; the desktop Electron session rewrites CORS on direct agent-runtime localhost responses.

## Test Plan
- `bun test components/chat/__tests__/chatImageActions.test.ts` (apps/mobile)
- `bun test src/__tests__/server-framework.test.ts -t "CORS"` (packages/shared-runtime)
- Covers: image blob clipboard write, no URL/text fallback, local `data:` decode without network, image download link, and the `shogo://` CORS allowance.

Closes #712
Related Jira: SHOG-697

Made with [Cursor](https://cursor.com)