### PR TITLE
fix(marketplace): don't fail creator profile create on Stripe Connect error

### DIFF
--- a/apps/api/src/routes/marketplace.ts
+++ b/apps/api/src/routes/marketplace.ts
@@ -476,7 +476,21 @@ export function marketplaceRoutes() {
         avatarUrl: body.avatarUrl ?? undefined,
         websiteUrl: body.websiteUrl ?? undefined,
       })
-      await stripeConnect.createCustomAccount(profile.id, authCtx.email)
+      // Best-effort: provision the Stripe Connect account so payouts can be
+      // configured later. If this fails (network, Stripe outage, missing
+      // config), don't fail the whole request — the profile is already
+      // persisted and `/creator/payout-details` will self-heal the Connect
+      // account on first payout setup. Failing here would surface as
+      // "Failed to create creator profile" even though the profile exists,
+      // forcing the user to navigate away and back to recover.
+      try {
+        await stripeConnect.createCustomAccount(profile.id, authCtx.email)
+      } catch (stripeErr) {
+        console.error(
+          '[marketplace] createCreatorProfile stripe connect (non-fatal)',
+          stripeErr,
+        )
+      }
       return c.json({ profile })
     } catch (err) {
       const code = (err as { code?: string }).code


### PR DESCRIPTION
## Summary

- POST `/api/marketplace/creator/profile` was returning a generic `500 "Failed to create creator profile"` whenever the follow-up Stripe Connect call (`stripeConnect.createCustomAccount`) threw — even though the `CreatorProfile` row had already been persisted.
- Symptom in the mobile app: clicking **Marketplace → Creator → Get started** showed the error toast, but navigating back and re-entering took the user straight to the Creator dashboard (because the GET endpoint found the profile that step 1 had successfully written).
- Fix: wrap the `stripeConnect.createCustomAccount` call in its own try/catch and log on failure. The profile is the source of truth; the Connect account is safely deferred — `/creator/payout-details` already self-heals by provisioning the Connect account on first payout setup.

## Test plan

- [ ] Manually trigger a Stripe Connect failure (e.g. invalid `STRIPE_SECRET_KEY` or temporary network block) and confirm `POST /creator/profile` returns 200 with the new profile.
- [ ] Confirm the mobile "Get started" flow lands directly on the Creator dashboard without requiring a back-and-forth.
- [ ] Confirm `/creator/payout-details` still self-heals and provisions the missing Connect account on first payout setup.
- [ ] Confirm the `P2002` (already exists) and other genuine failures still surface their existing 409 / 500 responses.
