### PR TITLE
fix(mobile): use in-place dictation on home mic when EZ Mode disabled

### DIFF
--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -238,7 +238,7 @@ const COMPOSER_WRAPPER_WEB_DARK = {
 const HomeScreen = observer(function HomeScreen() {
   const router = useRouter()
   const { user, isAuthenticated } = useAuth()
-  const { localMode } = usePlatformConfig()
+  const { localMode, features } = usePlatformConfig()
   const posthog = usePostHogSafe()
   const projects = useProjectCollection()
   const workspaces = useWorkspaceCollection()
@@ -842,7 +842,9 @@ const HomeScreen = observer(function HomeScreen() {
                 isPro={hasAdvancedModelAccess}
                 onUpgradeClick={() => router.push('/billing')}
                 onStartVoiceProjectCreation={
-                  Platform.OS === 'web' ? handleStartVoiceProjectCreation : undefined
+                  Platform.OS === 'web' && features.ezMode
+                    ? handleStartVoiceProjectCreation
+                    : undefined
                 }
                 // Consolidated "where does this project come from?" entry
                 // point. Sits at the leftmost edge of the toolbar so it


### PR DESCRIPTION
## Summary
- The home composer microphone (web) always triggered the EZ Mode project-creation flow: it created/opened a draft project and navigated in with `startEzMode=1` + `autoStartVoice=1`, even when EZ Mode was turned off via the `features.ezMode` flag.
- This change gates `onStartVoiceProjectCreation` on `features.ezMode`. When EZ Mode is disabled, the prop is `undefined`, so `CompactChatInput` falls back to its existing `useVoiceInput` dictation path, which streams the transcript directly into the home composer (`home-composer-input`) instead of navigating away.

## Behavior
- EZ Mode ON (web): unchanged — mic opens a new project in EZ Mode and auto-starts the voice session.
- EZ Mode OFF (web): mic starts speech recognition in place and appends the transcript into the home composer. No navigation.
- Native: unchanged (never received `onStartVoiceProjectCreation`).

No changes were needed in `CompactChatInput.tsx` or `useVoiceInput.ts`; the fallback path already existed.

## Test plan
- [ ] With `feature.ez_mode` OFF, tap the home mic on web → recording starts and transcribed text appears in the home composer; no project navigation.
- [ ] With `feature.ez_mode` ON, tap the home mic on web → opens a new project in EZ Mode with the voice session auto-started (unchanged).
- [ ] Native home mic behavior unchanged.

Made with [Cursor](https://cursor.com)