### PR TITLE
fix(desktop): ship canvas bridge into VM runtime

### DIFF
--- a/apps/desktop/src/vm/cloud-init.ts
+++ b/apps/desktop/src/vm/cloud-init.ts
@@ -370,11 +370,14 @@ function buildUserData(config: CloudInitConfig): string {
     lines.push('  - |')
     lines.push('    mkdir -p /mnt/seed /packages/sdk/bin')
     lines.push('    mount -t iso9660 /dev/sr0 /mnt/seed 2>/dev/null || mount /dev/cdrom /mnt/seed 2>/dev/null || mount -t iso9660 /dev/vdb /mnt/seed 2>/dev/null || true')
-    lines.push('    mkdir -p /opt/shogo/wasm')
+    lines.push('    mkdir -p /opt/shogo/wasm /opt/shogo/static')
+    // canvas-bridge.js must land in /opt/shogo/static (not /opt/shogo) so it
+    // matches CANVAS_BRIDGE_DIR below. server.js/shogo.js go to /opt/shogo,
+    // wasm grammars to /opt/shogo/wasm.
     lines.push('    for f in /mnt/seed/*; do')
-    lines.push('      case "$f" in *.wasm) cp "$f" /opt/shogo/wasm/ ;; *) cp "$f" /opt/shogo/ ;; esac 2>/dev/null || true')
+    lines.push('      case "$f" in *.wasm) cp "$f" /opt/shogo/wasm/ ;; *canvas-bridge.js) cp "$f" /opt/shogo/static/ ;; *) cp "$f" /opt/shogo/ ;; esac 2>/dev/null || true')
     lines.push('    done')
-    lines.push('    ls -la /opt/shogo/ /opt/shogo/wasm/')
+    lines.push('    ls -la /opt/shogo/ /opt/shogo/wasm/ /opt/shogo/static/')
     lines.push('    ln -sf /opt/shogo/shogo.js /packages/sdk/bin/shogo.ts 2>/dev/null || true')
     // Install a `shogo` shim on PATH so workspace `package.json` scripts
     // that say `bunx shogo generate` resolve to the bundled CLI instead
@@ -399,8 +402,13 @@ function buildUserData(config: CloudInitConfig): string {
       'PROJECT_DIR=/workspace',
       'NODE_ENV=development',
       'TREE_SITTER_WASM_DIR=/opt/shogo/wasm',
+      // The bundled runtime boots from /opt/shogo/server.js, so its default
+      // join(__dirname,'..','static') resolves to /opt/static (never shipped).
+      // Point it at the dir the seed-extraction step above populated so the
+      // canvas "Update available - Refresh" pill works inside the VM.
+      'CANVAS_BRIDGE_DIR=/opt/shogo/static',
     ]
-    const skip = new Set(['PROJECT_ID', 'PORT', 'WORKSPACE_DIR', 'AGENT_DIR', 'PROJECT_DIR', 'NODE_ENV', 'TREE_SITTER_WASM_DIR'])
+    const skip = new Set(['PROJECT_ID', 'PORT', 'WORKSPACE_DIR', 'AGENT_DIR', 'PROJECT_DIR', 'NODE_ENV', 'TREE_SITTER_WASM_DIR', 'CANVAS_BRIDGE_DIR'])
     if (config.env) {
       for (const [k, v] of Object.entries(config.env)) {
         if (!skip.has(k)) envParts.push(`${k}=${shellEscape(v)}`)

--- a/apps/desktop/src/vm/darwin-vm-manager.ts
+++ b/apps/desktop/src/vm/darwin-vm-manager.ts
@@ -301,6 +301,13 @@ export class DarwinVMManager implements VMManager {
       if (fs.existsSync(p)) files[name] = fs.readFileSync(p)
     }
 
+    // canvas-bridge.js powers the workspace iframe's "Update available -
+    // Refresh" pill. cloud-init.ts routes this file into /opt/shogo/static
+    // and points CANVAS_BRIDGE_DIR there; without embedding it the in-VM
+    // runtime serves the empty stub and the pill never renders.
+    const canvasBridge = path.join(bundleDir, 'static', 'canvas-bridge.js')
+    if (fs.existsSync(canvasBridge)) files['canvas-bridge.js'] = fs.readFileSync(canvasBridge)
+
     const wasmDir = path.join(bundleDir, 'wasm')
     if (fs.existsSync(wasmDir)) {
       for (const f of fs.readdirSync(wasmDir)) {

--- a/apps/desktop/src/vm/prepare-bundle.ts
+++ b/apps/desktop/src/vm/prepare-bundle.ts
@@ -304,6 +304,21 @@ export function prepareVMBundle(opts: PrepareVMBundleOptions): void {
   // --- Tree-sitter wasm files (always needed — embedded in seed ISO) ---
   copyWasmFiles(join(destDir, 'wasm'), repoRoot)
 
+  // --- Canvas bridge static asset (always needed - embedded in seed ISO) ---
+  // The in-VM runtime boots from /opt/shogo/server.js and reads the bridge
+  // from CANVAS_BRIDGE_DIR (set to /opt/shogo/static by cloud-init.ts). Ship
+  // the source asset into the bundle here so the VM managers can embed it in
+  // the seed ISO; without it the in-VM runtime falls back to the empty IIFE
+  // stub and the workspace iframe never shows "Update available - Refresh"
+  // (the same gap PR #677 closed for the host-execution path, but on the VM
+  // path that real Desktop installs actually use).
+  const canvasBridgeSrc = resolve(repoRoot, 'packages/agent-runtime/static/canvas-bridge.js')
+  if (existsSync(canvasBridgeSrc)) {
+    const staticDest = join(destDir, 'static')
+    mkdirSync(staticDest, { recursive: true })
+    copyFileSync(canvasBridgeSrc, join(staticDest, 'canvas-bridge.js'))
+  }
+
   // With pre-provisioned images the following are baked into rootfs-provisioned.qcow2:
   //   - /usr/local/bin/bun (+ node/npx/npm aliases)
   //   - /opt/shogo/node_modules/ (prisma, typescript-language-server, typescript, pyright)

--- a/apps/desktop/src/vm/win32-vm-manager.ts
+++ b/apps/desktop/src/vm/win32-vm-manager.ts
@@ -310,6 +310,13 @@ export class Win32VMManager implements VMManager {
       if (fs.existsSync(p)) files[name] = fs.readFileSync(p)
     }
 
+    // canvas-bridge.js powers the workspace iframe's "Update available -
+    // Refresh" pill. cloud-init.ts routes this file into /opt/shogo/static
+    // and points CANVAS_BRIDGE_DIR there; without embedding it the in-VM
+    // runtime serves the empty stub and the pill never renders.
+    const canvasBridge = path.join(bundleDir, 'static', 'canvas-bridge.js')
+    if (fs.existsSync(canvasBridge)) files['canvas-bridge.js'] = fs.readFileSync(canvasBridge)
+
     const wasmDir = path.join(bundleDir, 'wasm')
     if (fs.existsSync(wasmDir)) {
       for (const f of fs.readdirSync(wasmDir)) {

--- a/packages/agent-runtime/src/__tests__/canvas-bridge-loader.test.ts
+++ b/packages/agent-runtime/src/__tests__/canvas-bridge-loader.test.ts
@@ -32,6 +32,7 @@ import { tmpdir } from 'node:os'
 
 import {
   loadCanvasBridgeSource,
+  resolveCanvasBridgePath,
   CANVAS_BRIDGE_PATH,
   CANVAS_BRIDGE_MISSING_STUB,
   CANVAS_BRIDGE_URL,
@@ -139,6 +140,41 @@ describe('loadCanvasBridgeSource', () => {
     } finally {
       warnSpy.mockRestore()
     }
+  })
+
+  test('CANVAS_BRIDGE_DIR env override is honored (Desktop microVM path)', () => {
+    // The bundled runtime boots from /opt/shogo/server.js inside the VM, so
+    // the sibling formula would resolve to /opt/static (never shipped). The
+    // VM boot sets CANVAS_BRIDGE_DIR=/opt/shogo/static; the loader must read
+    // the bridge from there. Without this the in-VM runtime serves the empty
+    // stub and the "Update available - Refresh" pill never appears - the
+    // exact regression that survived PR #677 (which only fixed host exec).
+    expect(resolveCanvasBridgePath({ CANVAS_BRIDGE_DIR: '/opt/shogo/static' }))
+      .toBe(join('/opt/shogo/static', 'canvas-bridge.js'))
+    // Whitespace-only / empty override is ignored (falls back to sibling).
+    expect(resolveCanvasBridgePath({ CANVAS_BRIDGE_DIR: '   ' }))
+      .toMatch(/[\\/]static[\\/]canvas-bridge\.js$/)
+    // No override -> unchanged sibling-of-runtime-dir layout (Cloud + Desktop
+    // host execution behave exactly as before).
+    expect(resolveCanvasBridgePath({})).toBe(CANVAS_BRIDGE_PATH)
+    // `undefined` env value is treated as "no override" (defensive: the VM
+    // env block could omit the var on an older app build).
+    expect(resolveCanvasBridgePath({ CANVAS_BRIDGE_DIR: undefined }))
+      .toMatch(/[\\/]static[\\/]canvas-bridge\.js$/)
+  })
+
+  test('end-to-end: a CANVAS_BRIDGE_DIR override resolves AND loads the real file', () => {
+    // This is the VM path in miniature: the bridge lives in an arbitrary
+    // directory (in the VM, /opt/shogo/static) and the runtime is told about
+    // it via CANVAS_BRIDGE_DIR. resolve + load must return the real bytes,
+    // not the missing-file stub.
+    const body = '/* vm bridge */ window.__VM_BRIDGE__ = 1;\n'
+    writeFileSync(join(tmpDir, 'canvas-bridge.js'), body, 'utf-8')
+    const resolved = resolveCanvasBridgePath({ CANVAS_BRIDGE_DIR: tmpDir })
+    expect(resolved).toBe(join(tmpDir, 'canvas-bridge.js'))
+    const loaded = loadCanvasBridgeSource(resolved)
+    expect(loaded).toBe(body)
+    expect(loaded).not.toContain(STUB_MARKER)
   })
 
   test('exported URL + script-tag constants are coherent (injection points line up)', () => {

--- a/packages/agent-runtime/src/__tests__/vm-ships-canvas-bridge.integration.test.ts
+++ b/packages/agent-runtime/src/__tests__/vm-ships-canvas-bridge.integration.test.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Integration test guarding the Desktop microVM <-> agent-runtime contract for
+ * the canvas bridge.
+ *
+ * What broke (and survived PR #677):
+ *   PR #677 fixed the Desktop *host-execution* path - it shipped
+ *   `canvas-bridge.js` into `resources/static/` so the runtime launched from
+ *   `resources/bundle/agent-runtime.js` could find it. But the default
+ *   runtime path on VM-capable hardware is the microVM: the bundled runtime
+ *   boots from `/opt/shogo/server.js`, where
+ *   `join(__dirname, '..', 'static', 'canvas-bridge.js')` resolves to
+ *   `/opt/static/canvas-bridge.js` - a path the seed ISO never populated.
+ *   So the in-VM runtime fell into the empty-IIFE stub and the
+ *   "Update available - Refresh" pill never appeared on real Desktop installs
+ *   even after PR #677 shipped (it's present in v1.9.1, yet still broken).
+ *
+ * Root fix (pinned here):
+ *   1. `prepare-bundle.ts` copies `static/canvas-bridge.js` into the VM
+ *      bundle's `static/` dir so it can be embedded in the seed ISO.
+ *   2. Both VM managers embed `canvas-bridge.js` into the seed ISO.
+ *   3. `cloud-init.ts` extracts it into `/opt/shogo/static` AND sets
+ *      `CANVAS_BRIDGE_DIR=/opt/shogo/static`.
+ *   4. The loader honors `CANVAS_BRIDGE_DIR` (covered in the unit suite), so
+ *      these three values line up end-to-end.
+ *
+ * These are source-level assertions (same approach as
+ * `binary-ships-canvas-bridge.integration.test.ts`): cheap, and they fail the
+ * moment any leg of the wiring is reverted.
+ */
+import { describe, expect, test } from 'bun:test'
+import { existsSync, readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..')
+const VM_DIR = join(REPO_ROOT, 'apps', 'desktop', 'src', 'vm')
+const PREPARE_BUNDLE = join(VM_DIR, 'prepare-bundle.ts')
+const CLOUD_INIT = join(VM_DIR, 'cloud-init.ts')
+const DARWIN_MGR = join(VM_DIR, 'darwin-vm-manager.ts')
+const WIN32_MGR = join(VM_DIR, 'win32-vm-manager.ts')
+
+const GUEST_STATIC_DIR = '/opt/shogo/static'
+
+describe('Desktop microVM ships canvas-bridge.js so the in-VM canvas refresh pill works', () => {
+  test('prepare-bundle.ts copies static/canvas-bridge.js into the VM bundle', () => {
+    expect(existsSync(PREPARE_BUNDLE)).toBe(true)
+    const src = readFileSync(PREPARE_BUNDLE, 'utf-8')
+    expect(src).toMatch(/agent-runtime\/static\/canvas-bridge\.js/)
+    // Lands in a `static/` subdir of the bundle (where the managers look).
+    expect(src).toMatch(/join\(\s*destDir\s*,\s*['"]static['"]\s*\)/)
+  })
+
+  test('both VM managers embed canvas-bridge.js into the seed ISO', () => {
+    for (const mgr of [DARWIN_MGR, WIN32_MGR]) {
+      expect(existsSync(mgr)).toBe(true)
+      const src = readFileSync(mgr, 'utf-8')
+      // Reads <bundleDir>/static/canvas-bridge.js and keys it as the flat
+      // seed-ISO filename the cloud-init extraction loop matches on.
+      expect(src).toMatch(/['"]static['"]\s*,\s*['"]canvas-bridge\.js['"]/)
+      expect(src).toMatch(/files\[['"]canvas-bridge\.js['"]\]/)
+    }
+  })
+
+  test('cloud-init.ts routes canvas-bridge.js to /opt/shogo/static', () => {
+    expect(existsSync(CLOUD_INIT)).toBe(true)
+    const src = readFileSync(CLOUD_INIT, 'utf-8')
+    // The seed-extraction case must have a dedicated branch for the bridge
+    // that lands it in /opt/shogo/static (not the /opt/shogo catch-all).
+    expect(src).toMatch(/\*canvas-bridge\.js\)\s*cp\s+"\$f"\s+\/opt\/shogo\/static\//)
+    // The dir must be created before files are copied into it.
+    expect(src).toMatch(/mkdir -p \/opt\/shogo\/wasm \/opt\/shogo\/static/)
+  })
+
+  test('cloud-init.ts injects CANVAS_BRIDGE_DIR matching the extraction dir', () => {
+    const src = readFileSync(CLOUD_INIT, 'utf-8')
+    expect(src).toContain(`CANVAS_BRIDGE_DIR=${GUEST_STATIC_DIR}`)
+    // And it's whitelisted out of the skip set so a caller-supplied env can't
+    // silently shadow / drop it.
+    expect(src).toMatch(/skip\s*=\s*new Set\([^)]*['"]CANVAS_BRIDGE_DIR['"]/s)
+  })
+
+  test('loader override target equals the dir cloud-init populates (no drift)', () => {
+    // The dir cloud-init copies the bridge into must be the same dir it tells
+    // the runtime to read from - otherwise the file ships but is never found.
+    const cloud = readFileSync(CLOUD_INIT, 'utf-8')
+    const copiesInto = /cp\s+"\$f"\s+(\/opt\/shogo\/static)\//.exec(cloud)?.[1]
+    const pointsAt = /CANVAS_BRIDGE_DIR=(\/opt\/shogo\/static)\b/.exec(cloud)?.[1]
+    expect(copiesInto).toBe(GUEST_STATIC_DIR)
+    expect(pointsAt).toBe(GUEST_STATIC_DIR)
+    expect(copiesInto).toBe(pointsAt)
+  })
+})

--- a/packages/agent-runtime/src/canvas-bridge.ts
+++ b/packages/agent-runtime/src/canvas-bridge.ts
@@ -30,7 +30,39 @@ import { join } from 'node:path'
 
 export const CANVAS_BRIDGE_URL = '/agent/canvas/bridge.js'
 export const CANVAS_BRIDGE_SCRIPT_TAG = `<script src="${CANVAS_BRIDGE_URL}" defer></script>`
-export const CANVAS_BRIDGE_PATH = join(__dirname, '..', 'static', 'canvas-bridge.js')
+
+/**
+ * Where the bridge lives on disk. Two resolution strategies, in order:
+ *
+ *  1. `CANVAS_BRIDGE_DIR` env override - an explicit absolute directory that
+ *     holds `canvas-bridge.js`. Used by the Desktop microVM, where the
+ *     bundled runtime boots from `/opt/shogo/server.js` and the sibling
+ *     formula below would resolve to `/opt/static/...` - a path the seed ISO
+ *     never populates. The VM boot (`apps/desktop/src/vm/cloud-init.ts`)
+ *     extracts the bridge into `/opt/shogo/static` and points this var at it,
+ *     exactly the way it injects `TREE_SITTER_WASM_DIR=/opt/shogo/wasm`.
+ *
+ *  2. `join(__dirname, '..', 'static', 'canvas-bridge.js')` - the
+ *     sibling-of-runtime-dir layout that holds for Cloud (runs
+ *     `src/server.ts`, so `packages/agent-runtime/static/...`) and the
+ *     Desktop host-execution path (runs `resources/bundle/agent-runtime.js`,
+ *     so `resources/static/...`, shipped by `bundle-api.mjs` per PR #677).
+ *     Left untouched so those two targets behave identically to before.
+ *
+ * Before this override existed, the Desktop VM - the default runtime path on
+ * VM-capable hardware - always fell into the empty stub, so the
+ * "Update available - Refresh" pill never appeared there even though PR #677
+ * fixed the host-execution path. See the integration test for the contract.
+ */
+export function resolveCanvasBridgePath(
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const override = env.CANVAS_BRIDGE_DIR?.trim()
+  if (override) return join(override, 'canvas-bridge.js')
+  return join(__dirname, '..', 'static', 'canvas-bridge.js')
+}
+
+export const CANVAS_BRIDGE_PATH = resolveCanvasBridgePath()
 
 /**
  * Canonical fallback body served when `CANVAS_BRIDGE_PATH` cannot be read.


### PR DESCRIPTION
Closes #722

## Summary

The Desktop canvas refresh pill was fixed for the host-execution bundle in PR #677, but actual Desktop installs on VM-capable machines run the agent-runtime inside the microVM. That VM path still did not receive `canvas-bridge.js`, so `/agent/canvas/bridge.js` served the loader's empty stub and the iframe never opened the SSE listener that renders "Update available - Refresh".

This PR ships the bridge through the Desktop VM bundle/seed ISO path and gives the in-VM runtime an explicit `CANVAS_BRIDGE_DIR=/opt/shogo/static` lookup. The existing Cloud and Desktop host-execution lookup remains unchanged.

## RCA

`canvas-bridge.js` is loaded by the agent-runtime at startup and served at `/agent/canvas/bridge.js`. The file installs the iframe-side EventSource listener used for rebuild notifications.

The default loader path is:

```text
join(__dirname, '..', 'static', 'canvas-bridge.js')
```

That path works in two layouts:

- Cloud/dev: `__dirname = packages/agent-runtime/src` -> `packages/agent-runtime/static/canvas-bridge.js`
- Desktop host execution: `__dirname = resources/bundle` -> `resources/static/canvas-bridge.js`

But actual Desktop VM mode launches the runtime as `/opt/shogo/server.js`, so the same formula resolves to `/opt/static/canvas-bridge.js`. The seed ISO never populated `/opt/static` or any bridge asset at all.

```mermaid
flowchart TD
  A[Canvas rebuild happens] --> B[Workspace iframe waits for bridge SSE listener]
  B --> C[agent-runtime serves /agent/canvas/bridge.js]
  C --> D[loadCanvasBridgeSource]
  D --> E{Runtime layout}
  E -->|Cloud/dev| F[packages/agent-runtime/static/canvas-bridge.js]
  E -->|Desktop host execution| G[resources/static/canvas-bridge.js]
  E -->|Desktop VM before this PR| H[/opt/static/canvas-bridge.js]
  H --> I[missing]
  I --> J[empty IIFE stub]
  J --> K[no EventSource]
  K --> L[Refresh pill never renders]
```

## Detailed Implementation

This PR adds an explicit Desktop VM static-asset path while preserving the existing fallback path for all other runtimes.

- `packages/agent-runtime/src/canvas-bridge.ts`
  - Adds `resolveCanvasBridgePath()`.
  - Uses `CANVAS_BRIDGE_DIR/canvas-bridge.js` when the env var is set.
  - Falls back to the previous sibling path when unset, so Cloud and Desktop host execution are unchanged.

- `apps/desktop/src/vm/prepare-bundle.ts`
  - Copies `packages/agent-runtime/static/canvas-bridge.js` into `resources/vm-bundle/static/canvas-bridge.js`.

- `apps/desktop/src/vm/darwin-vm-manager.ts`
- `apps/desktop/src/vm/win32-vm-manager.ts`
  - Embed `static/canvas-bridge.js` into the seed ISO as `canvas-bridge.js`.

- `apps/desktop/src/vm/cloud-init.ts`
  - Creates `/opt/shogo/static` during VM boot.
  - Copies `canvas-bridge.js` from the seed ISO into `/opt/shogo/static/`.
  - Starts the runtime with `CANVAS_BRIDGE_DIR=/opt/shogo/static`.

- Tests
  - Extends the loader unit suite for env override, blank/undefined fallback, and end-to-end override loading.
  - Adds `vm-ships-canvas-bridge.integration.test.ts` to pin the VM bundle -> seed ISO -> cloud-init extraction -> env override contract.

## Architecture Diagram

```mermaid
flowchart TD
  S[packages/agent-runtime/static/canvas-bridge.js]
  S --> P[prepare-bundle.ts]
  P --> Q[resources/vm-bundle/static/canvas-bridge.js]
  Q --> R[Darwin/Win32 VM manager readBundleDir]
  R --> T[Seed ISO contains canvas-bridge.js]
  T --> U[cloud-init extraction]
  U --> V[/opt/shogo/static/canvas-bridge.js]
  U --> W[CANVAS_BRIDGE_DIR=/opt/shogo/static]
  W --> X[resolveCanvasBridgePath]
  V --> X
  X --> Y[loadCanvasBridgeSource reads real bridge]
  Y --> Z[/agent/canvas/bridge.js serves real JS]
  Z --> AA[Iframe EventSource subscribes]
  AA --> AB[Update available - Refresh pill renders]
```

## Runtime Matrix

```mermaid
flowchart LR
  A[agent-runtime bridge lookup] --> B{Runtime mode}
  B -->|Cloud/dev| C[packages/agent-runtime/static]
  B -->|Desktop VM off / host execution| D[resources/static]
  B -->|Desktop VM on / microVM| E[CANVAS_BRIDGE_DIR=/opt/shogo/static]
  C --> F[real canvas-bridge.js]
  D --> F
  E --> F
  F --> G[Refresh pill works after canvas rebuild]
```

## Test Plan

- [x] `git diff --check`
- [x] `bun test src/__tests__/canvas-bridge-loader.test.ts src/__tests__/binary-ships-canvas-bridge.integration.test.ts src/__tests__/vm-ships-canvas-bridge.integration.test.ts`
  - `20 pass`
  - `0 fail`
  - `64 expect() calls`

## Release Notes

This fix requires a new tagged Desktop release to reach users. It does not require rebuilding the VM base image: the bridge is shipped through the Desktop app's VM bundle, then mounted through the seed ISO and placed by cloud-init at boot.

Made with [Cursor](https://cursor.com)