### PR TITLE
refactor(billing): relative usage UI + revenue-derived window limits

### DIFF
--- a/apps/api/src/config/__tests__/usage-plans.test.ts
+++ b/apps/api/src/config/__tests__/usage-plans.test.ts
@@ -7,6 +7,8 @@ import {
   MONTHLY_DAILY_CAP_USD,
   FIVE_HOUR_MS,
   SEVEN_DAY_MS,
+  WEEKS_PER_MONTH,
+  TARGET_COMPUTE_COST_RATIO,
   PLAN_INCLUDED_USD,
   PLAN_VOICE_RATE_OVERRIDES,
   ROLLING_WINDOW_LIMITS,
@@ -15,9 +17,18 @@ import {
   comparePlanRank,
   getDailyIncludedForPlan,
   getMonthlyIncludedForPlan,
+  getMonthlyIncludedEquivalent,
   getWindowLimitsForPlan,
   normalizePlanId,
 } from '../usage-plans'
+import { MARKUP_MULTIPLIER } from '../../lib/usage-cost'
+
+/** List monthly subscription prices used for the don't-lose-money assertions. */
+const LIST_MONTHLY_PRICE: Record<'basic' | 'pro' | 'business', number> = {
+  basic: 8,
+  pro: 20,
+  business: 40,
+}
 
 describe('rolling usage windows', () => {
   it('FIVE_HOUR_MS and SEVEN_DAY_MS are correct durations', () => {
@@ -26,7 +37,10 @@ describe('rolling usage windows', () => {
   })
 
   it('ROLLING_WINDOW_LIMITS covers all tiers with enterprise uncapped', () => {
-    expect(ROLLING_WINDOW_LIMITS.free).toEqual({ fiveHourUsd: 0.5, weeklyUsd: 2 })
+    expect(ROLLING_WINDOW_LIMITS.free).toEqual({ fiveHourUsd: 0.2, weeklyUsd: 0.5 })
+    expect(ROLLING_WINDOW_LIMITS.basic).toEqual({ fiveHourUsd: 0.64, weeklyUsd: 1.6 })
+    expect(ROLLING_WINDOW_LIMITS.pro).toEqual({ fiveHourUsd: 1.6, weeklyUsd: 4 })
+    expect(ROLLING_WINDOW_LIMITS.business).toEqual({ fiveHourUsd: 3.2, weeklyUsd: 8 })
     expect(ROLLING_WINDOW_LIMITS.enterprise).toBeNull()
   })
 
@@ -41,16 +55,77 @@ describe('rolling usage windows', () => {
   })
 
   it('scales pro/business per seat', () => {
-    expect(getWindowLimitsForPlan('pro', 3)).toEqual({ fiveHourUsd: 24, weeklyUsd: 120 })
-    expect(getWindowLimitsForPlan('business', 2)).toEqual({ fiveHourUsd: 40, weeklyUsd: 240 })
+    const pro = ROLLING_WINDOW_LIMITS.pro!
+    expect(getWindowLimitsForPlan('pro', 3)).toEqual({
+      fiveHourUsd: pro.fiveHourUsd * 3,
+      weeklyUsd: pro.weeklyUsd * 3,
+    })
+    const biz = ROLLING_WINDOW_LIMITS.business!
+    expect(getWindowLimitsForPlan('business', 2)).toEqual({
+      fiveHourUsd: biz.fiveHourUsd * 2,
+      weeklyUsd: biz.weeklyUsd * 2,
+    })
   })
 
   it('clamps seats to a minimum of 1', () => {
-    expect(getWindowLimitsForPlan('pro', 0)).toEqual({ fiveHourUsd: 8, weeklyUsd: 40 })
+    expect(getWindowLimitsForPlan('pro', 0)).toEqual({ fiveHourUsd: 1.6, weeklyUsd: 4 })
   })
 
   it('returns null for enterprise regardless of seats', () => {
     expect(getWindowLimitsForPlan('enterprise', 50)).toBeNull()
+  })
+
+  it('5-hour window is 40% of the weekly budget for every capped tier', () => {
+    for (const plan of ['free', 'basic', 'pro', 'business'] as const) {
+      const w = ROLLING_WINDOW_LIMITS[plan]!
+      expect(w.fiveHourUsd).toBeCloseTo(w.weeklyUsd * 0.4, 10)
+    }
+  })
+
+  it('window limits keep the worst-case monthly compute COGS within target', () => {
+    // Worst case: a user pins their windows continuously for a whole month.
+    // monthly provider COGS = weeklyUsd × WEEKS_PER_MONTH / MARKUP.
+    for (const plan of ['basic', 'pro', 'business'] as const) {
+      const weekly = getWindowLimitsForPlan(plan, 1)!.weeklyUsd
+      const monthlyCogsRaw = (weekly * WEEKS_PER_MONTH) / MARKUP_MULTIPLIER
+      const ratio = monthlyCogsRaw / LIST_MONTHLY_PRICE[plan]
+      expect(ratio).toBeLessThanOrEqual(TARGET_COMPUTE_COST_RATIO)
+    }
+  })
+
+  it('per-seat windows preserve the COGS ratio at any seat count', () => {
+    const seats = 7
+    const weekly = getWindowLimitsForPlan('pro', seats)!.weeklyUsd
+    const monthlyCogsRaw = (weekly * WEEKS_PER_MONTH) / MARKUP_MULTIPLIER
+    const ratio = monthlyCogsRaw / (LIST_MONTHLY_PRICE.pro * seats)
+    expect(ratio).toBeLessThanOrEqual(TARGET_COMPUTE_COST_RATIO)
+  })
+})
+
+describe('getMonthlyIncludedEquivalent', () => {
+  it('WEEKS_PER_MONTH ≈ 4.348', () => {
+    expect(WEEKS_PER_MONTH).toBeCloseTo(4.3482, 3)
+  })
+
+  it('is weeklyUsd × WEEKS_PER_MONTH for capped plans', () => {
+    expect(getMonthlyIncludedEquivalent('pro', 1)).toBeCloseTo(4 * WEEKS_PER_MONTH, 10)
+    expect(getMonthlyIncludedEquivalent('basic')).toBeCloseTo(1.6 * WEEKS_PER_MONTH, 10)
+  })
+
+  it('scales pro/business per seat', () => {
+    expect(getMonthlyIncludedEquivalent('pro', 4)).toBeCloseTo(
+      getMonthlyIncludedEquivalent('pro', 1)! * 4,
+      10,
+    )
+  })
+
+  it('returns null for uncapped enterprise', () => {
+    expect(getMonthlyIncludedEquivalent('enterprise')).toBeNull()
+    expect(getMonthlyIncludedEquivalent('enterprise', 10)).toBeNull()
+  })
+
+  it('falls back to the free window for unknown plans', () => {
+    expect(getMonthlyIncludedEquivalent('platinum')).toBeCloseTo(0.5 * WEEKS_PER_MONTH, 10)
   })
 })
 

--- a/apps/api/src/config/usage-plans.ts
+++ b/apps/api/src/config/usage-plans.ts
@@ -149,6 +149,43 @@ export const FIVE_HOUR_MS = 5 * 60 * 60 * 1000
 export const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1000
 
 /**
+ * Average weeks per calendar month (365.25 / 12 / 7 ≈ 4.348). The weekly
+ * rolling window is the binding constraint on monthly usage, so the
+ * "effective monthly included" usage of a plan is `weeklyUsd × WEEKS_PER_MONTH`
+ * for back-to-back windows. See `getMonthlyIncludedEquivalent`.
+ */
+export const WEEKS_PER_MONTH = 365.25 / 12 / 7
+
+/**
+ * ── How the window limits are sized (don't-lose-money math) ──────────────
+ *
+ * Windows count *marked-up* USD (`billedUsd = providerRawCost × MARKUP`,
+ * MARKUP = 1.20). Included usage is covered by the subscription — we don't
+ * charge per unit inside a window — so our real cost for a maxed window is the
+ * underlying provider COGS = `markedUp / MARKUP`.
+ *
+ * Worst case is a user who pins their windows continuously for a whole month.
+ * Their monthly provider COGS is:
+ *
+ *     monthlyCogsRaw = weeklyUsd × WEEKS_PER_MONTH / MARKUP
+ *
+ * We size `weeklyUsd` so that this worst case stays at or below
+ * `TARGET_COMPUTE_COST_RATIO` of the *list* monthly subscription price,
+ * leaving headroom for the ~17% annual discount, ~3% payment fees, infra and
+ * margin. Solving for the cap:
+ *
+ *     weeklyUsd ≤ TARGET_COMPUTE_COST_RATIO × monthlyPrice × MARKUP / WEEKS_PER_MONTH
+ *
+ * At MARKUP 1.20, ratio 0.75, prices basic $8 / pro $20 / business $40 the
+ * caps are ≈ $1.66 / $4.14 / $8.28 per seat; the values below round *down* to
+ * clean figures (worst-case COGS lands ≈72.5% of list / ≈87% of annual
+ * revenue). 5-hour windows are sized at 40% of the weekly budget so a single
+ * burst can't drain the whole week. `null` = uncapped (enterprise). Values are
+ * intended to be tuned operationally — see `TARGET_COMPUTE_COST_RATIO`.
+ */
+export const TARGET_COMPUTE_COST_RATIO = 0.75
+
+/**
  * Per-window included USD-of-compute per plan. Within these windows usage is
  * effectively unlimited (no finite monthly pool is drained); when a window is
  * exhausted, usage falls through to metered overage (if enabled) and otherwise
@@ -158,19 +195,20 @@ export const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1000
  *
  * For per-seat plans (`pro`, `business`) the limits below are *per seat* and
  * are multiplied by the seat count in `getWindowLimitsForPlan`. `free` and
- * `basic` are single-pool (not scaled by seats).
+ * `basic` are single-pool (not scaled by seats). `free` is a deliberate
+ * loss-leader (no revenue) capped small.
  *
- * Values are USD of marked-up compute (see `usage-cost.ts`) and are intended
- * to be tuned operationally.
+ * Values are USD of marked-up compute (see `usage-cost.ts`). See the block
+ * comment above for the don't-lose-money derivation.
  */
 export const ROLLING_WINDOW_LIMITS: Record<
   PlanId,
   { fiveHourUsd: number; weeklyUsd: number } | null
 > = {
-  free: { fiveHourUsd: 0.5, weeklyUsd: 2 },
-  basic: { fiveHourUsd: 2, weeklyUsd: 10 },
-  pro: { fiveHourUsd: 8, weeklyUsd: 40 },
-  business: { fiveHourUsd: 20, weeklyUsd: 120 },
+  free: { fiveHourUsd: 0.2, weeklyUsd: 0.5 },
+  basic: { fiveHourUsd: 0.64, weeklyUsd: 1.6 },
+  pro: { fiveHourUsd: 1.6, weeklyUsd: 4 },
+  business: { fiveHourUsd: 3.2, weeklyUsd: 8 },
   enterprise: null,
 }
 
@@ -208,6 +246,29 @@ export function getWindowLimitsForPlan(
     fiveHourUsd: base.fiveHourUsd * safeSeats,
     weeklyUsd: base.weeklyUsd * safeSeats,
   }
+}
+
+/**
+ * Effective monthly included usage (marked-up USD) implied by the weekly
+ * rolling window for a (plan, seats) tuple. The weekly window is the binding
+ * monthly constraint, so for back-to-back windows the monthly ceiling is
+ * `weeklyUsd × WEEKS_PER_MONTH`.
+ *
+ * This is the *upper bound* of included usage assuming continuous use — pausing
+ * pushes each window's reset later, fitting fewer full weekly buckets per
+ * month. It is the included/unlimited zone only; usage beyond it falls through
+ * to metered overage. Returns `null` for uncapped plans (enterprise).
+ *
+ * Intended for internal/finance/admin surfaces — the customer UI shows usage
+ * relative to the window (utilization %), not this dollar figure.
+ */
+export function getMonthlyIncludedEquivalent(
+  planId: string | null | undefined,
+  seats: number = 1,
+): number | null {
+  const limits = getWindowLimitsForPlan(planId, seats)
+  if (limits == null) return null
+  return limits.weeklyUsd * WEEKS_PER_MONTH
 }
 
 /**

--- a/apps/api/src/services/__tests__/billing.service.test.ts
+++ b/apps/api/src/services/__tests__/billing.service.test.ts
@@ -561,15 +561,15 @@ describe('hasBalance (rolling windows)', () => {
     expect(wallets.get('w1')).toBeDefined()
   })
   it('returns true when a window still has room (pro plan)', async () => {
-    setPlan('pro') // 5h=8, weekly=40
+    setPlan('pro') // 5h=1.6, weekly=4
     wallets.set('w1', freshWallet())
-    expect(await billing.hasBalance('w1', 3)).toBe(true)
+    expect(await billing.hasBalance('w1', 0.5)).toBe(true)
   })
   it('returns false when both windows exhausted and no overage (free)', async () => {
     wallets.set('w1', freshWallet({
       overageEnabled: false,
-      fiveHourWindowStart: now0(), fiveHourUsedUsd: 0.5, // free 5h cap = 0.5
-      weeklyWindowStart: now0(), weeklyUsedUsd: 2,         // free weekly cap = 2
+      fiveHourWindowStart: now0(), fiveHourUsedUsd: 0.5, // over free 5h cap = 0.2
+      weeklyWindowStart: now0(), weeklyUsedUsd: 2,         // over free weekly cap = 0.5
     }))
     expect(await billing.hasBalance('w1', 0.4)).toBe(false)
   })
@@ -600,7 +600,7 @@ describe('hasBalance (rolling windows)', () => {
       fiveHourWindowStart: sixHoursAgo, fiveHourUsedUsd: 0.5, // would block if not reset
       weeklyWindowStart: now0(), weeklyUsedUsd: 0,
     }))
-    expect(await billing.hasBalance('w1', 0.4)).toBe(true)
+    expect(await billing.hasBalance('w1', 0.1)).toBe(true)
   })
 })
 
@@ -678,9 +678,10 @@ describe('consumeUsage (rolling windows)', () => {
   })
 
   it('scales window per seat (pro x3 seats → 3x the 5h cap)', async () => {
-    setPlan('pro', 3) // 5h = 8 * 3 = 24
+    setPlan('pro', 3) // 5h = 1.6 * 3 = 4.8, weekly = 4 * 3 = 12
     wallets.set('w1', freshWallet())
-    const r = await billing.consumeUsage({ ...base, billedUsd: 20 })
+    // 2.5 fits the 3-seat 5h cap (4.8) but would exceed the 1-seat cap (1.6).
+    const r = await billing.consumeUsage({ ...base, billedUsd: 2.5 })
     expect(r.success).toBe(true)
     expect(r.source).toBe('window')
   })
@@ -699,10 +700,10 @@ describe('consumeUsage (rolling windows)', () => {
       fiveHourWindowStart: sixHoursAgo, fiveHourUsedUsd: 0.5,
       weeklyWindowStart: now0(), weeklyUsedUsd: 0,
     }))
-    const r = await billing.consumeUsage({ ...base, billedUsd: 0.3 })
+    const r = await billing.consumeUsage({ ...base, billedUsd: 0.1 })
     expect(r.success).toBe(true)
     const w = wallets.get('w1')!
-    expect(w.fiveHourUsedUsd).toBeCloseTo(0.3, 5)
+    expect(w.fiveHourUsedUsd).toBeCloseTo(0.1, 5)
     expect(w.fiveHourWindowStart!.getTime()).toBeGreaterThan(sixHoursAgo.getTime())
   })
 
@@ -721,11 +722,11 @@ describe('getUsageWindows', () => {
   it('reports utilization and resetsAt for an open window (free)', async () => {
     const start = now0()
     wallets.set('w1', freshWallet({
-      fiveHourWindowStart: start, fiveHourUsedUsd: 0.25, // free 5h cap 0.5 → 50%
-      weeklyWindowStart: start, weeklyUsedUsd: 0.5,       // free weekly cap 2 → 25%
+      fiveHourWindowStart: start, fiveHourUsedUsd: 0.1,   // free 5h cap 0.2 → 50%
+      weeklyWindowStart: start, weeklyUsedUsd: 0.125,     // free weekly cap 0.5 → 25%
     }))
     const w = await billing.getUsageWindows('w1')
-    expect(w.fiveHour.limitUsd).toBe(0.5)
+    expect(w.fiveHour.limitUsd).toBe(0.2)
     expect(w.fiveHour.utilization).toBeCloseTo(0.5, 5)
     expect(w.fiveHour.resetsAt).toBeInstanceOf(Date)
     expect(w.weekly.utilization).toBeCloseTo(0.25, 5)
@@ -762,7 +763,8 @@ describe('getUsageWindows', () => {
 describe('consumeCredits (legacy)', () => {
   it('converts credit-cost to USD and returns credits-remaining', async () => {
     wallets.set('w1', freshWallet({ dailyIncludedUsd: 0.5, monthlyIncludedUsd: 10 }))
-    const r = await billing.consumeCredits('w1', null, 'u', 'x', 2)
+    // 1 credit → $0.10 billed; leaves room under the free 5h cap ($0.20).
+    const r = await billing.consumeCredits('w1', null, 'u', 'x', 1)
     expect(r.success).toBe(true)
     expect(r.remainingCredits).toBeGreaterThan(0)
   })
@@ -1134,6 +1136,9 @@ describe('consumeUsage — FK retry (L398-404, isFkConstraintError branches)', (
   })
 
   it('re-throws FK errors after exhausting retry attempts', async () => {
+    // Uncapped plan so the (non-transactional) retry loop always reaches the
+    // usage-event create — keeps this FK test independent of window cap tuning.
+    setPlan('enterprise')
     wallets.set('w1', freshWallet({ dailyIncludedUsd: 1, monthlyIncludedUsd: 0 }))
     usageEventCreateImpl = () => {
       const err: any = new Error('FK constraint')

--- a/apps/mobile/app/(app)/billing.tsx
+++ b/apps/mobile/app/(app)/billing.tsx
@@ -51,9 +51,7 @@ import {
   PRO_FEATURES,
   BUSINESS_FEATURES,
   ENTERPRISE_FEATURES,
-  SEAT_INCLUDED_USD,
-  getIncludedUsdForPlan,
-  getIncludedUsdCapacityForDisplay,
+  getWindowLimitsForPlan,
   formatUsd,
   formatCurrencyPrice,
   formatResetCountdown,
@@ -73,6 +71,23 @@ import {
 
 // ─── Rolling usage-window bar ──────────────────────────────
 
+// Relative usage framing for plan cards (no dollar figures, like Codex /
+// Claude Code). Expresses each tier's rolling-window allowance as a multiple
+// of the entry paid tier (Basic), derived from the weekly window so copy
+// stays in sync with ROLLING_WINDOW_LIMITS. Enterprise is uncapped.
+const BASIC_WEEKLY_USD = getWindowLimitsForPlan('basic', 1)?.weeklyUsd ?? 0
+
+function relativeUsageCopy(planId: string): string {
+  const limits = getWindowLimitsForPlan(planId, 1)
+  if (!limits) return 'Unlimited usage — no rate windows'
+  if (!BASIC_WEEKLY_USD || limits.weeklyUsd <= BASIC_WEEKLY_USD) {
+    return 'Standard 5-hour & weekly usage windows'
+  }
+  // Round to one decimal, dropping a trailing ".0" (e.g. 2.5×, 5×).
+  const multiple = Number((limits.weeklyUsd / BASIC_WEEKLY_USD).toFixed(1))
+  return `${multiple}× the usage of Basic — higher 5-hour & weekly windows`
+}
+
 function UsageWindowBar({ label, window }: { label: string; window: UsageWindowView | undefined }) {
   // Uncapped (enterprise) plans report a null limit.
   const uncapped = !!window && window.limitUsd == null
@@ -84,7 +99,7 @@ function UsageWindowBar({ label, window }: { label: string; window: UsageWindowV
     ? '—'
     : uncapped
       ? 'Unlimited'
-      : `${formatUsd(window.usedUsd)} of ${formatUsd(window.limitUsd ?? 0)}`
+      : `${pct}% used`
 
   return (
     <View className="gap-1.5">
@@ -305,16 +320,6 @@ export default observer(function BillingPage() {
     }).catch(() => {})
     return () => { cancelled = true }
   }, [http])
-
-  const subSeats = subscription?.seats ?? 1
-  const usdRemaining =
-    effectiveBalance?.total ?? getIncludedUsdForPlan(subscription?.planId, subSeats)
-  const usdTotal = getIncludedUsdCapacityForDisplay({
-    planId: subscription?.planId,
-    seats: subSeats,
-    remainingTotal: effectiveBalance?.total,
-    monthlyIncludedAllocationUsd: effectiveBalance?.monthlyIncludedAllocationUsd,
-  })
 
   const planName = subscription
     ? `${getPlanDisplayName(subscription.planId)} Plan`
@@ -768,7 +773,7 @@ export default observer(function BillingPage() {
 
               <View className="lg:flex-1 gap-2">
                 <Text className="text-sm font-medium text-foreground">
-                  {formatUsd(SEAT_INCLUDED_USD.basic)} of usage / month
+                  {relativeUsageCopy('basic')}
                 </Text>
                 <Text className="text-sm text-muted-foreground">
                   All features in Free, plus:
@@ -830,7 +835,7 @@ export default observer(function BillingPage() {
                     onChange={setProSeats}
                     min={1}
                     max={500}
-                    label={`$${SEAT_INCLUDED_USD.pro} / seat / month`}
+                    label="Usage windows scale per seat"
                   />
                 )}
               </View>
@@ -847,7 +852,7 @@ export default observer(function BillingPage() {
 
               <View className="lg:flex-1 gap-2">
                 <Text className="text-sm font-medium text-foreground">
-                  {formatUsd(SEAT_INCLUDED_USD.pro * proSeats)} of usage / month
+                  {relativeUsageCopy('pro')}
                 </Text>
                 <Text className="text-sm text-muted-foreground">
                   All features in Free, plus:
@@ -913,7 +918,7 @@ export default observer(function BillingPage() {
                     onChange={setBusinessSeats}
                     min={1}
                     max={500}
-                    label={`$${SEAT_INCLUDED_USD.business} / seat / month`}
+                    label="Usage windows scale per seat"
                   />
                 )}
               </View>
@@ -930,7 +935,7 @@ export default observer(function BillingPage() {
 
               <View className="lg:flex-1 gap-2">
                 <Text className="text-sm font-medium text-foreground">
-                  {formatUsd(SEAT_INCLUDED_USD.business * businessSeats)} of usage / month
+                  {relativeUsageCopy('business')}
                 </Text>
                 <FeatureList features={BUSINESS_FEATURES} />
               </View>

--- a/apps/mobile/lib/__tests__/billing-config.test.ts
+++ b/apps/mobile/lib/__tests__/billing-config.test.ts
@@ -17,9 +17,11 @@ import {
   FREE_DAILY_INCLUDED_USD,
   SEAT_INCLUDED_USD,
   ROLLING_WINDOW_LIMITS,
+  WEEKS_PER_MONTH,
   getDailyIncludedForPlan,
   getIncludedUsdCapacityForDisplay,
   getIncludedUsdForPlan,
+  getMonthlyIncludedEquivalent,
   getWindowLimitsForPlan,
   formatResetCountdown,
   formatUsd,
@@ -39,15 +41,17 @@ describe('getWindowLimitsForPlan', () => {
   })
 
   test('scales per-seat plans linearly', () => {
+    const proBase = ROLLING_WINDOW_LIMITS.pro!
     const pro3 = getWindowLimitsForPlan('pro', 3)
-    expect(pro3).toEqual({ fiveHourUsd: 8 * 3, weeklyUsd: 40 * 3 })
+    expect(pro3).toEqual({ fiveHourUsd: proBase.fiveHourUsd * 3, weeklyUsd: proBase.weeklyUsd * 3 })
+    const bizBase = ROLLING_WINDOW_LIMITS.business!
     const biz2 = getWindowLimitsForPlan('business', 2)
-    expect(biz2).toEqual({ fiveHourUsd: 20 * 2, weeklyUsd: 120 * 2 })
+    expect(biz2).toEqual({ fiveHourUsd: bizBase.fiveHourUsd * 2, weeklyUsd: bizBase.weeklyUsd * 2 })
   })
 
   test('clamps non-positive / fractional seats to at least 1', () => {
-    expect(getWindowLimitsForPlan('pro', 0)).toEqual({ fiveHourUsd: 8, weeklyUsd: 40 })
-    expect(getWindowLimitsForPlan('pro', -4)).toEqual({ fiveHourUsd: 8, weeklyUsd: 40 })
+    expect(getWindowLimitsForPlan('pro', 0)).toEqual(ROLLING_WINDOW_LIMITS.pro!)
+    expect(getWindowLimitsForPlan('pro', -4)).toEqual(ROLLING_WINDOW_LIMITS.pro!)
   })
 
   test('returns null (uncapped) for enterprise', () => {
@@ -55,7 +59,27 @@ describe('getWindowLimitsForPlan', () => {
   })
 
   test('matches legacy suffixed plan ids by prefix', () => {
-    expect(getWindowLimitsForPlan('pro_200', 1)).toEqual({ fiveHourUsd: 8, weeklyUsd: 40 })
+    expect(getWindowLimitsForPlan('pro_200', 1)).toEqual(ROLLING_WINDOW_LIMITS.pro!)
+  })
+})
+
+describe('getMonthlyIncludedEquivalent', () => {
+  test('is weeklyUsd × WEEKS_PER_MONTH for capped plans', () => {
+    expect(getMonthlyIncludedEquivalent('pro', 1)).toBeCloseTo(
+      ROLLING_WINDOW_LIMITS.pro!.weeklyUsd * WEEKS_PER_MONTH,
+      6,
+    )
+  })
+
+  test('scales per seat', () => {
+    expect(getMonthlyIncludedEquivalent('business', 3)).toBeCloseTo(
+      getMonthlyIncludedEquivalent('business', 1)! * 3,
+      6,
+    )
+  })
+
+  test('returns null for uncapped enterprise', () => {
+    expect(getMonthlyIncludedEquivalent('enterprise')).toBeNull()
   })
 })
 

--- a/apps/mobile/lib/billing-config.ts
+++ b/apps/mobile/lib/billing-config.ts
@@ -38,14 +38,23 @@ export interface WindowLimits {
   weeklyUsd: number
 }
 
-/** Per-window included USD of compute per plan. `null` = uncapped. */
+/**
+ * Per-window included USD of compute per plan. `null` = uncapped. Sized so a
+ * worst-case (window-pinning) user's monthly provider COGS stays ≈72.5% of
+ * list subscription revenue (TARGET_COMPUTE_COST_RATIO 0.75) — see the
+ * don't-lose-money derivation in the backend `usage-plans.ts`. Keep these in
+ * sync with the backend values.
+ */
 export const ROLLING_WINDOW_LIMITS: Record<PlanId, WindowLimits | null> = {
-  free: { fiveHourUsd: 0.5, weeklyUsd: 2 },
-  basic: { fiveHourUsd: 2, weeklyUsd: 10 },
-  pro: { fiveHourUsd: 8, weeklyUsd: 40 },
-  business: { fiveHourUsd: 20, weeklyUsd: 120 },
+  free: { fiveHourUsd: 0.2, weeklyUsd: 0.5 },
+  basic: { fiveHourUsd: 0.64, weeklyUsd: 1.6 },
+  pro: { fiveHourUsd: 1.6, weeklyUsd: 4 },
+  business: { fiveHourUsd: 3.2, weeklyUsd: 8 },
   enterprise: null,
 }
+
+/** Average weeks per calendar month (365.25 / 12 / 7 ≈ 4.348). */
+export const WEEKS_PER_MONTH = 365.25 / 12 / 7
 
 /**
  * Window limits for a (plan, seats) pair. Pro/Business scale per seat; Free
@@ -69,6 +78,20 @@ export function getWindowLimitsForPlan(
     return { fiveHourUsd: base.fiveHourUsd * s, weeklyUsd: base.weeklyUsd * s }
   }
   return { fiveHourUsd: base.fiveHourUsd, weeklyUsd: base.weeklyUsd }
+}
+
+/**
+ * Effective monthly included usage (marked-up USD) implied by the weekly
+ * window: `weeklyUsd × WEEKS_PER_MONTH`. Upper bound assuming continuous use.
+ * Returns `null` for uncapped (enterprise). Mirrors the backend helper.
+ */
+export function getMonthlyIncludedEquivalent(
+  planId: string | null | undefined,
+  seats: number = 1,
+): number | null {
+  const limits = getWindowLimitsForPlan(planId, seats)
+  if (limits == null) return null
+  return limits.weeklyUsd * WEEKS_PER_MONTH
 }
 
 /**


### PR DESCRIPTION
## Summary
Follow-up to #721 (time-gated rolling windows).

- **UI is now relative, not dollar-based** (matches Codex / Claude Code): live usage bars show utilization % + reset countdown; plan cards show relative multipliers (Pro = 2.5× Basic, Business = 5× Basic) instead of the now-defunct "$X / month" included pool. Removed dead monthly-pool display vars.
- **`getMonthlyIncludedEquivalent(plan, seats)`** helper (= `weeklyUsd × WEEKS_PER_MONTH`) for internal/finance surfaces.
- **Revenue-derived window limits**: `ROLLING_WINDOW_LIMITS` sized so a worst-case window-pinning user's monthly provider COGS stays within `TARGET_COMPUTE_COST_RATIO` (0.75) of list subscription revenue — i.e. the "unlimited within windows" model can't lose money. Mirrored in the mobile billing-config.

## Test plan
- [x] `apps/api` usage-plans tests (54 pass) — values, COGS-ratio bound, new helper
- [x] `apps/api` billing.service tests (93 pass) — real-config window assertions retuned
- [x] `apps/mobile` billing-config tests (41 pass)

Made with [Cursor](https://cursor.com)