### PR TITLE
feat(affiliate): single-level payouts by default with 20%->10% step-down

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,11 +156,14 @@ SHOGO_VOICE_TRANSLATOR_MODEL=
 # -----------------------------------------------------------------------------
 # Master switch — when false, signup hook + webhook + cron all short-circuit.
 SHOGO_AFFILIATES_NATIVE=false
-# Max upline depth honored at commission time. Also the cap on enroll
-# (rejects parent chains that would push a new affiliate beyond this).
-# Should match the row count in `affiliate_commission_tiers` for the
-# intended max payout depth — extra tier rows above this are ignored.
+# Max ENROLLMENT depth — the cap on enroll (rejects parent chains that
+# would push a new affiliate beyond this). Controls how deep the referral
+# tree can grow; does NOT by itself pay deep commissions (see below).
 SHOGO_AFFILIATE_MAX_DEPTH=3
+# Max PAYOUT depth — how many upline levels actually earn a commission on
+# each invoice. 1 = direct referrer only (MLM payouts disabled by default,
+# deep enrollment still works). Set to 3 to pay the full upline again.
+SHOGO_AFFILIATE_PAYOUT_MAX_DEPTH=1
 # Refund hold in days. Commissions become `approved` (payable) after
 # `createdAt + this many days`. Matches the standard 30-day Stripe
 # refund window so we never pay out on a charge that gets refunded.

--- a/apps/api/src/services/__tests__/affiliate.service.test.ts
+++ b/apps/api/src/services/__tests__/affiliate.service.test.ts
@@ -331,9 +331,9 @@ beforeEach(() => {
   commissions = []
   payouts = []
   tiers = [
-    { id: 'tier_l1', level: 1, rateBps: 2000, durationDays: 365, label: 'L1' },
-    { id: 'tier_l2', level: 2, rateBps: 500, durationDays: 365, label: 'L2' },
-    { id: 'tier_l3', level: 3, rateBps: 200, durationDays: 365, label: 'L3' },
+    { id: 'tier_l1', level: 1, rateBps: 2000, durationDays: 365, secondaryRateBps: 1000, label: 'L1' },
+    { id: 'tier_l2', level: 2, rateBps: 500, durationDays: 365, secondaryRateBps: null, label: 'L2' },
+    { id: 'tier_l3', level: 3, rateBps: 200, durationDays: 365, secondaryRateBps: null, label: 'L3' },
   ]
   users = new Map()
   nextId = 0
@@ -343,6 +343,7 @@ beforeEach(() => {
   stripeFailureMethod = null
   process.env.SHOGO_AFFILIATES_NATIVE = 'true'
   delete process.env.SHOGO_AFFILIATE_MAX_DEPTH
+  delete process.env.SHOGO_AFFILIATE_PAYOUT_MAX_DEPTH
   delete process.env.SHOGO_AFFILIATE_REFUND_HOLD_DAYS
   delete process.env.SHOGO_AFFILIATE_MIN_PAYOUT_CENTS
   delete process.env.SHOGO_AFFILIATE_COOKIE_DAYS
@@ -641,6 +642,8 @@ describe('recordCommissionsForInvoice', () => {
   }
 
   test('writes 3-level commission split with seeded tier table', async () => {
+    // Opt into multi-level payouts; default is direct-referrer only.
+    process.env.SHOGO_AFFILIATE_PAYOUT_MAX_DEPTH = '3'
     setupTree()
     const stripe = makeStripe()
     const created = await svc.recordCommissionsForInvoice(buildInvoice(), stripe, new Date('2026-05-15'))
@@ -711,6 +714,7 @@ describe('recordCommissionsForInvoice', () => {
   })
 
   test('attribution older than L1 durationDays → skips L1 but still pays L2/L3 with longer windows', async () => {
+    process.env.SHOGO_AFFILIATE_PAYOUT_MAX_DEPTH = '3'
     const { direct } = setupTree()
     attributions.set('u-buyer', {
       id: 'attr_buyer',
@@ -724,9 +728,56 @@ describe('recordCommissionsForInvoice', () => {
       { id: 't3', level: 3, rateBps: 200, durationDays: 365, label: 'L3 expired' },
     ]
     const created = await svc.recordCommissionsForInvoice(buildInvoice(), makeStripe(), new Date('2026-05-15'))
-    // L1 expired (30d < ~500d), L2 forever applies, L3 365d < ~500d, also skip.
+    // L1 expired (30d < ~500d) with no step-down rate, L2 forever applies,
+    // L3 365d < ~500d, also skip.
     expect(created).toBe(1)
     expect(commissions[0].level).toBe(2)
+  })
+
+  test('default payout depth pays only the direct referrer (MLM off)', async () => {
+    // No SHOGO_AFFILIATE_PAYOUT_MAX_DEPTH set → defaults to 1.
+    setupTree()
+    const created = await svc.recordCommissionsForInvoice(buildInvoice(), makeStripe(), new Date('2026-05-15'))
+    expect(created).toBe(1)
+    expect(commissions).toHaveLength(1)
+    expect(commissions[0].affiliateId).toBe('aff_direct')
+    expect(commissions[0].level).toBe(1)
+    expect(commissions[0].amountCents).toBe(2000) // 20%
+    // Upline (l2, root) earns nothing.
+    expect(affiliates.get('aff_l2')!.pendingPayoutCents).toBe(0)
+    expect(affiliates.get('aff_root')!.pendingPayoutCents).toBe(0)
+  })
+
+  test('direct referrer earns 20% in year one', async () => {
+    setupTree() // attributedAt 2026-05-01
+    // 14 days in → inside the 365-day window.
+    const created = await svc.recordCommissionsForInvoice(buildInvoice(), makeStripe(), new Date('2026-05-15'))
+    expect(created).toBe(1)
+    expect(commissions[0].rateBps).toBe(2000)
+    expect(commissions[0].amountCents).toBe(2000) // 20% of 10_000
+  })
+
+  test('direct referrer steps down to 10% forever after year one', async () => {
+    setupTree() // attributedAt 2026-05-01
+    // ~13 months later → past the 365-day window, secondaryRateBps applies.
+    const created = await svc.recordCommissionsForInvoice(buildInvoice(), makeStripe(), new Date('2027-06-15'))
+    expect(created).toBe(1)
+    expect(commissions[0].rateBps).toBe(1000)
+    expect(commissions[0].amountCents).toBe(1000) // 10% of 10_000
+    expect(affiliates.get('aff_direct')!.pendingPayoutCents).toBe(1000)
+  })
+
+  test('no step-down rate → level stops earning after its window', async () => {
+    const { direct } = setupTree()
+    tiers = [{ id: 't1', level: 1, rateBps: 2000, durationDays: 30, secondaryRateBps: null, label: 'L1' }]
+    attributions.set('u-buyer', {
+      id: 'attr_buyer',
+      userId: 'u-buyer',
+      affiliateId: direct.id,
+      attributedAt: new Date('2026-01-01'),
+    })
+    const created = await svc.recordCommissionsForInvoice(buildInvoice(), makeStripe(), new Date('2026-05-15'))
+    expect(created).toBe(0)
   })
 })
 

--- a/apps/api/src/services/affiliate.service.ts
+++ b/apps/api/src/services/affiliate.service.ts
@@ -39,14 +39,31 @@ import { withGlobalJobLock } from '../lib/global-job-lock'
 const isLocalMode = process.env.SHOGO_LOCAL_MODE === 'true'
 
 export const DEFAULT_MAX_DEPTH = 3
+// Levels actually PAID commissions. Default 1 = direct referrer only (MLM
+// payouts off). This is decoupled from DEFAULT_MAX_DEPTH so deep enrollment
+// trees still form; we just don't pay the upline beyond this depth. Set
+// SHOGO_AFFILIATE_PAYOUT_MAX_DEPTH=3 to re-enable full multi-level payouts.
+export const DEFAULT_PAYOUT_MAX_DEPTH = 1
 export const DEFAULT_REFUND_HOLD_DAYS = 30
 export const DEFAULT_MIN_PAYOUT_CENTS = 5000
 export const DEFAULT_COOKIE_DAYS = 60
 
+/** Max enrollment depth: how deep a `parentCode` chain may grow. */
 export function getMaxDepth(): number {
   const raw = process.env.SHOGO_AFFILIATE_MAX_DEPTH
   const n = raw ? parseInt(raw, 10) : DEFAULT_MAX_DEPTH
   return Number.isFinite(n) && n > 0 ? n : DEFAULT_MAX_DEPTH
+}
+
+/**
+ * Max PAYOUT depth: how many upline levels actually earn a commission on an
+ * invoice. Defaults to 1 (direct referrer only). Independent from
+ * getMaxDepth() so the enrollment tree can be deeper than what we pay.
+ */
+export function getPayoutMaxDepth(): number {
+  const raw = process.env.SHOGO_AFFILIATE_PAYOUT_MAX_DEPTH
+  const n = raw ? parseInt(raw, 10) : DEFAULT_PAYOUT_MAX_DEPTH
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_PAYOUT_MAX_DEPTH
 }
 
 export function getRefundHoldDays(): number {
@@ -508,7 +525,10 @@ export async function recordCommissionsForInvoice(
     orderBy: { level: 'asc' },
   })
   if (tiers.length === 0) return 0
-  const cap = Math.min(tiers.length, getMaxDepth())
+  // Payout depth is capped independently of enrollment depth: by default
+  // only the direct referrer (level 1) earns, even when the enrollment
+  // upline is deeper. Bump SHOGO_AFFILIATE_PAYOUT_MAX_DEPTH to pay deeper.
+  const cap = Math.min(tiers.length, getPayoutMaxDepth())
   const upline = await getUpline(affiliateId, cap)
 
   const refundHoldDays = getRefundHoldDays()
@@ -526,12 +546,18 @@ export async function recordCommissionsForInvoice(
     if (level > cap) break
     const uplineEntry = upline.find((u) => u.level === level)
     if (!uplineEntry) continue
+    let rateBps = tier.rateBps as number
     if (tier.durationDays != null && attrAgeDays > tier.durationDays) {
-      // This level's window has expired; skip it but keep walking
-      // (callers may have configured a longer L3 window than L1).
-      continue
+      // This level's primary window has expired. If a step-down rate is
+      // configured (e.g. 20% for year one -> 10% forever), keep paying at
+      // that reduced rate; otherwise the level stops earning (legacy
+      // behavior — and callers may set a longer window on a deeper level).
+      if (tier.secondaryRateBps != null) {
+        rateBps = tier.secondaryRateBps as number
+      } else {
+        continue
+      }
     }
-    const rateBps = tier.rateBps as number
     const amountCents = Math.floor((basisCents * rateBps) / 10_000)
     if (amountCents <= 0) continue
 

--- a/apps/desktop/prisma/migrations/20260530202030_affiliate_secondary_rate/migration.sql
+++ b/apps/desktop/prisma/migrations/20260530202030_affiliate_secondary_rate/migration.sql
@@ -1,0 +1,18 @@
+-- Migration: affiliate_secondary_rate
+-- Source:    prisma/schema.local.prisma
+--
+-- Adds an optional step-down commission rate to affiliate tiers. After a
+-- tier's `durationDays` window expires, `secondaryRateBps` (if set) is the
+-- rate paid forever after (e.g. 20% for year one -> 10% thereafter). NULL
+-- preserves the legacy behavior where the level simply stops earning.
+-- Seeds the direct-referrer tier (level 1) with a 10% (1000 bps) step-down.
+--
+-- Scoped to the affiliate change only; pre-existing ACCEPTED_DRIFT
+-- redefinitions of other tables (see scripts/check-desktop-schema-drift.ts)
+-- are intentionally left out.
+
+-- AlterTable
+ALTER TABLE "affiliate_commission_tiers" ADD COLUMN "secondaryRateBps" INTEGER;
+
+-- Seed: direct referral steps down to 10% after its 365-day window.
+UPDATE "affiliate_commission_tiers" SET "secondaryRateBps" = 1000 WHERE "level" = 1;

--- a/docs/affiliate-mlm-rollout.md
+++ b/docs/affiliate-mlm-rollout.md
@@ -16,6 +16,33 @@ SHOGO_AFFILIATES_NATIVE=true   →  click tracking, attribution, commissions,
 Every server-side surface checks the flag and short-circuits when off,
 so a code rollout without the flag flip is a no-op for users.
 
+## Commission structure (default: single-level)
+
+The program ships with **multi-level payouts disabled by default**. Only
+the direct referrer earns:
+
+- **20%** of a referred customer's invoices for the **first 365 days**
+  (from their attribution date), then **10% forever after**. This
+  step-down is configured per tier via the new `secondaryRateBps` column
+  on `affiliate_commission_tiers` (level 1 seeded at `1000` bps).
+- Levels 2 and 3 of someone's downline earn **nothing** by default — a
+  referrer is not paid for the customers that *their* referrals bring in.
+
+Two independent depth knobs control this:
+
+```
+SHOGO_AFFILIATE_MAX_DEPTH=3          →  how deep the enrollment tree may grow
+                                         (parentCode chains). Deep trees still
+                                         form even when payouts are single-level.
+SHOGO_AFFILIATE_PAYOUT_MAX_DEPTH=1   →  how many upline levels actually earn a
+                                         commission. 1 = direct referrer only.
+                                         Set to 3 to re-enable full MLM payouts.
+```
+
+Re-enabling MLM payouts later is a single env flip
+(`SHOGO_AFFILIATE_PAYOUT_MAX_DEPTH=3`) — no code change, no migration. The
+L2/L3 tier rows and the enrollment tree are preserved the whole time.
+
 ## What's already shipped (gated)
 
 - Prisma models + migrations on both Postgres and SQLite.
@@ -45,7 +72,8 @@ In every cloud region's API deployment:
 | Var | Recommended value | Notes |
 | --- | --- | --- |
 | `SHOGO_AFFILIATES_NATIVE` | `true` at flip time | Master kill switch. |
-| `SHOGO_AFFILIATE_MAX_DEPTH` | `3` | Matches seed tier rows. |
+| `SHOGO_AFFILIATE_MAX_DEPTH` | `3` | Enrollment tree depth (parentCode chains). |
+| `SHOGO_AFFILIATE_PAYOUT_MAX_DEPTH` | `1` | Levels actually paid. `1` = direct referrer only (MLM payouts off); `3` re-enables full MLM. |
 | `SHOGO_AFFILIATE_REFUND_HOLD_DAYS` | `30` | Commissions stay `pending` for this long. |
 | `SHOGO_AFFILIATE_MIN_PAYOUT_CENTS` | `5000` | Minimum payout balance. |
 | `SHOGO_AFFILIATE_COOKIE_DAYS` | `60` | Click-attribution window. |
@@ -73,8 +101,10 @@ In the Cloudflare Pages project for `shogo-website`:
    `affiliate_attribution` row exists for the new user.
 5. Complete a paid checkout. Confirm:
    - Stripe Customer + Subscription metadata contain `affiliateId`.
-   - On `invoice.payment_succeeded`, three `affiliate_commission` rows
-     are written (one per upline level present).
+   - On `invoice.payment_succeeded`, one `affiliate_commission` row is
+     written for the direct referrer at 20% (default single-level). If you
+     set `SHOGO_AFFILIATE_PAYOUT_MAX_DEPTH=3` to test MLM, expect one row
+     per upline level present.
 6. Wait out the refund-hold (or temporarily set
    `SHOGO_AFFILIATE_REFUND_HOLD_DAYS=0`) and run
    `runApproveEligibleCommissions` manually. Confirm `pending → approved`.

--- a/k8s/overlays/staging/api-service.yaml
+++ b/k8s/overlays/staging/api-service.yaml
@@ -356,6 +356,11 @@ spec:
               value: "true"
             - name: SHOGO_AFFILIATE_MAX_DEPTH
               value: "3"
+            # Pay only the direct referrer by default (MLM payouts off);
+            # enrollment tree depth above is unaffected. Set to "3" to
+            # re-enable full multi-level payouts.
+            - name: SHOGO_AFFILIATE_PAYOUT_MAX_DEPTH
+              value: "1"
             - name: SHOGO_AFFILIATE_REFUND_HOLD_DAYS
               value: "30"
             - name: SHOGO_AFFILIATE_MIN_PAYOUT_CENTS

--- a/prisma/migrations/20260530202030_affiliate_secondary_rate/migration.sql
+++ b/prisma/migrations/20260530202030_affiliate_secondary_rate/migration.sql
@@ -1,0 +1,18 @@
+-- Migration: affiliate secondary (step-down) commission rate.
+--
+-- Adds an optional second-phase rate to affiliate commission tiers (see
+-- prisma/schema.prisma `AffiliateCommissionTier` and the commission engine
+-- in apps/api/src/services/affiliate.service.ts). After a tier's
+-- `durationDays` window expires, `secondaryRateBps` (if set) becomes the
+-- rate paid forever after — e.g. 20% (2000 bps) for the first year, then
+-- 10% (1000 bps) thereafter. NULL preserves the legacy behavior where the
+-- level simply stops earning once its window ends.
+--
+-- Seeds the direct-referral tier (level 1) with a 10% step-down so the
+-- default program pays 20% year one and 10% forever after.
+
+-- AlterTable
+ALTER TABLE "affiliate_commission_tiers" ADD COLUMN "secondaryRateBps" INTEGER;
+
+-- Seed: direct referral steps down to 10% after its 365-day window.
+UPDATE "affiliate_commission_tiers" SET "secondaryRateBps" = 1000 WHERE "level" = 1;

--- a/prisma/schema.local.prisma
+++ b/prisma/schema.local.prisma
@@ -2053,6 +2053,7 @@ model AffiliateCommissionTier {
   level        Int     @unique
   rateBps      Int
   durationDays Int?
+  secondaryRateBps Int?
   label        String?
 
   @@map("affiliate_commission_tiers")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2715,8 +2715,9 @@ model AffiliatePayout {
 }
 
 /// Per-level commission configuration. The number of rows defines the
-/// max upline depth (default 3) — adding a row enables L4 commissions
-/// across the system. `rateBps` is in basis points (2000 = 20.00%).
+/// enrollment tree depth; how many levels are actually PAID is capped
+/// separately by SHOGO_AFFILIATE_PAYOUT_MAX_DEPTH (default 1 = direct
+/// referrer only). `rateBps` is in basis points (2000 = 20.00%).
 /// `durationDays` caps the recurring window per level (null = forever);
 /// default 365 matches Rewardful's 12-month policy.
 model AffiliateCommissionTier {
@@ -2724,6 +2725,11 @@ model AffiliateCommissionTier {
   level        Int     @unique
   rateBps      Int
   durationDays Int?
+  /// Optional step-down rate (basis points) applied AFTER `durationDays`
+  /// expires (e.g. 1000 = 10.00% forever once the 365-day window ends).
+  /// Null preserves legacy behavior: the level stops earning after its
+  /// window.
+  secondaryRateBps Int?
   /// Optional display label for the admin UI (e.g. "Direct referral",
   /// "L2 upline"). Free-form; ignored by the commission engine.
   label        String?


### PR DESCRIPTION
## Summary

Disables the MLM aspect of the affiliate program by default while keeping the infrastructure (and re-enable path) intact.

- **Single-level payouts by default.** Adds a new payout-depth cap `SHOGO_AFFILIATE_PAYOUT_MAX_DEPTH` (default `1`), decoupled from the existing enrollment-depth cap `SHOGO_AFFILIATE_MAX_DEPTH` (still `3`). Only the direct referrer earns; a referrer is no longer paid for customers brought in by *their* referrals. Deep enrollment trees still form, and full MLM payouts can be restored with a single env flip (`SHOGO_AFFILIATE_PAYOUT_MAX_DEPTH=3`) — no code change or migration.
- **20% first year, then 10% forever.** Adds a per-tier `secondaryRateBps` column: after a tier's `durationDays` window expires, it pays the step-down rate forever (null = legacy behavior, level stops earning). Level 1 is seeded at `1000` bps (10%).

### Changes
- `affiliate.service.ts`: new `getPayoutMaxDepth()`; commission cap uses it; step-down rate logic in `recordCommissionsForInvoice`.
- `AffiliateCommissionTier.secondaryRateBps` added to both Prisma schemas + PG and SQLite migrations (column add + seed L1=1000).
- `.env.example`, k8s staging overlay, and rollout docs updated.

## Test plan
- [x] `bun test affiliate.service.test.ts` — 51 pass / 0 fail (added: single-level default, 20% year-one, 10% step-down, null-step-down legacy)
- [x] `check:schema-parity` — OK
- [x] `check:desktop-schema-drift` — only pre-existing accepted-drift tables
- [x] `check:migrations` — all 4 checkpoints clean

Made with [Cursor](https://cursor.com)