### PR TITLE
feat(chat): attach pending questions to the composer

### DIFF
--- a/apps/mobile/components/chat/ChatContext.tsx
+++ b/apps/mobile/components/chat/ChatContext.tsx
@@ -85,6 +85,10 @@ export interface ChatContextValue {
   /** Persist a tool output to in-memory messages and the DB (e.g. ask_user answers) */
   saveToolOutput?: (params: { messageId: string; toolCallId: string; output: string }) => void
 
+  /** Scroll the chat to the input-attached pending question (e.g. when the
+   *  collapsed in-stream question bar is tapped). */
+  focusPendingQuestion?: () => void
+
   /** Build and execute a pending plan. Null when no plan is pending. */
   buildPlan?: ((plan?: PlanData | null) => void) | null
 

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -72,6 +72,8 @@ import {
 import { FileViewerModal } from "./FileViewerModal"
 import { PastedTextChip } from "./PastedTextChip"
 import { useChatBridgeOptional } from "../voice-mode/ChatBridgeContext"
+import { AskUserQuestionWidget } from "./turns/AskUserQuestionWidget"
+import type { ToolCallData } from "./tools/types"
 
 export const DEFAULT_MODEL_PRO = "claude-sonnet-4-6"
 export const DEFAULT_MODEL_FREE = "claude-haiku-4-5-20251001"
@@ -180,6 +182,14 @@ export interface ChatInputProps {
   onModelChange?: (modelId: string) => void
   isPro?: boolean
   onUpgradeClick?: () => void
+  /**
+   * Pending ask_user tool call to render as an interactive question widget
+   * attached above the composer (instead of inline in the message stream).
+   * Null when there is no open question.
+   */
+  pendingQuestion?: { messageId: string; tool: ToolCallData } | null
+  /** Called with the formatted response when the attached question is submitted. */
+  onSubmitQuestionResponse?: (response: string) => void
   queuedMessages?: QueuedMessage[]
   onRemoveQueuedMessage?: (messageId: string) => void
   onReorderQueuedMessage?: (messageId: string, direction: "up" | "down") => void
@@ -237,6 +247,8 @@ function ChatInputImpl({
   onModelChange,
   isPro = false,
   onUpgradeClick,
+  pendingQuestion,
+  onSubmitQuestionResponse,
   queuedMessages = [],
   onRemoveQueuedMessage,
   onReorderQueuedMessage,
@@ -766,6 +778,18 @@ function ChatInputImpl({
 
       {voiceInput.error && (
         <Text className="text-sm text-destructive mb-2">{voiceInput.error}</Text>
+      )}
+
+      {/* Pending question — interactive answer UI attached above the composer.
+          Stays expanded while pending; submitting persists the answer and
+          clears `pendingQuestion`, unmounting this panel. */}
+      {pendingQuestion && (
+        <View className="mb-2">
+          <AskUserQuestionWidget
+            tool={pendingQuestion.tool}
+            onSubmitResponse={(response) => onSubmitQuestionResponse?.(response)}
+          />
+        </View>
       )}
 
       {/* Queued messages */}

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -147,6 +147,7 @@ import { buildStopRequest } from "../../lib/chat-stop"
 import { configureSubagentStop } from "../../lib/subagent-stop"
 import { useChatBridgeRegistrar } from "../voice-mode/ChatBridgeContext"
 import { extractTaskToolsFromMessages } from "./turns/messageParts"
+import { derivePendingQuestion } from "./turns/pendingQuestion"
 import {
   FIX_IN_AGENT_EVENT,
   buildFixPrompt,
@@ -3304,19 +3305,15 @@ export const ChatPanel = observer(function ChatPanel({
     }
   }, [displayMessages.length, messages, currentSessionId, isNative, shouldFollowBottom, scrollToBottomIfFollowing, markProgrammaticScroll])
 
-  // Detect a pending ask_user tool call in the last assistant message
-  const hasPendingQuestion = useMemo(() => {
-    const lastMsg = messages[messages.length - 1]
-    if (!lastMsg || lastMsg.role !== "assistant") return false
-    const parts = (lastMsg as any).parts as any[] | undefined
-    if (!parts) return false
-    return parts.some(
-      (p: any) =>
-        p.type === "dynamic-tool" &&
-        p.toolName === "ask_user" &&
-        (p.state === "input-available" || p.state === "input-streaming")
-    )
-  }, [messages])
+  // Detect a pending ask_user tool call in the last assistant message and
+  // surface its tool data so the interactive question UI can be attached
+  // above the chat input (instead of rendered inline in the stream).
+  const pendingQuestion = useMemo(
+    () => derivePendingQuestion(messages),
+    [messages]
+  )
+
+  const hasPendingQuestion = pendingQuestion != null
 
   const extractMediaType = useCallback((dataUrl: string): string => {
     const match = dataUrl.match(/^data:([^;]+);/)
@@ -4258,6 +4255,23 @@ export const ChatPanel = observer(function ChatPanel({
     [setMessages, sessionMessages]
   )
 
+  // Submit handler for the input-attached question widget. Mirrors the
+  // inline ask_user handler: send the formatted response as a user message
+  // and persist the tool output so the part flips to answered (which also
+  // clears `pendingQuestion`, unmounting the attached widget).
+  const handleSubmitQuestionResponse = useCallback(
+    (response: string) => {
+      if (!pendingQuestion) return
+      handleSendMessage(response)
+      handleSaveToolOutput({
+        messageId: pendingQuestion.messageId,
+        toolCallId: pendingQuestion.tool.id,
+        output: response,
+      })
+    },
+    [pendingQuestion, handleSendMessage, handleSaveToolOutput]
+  )
+
   // Stable session summary so a new object literal isn't allocated each
   // render even when the underlying session id/name haven't changed.
   const sessionSummary = useMemo(
@@ -4303,6 +4317,7 @@ export const ChatPanel = observer(function ChatPanel({
       agentUrl: resolvedAgentUrl,
       addToolOutput: stableAddToolOutput,
       saveToolOutput: handleSaveToolOutput,
+      focusPendingQuestion: jumpToLatest,
       buildPlan: pendingPlan ? handleConfirmPlan : null,
       confirmPlan: pendingPlan ? handleConfirmPlan : null,
       pendingPlan,
@@ -4319,6 +4334,7 @@ export const ChatPanel = observer(function ChatPanel({
       resolvedAgentUrl,
       stableAddToolOutput,
       handleSaveToolOutput,
+      jumpToLatest,
       pendingPlan,
       handleConfirmPlan,
       confirmedPlan,
@@ -4778,7 +4794,7 @@ export const ChatPanel = observer(function ChatPanel({
                 !featureId
                   ? "Select a feature to start chatting..."
                   : hasPendingQuestion
-                    ? "Respond to the question above, or type a message..."
+                    ? "Respond to the question below, or type a message..."
                     : interactionMode === "plan"
                       ? "Describe what you want to plan..."
                       : interactionMode === "ask"
@@ -4791,6 +4807,8 @@ export const ChatPanel = observer(function ChatPanel({
               onModelChange={handleModelChange}
               isPro={hasAdvancedModelAccess}
               onUpgradeClick={handleUpgradeClick}
+              pendingQuestion={pendingQuestion}
+              onSubmitQuestionResponse={handleSubmitQuestionResponse}
               queuedMessages={messageQueue}
               onRemoveQueuedMessage={handleRemoveQueuedMessage}
               onReorderQueuedMessage={handleReorderQueuedMessage}

--- a/apps/mobile/components/chat/__tests__/pending-question-attachment.test.ts
+++ b/apps/mobile/components/chat/__tests__/pending-question-attachment.test.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Pending ask_user attachment — derivation + in-stream routing contract.
+ *
+ * The interactive question UI is attached above the chat input (like the
+ * message queue) instead of rendered inline. ChatPanel derives the pending
+ * question via `derivePendingQuestion`; AssistantContent routes a given
+ * ask_user part to a collapsed bar (pending) or the answered summary widget
+ * via `askUserStreamVariant`. These pure helpers are the single source of
+ * truth, imported by both the panel and this test.
+ *
+ * Run: bun test apps/mobile/components/chat/__tests__/pending-question-attachment.test.ts
+ */
+
+import { describe, test, expect } from "bun:test"
+import type { UIMessage } from "@ai-sdk/react"
+import {
+  derivePendingQuestion,
+  askUserStreamVariant,
+} from "../turns/pendingQuestion"
+
+function assistantWithAskUser(part: Record<string, unknown>): UIMessage {
+  return {
+    id: "msg-assistant-1",
+    role: "assistant",
+    parts: [{ type: "text", text: "Let me ask." }, part],
+  } as unknown as UIMessage
+}
+
+const PENDING_PART = {
+  type: "dynamic-tool",
+  toolName: "ask_user",
+  toolCallId: "call-abc",
+  state: "input-available",
+  input: {
+    questions: [
+      {
+        header: "Stack",
+        question: "Which stack?",
+        options: [
+          { label: "Next.js", description: "" },
+          { label: "Remix", description: "" },
+        ],
+      },
+    ],
+  },
+}
+
+describe("derivePendingQuestion", () => {
+  test("returns null when there are no messages", () => {
+    expect(derivePendingQuestion([])).toBeNull()
+  })
+
+  test("returns null when the last message is from the user", () => {
+    const messages = [
+      { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+    ] as unknown as UIMessage[]
+    expect(derivePendingQuestion(messages)).toBeNull()
+  })
+
+  test("captures messageId + tool data for a pending ask_user", () => {
+    const messages = [assistantWithAskUser(PENDING_PART)]
+    const pending = derivePendingQuestion(messages)
+
+    expect(pending).not.toBeNull()
+    expect(pending!.messageId).toBe("msg-assistant-1")
+    expect(pending!.tool.id).toBe("call-abc")
+    expect(pending!.tool.toolName).toBe("ask_user")
+    // `input` becomes `args`, `output` becomes `result`.
+    expect((pending!.tool.args as any).questions).toHaveLength(1)
+    expect(pending!.tool.result).toBeUndefined()
+  })
+
+  test("treats input-streaming as pending too", () => {
+    const messages = [
+      assistantWithAskUser({ ...PENDING_PART, state: "input-streaming" }),
+    ]
+    expect(derivePendingQuestion(messages)).not.toBeNull()
+  })
+
+  test("returns null once the question is answered (output-available)", () => {
+    const messages = [
+      assistantWithAskUser({
+        ...PENDING_PART,
+        state: "output-available",
+        output: "Next.js",
+      }),
+    ]
+    expect(derivePendingQuestion(messages)).toBeNull()
+  })
+
+  test("only considers the LAST message — an older pending ask_user does not count", () => {
+    const messages = [
+      assistantWithAskUser(PENDING_PART),
+      { id: "u2", role: "user", parts: [{ type: "text", text: "Next.js" }] },
+    ] as unknown as UIMessage[]
+    expect(derivePendingQuestion(messages)).toBeNull()
+  })
+
+  test("falls back to a stable id when toolCallId is missing", () => {
+    const { toolCallId, ...noId } = PENDING_PART
+    const messages = [assistantWithAskUser(noId)]
+    expect(derivePendingQuestion(messages)!.tool.id).toBe("tool-ask_user")
+  })
+})
+
+describe("askUserStreamVariant", () => {
+  test("pending (no result) renders the collapsed bar in-stream", () => {
+    expect(askUserStreamVariant(undefined)).toBe("bar")
+  })
+
+  test("answered (result present) renders the summary widget in-stream", () => {
+    expect(askUserStreamVariant("Next.js")).toBe("widget")
+    expect(askUserStreamVariant("")).toBe("widget")
+  })
+})

--- a/apps/mobile/components/chat/turns/AskUserQuestionWidget.tsx
+++ b/apps/mobile/components/chat/turns/AskUserQuestionWidget.tsx
@@ -16,6 +16,8 @@ import {
   ChevronRight,
   ChevronDown,
   RefreshCw,
+  MessageCircleQuestion,
+  ArrowDown,
 } from "lucide-react-native"
 import {
   type ToolCallData,
@@ -703,6 +705,50 @@ export function AskUserQuestionWidget({
         </View>
       )}
     </View>
+  )
+}
+
+export interface AskUserQuestionBarProps {
+  tool: ToolCallData
+  /** Tap handler — typically scrolls to the input-attached question widget. */
+  onPress?: () => void
+  className?: string
+}
+
+/**
+ * Collapsed in-stream placeholder for a pending ask_user call. Styled like the
+ * unexpanded TodoWidget header. The interactive answer UI lives attached above
+ * the chat input; tapping this bar scrolls there via `onPress`.
+ */
+export function AskUserQuestionBar({
+  tool,
+  onPress,
+  className,
+}: AskUserQuestionBarProps) {
+  const questions = useMemo(() => parseQuestions(tool.args), [tool.args])
+  const count = questions.length
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityLabel="Pending question — answer below"
+      className={cn(
+        "rounded-md border border-primary/30 bg-primary/5 w-full flex-row items-center gap-1.5 py-1.5 px-2",
+        className
+      )}
+    >
+      <MessageCircleQuestion className="w-3 h-3 text-primary" />
+
+      <Text className="font-mono text-[10px] font-medium text-foreground">
+        Questions
+      </Text>
+
+      <Text className="flex-1 text-[9px] text-muted-foreground text-right">
+        {count > 1 ? `${count} questions • ` : ""}Answer below
+      </Text>
+
+      <ArrowDown className="w-3 h-3 text-primary" />
+    </Pressable>
   )
 }
 

--- a/apps/mobile/components/chat/turns/AssistantContent.tsx
+++ b/apps/mobile/components/chat/turns/AssistantContent.tsx
@@ -20,7 +20,8 @@ import {
   ConnectToolWidget,
   parseToolInstallResult,
 } from "./ConnectToolWidget"
-import { AskUserQuestionWidget } from "./AskUserQuestionWidget"
+import { AskUserQuestionWidget, AskUserQuestionBar } from "./AskUserQuestionWidget"
+import { askUserStreamVariant } from "./pendingQuestion"
 import { TodoWidget } from "./TodoWidget"
 import { ToolCallGroup } from "./ToolCallGroup"
 import { ExplorationGroup } from "./ExplorationGroup"
@@ -768,14 +769,25 @@ export const AssistantContent = memo(
           }
 
           if (part.tool.toolName === "ask_user") {
-            const isPending = part.tool.result === undefined
-            const isExpanded = isPending || expandedTools.has(part.id)
+            // While pending, the interactive answer UI is attached above the
+            // chat input. The stream only shows a small collapsed bar that
+            // scrolls to that widget when tapped.
+            if (askUserStreamVariant(part.tool.result) === "bar") {
+              return (
+                <AskUserQuestionBar
+                  key={part.id}
+                  tool={part.tool}
+                  onPress={() => chatContext?.focusPendingQuestion?.()}
+                />
+              )
+            }
 
+            // Answered: keep the existing collapsed summary widget in-stream.
             return (
               <AskUserQuestionWidget
                 key={part.id}
                 tool={part.tool}
-                isExpanded={isExpanded}
+                isExpanded={expandedTools.has(part.id)}
                 onToggle={getToggle(part.id)}
                 onSubmitResponse={(response) => {
                   if (chatContext?.sendMessage) {

--- a/apps/mobile/components/chat/turns/index.ts
+++ b/apps/mobile/components/chat/turns/index.ts
@@ -22,5 +22,10 @@ export {
   type CollapsibleToolGroupProps,
 } from "./CollapsibleToolGroup"
 export { TodoWidget, type TodoWidgetProps } from "./TodoWidget"
-export { AskUserQuestionWidget, type AskUserQuestionWidgetProps } from "./AskUserQuestionWidget"
+export {
+  AskUserQuestionWidget,
+  type AskUserQuestionWidgetProps,
+  AskUserQuestionBar,
+  type AskUserQuestionBarProps,
+} from "./AskUserQuestionWidget"
 export { type ConversationTurn, type TurnBoundary, type MessagePart } from "./types"

--- a/apps/mobile/components/chat/turns/pendingQuestion.ts
+++ b/apps/mobile/components/chat/turns/pendingQuestion.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Pending `ask_user` derivation.
+ *
+ * The interactive question UI is attached above the chat input (like the
+ * message queue) rather than rendered inline in the message stream. ChatPanel
+ * derives the pending question from the live message list with
+ * `derivePendingQuestion`; AssistantContent decides whether a given `ask_user`
+ * part renders as a collapsed in-stream bar or the answered summary widget with
+ * `askUserStreamVariant`. Both are pure so they can be unit-tested without
+ * React / React Native.
+ */
+
+import type { UIMessage } from "@ai-sdk/react"
+import { type ToolCallData, getToolCategory } from "../tools/types"
+import { mapToolState } from "./messageParts"
+
+export interface PendingQuestion {
+  messageId: string
+  tool: ToolCallData
+}
+
+/**
+ * Returns the pending `ask_user` tool call in the last assistant message, or
+ * `null` when there is no open question. A question is "pending" while its
+ * dynamic-tool part is still awaiting input (`input-available` /
+ * `input-streaming`) — i.e. the agent has asked but no answer has been
+ * persisted yet.
+ */
+export function derivePendingQuestion(
+  messages: readonly UIMessage[],
+): PendingQuestion | null {
+  const lastMsg = messages[messages.length - 1]
+  if (!lastMsg || (lastMsg as any).role !== "assistant") return null
+  const parts = (lastMsg as any).parts as any[] | undefined
+  if (!parts) return null
+  const part = parts.find(
+    (p: any) =>
+      p.type === "dynamic-tool" &&
+      p.toolName === "ask_user" &&
+      (p.state === "input-available" || p.state === "input-streaming"),
+  )
+  if (!part) return null
+  const toolCallId = part.toolCallId || "tool-ask_user"
+  return {
+    messageId: (lastMsg as any).id,
+    tool: {
+      id: toolCallId,
+      toolName: "ask_user",
+      category: getToolCategory("ask_user"),
+      state: mapToolState(part.state),
+      args: part.input,
+      result: part.output,
+      timestamp: 0,
+    },
+  }
+}
+
+/**
+ * How an `ask_user` part should render in the message stream.
+ *
+ * - `"bar"`: pending — a small collapsed status bar (the interactive widget
+ *   lives attached above the composer).
+ * - `"widget"`: answered — the existing collapsed summary widget.
+ */
+export function askUserStreamVariant(toolResult: unknown): "bar" | "widget" {
+  return toolResult === undefined ? "bar" : "widget"
+}


### PR DESCRIPTION
## Summary
- Pending `ask_user` questions now render their interactive answer UI **attached above the chat input** (like the message queue) instead of inline in the message stream.
- The message stream shows only a small **collapsed bar** (styled like the unexpanded Tasks bar). Tapping it scrolls to the composer-attached question (`focusPendingQuestion`).
- Answered questions keep the existing in-stream collapsed summary widget.

## Implementation
- `turns/pendingQuestion.ts` (new): pure `derivePendingQuestion(messages)` maps the last assistant message's pending `ask_user` dynamic-tool part into `{ messageId, tool }`; `askUserStreamVariant(result)` returns `"bar"` (pending) or `"widget"` (answered). Shared by the panel and the tests as the single source of truth.
- `ChatPanel.tsx`: derive `pendingQuestion` via the helper, add `handleSubmitQuestionResponse` (sends the answer + persists tool output, mirroring the old inline handler), expose `focusPendingQuestion: jumpToLatest` on the chat context, pass `pendingQuestion`/`onSubmitQuestionResponse` to `ChatInput`, and update the placeholder ("question above" -> "below").
- `ChatContext.tsx`: add optional `focusPendingQuestion`.
- `ChatInput.tsx`: new `pendingQuestion` + `onSubmitQuestionResponse` props; render the interactive `AskUserQuestionWidget` in a panel directly above the queued-messages block.
- `AskUserQuestionWidget.tsx`: add exported `AskUserQuestionBar` (the small collapsed in-stream bar that scrolls to the composer on tap).
- `AssistantContent.tsx`: pending `ask_user` -> `AskUserQuestionBar`; answered -> existing summary widget.

## Test plan
- [x] New `__tests__/pending-question-attachment.test.ts` (9 tests): derivation + routing, incl. `input-streaming`, answered, last-message-only, missing `toolCallId` fallback.
- [x] Existing chat tests pass (queue behavior, queue chevrons, panel wedge, ask_user draft store): 82 pass, 1 pre-existing skip.
- [x] `tsc` on `apps/mobile`: no new errors from the changed files.
- [ ] Manual: verify a pending question appears above the composer, the in-stream bar scrolls to it, and submitting clears the attachment and shows the answered summary in-stream.

Made with [Cursor](https://cursor.com)