### PR TITLE
fix(composio): scope local agent to cloud identity so tools resolve

### DIFF
--- a/apps/api/src/lib/__tests__/federated-upstream.test.ts
+++ b/apps/api/src/lib/__tests__/federated-upstream.test.ts
@@ -28,6 +28,7 @@ mock.module('../cloud-urls', () => ({
 const {
   getUpstreamCredential,
   getUpstreamWorkspaceId,
+  getUpstreamIdentity,
   isFederatedEnabled,
   getUpstreamOrigin,
   listCloudInstancesForWorkspace,
@@ -164,6 +165,46 @@ describe('getUpstreamWorkspaceId', () => {
   test('returns null when SHOGO_KEY_INFO is malformed JSON', async () => {
     findUniqueMock.mockImplementation(async () => ({ value: 'not-json' }))
     expect(await getUpstreamWorkspaceId()).toBeNull()
+  })
+})
+
+describe('getUpstreamIdentity', () => {
+  test('fast path: returns user+workspace from SHOGO_KEY_INFO without a fetch', async () => {
+    findUniqueMock.mockImplementation(async ({ where }: any) => {
+      if (where.key === 'SHOGO_KEY_INFO') {
+        return { value: JSON.stringify({ workspace: { id: 'cloud-ws-1' }, user: { id: 'cloud-user-1' } }) }
+      }
+      return null
+    })
+    installFetch(() => { throw new Error('should not be called') })
+    expect(await getUpstreamIdentity()).toEqual({ userId: 'cloud-user-1', workspaceId: 'cloud-ws-1' })
+    expect(fetchCalls).toHaveLength(0)
+  })
+
+  test('backfill: older SHOGO_KEY_INFO (workspace only) validates the key to learn the user', async () => {
+    findUniqueMock.mockImplementation(async ({ where }: any) => {
+      if (where.key === 'SHOGO_KEY_INFO') {
+        return { value: JSON.stringify({ workspace: { id: 'cloud-ws-1' } }) }
+      }
+      return null
+    })
+    installFetch(() => jsonResponse({ valid: true, workspace: { id: 'cloud-ws-1' }, user: { id: 'cloud-user-9' } }))
+    expect(await getUpstreamIdentity()).toEqual({ userId: 'cloud-user-9', workspaceId: 'cloud-ws-1' })
+    expect(fetchCalls[0].url).toBe('https://cloud.test/api/api-keys/validate')
+  })
+
+  test('returns null (and caches) when the cloud rejects the key', async () => {
+    findUniqueMock.mockImplementation(async () => null)
+    installFetch(() => jsonResponse({ valid: false, error: 'revoked' }, 200))
+    expect(await getUpstreamIdentity()).toBeNull()
+  })
+
+  test('returns null without a fetch when there is no credential', async () => {
+    delete process.env.SHOGO_API_KEY
+    findUniqueMock.mockImplementation(async () => null)
+    installFetch(() => { throw new Error('should not be called') })
+    expect(await getUpstreamIdentity()).toBeNull()
+    expect(fetchCalls).toHaveLength(0)
   })
 })
 

--- a/apps/api/src/lib/federated-upstream.ts
+++ b/apps/api/src/lib/federated-upstream.ts
@@ -35,8 +35,10 @@ import { getShogoCloudUrl } from './cloud-urls'
 // ─── Auth + gate ────────────────────────────────────────────────────────────
 
 const CREDENTIAL_TTL_MS = 30_000
+const IDENTITY_TTL_MS = 5 * 60_000
 let cachedCredential: { value: string | null; expiresAt: number } | null = null
 let cachedCloudWorkspaceId: { value: string | null; expiresAt: number } | null = null
+let cachedCloudIdentity: { value: { userId: string; workspaceId: string } | null; expiresAt: number } | null = null
 
 /**
  * Resolve the cloud credential local mode uses. Reads `process.env`
@@ -71,6 +73,20 @@ export async function getUpstreamCredential(): Promise<string | null> {
 export function _resetUpstreamCredentialCache(): void {
   cachedCredential = null
   cachedCloudWorkspaceId = null
+  cachedCloudIdentity = null
+}
+
+/** Read + parse `localConfig.SHOGO_KEY_INFO`. Returns null when unset/malformed. */
+async function readKeyInfo(): Promise<{ workspace?: { id?: string }; user?: { id?: string } } | null> {
+  try {
+    const row = await (prisma as any).localConfig
+      .findUnique({ where: { key: 'SHOGO_KEY_INFO' } })
+      .catch(() => null)
+    if (!row?.value) return null
+    return JSON.parse(row.value)
+  } catch {
+    return null
+  }
 }
 
 /**
@@ -103,6 +119,65 @@ export async function getUpstreamWorkspaceId(): Promise<string | null> {
   }
   cachedCloudWorkspaceId = { value, expiresAt: now + CREDENTIAL_TTL_MS }
   return value
+}
+
+/**
+ * Resolve the *cloud* identity (user + workspace) the local SHOGO_API_KEY is
+ * bound to. Composio connections live on the cloud's Composio account keyed by
+ * this identity — the integrations UI forwards "Connect" to the cloud (see
+ * `routes/integrations.ts` `shouldForwardToCloud`), so connections are created
+ * under `shogo_{cloudUser}_{cloudWs}`. The agent-runtime must scope Composio to
+ * the same identity instead of the synthetic local user/workspace, otherwise
+ * every auth check returns `needs_auth`. See
+ * `packages/agent-runtime/src/composio.ts` (`resolveComposioIdentity`).
+ *
+ * Fast path reads both ids from `localConfig.SHOGO_KEY_INFO`. Older sign-ins
+ * persisted only `workspace`, so when `user.id` is missing we validate the key
+ * against the cloud once to learn it (result cached). Returns null when there
+ * is no key, the cloud is unreachable, or it rejects — callers then fall back
+ * to local ids and behave exactly as before.
+ */
+export async function getUpstreamIdentity(): Promise<{ userId: string; workspaceId: string } | null> {
+  const now = Date.now()
+  if (cachedCloudIdentity && cachedCloudIdentity.expiresAt > now) return cachedCloudIdentity.value
+
+  const cache = (value: { userId: string; workspaceId: string } | null) => {
+    cachedCloudIdentity = { value, expiresAt: now + (value ? IDENTITY_TTL_MS : CREDENTIAL_TTL_MS) }
+    return value
+  }
+
+  // Fast path: both ids already persisted by PUT /api/local/shogo-key.
+  const info = await readKeyInfo()
+  const storedWs = info?.workspace?.id
+  const storedUser = info?.user?.id
+  if (typeof storedWs === 'string' && storedWs && typeof storedUser === 'string' && storedUser) {
+    return cache({ userId: storedUser, workspaceId: storedWs })
+  }
+
+  // Backfill: older sessions stored only `workspace`. Validate the key once to
+  // learn the cloud user the key is bound to.
+  const key = await getUpstreamCredential()
+  if (!key) return cache(null)
+  try {
+    const resp = await fetch(`${getShogoCloudUrl()}/api/api-keys/validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key }),
+      signal: AbortSignal.timeout(5_000),
+    })
+    if (!resp.ok) return cache(null)
+    const data = (await resp.json().catch(() => null)) as
+      | { valid?: boolean; workspace?: { id?: string }; user?: { id?: string } }
+      | null
+    const vWs = data?.workspace?.id
+    const vUser = data?.user?.id
+    if (data?.valid && typeof vWs === 'string' && vWs && typeof vUser === 'string' && vUser) {
+      return cache({ userId: vUser, workspaceId: vWs })
+    }
+  } catch {
+    /* offline / timeout — fall through to local ids */
+  }
+  return cache(null)
 }
 
 /** Federation is on when local mode is active and we have a credential. */

--- a/apps/api/src/lib/runtime/manager.ts
+++ b/apps/api/src/lib/runtime/manager.ts
@@ -1447,6 +1447,25 @@ export class ShogoErrorBoundary extends Component<Props, State> {
           // OPENROUTER_API_KEY is preserved so BYOK OpenRouter routing
           // works end-to-end.
           console.log(`[RuntimeManager] Shogo Cloud mode: all providers routed through proxy for ${projectId}`)
+
+          // Composio connections live on the cloud's Composio account keyed by
+          // the cloud user/workspace the SHOGO_API_KEY is bound to (the
+          // integrations UI forwards "Connect" to the cloud). Scope the
+          // runtime's Composio identity to those cloud ids so the agent
+          // resolves the same connections instead of the *synthetic local*
+          // user/workspace (which would always read back needs_auth). See
+          // packages/agent-runtime/src/composio.ts (resolveComposioIdentity).
+          try {
+            const { getUpstreamIdentity } = await import('../federated-upstream')
+            const cloudIdentity = await getUpstreamIdentity()
+            if (cloudIdentity) {
+              runtimeEnv.COMPOSIO_CLOUD_USER_ID = cloudIdentity.userId
+              runtimeEnv.COMPOSIO_CLOUD_WORKSPACE_ID = cloudIdentity.workspaceId
+              console.log(`[RuntimeManager] Composio scoped to cloud identity for ${projectId}`)
+            }
+          } catch (err: any) {
+            console.warn(`[RuntimeManager] Could not resolve cloud Composio identity: ${err?.message}`)
+          }
         }
 
         // Security policy — read user prefs + project overrides, merge, and pass to runtime

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1214,7 +1214,7 @@ if (process.env.SHOGO_LOCAL_MODE === 'true') {
         body: JSON.stringify({ key: body.key }),
         signal: AbortSignal.timeout(10000),
       })
-      let validateData: { valid: boolean; workspace?: any; error?: string }
+      let validateData: { valid: boolean; workspace?: any; user?: any; error?: string }
       try {
         validateData = await validateRes.json()
       } catch {
@@ -1234,8 +1234,11 @@ if (process.env.SHOGO_LOCAL_MODE === 'true') {
         }),
         localDb.localConfig.upsert({
           where: { key: 'SHOGO_KEY_INFO' },
-          update: { value: JSON.stringify({ workspace: validateData.workspace }) },
-          create: { key: 'SHOGO_KEY_INFO', value: JSON.stringify({ workspace: validateData.workspace }) },
+          // Persist `user` alongside `workspace` so the agent-runtime can scope
+          // Composio to the cloud identity the key is bound to without a
+          // validate round-trip (see lib/federated-upstream getUpstreamIdentity).
+          update: { value: JSON.stringify({ workspace: validateData.workspace, user: validateData.user }) },
+          create: { key: 'SHOGO_KEY_INFO', value: JSON.stringify({ workspace: validateData.workspace, user: validateData.user }) },
         }),
       ])
 

--- a/packages/agent-runtime/src/__tests__/composio.test.ts
+++ b/packages/agent-runtime/src/__tests__/composio.test.ts
@@ -66,6 +66,7 @@ const ENV_KEYS = [
   'COMPOSIO_GITHUB_AUTH_CONFIG', 'COMPOSIO_LINEAR_AUTH_CONFIG',
   'COMPOSIO_NOTION_AUTH_CONFIG',
   'SHOGO_API_KEY', 'SHOGO_CLOUD_URL', 'BETTER_AUTH_URL', 'API_URL',
+  'COMPOSIO_CLOUD_USER_ID', 'COMPOSIO_CLOUD_WORKSPACE_ID',
 ]
 const savedEnv: Record<string, string | undefined> = {}
 function setEnv(k: string, v?: string) {
@@ -172,6 +173,63 @@ describe('buildComposioUserId / buildLegacyComposioUserId', () => {
   })
   it('legacy id is user_project', () => {
     expect(buildLegacyComposioUserId('u', 'p')).toBe('shogo_u_p')
+  })
+})
+
+// --------------------------------------------------------------------------
+// Regression: local cloud-forwarding identity mismatch.
+//
+// In local mode the agent-runtime runs as a *synthetic* local user/workspace
+// (e.g. local@shogo.local / "Local User Personal"), but Composio connections
+// live on the cloud's Composio account keyed by the cloud user/workspace the
+// SHOGO_API_KEY is bound to — the integrations UI forwards "Connect" to the
+// cloud. Without the override the agent builds `shogo_{localUser}_{localWs}`
+// and never resolves the connection, so every toolkit (Google Docs, Gmail,
+// Slack, …) reports needs_auth. The desktop RuntimeManager exports the cloud
+// identity via COMPOSIO_CLOUD_USER_ID / COMPOSIO_CLOUD_WORKSPACE_ID.
+describe('cloud-identity override (local cloud-forwarding mode)', () => {
+  it('buildComposioUserId prefers cloud identity env over the synthetic local ids', () => {
+    setEnv('COMPOSIO_CLOUD_USER_ID', 'cloudUser')
+    setEnv('COMPOSIO_CLOUD_WORKSPACE_ID', 'cloudWs')
+    expect(buildComposioUserId('localUser', 'localWs', 'p', 'workspace')).toBe('shogo_cloudUser_cloudWs')
+    expect(buildComposioUserId('localUser', 'localWs', 'p')).toBe('shogo_cloudUser_cloudWs_p')
+  })
+
+  it('falls back to caller ids when the cloud identity env is unset (self-hosted / BYO-key)', () => {
+    expect(buildComposioUserId('localUser', 'localWs', 'p', 'workspace')).toBe('shogo_localUser_localWs')
+  })
+
+  it('mixes cloud + local halves when only one env var is present', () => {
+    setEnv('COMPOSIO_CLOUD_WORKSPACE_ID', 'cloudWs')
+    expect(buildComposioUserId('localUser', 'localWs', 'p', 'workspace')).toBe('shogo_localUser_cloudWs')
+  })
+
+  it('initComposioSession authorizes the cloud-scoped user id, not the local one', async () => {
+    setEnv('COMPOSIO_API_KEY', 'k')
+    setEnv('COMPOSIO_CLOUD_USER_ID', 'cloudUser')
+    setEnv('COMPOSIO_CLOUD_WORKSPACE_ID', 'cloudWs')
+    let seenId: string | undefined
+    handlers.create = async (id: string) => { seenId = id; return {} }
+    const ok = await initComposioSession('localUser', 'localWs', 'p', 'workspace')
+    expect(ok).toBe(true)
+    expect(seenId).toBe('shogo_cloudUser_cloudWs')
+  })
+
+  it('checkComposioAuth looks up the connection under the cloud identity', async () => {
+    setEnv('COMPOSIO_API_KEY', 'k')
+    setEnv('COMPOSIO_CLOUD_USER_ID', 'cloudUser')
+    setEnv('COMPOSIO_CLOUD_WORKSPACE_ID', 'cloudWs')
+    let listedUserIds: string[] | undefined
+    handlers.create = async () => ({})
+    handlers.connectedAccountsList = async (opts: any) => {
+      listedUserIds = opts?.userIds
+      return { items: [{ status: 'ACTIVE' }] }
+    }
+    await initComposioSession('localUser', 'localWs', 'p', 'workspace')
+    const r = await checkComposioAuth('googledocs')
+    expect(r.status).toBe('active')
+    expect(listedUserIds).toContain('shogo_cloudUser_cloudWs')
+    expect(listedUserIds).not.toContain('shogo_localUser_localWs')
   })
 })
 

--- a/packages/agent-runtime/src/composio.ts
+++ b/packages/agent-runtime/src/composio.ts
@@ -47,6 +47,36 @@ interface ComposioAuthConfigs {
   [toolkit: string]: string
 }
 
+/**
+ * In local cloud-forwarding mode the agent-runtime runs against a *synthetic*
+ * local identity (e.g. user `local@shogo.local`, workspace "Local User
+ * Personal") that does NOT match the cloud user/workspace the `SHOGO_API_KEY`
+ * is bound to. Composio connections, however, live on the cloud's Composio
+ * account keyed by the cloud identity — the integrations UI forwards
+ * "Connect" to the cloud (see `routes/integrations.ts` `shouldForwardToCloud`),
+ * so every OAuth connection is created under `shogo_{cloudUser}_{cloudWs}`.
+ *
+ * If the agent scopes Composio to the local ids it builds
+ * `shogo_{localUser}_{localWs}` and never resolves those connections — every
+ * auth check falls through to `needs_auth` and every toolkit (Google Docs,
+ * Gmail, Slack, …) appears disconnected.
+ *
+ * The desktop `RuntimeManager` resolves the cloud identity bound to the key
+ * and exports it via `COMPOSIO_CLOUD_USER_ID` / `COMPOSIO_CLOUD_WORKSPACE_ID`.
+ * When present we prefer them so the agent's Composio user id matches what the
+ * cloud (and the UI) use. When absent (self-hosted, BYO-key, tests) we fall
+ * back to the caller-supplied ids and behave exactly as before.
+ */
+function resolveComposioIdentity(
+  userId: string,
+  workspaceId: string,
+): { userId: string; workspaceId: string } {
+  return {
+    userId: process.env.COMPOSIO_CLOUD_USER_ID || userId,
+    workspaceId: process.env.COMPOSIO_CLOUD_WORKSPACE_ID || workspaceId,
+  }
+}
+
 export interface ComposioToolkitInfo {
   slug: string
   name: string
@@ -266,9 +296,11 @@ export async function initComposioSession(
   projectId: string,
   scope: ComposioScope = 'project',
 ): Promise<boolean> {
+  const { userId: effectiveUserId, workspaceId: effectiveWorkspaceId } =
+    resolveComposioIdentity(userId, workspaceId)
   const composioUserId = scope === 'workspace'
-    ? `shogo_${userId}_${workspaceId}`
-    : `shogo_${userId}_${workspaceId}_${projectId}`
+    ? `shogo_${effectiveUserId}_${effectiveWorkspaceId}`
+    : `shogo_${effectiveUserId}_${effectiveWorkspaceId}_${projectId}`
 
   if (storedComposioUserId === composioUserId) return true
 
@@ -290,10 +322,10 @@ export async function initComposioSession(
 
     storedComposioUserId = composioUserId
     storedProjectScopedComposioUserId = scope === 'workspace'
-      ? `shogo_${userId}_${workspaceId}_${projectId}`
+      ? `shogo_${effectiveUserId}_${effectiveWorkspaceId}_${projectId}`
       : null
     // TODO: Remove legacy ID tracking after migration period
-    storedLegacyComposioUserId = `shogo_${userId}_${projectId}`
+    storedLegacyComposioUserId = `shogo_${effectiveUserId}_${projectId}`
     const elapsed = performance.now() - t0
     recordTiming('session init', elapsed)
     console.log(`[Composio] Session initialized for user "${composioUserId}"`)
@@ -352,9 +384,11 @@ export function buildComposioUserId(
   projectId: string,
   scope: ComposioScope = 'project',
 ): string {
+  const { userId: effectiveUserId, workspaceId: effectiveWorkspaceId } =
+    resolveComposioIdentity(userId, workspaceId)
   return scope === 'workspace'
-    ? `shogo_${userId}_${workspaceId}`
-    : `shogo_${userId}_${workspaceId}_${projectId}`
+    ? `shogo_${effectiveUserId}_${effectiveWorkspaceId}`
+    : `shogo_${effectiveUserId}_${effectiveWorkspaceId}_${projectId}`
 }
 
 /**


### PR DESCRIPTION
## Summary

Composio toolkits (Google Docs, Gmail, Slack, …) failed in local installs even though they work in the cloud. Root cause is an **identity mismatch**, not auth/proxy:

- The agent-runtime in local cloud-forwarding mode runs against a **synthetic local** user/workspace (e.g. `local@shogo.local` / "Local User Personal"), so it builds the Composio user id `shogo_{localUser}_{localWs}`.
- But Composio connections live on the **cloud's** Composio account, keyed by the cloud user/workspace the `SHOGO_API_KEY` is bound to. The integrations UI **forwards "Connect" to the cloud** (`routes/integrations.ts` `shouldForwardToCloud`), so every OAuth connection is created under `shogo_{cloudUser}_{cloudWs}`.
- The agent therefore never finds the connection — every auth check returns `needs_auth` for every toolkit. (AI worked because it isn't identity-scoped; the cloud works because both sides share the cloud identity there. The `cloudKeyRejected` 401 banner is unrelated — it only drives a UI banner.)

Confirmed against the live local DB: agent used `shogo_0b72319b…(local@shogo.local)_ec94b79f…(Local User Personal)`, while the key is bound to cloud workspace `b61e4156…` ("Odin").

## Changes

- **`packages/agent-runtime/src/composio.ts`** — `resolveComposioIdentity()` prefers `COMPOSIO_CLOUD_USER_ID` / `COMPOSIO_CLOUD_WORKSPACE_ID` when present (used by `buildComposioUserId` + `initComposioSession`); falls back to caller ids otherwise (self-hosted / BYO-key unchanged).
- **`apps/api/src/lib/federated-upstream.ts`** — `getUpstreamIdentity()` resolves the cloud user+workspace from `SHOGO_KEY_INFO`, validating the key once to backfill the user id for older sign-ins (self-heals without re-sign-in). Cached.
- **`apps/api/src/lib/runtime/manager.ts`** — exports the cloud identity to the runtime env in cloud-forwarding mode.
- **`apps/api/src/server.ts`** — sign-in now persists `user` alongside `workspace` in `SHOGO_KEY_INFO` (fast path for new logins).

## Test plan

- [x] `composio.test.ts` — 61 pass incl. 5 new regression tests (fail without the fix): build/session/auth-lookup all use the cloud-scoped id.
- [x] `federated-upstream.test.ts` — 49 pass incl. 4 new tests for `getUpstreamIdentity` (fast path / validate backfill / reject / no-credential).
- [x] `runtime-manager-doStart.test.ts` — 23 pass. No lint errors.
- [ ] Manual: relaunch a local install signed into a cloud workspace with Google Docs connected, confirm the agent resolves the connection (no `needs_auth` loop).

Made with [Cursor](https://cursor.com)