### PR TITLE
feat(ide): GitKraken-style commit graph view

### DIFF
--- a/apps/api/src/__tests__/git-service-graph.test.ts
+++ b/apps/api/src/__tests__/git-service-graph.test.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Tests for the GitKraken-style graph helpers: getGraph (parents + ref
+ * decorations + co-authors), listTags, and getCommitDetail. Uses a real
+ * temporary git repo with a branch + merge so topology is exercised.
+ *
+ * Run: bun test apps/api/src/__tests__/git-service-graph.test.ts
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
+import { execFileSync } from 'child_process'
+import { mkdtempSync, writeFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import * as gitService from '../services/git.service'
+
+let ws: string
+
+function git(args: string[]): void {
+  execFileSync('git', args, { cwd: ws, stdio: 'pipe' })
+}
+
+function write(name: string, content: string): void {
+  writeFileSync(join(ws, name), content)
+}
+
+beforeEach(() => {
+  ws = mkdtempSync(join(tmpdir(), 'git-graph-test-'))
+  git(['init', '-b', 'main'])
+  git(['config', 'user.name', 'Test User'])
+  git(['config', 'user.email', 'test@example.com'])
+})
+
+afterEach(() => {
+  rmSync(ws, { recursive: true, force: true })
+})
+
+describe('getGraph', () => {
+  test('returns linear history with parents and HEAD ref', async () => {
+    write('a.txt', '1')
+    git(['add', '-A'])
+    git(['commit', '-m', 'first'])
+    write('b.txt', '2')
+    git(['add', '-A'])
+    git(['commit', '-m', 'second'])
+
+    const commits = await gitService.getGraph(ws)
+    expect(commits.length).toBe(2)
+    // Newest first (date-order).
+    expect(commits[0].subject).toBe('second')
+    expect(commits[1].subject).toBe('first')
+    // second's parent is first.
+    expect(commits[0].parents).toEqual([commits[1].sha])
+    // first (root) has no parents.
+    expect(commits[1].parents).toEqual([])
+    // HEAD + branch decoration land on the tip.
+    const tipRefs = commits[0].refs
+    expect(tipRefs.some((r) => r.type === 'HEAD')).toBe(true)
+    expect(tipRefs.some((r) => r.type === 'head' && r.name === 'main')).toBe(true)
+  })
+
+  test('captures merge commits with two parents', async () => {
+    write('base.txt', 'base')
+    git(['add', '-A'])
+    git(['commit', '-m', 'base'])
+    git(['checkout', '-b', 'feature'])
+    write('feat.txt', 'feature')
+    git(['add', '-A'])
+    git(['commit', '-m', 'feature work'])
+    git(['checkout', 'main'])
+    write('main.txt', 'main change')
+    git(['add', '-A'])
+    git(['commit', '-m', 'main work'])
+    git(['merge', '--no-ff', 'feature', '-m', 'merge feature'])
+
+    const commits = await gitService.getGraph(ws)
+    const merge = commits.find((c) => c.subject === 'merge feature')
+    expect(merge).toBeDefined()
+    expect(merge!.parents.length).toBe(2)
+    // The branch ref should appear somewhere in the graph.
+    expect(commits.some((c) => c.refs.some((r) => r.name === 'feature'))).toBe(true)
+  })
+
+  test('parses Co-authored-by trailers', async () => {
+    write('x.txt', 'x')
+    git(['add', '-A'])
+    git([
+      'commit',
+      '-m',
+      'pair commit\n\nCo-authored-by: Robin Dev <robin@example.com>',
+    ])
+
+    const commits = await gitService.getGraph(ws)
+    expect(commits[0].coAuthors).toEqual([
+      { name: 'Robin Dev', email: 'robin@example.com' },
+    ])
+  })
+})
+
+describe('listTags', () => {
+  test('lists tags', async () => {
+    write('a.txt', '1')
+    git(['add', '-A'])
+    git(['commit', '-m', 'first'])
+    git(['tag', 'v1.0.0'])
+    const tags = await gitService.listTags(ws)
+    expect(tags).toContain('v1.0.0')
+  })
+})
+
+describe('getCommitDetail', () => {
+  test('returns metadata + changed files, including the root commit', async () => {
+    write('a.txt', 'one\ntwo\n')
+    git(['add', '-A'])
+    git(['commit', '-m', 'root commit'])
+
+    const head = (await gitService.getHeadSha(ws))!
+    const detail = await gitService.getCommitDetail(ws, head)
+    expect(detail).not.toBeNull()
+    expect(detail!.subject).toBe('root commit')
+    expect(detail!.parents).toEqual([])
+    // Root commit still lists its added file (diff vs empty tree).
+    expect(detail!.files.some((f) => f.path === 'a.txt' && f.status === 'added')).toBe(true)
+  })
+})

--- a/apps/api/src/routes/checkpoints.ts
+++ b/apps/api/src/routes/checkpoints.ts
@@ -15,6 +15,7 @@
 import { Hono } from 'hono';
 import { join } from 'path';
 import * as checkpointService from '../services/checkpoint.service';
+import * as gitService from '../services/git.service';
 import { prisma } from '../lib/prisma';
 
 // =============================================================================
@@ -328,6 +329,94 @@ export function checkpointRoutes(config: CheckpointRoutesConfig) {
       console.error('[Checkpoints] Status error:', error);
       return c.json(
         { error: { code: 'status_failed', message: error.message || 'Failed to get status' } },
+        500
+      );
+    }
+  });
+
+  /**
+   * GET /projects/:projectId/git/graph - Commit DAG for the GitKraken view.
+   * Returns commits (with parents + ref decorations + co-authors), the
+   * branch + tag lists, and the current HEAD.
+   */
+  router.get('/projects/:projectId/git/graph', async (c) => {
+    const projectId = c.req.param('projectId');
+    const limit = Math.min(parseInt(c.req.query('limit') || '200', 10) || 200, 1000);
+    const skip = Math.max(parseInt(c.req.query('skip') || '0', 10) || 0, 0);
+
+    try {
+      const project = await validateProject(projectId);
+      if (!project) {
+        return c.json(
+          { error: { code: 'project_not_found', message: 'Project not found' } },
+          404
+        );
+      }
+      if (isExternal(project as any)) return externalModeResponse(c);
+
+      const workspacePath = getWorkspacePath(projectId);
+      const [commits, branches, tags, head, currentBranch] = await Promise.all([
+        gitService.getGraph(workspacePath, { limit, skip }),
+        gitService.listBranches(workspacePath),
+        gitService.listTags(workspacePath),
+        gitService.getHeadSha(workspacePath),
+        gitService.getCurrentBranch(workspacePath),
+      ]);
+
+      return c.json({
+        ok: true,
+        graph: { commits, branches, tags, head, currentBranch },
+        hasMore: commits.length === limit,
+      });
+    } catch (error: any) {
+      console.error('[Checkpoints] Graph error:', error);
+      return c.json(
+        { error: { code: 'graph_failed', message: error.message || 'Failed to get graph' } },
+        500
+      );
+    }
+  });
+
+  /**
+   * GET /projects/:projectId/git/commit/:sha - Full detail for one commit
+   * (metadata, parents, co-authors, and the files it changed).
+   */
+  router.get('/projects/:projectId/git/commit/:sha', async (c) => {
+    const projectId = c.req.param('projectId');
+    const sha = c.req.param('sha');
+
+    // Reject anything that isn't a plausible git object id / ref so the value
+    // can't smuggle args into the git CLI.
+    if (!/^[0-9a-zA-Z][0-9a-zA-Z._/-]{0,199}$/.test(sha)) {
+      return c.json(
+        { error: { code: 'invalid_request', message: 'Invalid commit ref' } },
+        400
+      );
+    }
+
+    try {
+      const project = await validateProject(projectId);
+      if (!project) {
+        return c.json(
+          { error: { code: 'project_not_found', message: 'Project not found' } },
+          404
+        );
+      }
+      if (isExternal(project as any)) return externalModeResponse(c);
+
+      const detail = await gitService.getCommitDetail(getWorkspacePath(projectId), sha);
+      if (!detail) {
+        return c.json(
+          { error: { code: 'commit_not_found', message: 'Commit not found' } },
+          404
+        );
+      }
+
+      return c.json({ ok: true, commit: detail });
+    } catch (error: any) {
+      console.error('[Checkpoints] Commit detail error:', error);
+      return c.json(
+        { error: { code: 'commit_failed', message: error.message || 'Failed to get commit' } },
         500
       );
     }

--- a/apps/api/src/services/git.service.ts
+++ b/apps/api/src/services/git.service.ts
@@ -88,6 +88,47 @@ export interface GitDiff {
   totalDeletions: number;
 }
 
+export type GitRefType = 'head' | 'remote' | 'tag' | 'HEAD';
+
+export interface GitRef {
+  name: string;
+  type: GitRefType;
+}
+
+export interface GitCoAuthor {
+  name: string;
+  email: string;
+}
+
+/**
+ * A commit as needed to render a GitKraken-style DAG: includes parent SHAs
+ * (graph topology), ref decorations (branch/tag/HEAD pills), author +
+ * committer identity, and any `Co-authored-by:` trailers.
+ */
+export interface GitGraphCommit {
+  sha: string;
+  shortSha: string;
+  parents: string[];
+  refs: GitRef[];
+  subject: string;
+  body: string;
+  author: string;
+  authorEmail: string;
+  committer: string;
+  committerEmail: string;
+  /** ISO author date. */
+  date: string;
+  coAuthors: GitCoAuthor[];
+}
+
+export interface GitGraph {
+  commits: GitGraphCommit[];
+  branches: { name: string; isCurrent: boolean }[];
+  tags: string[];
+  head: string | null;
+  currentBranch: string;
+}
+
 export interface CommitOptions {
   message: string;
   author?: string;
@@ -840,6 +881,187 @@ export async function getHistory(
     return commits;
   } catch {
     return [];
+  }
+}
+
+// Field separator (unit sep) between fields, record separator between commits.
+const GIT_GRAPH_FORMAT =
+  '%H%x1f%h%x1f%P%x1f%D%x1f%an%x1f%ae%x1f%cn%x1f%ce%x1f%aI%x1f%s%x1f%b%x1e';
+
+const COAUTHOR_RE = /^\s*Co-authored-by:\s*(.+?)\s*<([^>]+)>\s*$/gim;
+
+/** Parse `Co-authored-by:` trailers out of a commit body. */
+function parseCoAuthors(body: string): GitCoAuthor[] {
+  const out: GitCoAuthor[] = [];
+  if (!body) return out;
+  let m: RegExpExecArray | null;
+  COAUTHOR_RE.lastIndex = 0;
+  while ((m = COAUTHOR_RE.exec(body)) !== null) {
+    out.push({ name: m[1].trim(), email: m[2].trim() });
+  }
+  return out;
+}
+
+/**
+ * Parse the `%D` ref-decoration string git emits, e.g.
+ * `HEAD -> main, origin/main, tag: v1.2.0`.
+ */
+function parseRefs(decoration: string): GitRef[] {
+  const refs: GitRef[] = [];
+  if (!decoration) return refs;
+  for (const raw of decoration.split(',')) {
+    const token = raw.trim();
+    if (!token) continue;
+    if (token.startsWith('tag: ')) {
+      refs.push({ name: token.slice('tag: '.length).trim(), type: 'tag' });
+    } else if (token.includes('HEAD -> ')) {
+      const branch = token.slice(token.indexOf('HEAD -> ') + 'HEAD -> '.length).trim();
+      refs.push({ name: 'HEAD', type: 'HEAD' });
+      if (branch) refs.push({ name: branch, type: 'head' });
+    } else if (token === 'HEAD') {
+      refs.push({ name: 'HEAD', type: 'HEAD' });
+    } else if (token.includes('/')) {
+      // origin/main, upstream/feature-x, etc.
+      refs.push({ name: token, type: 'remote' });
+    } else {
+      refs.push({ name: token, type: 'head' });
+    }
+  }
+  return refs;
+}
+
+function parseGraphCommits(output: string): GitGraphCommit[] {
+  const commits: GitGraphCommit[] = [];
+  for (const record of output.split('\x1e')) {
+    const trimmed = record.replace(/^\s+/, '');
+    if (!trimmed) continue;
+    const fields = trimmed.split('\x1f');
+    if (fields.length < 11) continue;
+    const [
+      sha,
+      shortSha,
+      parentStr,
+      decoration,
+      author,
+      authorEmail,
+      committer,
+      committerEmail,
+      dateStr,
+      subject,
+      body,
+    ] = fields;
+    if (!sha) continue;
+    commits.push({
+      sha,
+      shortSha,
+      parents: parentStr.trim() ? parentStr.trim().split(/\s+/) : [],
+      refs: parseRefs(decoration),
+      subject,
+      body: (body ?? '').trim(),
+      author,
+      authorEmail,
+      committer,
+      committerEmail,
+      date: dateStr,
+      coAuthors: parseCoAuthors(body ?? ''),
+    });
+  }
+  return commits;
+}
+
+/**
+ * Get the commit graph for a workspace: every ref's history with parent
+ * pointers and ref decorations, suitable for a GitKraken-style DAG.
+ */
+export async function getGraph(
+  workspacePath: string,
+  options?: { limit?: number; skip?: number; all?: boolean }
+): Promise<GitGraphCommit[]> {
+  const { limit = 200, skip = 0, all = true } = options || {};
+  if (!isGitRepo(workspacePath)) return [];
+
+  const args = ['log', `--format=${GIT_GRAPH_FORMAT}`, '--date-order', '-n', String(limit)];
+  if (skip > 0) args.push('--skip', String(skip));
+  if (all) args.push('--all');
+
+  try {
+    const output = execFileSync('git', args, {
+      cwd: workspacePath,
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    return parseGraphCommits(output);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * List tag names (most recent first when possible).
+ */
+export async function listTags(workspacePath: string): Promise<string[]> {
+  if (!isGitRepo(workspacePath)) return [];
+  try {
+    const output = execFileSync(
+      'git',
+      ['tag', '--list', '--sort=-creatordate'],
+      { cwd: workspacePath, encoding: 'utf-8', stdio: 'pipe' }
+    );
+    return output.trim().split('\n').map((l) => l.trim()).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Files changed by a single commit. Handles the root commit (no parent) by
+ * diffing against the empty tree so the very first commit still lists files.
+ */
+export async function getCommitFiles(
+  workspacePath: string,
+  sha: string
+): Promise<GitDiff> {
+  // Empty-tree object id — diffing against it yields a root commit's files.
+  const EMPTY_TREE = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+  let parent = `${sha}^`;
+  try {
+    execFileSync('git', ['rev-parse', '--verify', `${sha}^`], {
+      cwd: workspacePath,
+      stdio: 'pipe',
+    });
+  } catch {
+    parent = EMPTY_TREE;
+  }
+  return getDiff(workspacePath, parent, sha);
+}
+
+/**
+ * Full detail for one commit: metadata + ref decorations + co-authors +
+ * the list of files it changed.
+ */
+export async function getCommitDetail(
+  workspacePath: string,
+  sha: string
+): Promise<(GitGraphCommit & { files: GitDiffFile[]; totalAdditions: number; totalDeletions: number }) | null> {
+  if (!isGitRepo(workspacePath)) return null;
+  try {
+    const output = execFileSync(
+      'git',
+      ['log', '-1', `--format=${GIT_GRAPH_FORMAT}`, sha],
+      { cwd: workspacePath, encoding: 'utf-8', stdio: 'pipe', maxBuffer: 8 * 1024 * 1024 }
+    );
+    const [commit] = parseGraphCommits(output);
+    if (!commit) return null;
+    const diff = await getCommitFiles(workspacePath, sha);
+    return {
+      ...commit,
+      files: diff.files,
+      totalAdditions: diff.totalAdditions,
+      totalDeletions: diff.totalDeletions,
+    };
+  } catch {
+    return null;
   }
 }
 

--- a/apps/mobile/components/project/panels/ide/Workbench.tsx
+++ b/apps/mobile/components/project/panels/ide/Workbench.tsx
@@ -7,6 +7,7 @@ import { StatusBar } from "./StatusBar";
 import { useGitStatus } from "./git/useGitStatus";
 import { GitStatusProvider } from "./git/GitStatusContext";
 import { SourceControlViewlet } from "./scm/SourceControlViewlet";
+import { GraphView } from "./graph/GraphView";
 import { attachGitDecorations, maybeAutoStageIfConflictResolved } from "./git/editorIntegration";
 import { MergeEditorModal } from "./git/MergeEditorModal";
 import { getDesktopGitBridge } from "./git/bridge";
@@ -59,6 +60,7 @@ import {
   FolderPlus,
   FolderOpen,
   PanelLeftClose,
+  GitBranch,
   X,
 } from "lucide-react-native";
 
@@ -206,6 +208,7 @@ export function Workbench({
 }) {
   const themeMode = useResolvedTheme();
   const [activity, setActivity] = useState<ActivityId>("files");
+  const [graphOpen, setGraphOpen] = useState<boolean>(false);
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(() => {
     try {
       const raw = localStorage.getItem("shogo.ide.sidebarOpen");
@@ -717,6 +720,23 @@ export function Workbench({
       void openFileInGroup(node, activeGroupIdx);
     },
     [openFileInGroup, activeGroupIdx],
+  );
+
+  // Open a workspace-relative path (used by the commit graph's file list).
+  // Synthesizes a minimal file node against the primary (agent) root.
+  const openWorkspaceFile = useCallback(
+    (path: string) => {
+      const rootId =
+        roots.find((r) => r.kind === "agent")?.id ?? roots[0]?.id;
+      if (!rootId) return;
+      const name = path.split("/").pop() ?? path;
+      setGraphOpen(false);
+      void openFileInGroup(
+        { kind: "file", rootId, path, name } as unknown as TreeNode,
+        activeGroupIdx,
+      );
+    },
+    [roots, openFileInGroup, activeGroupIdx],
   );
 
 
@@ -1478,6 +1498,17 @@ export function Workbench({
                   />
                 )}
                 {activity === "git" && (
+                  <div className="flex flex-col h-full">
+                    {projectId && (
+                      <button
+                        onClick={() => setGraphOpen(true)}
+                        className="flex items-center gap-1.5 mx-2 mt-2 mb-1 px-2 py-1.5 rounded text-[12px] border border-[color:var(--ide-border-strong)] text-[color:var(--ide-text)] hover:bg-[color:var(--ide-hover)]"
+                      >
+                        <GitBranch size={13} className="text-[color:var(--ide-muted)]" />
+                        Open Commit Graph
+                      </button>
+                    )}
+                    <div className="flex-1 min-h-0">
                   <SourceControlViewlet
                     workspaceRoot={gitWorkspaceRoot}
                     onOpenDiff={(path, group) => {
@@ -1491,6 +1522,8 @@ export function Workbench({
                     }}
                     fallback={projectId ? <CheckpointsPanel visible projectId={projectId} /> : undefined}
                   />
+                    </div>
+                  </div>
                 )}
                 {activity === "settings" && (
                   <SettingsPane settings={settings} onChange={setSettings} />
@@ -1510,6 +1543,25 @@ export function Workbench({
             />
             <div className="flex flex-1 min-h-0 flex-col">
             <div className="flex flex-1 min-h-0 relative">
+              {graphOpen && projectId && (
+                <div className="absolute inset-0 z-30 flex flex-col bg-[color:var(--ide-bg)]">
+                  <div className="flex items-center gap-2 px-3 h-9 border-b border-[color:var(--ide-border)] bg-[color:var(--ide-surface)]">
+                    <GitBranch size={13} className="text-[color:var(--ide-muted)]" />
+                    <span className="text-[12px] text-[color:var(--ide-text-strong)]">Commit Graph</span>
+                    <span className="flex-1" />
+                    <button
+                      onClick={() => setGraphOpen(false)}
+                      title="Close graph"
+                      className="p-1 rounded hover:bg-[color:var(--ide-hover)] text-[color:var(--ide-muted)] hover:text-[color:var(--ide-text-strong)]"
+                    >
+                      <X size={14} />
+                    </button>
+                  </div>
+                  <div className="flex-1 min-h-0">
+                    <GraphView projectId={projectId} onOpenFile={openWorkspaceFile} />
+                  </div>
+                </div>
+              )}
               {groups
                 .map((g, i) => (
                   <div

--- a/apps/mobile/components/project/panels/ide/graph/BranchTagRail.tsx
+++ b/apps/mobile/components/project/panels/ide/graph/BranchTagRail.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+//
+// The BRANCH / TAG column: ref pills aligned to the commit row each ref
+// points at, with local / remote / tag iconography (GitKraken-style).
+
+import { Check, GitBranch, Monitor, Tag } from "lucide-react-native";
+
+import type { GitRef } from "@shogo/shared-app/hooks";
+import { ROW_HEIGHT, type DisplayRow } from "./types";
+
+export function BranchTagRail({
+  rows,
+  currentBranch,
+}: {
+  rows: DisplayRow[];
+  currentBranch: string | null;
+}) {
+  return (
+    <div className="shrink-0 border-r border-[color:var(--ide-border)]" style={{ width: 200 }}>
+      {rows.map((row, i) => (
+        <div
+          key={row.sha ?? `wip-${i}`}
+          className="flex items-center gap-1 px-2 overflow-hidden"
+          style={{ height: ROW_HEIGHT }}
+        >
+          {row.refs.map((ref) => (
+            <RefPill key={`${ref.type}:${ref.name}`} refInfo={ref} isCurrent={ref.name === currentBranch} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RefPill({ refInfo, isCurrent }: { refInfo: GitRef; isCurrent: boolean }) {
+  if (refInfo.type === "HEAD") return null;
+
+  const isTag = refInfo.type === "tag";
+  const isRemote = refInfo.type === "remote";
+
+  return (
+    <span
+      className="flex items-center gap-1 rounded px-1.5 h-[18px] max-w-[160px] border text-[11px]"
+      style={{
+        background: isCurrent ? "var(--ide-active-bg)" : "var(--ide-surface)",
+        borderColor: isCurrent ? "var(--ide-active-ring)" : "var(--ide-border-strong)",
+        color: "var(--ide-text-strong)",
+      }}
+      title={refInfo.name}
+    >
+      {isCurrent && <Check size={10} className="shrink-0 text-emerald-400" />}
+      {isTag ? (
+        <Tag size={10} className="shrink-0 text-[color:var(--ide-warning)]" />
+      ) : isRemote ? (
+        <Monitor size={10} className="shrink-0 text-[color:var(--ide-muted)]" />
+      ) : (
+        <GitBranch size={10} className="shrink-0 text-[color:var(--ide-muted)]" />
+      )}
+      <span className="truncate">{shortName(refInfo.name)}</span>
+    </span>
+  );
+}
+
+function shortName(name: string): string {
+  // origin/feature/foo -> feature/foo for display brevity.
+  const slash = name.indexOf("/");
+  if (slash !== -1 && /^(origin|upstream)\//.test(name)) {
+    return name.slice(slash + 1);
+  }
+  return name;
+}

--- a/apps/mobile/components/project/panels/ide/graph/CommitDetailPanel.tsx
+++ b/apps/mobile/components/project/panels/ide/graph/CommitDetailPanel.tsx
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+//
+// The right-hand detail panel for the commit graph. Mirrors GitKraken:
+// working-directory summary (for the WIP selection) or a commit's metadata,
+// message, author + co-authors, and the file list with Path / Tree views.
+
+import {
+  FilePlus,
+  FilePen,
+  FileMinus,
+  FileText,
+  Folder,
+  GitCommit,
+  ListTree,
+  Loader2,
+  RotateCcw,
+} from "lucide-react-native";
+import { useMemo, useState } from "react";
+
+import type {
+  GitCommitDetail,
+  GitCommitDetailFile,
+  GitStatus,
+} from "@shogo/shared-app/hooks";
+import { avatarColor, formatDateTime, initials, isAiAuthor } from "./gitAvatar";
+
+export function CommitDetailPanel({
+  detail,
+  loading,
+  isWip,
+  workingStatus,
+  checkpointId,
+  isRollingBack,
+  onRollback,
+  onOpenFile,
+  onViewChanges,
+}: {
+  detail: GitCommitDetail | null;
+  loading: boolean;
+  isWip: boolean;
+  workingStatus: GitStatus | null;
+  checkpointId: string | null;
+  isRollingBack: boolean;
+  onRollback: (checkpointId: string) => void;
+  onOpenFile: (path: string) => void;
+  onViewChanges: () => void;
+}) {
+  if (isWip) {
+    return <WorkingDirView workingStatus={workingStatus} onViewChanges={onViewChanges} onOpenFile={onOpenFile} />;
+  }
+
+  if (loading && !detail) {
+    return (
+      <div className="flex h-full items-center justify-center text-[12px] text-[color:var(--ide-muted)]">
+        <Loader2 size={14} className="animate-spin mr-2" /> Loading commit…
+      </div>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center text-[color:var(--ide-muted)]">
+        <GitCommit size={26} />
+        <div className="text-[13px]">Select a commit to see its details.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between gap-2 px-4 py-2 border-b border-[color:var(--ide-border)]">
+        <span className="text-[12px] text-[color:var(--ide-muted)]">
+          commit <span className="font-mono text-[color:var(--ide-text-strong)]">{detail.shortSha}</span>
+        </span>
+      </div>
+
+      <div className="flex-1 overflow-auto">
+        <div className="px-4 py-3">
+          <div className="text-[15px] font-semibold text-[color:var(--ide-text-strong)] whitespace-pre-wrap">
+            {detail.subject}
+          </div>
+          {detail.body && (
+            <div className="mt-2 text-[12px] leading-relaxed text-[color:var(--ide-text)] whitespace-pre-wrap">
+              {stripTrailers(detail.body)}
+            </div>
+          )}
+        </div>
+
+        <div className="px-4 py-3 border-t border-[color:var(--ide-border)]">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex items-center gap-2 min-w-0">
+              <Avatar name={detail.author} email={detail.authorEmail} />
+              <div className="min-w-0">
+                <div className="text-[12px] text-[color:var(--ide-text-strong)] truncate">{detail.author}</div>
+                <div className="text-[11px] text-[color:var(--ide-muted)]">
+                  authored {formatDateTime(detail.date)}
+                </div>
+              </div>
+            </div>
+            {detail.parents[0] && (
+              <span className="text-[11px] text-[color:var(--ide-muted)] whitespace-nowrap">
+                parent: <span className="font-mono">{detail.parents[0].slice(0, 6)}</span>
+              </span>
+            )}
+          </div>
+          {detail.coAuthors.length > 0 && (
+            <div className="mt-2 flex items-center gap-2">
+              <span className="text-[11px] text-[color:var(--ide-muted)]">Co-authors:</span>
+              <div className="flex -space-x-1">
+                {detail.coAuthors.map((ca) => (
+                  <div key={ca.email} title={`${ca.name} <${ca.email}>`}>
+                    <Avatar name={ca.name} email={ca.email} small />
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <FileList files={detail.files} onOpenFile={onOpenFile} />
+      </div>
+
+      {checkpointId && (
+        <div className="px-4 py-2 border-t border-[color:var(--ide-border)]">
+          <button
+            onClick={() => onRollback(checkpointId)}
+            disabled={isRollingBack}
+            className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[12px] font-medium disabled:opacity-50"
+            style={{ background: "var(--ide-btn-secondary-bg)", color: "var(--ide-warning)" }}
+          >
+            {isRollingBack ? <Loader2 size={12} className="animate-spin" /> : <RotateCcw size={12} />}
+            Roll back to this checkpoint
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WorkingDirView({
+  workingStatus,
+  onViewChanges,
+  onOpenFile,
+}: {
+  workingStatus: GitStatus | null;
+  onViewChanges: () => void;
+  onOpenFile: (path: string) => void;
+}) {
+  const changed = useMemo(() => {
+    if (!workingStatus) return [] as { path: string; status: GitCommitDetailFile["status"] }[];
+    const ws = workingStatus as GitStatus & { modified?: string[] };
+    const out: { path: string; status: GitCommitDetailFile["status"] }[] = [];
+    for (const p of ws.staged ?? []) out.push({ path: p, status: "modified" });
+    for (const p of ws.unstaged ?? []) out.push({ path: p, status: "modified" });
+    for (const p of ws.modified ?? []) out.push({ path: p, status: "modified" });
+    for (const p of ws.untracked ?? []) out.push({ path: p, status: "added" });
+    // De-dupe by path (staged + unstaged overlap).
+    const seen = new Set<string>();
+    return out.filter((f) => (seen.has(f.path) ? false : (seen.add(f.path), true)));
+  }, [workingStatus]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between gap-2 px-4 py-2 border-b border-[color:var(--ide-border)]">
+        <span className="text-[12px] text-[color:var(--ide-text-strong)]">
+          {changed.length} file change{changed.length === 1 ? "" : "s"} in working directory
+        </span>
+        <button
+          onClick={onViewChanges}
+          className="rounded-md border border-[color:var(--ide-border-strong)] px-2.5 py-1 text-[12px] text-[color:var(--ide-text)] hover:bg-[color:var(--ide-hover)]"
+        >
+          View Changes
+        </button>
+      </div>
+      <div className="flex-1 overflow-auto">
+        <FileList
+          files={changed.map((c) => ({ path: c.path, status: c.status, additions: 0, deletions: 0 }))}
+          onOpenFile={onOpenFile}
+          hideStats
+        />
+      </div>
+    </div>
+  );
+}
+
+type FileView = "path" | "tree";
+
+function FileList({
+  files,
+  onOpenFile,
+  hideStats,
+}: {
+  files: GitCommitDetailFile[];
+  onOpenFile: (path: string) => void;
+  hideStats?: boolean;
+}) {
+  const [view, setView] = useState<FileView>("path");
+  const modified = files.filter((f) => f.status === "modified" || f.status === "renamed").length;
+  const added = files.filter((f) => f.status === "added").length;
+  const deleted = files.filter((f) => f.status === "deleted").length;
+
+  return (
+    <div className="border-t border-[color:var(--ide-border)]">
+      <div className="flex items-center justify-between gap-2 px-4 py-2">
+        <div className="flex items-center gap-3 text-[11px]">
+          {modified > 0 && <span className="text-[color:var(--ide-warning)]">✎ {modified} modified</span>}
+          {added > 0 && <span className="text-emerald-400">+ {added} added</span>}
+          {deleted > 0 && <span className="text-[color:var(--ide-error)]">− {deleted} deleted</span>}
+        </div>
+        <div className="flex items-center rounded-md border border-[color:var(--ide-border-strong)] overflow-hidden">
+          <button
+            onClick={() => setView("path")}
+            className={`flex items-center gap-1 px-2 py-0.5 text-[11px] ${view === "path" ? "bg-[color:var(--ide-active-bg)] text-[color:var(--ide-text-strong)]" : "text-[color:var(--ide-muted)]"}`}
+          >
+            <FileText size={11} /> Path
+          </button>
+          <button
+            onClick={() => setView("tree")}
+            className={`flex items-center gap-1 px-2 py-0.5 text-[11px] ${view === "tree" ? "bg-[color:var(--ide-active-bg)] text-[color:var(--ide-text-strong)]" : "text-[color:var(--ide-muted)]"}`}
+          >
+            <ListTree size={11} /> Tree
+          </button>
+        </div>
+      </div>
+
+      {files.length === 0 ? (
+        <div className="px-4 py-3 text-[12px] italic text-[color:var(--ide-muted)]">No file changes.</div>
+      ) : view === "path" ? (
+        <div className="pb-3">
+          {files.map((f) => (
+            <FileRow key={f.path} file={f} onOpenFile={onOpenFile} hideStats={hideStats} />
+          ))}
+        </div>
+      ) : (
+        <TreeView files={files} onOpenFile={onOpenFile} hideStats={hideStats} />
+      )}
+    </div>
+  );
+}
+
+function FileRow({
+  file,
+  onOpenFile,
+  hideStats,
+  indent = 0,
+}: {
+  file: GitCommitDetailFile;
+  onOpenFile: (path: string) => void;
+  hideStats?: boolean;
+  indent?: number;
+}) {
+  const name = file.path.split("/").pop() ?? file.path;
+  const dir = file.path.slice(0, file.path.length - name.length);
+  return (
+    <button
+      onClick={() => onOpenFile(file.path)}
+      className="group flex w-full items-center gap-2 px-4 py-1 text-left hover:bg-[color:var(--ide-hover)]"
+      style={{ paddingLeft: 16 + indent * 14 }}
+      title={file.path}
+    >
+      <StatusIcon status={file.status} />
+      <span className="text-[12px] text-[color:var(--ide-muted)] truncate">{dir}</span>
+      <span className="text-[12px] text-[color:var(--ide-text-strong)] truncate">{name}</span>
+      <span className="flex-1" />
+      {!hideStats && file.additions > 0 && (
+        <span className="text-[10px] text-emerald-400 tabular-nums">+{file.additions}</span>
+      )}
+      {!hideStats && file.deletions > 0 && (
+        <span className="text-[10px] text-[color:var(--ide-error)] tabular-nums">−{file.deletions}</span>
+      )}
+    </button>
+  );
+}
+
+function TreeView({
+  files,
+  onOpenFile,
+  hideStats,
+}: {
+  files: GitCommitDetailFile[];
+  onOpenFile: (path: string) => void;
+  hideStats?: boolean;
+}) {
+  // Group by directory; render dir headers + files. One level of grouping is
+  // enough to feel "tree-like" without a full collapsible tree.
+  const groups = useMemo(() => {
+    const map = new Map<string, GitCommitDetailFile[]>();
+    for (const f of files) {
+      const idx = f.path.lastIndexOf("/");
+      const dir = idx === -1 ? "" : f.path.slice(0, idx);
+      const arr = map.get(dir) ?? [];
+      arr.push(f);
+      map.set(dir, arr);
+    }
+    return [...map.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  }, [files]);
+
+  return (
+    <div className="pb-3">
+      {groups.map(([dir, dirFiles]) => (
+        <div key={dir || "(root)"}>
+          {dir !== "" && (
+            <div className="flex items-center gap-1.5 px-4 py-1 text-[11px] text-[color:var(--ide-muted)]">
+              <Folder size={11} className="text-[color:var(--ide-accent-folder)]" />
+              <span className="truncate">{dir}</span>
+            </div>
+          )}
+          {dirFiles.map((f) => (
+            <FileRow
+              key={f.path}
+              file={{ ...f, path: f.path }}
+              onOpenFile={onOpenFile}
+              hideStats={hideStats}
+              indent={dir === "" ? 0 : 1}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function StatusIcon({ status }: { status: GitCommitDetailFile["status"] }) {
+  if (status === "added") return <FilePlus size={13} className="shrink-0 text-emerald-400" />;
+  if (status === "deleted") return <FileMinus size={13} className="shrink-0 text-[color:var(--ide-error)]" />;
+  return <FilePen size={13} className="shrink-0 text-[color:var(--ide-warning)]" />;
+}
+
+function Avatar({ name, email, small }: { name: string; email: string; small?: boolean }) {
+  const ai = isAiAuthor(name, email);
+  const bg = ai ? "#e0457b" : avatarColor(email || name);
+  const size = small ? 18 : 28;
+  return (
+    <span
+      className="flex items-center justify-center rounded-full shrink-0 text-white font-semibold"
+      style={{ width: size, height: size, background: bg, fontSize: small ? 8 : 11, border: "1px solid var(--ide-bg)" }}
+    >
+      {ai ? "S" : initials(name)}
+    </span>
+  );
+}
+
+/** Drop `Co-authored-by:` / `Signed-off-by:` trailer lines from a body for display. */
+function stripTrailers(body: string): string {
+  return body
+    .split("\n")
+    .filter((l) => !/^\s*(Co-authored-by|Signed-off-by):/i.test(l))
+    .join("\n")
+    .trim();
+}

--- a/apps/mobile/components/project/panels/ide/graph/CommitGraphCanvas.tsx
+++ b/apps/mobile/components/project/panels/ide/graph/CommitGraphCanvas.tsx
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+//
+// The GRAPH column: an SVG layer drawing lane connectors (curved beziers)
+// behind DOM avatar nodes positioned at each commit. Web-only (rendered
+// inside the IDE Workbench), so it uses native <svg> rather than
+// react-native-svg.
+
+import { avatarColor, initials, isAiAuthor } from "./gitAvatar";
+import {
+  GRAPH_PAD_LEFT,
+  LANE_WIDTH,
+  NODE_RADIUS,
+  ROW_HEIGHT,
+  graphWidth,
+  laneCenterX,
+  type DisplayRow,
+} from "./types";
+
+export function CommitGraphCanvas({
+  rows,
+  maxLanes,
+  selectedSha,
+  onSelect,
+}: {
+  rows: DisplayRow[];
+  maxLanes: number;
+  selectedSha: string | null;
+  onSelect: (sha: string | null) => void;
+}) {
+  const width = graphWidth(maxLanes);
+  const height = rows.length * ROW_HEIGHT;
+
+  return (
+    <div className="relative shrink-0" style={{ width, height }}>
+      <svg
+        width={width}
+        height={height}
+        className="absolute inset-0 pointer-events-none"
+        style={{ overflow: "visible" }}
+      >
+        {rows.map((row, i) => {
+          const topY = i * ROW_HEIGHT + ROW_HEIGHT / 2;
+          const bottomY = (i + 1) * ROW_HEIGHT + ROW_HEIGHT / 2;
+          return row.edges.map((e, j) => {
+            const x1 = laneCenterX(e.fromLane);
+            const x2 = laneCenterX(e.toLane);
+            if (x1 === x2) {
+              return (
+                <line
+                  key={`${i}-${j}`}
+                  x1={x1}
+                  y1={topY}
+                  x2={x2}
+                  y2={bottomY}
+                  stroke={e.color}
+                  strokeWidth={2}
+                />
+              );
+            }
+            const midY = (topY + bottomY) / 2;
+            const d = `M ${x1} ${topY} C ${x1} ${midY}, ${x2} ${midY}, ${x2} ${bottomY}`;
+            return (
+              <path
+                key={`${i}-${j}`}
+                d={d}
+                fill="none"
+                stroke={e.color}
+                strokeWidth={2}
+              />
+            );
+          });
+        })}
+      </svg>
+
+      {rows.map((row, i) => {
+        const cx = laneCenterX(row.lane);
+        const cy = i * ROW_HEIGHT + ROW_HEIGHT / 2;
+        const selected = !!row.sha && row.sha === selectedSha;
+        return (
+          <GraphNode
+            key={row.sha ?? `wip-${i}`}
+            row={row}
+            cx={cx}
+            cy={cy}
+            selected={selected}
+            onClick={() => onSelect(row.sha)}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function GraphNode({
+  row,
+  cx,
+  cy,
+  selected,
+  onClick,
+}: {
+  row: DisplayRow;
+  cx: number;
+  cy: number;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  const size = NODE_RADIUS * 2 + 6;
+  const common = {
+    onClick,
+    style: {
+      position: "absolute" as const,
+      left: cx - size / 2,
+      top: cy - size / 2,
+      width: size,
+      height: size,
+    },
+  };
+
+  if (row.kind === "wip") {
+    return (
+      <div
+        {...common}
+        title="Uncommitted changes"
+        className="flex items-center justify-center rounded-full cursor-pointer"
+      >
+        <span
+          className="block rounded-full"
+          style={{
+            width: NODE_RADIUS * 2,
+            height: NODE_RADIUS * 2,
+            border: `2px dashed ${row.color}`,
+            boxShadow: selected ? `0 0 0 2px var(--ide-active-ring)` : undefined,
+          }}
+        />
+      </div>
+    );
+  }
+
+  const commit = row.commit!;
+  const ai = isAiAuthor(commit.author, commit.authorEmail);
+  const bg = ai ? "#e0457b" : avatarColor(commit.authorEmail || commit.author);
+
+  return (
+    <div
+      {...common}
+      title={`${commit.author} · ${commit.shortSha}`}
+      className="flex items-center justify-center rounded-full cursor-pointer select-none"
+      style={{
+        ...common.style,
+        background: bg,
+        border: `2px solid var(--ide-bg)`,
+        boxShadow: selected
+          ? `0 0 0 2px var(--ide-active-ring)`
+          : `0 0 0 1px rgba(0,0,0,0.4)`,
+      }}
+    >
+      <span className="text-[8px] font-bold leading-none text-white">
+        {ai ? "S" : initials(commit.author)}
+      </span>
+    </div>
+  );
+}

--- a/apps/mobile/components/project/panels/ide/graph/GraphView.tsx
+++ b/apps/mobile/components/project/panels/ide/graph/GraphView.tsx
@@ -1,0 +1,385 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+//
+// GitKraken-style commit graph, rendered as a full main-area view. Three
+// aligned columns (BRANCH/TAG rail, GRAPH, COMMIT MESSAGE) plus a right-hand
+// commit detail panel. Data is the project workspace's real git history via
+// the API; checkpoint metadata is overlaid so checkpoint commits offer
+// rollback.
+
+import {
+  AlertTriangle,
+  GitBranch,
+  Loader2,
+  RefreshCw,
+  Search,
+} from "lucide-react-native";
+import { Platform } from "react-native";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  useCheckpoints,
+  useGitGraph,
+  type GitCommitDetail,
+} from "@shogo/shared-app/hooks";
+import { API_URL } from "../../../../../lib/api";
+import { authClient } from "../../../../../lib/auth-client";
+import { computeGraphLayout } from "./graphLayout";
+import { BranchTagRail } from "./BranchTagRail";
+import { CommitGraphCanvas } from "./CommitGraphCanvas";
+import { CommitDetailPanel } from "./CommitDetailPanel";
+import { relativeTime } from "./gitAvatar";
+import { ROW_HEIGHT, type DisplayRow } from "./types";
+
+type Selection = { kind: "wip" } | { kind: "commit"; sha: string } | null;
+
+export function GraphView({
+  projectId,
+  onOpenFile,
+}: {
+  projectId: string;
+  onOpenFile?: (path: string) => void;
+}) {
+  const credentials = Platform.OS === "web" ? "include" : undefined;
+  const nativeHeaders = useMemo(() => {
+    if (Platform.OS === "web") return undefined;
+    return (): Record<string, string> => {
+      const cookie = (authClient as any).getCookie?.();
+      return cookie ? { Cookie: cookie } : {};
+    };
+  }, []);
+
+  const graph = useGitGraph(projectId, { baseUrl: API_URL, credentials, headers: nativeHeaders });
+  const { checkpoints, rollback, isMutating, refetch: refetchCheckpoints } = useCheckpoints(projectId, {
+    baseUrl: API_URL,
+    credentials,
+    headers: nativeHeaders,
+  });
+
+  const [selection, setSelection] = useState<Selection>(null);
+  const [query, setQuery] = useState("");
+  const [detail, setDetail] = useState<GitCommitDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+
+  const checkpointBySha = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const cp of checkpoints) m.set(cp.commitSha, cp.id);
+    return m;
+  }, [checkpoints]);
+
+  // Build aligned display rows (+ a WIP row when the working tree is dirty).
+  const { rows, maxLanes } = useMemo(() => {
+    const layout = computeGraphLayout(
+      graph.commits.map((c) => ({ sha: c.sha, parents: c.parents })),
+    );
+    const commitRows: DisplayRow[] = layout.rows.map((r, i) => ({
+      kind: "commit",
+      sha: graph.commits[i].sha,
+      commit: graph.commits[i],
+      lane: r.lane,
+      color: r.color,
+      edges: r.edges,
+      refs: graph.commits[i].refs,
+      isCheckpoint: checkpointBySha.has(graph.commits[i].sha),
+    }));
+
+    const ws = graph.workingStatus as
+      | (typeof graph.workingStatus & { modified?: string[] })
+      | null;
+    const wipCount = ws
+      ? (ws.staged?.length ?? 0) +
+        (ws.unstaged?.length ?? 0) +
+        (ws.modified?.length ?? 0) +
+        (ws.untracked?.length ?? 0)
+      : 0;
+
+    if (graph.workingStatus?.hasChanges && commitRows.length > 0) {
+      const headLane = commitRows[0].lane;
+      const wip: DisplayRow = {
+        kind: "wip",
+        sha: null,
+        lane: headLane,
+        color: commitRows[0].color,
+        edges: [{ fromLane: headLane, toLane: commitRows[0].lane, color: commitRows[0].color }],
+        refs: [],
+        isCheckpoint: false,
+        wipCount,
+      };
+      return { rows: [wip, ...commitRows], maxLanes: layout.maxLanes };
+    }
+    return { rows: commitRows, maxLanes: layout.maxLanes };
+  }, [graph.commits, graph.workingStatus, checkpointBySha]);
+
+  // Default selection: WIP if present, else the head commit.
+  useEffect(() => {
+    if (selection || rows.length === 0) return;
+    const first = rows[0];
+    setSelection(first.kind === "wip" ? { kind: "wip" } : { kind: "commit", sha: first.sha! });
+  }, [rows, selection]);
+
+  // Fetch detail for the selected commit.
+  useEffect(() => {
+    if (!selection || selection.kind !== "commit") {
+      setDetail(null);
+      return;
+    }
+    let cancelled = false;
+    setDetailLoading(true);
+    graph.getCommitDetail(selection.sha).then((d) => {
+      if (cancelled) return;
+      setDetail(d);
+      setDetailLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [selection, graph.getCommitDetail]);
+
+  const handleSelect = useCallback((sha: string | null) => {
+    setSelection(sha == null ? { kind: "wip" } : { kind: "commit", sha });
+  }, []);
+
+  const handleRollback = useCallback(
+    async (checkpointId: string) => {
+      const ok = await rollback(checkpointId);
+      if (ok) {
+        graph.refetch();
+        refetchCheckpoints();
+      }
+    },
+    [rollback, graph, refetchCheckpoints],
+  );
+
+  const lowerQuery = query.trim().toLowerCase();
+  const matches = useCallback(
+    (row: DisplayRow): boolean => {
+      if (!lowerQuery) return true;
+      if (row.kind === "wip") return false;
+      const c = row.commit!;
+      return (
+        c.subject.toLowerCase().includes(lowerQuery) ||
+        c.author.toLowerCase().includes(lowerQuery) ||
+        c.shortSha.toLowerCase().includes(lowerQuery)
+      );
+    },
+    [lowerQuery],
+  );
+
+  const selectedSha = selection?.kind === "commit" ? selection.sha : null;
+  const selectedCheckpointId = selectedSha ? checkpointBySha.get(selectedSha) ?? null : null;
+
+  return (
+    <div className="flex h-full w-full min-h-0 bg-[color:var(--ide-bg)]">
+      {/* Left: header + 3 aligned columns */}
+      <div className="flex flex-1 min-w-0 flex-col border-r border-[color:var(--ide-border)]">
+        <Header
+          currentBranch={graph.currentBranch}
+          commitCount={graph.commits.length}
+          query={query}
+          onQuery={setQuery}
+          onRefresh={() => graph.refetch()}
+          loading={graph.isLoading}
+        />
+
+        {graph.disabledForExternalMode ? (
+          <ExternalModeState />
+        ) : graph.isLoading && graph.commits.length === 0 ? (
+          <Centered>
+            <Loader2 size={18} className="animate-spin" /> Loading commit graph…
+          </Centered>
+        ) : graph.error ? (
+          <Centered>
+            <AlertTriangle size={18} className="text-[color:var(--ide-error)]" /> {graph.error.message}
+          </Centered>
+        ) : graph.commits.length === 0 ? (
+          <Centered>
+            <GitBranch size={22} /> No commits yet.
+          </Centered>
+        ) : (
+          <div className="flex-1 min-h-0 overflow-auto">
+            <div className="flex min-w-max">
+              <BranchTagRail rows={rows} currentBranch={graph.currentBranch} />
+              <CommitGraphCanvas
+                rows={rows}
+                maxLanes={maxLanes}
+                selectedSha={selection?.kind === "wip" ? null : selectedSha}
+                onSelect={handleSelect}
+              />
+              <MessageColumn
+                rows={rows}
+                selection={selection}
+                matches={matches}
+                hasQuery={!!lowerQuery}
+                onSelect={(row) =>
+                  setSelection(row.kind === "wip" ? { kind: "wip" } : { kind: "commit", sha: row.sha! })
+                }
+              />
+            </div>
+            {graph.hasMore && (
+              <div className="px-4 py-3">
+                <button
+                  onClick={() => graph.loadMore()}
+                  disabled={graph.isLoadingMore}
+                  className="flex items-center gap-1.5 rounded-md border border-[color:var(--ide-border-strong)] px-3 py-1 text-[12px] text-[color:var(--ide-text)] hover:bg-[color:var(--ide-hover)] disabled:opacity-50"
+                >
+                  {graph.isLoadingMore && <Loader2 size={12} className="animate-spin" />}
+                  Load more
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Right: detail panel */}
+      <div className="shrink-0 w-[400px] min-w-[320px] bg-[color:var(--ide-surface)]">
+        <CommitDetailPanel
+          detail={detail}
+          loading={detailLoading}
+          isWip={selection?.kind === "wip"}
+          workingStatus={graph.workingStatus}
+          checkpointId={selectedCheckpointId}
+          isRollingBack={isMutating}
+          onRollback={handleRollback}
+          onOpenFile={(p) => onOpenFile?.(p)}
+          onViewChanges={() => {
+            const ws = graph.workingStatus as
+              | (typeof graph.workingStatus & { modified?: string[] })
+              | null;
+            const first =
+              ws?.staged?.[0] ??
+              ws?.unstaged?.[0] ??
+              ws?.modified?.[0] ??
+              ws?.untracked?.[0];
+            if (first) onOpenFile?.(first);
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function Header({
+  currentBranch,
+  commitCount,
+  query,
+  onQuery,
+  onRefresh,
+  loading,
+}: {
+  currentBranch: string | null;
+  commitCount: number;
+  query: string;
+  onQuery: (q: string) => void;
+  onRefresh: () => void;
+  loading: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 border-b border-[color:var(--ide-border)]">
+      <GitBranch size={13} className="text-[color:var(--ide-muted)]" />
+      <span className="text-[12px] font-medium text-[color:var(--ide-text-strong)]">
+        {currentBranch ?? "—"}
+      </span>
+      <span className="text-[11px] text-[color:var(--ide-muted)]">{commitCount} commits</span>
+      <span className="flex-1" />
+      <div className="flex items-center gap-1 rounded-md border border-[color:var(--ide-border-strong)] px-2 py-0.5">
+        <Search size={12} className="text-[color:var(--ide-muted)]" />
+        <input
+          value={query}
+          onChange={(e) => onQuery(e.target.value)}
+          placeholder="Filter commits…"
+          className="w-40 bg-transparent text-[12px] focus:outline-none placeholder-[color:var(--ide-muted)] text-[color:var(--ide-text-strong)]"
+        />
+      </div>
+      <button
+        onClick={onRefresh}
+        title="Refresh"
+        className="p-1 rounded hover:bg-[color:var(--ide-hover)] text-[color:var(--ide-muted)] hover:text-[color:var(--ide-text-strong)]"
+      >
+        {loading ? <Loader2 size={13} className="animate-spin" /> : <RefreshCw size={13} />}
+      </button>
+    </div>
+  );
+}
+
+function MessageColumn({
+  rows,
+  selection,
+  matches,
+  hasQuery,
+  onSelect,
+}: {
+  rows: DisplayRow[];
+  selection: Selection;
+  matches: (row: DisplayRow) => boolean;
+  hasQuery: boolean;
+  onSelect: (row: DisplayRow) => void;
+}) {
+  return (
+    <div className="flex-1 min-w-[280px]">
+      {rows.map((row, i) => {
+        const isSelected =
+          (row.kind === "wip" && selection?.kind === "wip") ||
+          (row.kind === "commit" && selection?.kind === "commit" && selection.sha === row.sha);
+        const dim = hasQuery && !matches(row);
+        return (
+          <div
+            key={row.sha ?? `wip-${i}`}
+            onClick={() => onSelect(row)}
+            className="flex items-center gap-2 px-3 cursor-pointer"
+            style={{
+              height: ROW_HEIGHT,
+              background: isSelected ? "var(--ide-active-bg)" : undefined,
+              opacity: dim ? 0.4 : 1,
+            }}
+          >
+            {row.kind === "wip" ? (
+              <>
+                <span className="text-[12px] font-mono text-[color:var(--ide-muted)]">// WIP</span>
+                {row.wipCount ? (
+                  <span className="text-[10px] text-emerald-400">+{row.wipCount}</span>
+                ) : null}
+              </>
+            ) : (
+              <>
+                <span className="text-[13px] text-[color:var(--ide-text-strong)] truncate">
+                  {row.commit!.subject}
+                </span>
+                <span className="flex-1" />
+                <span className="text-[11px] text-[color:var(--ide-muted)] whitespace-nowrap">
+                  {relativeTime(row.commit!.date)}
+                </span>
+                <span className="text-[11px] font-mono text-[color:var(--ide-muted)] whitespace-nowrap">
+                  {row.commit!.shortSha}
+                </span>
+              </>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function Centered({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-1 items-center justify-center gap-2 text-[13px] text-[color:var(--ide-muted)]">
+      {children}
+    </div>
+  );
+}
+
+function ExternalModeState() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-2 px-8 text-center text-[color:var(--ide-muted)]">
+      <GitBranch size={24} />
+      <div className="text-[14px] font-semibold text-[color:var(--ide-text-strong)]">
+        Graph is off in folder mode
+      </div>
+      <div className="text-[12px]">
+        This project is linked to a folder on your machine. Use your own git client for history on
+        local folders.
+      </div>
+    </div>
+  );
+}

--- a/apps/mobile/components/project/panels/ide/graph/__tests__/graphLayout.test.ts
+++ b/apps/mobile/components/project/panels/ide/graph/__tests__/graphLayout.test.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, expect, it } from "bun:test";
+
+import { colorForLane, computeGraphLayout } from "../graphLayout";
+
+describe("computeGraphLayout", () => {
+  it("lays out a linear history in a single lane", () => {
+    const layout = computeGraphLayout([
+      { sha: "c", parents: ["b"] },
+      { sha: "b", parents: ["a"] },
+      { sha: "a", parents: [] },
+    ]);
+    expect(layout.maxLanes).toBe(1);
+    expect(layout.rows.map((r) => r.lane)).toEqual([0, 0, 0]);
+    // Each non-root row connects straight down in lane 0.
+    expect(layout.rows[0].edges).toEqual([
+      { fromLane: 0, toLane: 0, color: colorForLane(0) },
+    ]);
+    // Root commit has no outgoing edges.
+    expect(layout.rows[2].edges).toEqual([]);
+  });
+
+  it("opens a second lane for a branch and joins on merge", () => {
+    // m is a merge of branch tip f (lane 1) back into main b (lane 0).
+    //   m -> [b, f]
+    //   f -> [b]
+    //   b -> [a]
+    //   a -> []
+    const layout = computeGraphLayout([
+      { sha: "m", parents: ["b", "f"] },
+      { sha: "f", parents: ["b"] },
+      { sha: "b", parents: ["a"] },
+      { sha: "a", parents: [] },
+    ]);
+    expect(layout.maxLanes).toBe(2);
+    expect(layout.rows[0].lane).toBe(0); // merge node on lane 0
+    expect(layout.rows[1].lane).toBe(1); // branch tip on lane 1
+    expect(layout.rows[2].lane).toBe(0); // base back on lane 0
+    // From the merge node, one edge continues lane 0 and another branches to lane 1.
+    const mEdges = layout.rows[0].edges;
+    expect(mEdges).toContainEqual({ fromLane: 0, toLane: 0, color: colorForLane(0) });
+    expect(mEdges.some((e) => e.toLane === 1)).toBe(true);
+    // f (lane 1) merges back into b (lane 0) in the gap below it.
+    expect(layout.rows[1].edges.some((e) => e.fromLane === 1 && e.toLane === 0)).toBe(true);
+  });
+
+  it("handles multiple disjoint roots", () => {
+    const layout = computeGraphLayout([
+      { sha: "x", parents: [] },
+      { sha: "y", parents: [] },
+    ]);
+    expect(layout.rows[0].lane).toBe(0);
+    expect(layout.rows[1].lane).toBe(0);
+    expect(layout.rows[0].edges).toEqual([]);
+  });
+
+  it("assigns deterministic, cycling lane colors", () => {
+    expect(colorForLane(0)).toBe(colorForLane(8));
+    expect(colorForLane(0)).not.toBe(colorForLane(1));
+  });
+});

--- a/apps/mobile/components/project/panels/ide/graph/gitAvatar.ts
+++ b/apps/mobile/components/project/panels/ide/graph/gitAvatar.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+//
+// Small identity helpers for the commit graph: deterministic avatar colors
+// and initials, plus detection of Shogo-AI–authored commits (which get a
+// distinct node in the graph, like GitKraken's bot avatars).
+
+const AVATAR_COLORS = [
+  "#1f9cf0",
+  "#cf6edf",
+  "#42c88a",
+  "#f0883e",
+  "#f14c4c",
+  "#3ecfcf",
+  "#e2c08d",
+  "#7aa6ff",
+  "#d18df0",
+  "#5fb85f",
+];
+
+function hashString(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (h << 5) - h + s.charCodeAt(i);
+    h |= 0;
+  }
+  return Math.abs(h);
+}
+
+export function avatarColor(seed: string): string {
+  return AVATAR_COLORS[hashString(seed || "?") % AVATAR_COLORS.length];
+}
+
+export function initials(name: string): string {
+  const cleaned = (name || "").trim();
+  if (!cleaned) return "?";
+  const parts = cleaned.split(/\s+/).filter(Boolean);
+  if (parts.length === 1) {
+    return parts[0].slice(0, 2).toUpperCase();
+  }
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+const AI_EMAILS = new Set(["ai@shogo.dev"]);
+const AI_NAMES = new Set(["shogo ai", "shogo"]);
+
+export function isAiAuthor(name: string, email: string): boolean {
+  return (
+    AI_EMAILS.has((email || "").toLowerCase()) ||
+    AI_NAMES.has((name || "").trim().toLowerCase())
+  );
+}
+
+export function relativeTime(iso: string): string {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return "";
+  const diff = Date.now() - t;
+  const sec = Math.round(diff / 1000);
+  if (sec < 60) return "just now";
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.round(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  const mo = Math.round(day / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  return `${Math.round(mo / 12)}y ago`;
+}
+
+export function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleString(undefined, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/apps/mobile/components/project/panels/ide/graph/graphLayout.ts
+++ b/apps/mobile/components/project/panels/ide/graph/graphLayout.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+//
+// Pure git-graph lane-layout. Turns a topologically/date-ordered list of
+// commits (each with parent SHAs) into per-row column ("lane") assignments
+// and the edge segments to draw between consecutive rows — the data a
+// GitKraken-style DAG canvas renders.
+//
+// Design choice: lanes do NOT compact. A lane keeps its column index from
+// the row it is born (a commit node, or a branch-out) until the row it dies
+// (the commit it was waiting for). This makes pass-through lines perfectly
+// vertical and keeps edge math simple and correct; it is marginally less
+// dense than GitKraken's compaction but visually clean.
+
+export interface GraphCommitInput {
+  sha: string;
+  parents: string[];
+}
+
+export interface GraphEdge {
+  /** Column at the top boundary of the row gap (this row's node level). */
+  fromLane: number;
+  /** Column at the bottom boundary of the row gap (next row's node level). */
+  toLane: number;
+  color: string;
+}
+
+export interface GraphRow {
+  sha: string;
+  /** Column index of this commit's node. */
+  lane: number;
+  /** Node color (derived from its lane). */
+  color: string;
+  /** Edges to draw in the gap BELOW this row (down toward the next row). */
+  edges: GraphEdge[];
+  /** Number of columns occupied at/around this row (drives canvas width). */
+  laneCount: number;
+}
+
+export interface GraphLayout {
+  rows: GraphRow[];
+  maxLanes: number;
+}
+
+// GitKraken-ish lane palette. Cycled by column index.
+export const LANE_PALETTE = [
+  "#1f9cf0", // blue
+  "#cf6edf", // purple
+  "#42c88a", // green
+  "#f0883e", // orange
+  "#f14c4c", // red
+  "#3ecfcf", // teal
+  "#e2c08d", // tan
+  "#7aa6ff", // periwinkle
+];
+
+export function colorForLane(lane: number): string {
+  return LANE_PALETTE[((lane % LANE_PALETTE.length) + LANE_PALETTE.length) % LANE_PALETTE.length];
+}
+
+interface RowInternal {
+  sha: string;
+  lane: number;
+  /** lane state (column -> awaited parent sha) AFTER processing this row. */
+  outgoing: (string | null)[];
+  /** columns newly created this row to hold a parent. */
+  newLanes: number[];
+  /** pre-existing columns a parent reused (a merge into an active lane). */
+  reusedLanes: number[];
+}
+
+export function computeGraphLayout(commits: GraphCommitInput[]): GraphLayout {
+  const internal: RowInternal[] = [];
+  // lanes[col] = sha that column is currently waiting to reach, or null.
+  let lanes: (string | null)[] = [];
+
+  const firstFree = (): number => {
+    const i = lanes.indexOf(null);
+    return i === -1 ? lanes.length : i;
+  };
+
+  for (const commit of commits) {
+    // 1. Node lane: the lowest column already waiting for this sha, else free.
+    let nodeLane = lanes.indexOf(commit.sha);
+    if (nodeLane === -1) nodeLane = firstFree();
+    if (nodeLane >= lanes.length) lanes.length = nodeLane + 1;
+
+    // 2. Every column waiting for this sha converges into nodeLane; clear them.
+    for (let c = 0; c < lanes.length; c++) {
+      if (lanes[c] === commit.sha) lanes[c] = null;
+    }
+
+    // 3. Place parents into lanes.
+    const newLanes: number[] = [];
+    const reusedLanes: number[] = [];
+    const parentLanes: number[] = [];
+
+    commit.parents.forEach((parent, idx) => {
+      const existing = lanes.indexOf(parent);
+      if (existing !== -1) {
+        reusedLanes.push(existing);
+        parentLanes.push(existing);
+        return;
+      }
+      const target = idx === 0 ? nodeLane : firstFree();
+      if (target >= lanes.length) lanes.length = target + 1;
+      lanes[target] = parent;
+      newLanes.push(target);
+      parentLanes.push(target);
+    });
+
+    // If first parent reused an existing lane (or there are no parents), the
+    // node's own lane is no longer carrying anything.
+    if (!parentLanes.includes(nodeLane)) lanes[nodeLane] = null;
+
+    // Trim trailing nulls so width doesn't grow unbounded.
+    while (lanes.length > 0 && lanes[lanes.length - 1] === null) lanes.pop();
+
+    internal.push({
+      sha: commit.sha,
+      lane: nodeLane,
+      outgoing: lanes.slice(),
+      newLanes,
+      reusedLanes,
+    });
+  }
+
+  // Build the edge list for each row's bottom gap from the lane states.
+  const rows: GraphRow[] = internal.map((r) => ({
+    sha: r.sha,
+    lane: r.lane,
+    color: colorForLane(r.lane),
+    edges: [],
+    laneCount: 0,
+  }));
+
+  for (let i = 0; i < internal.length; i++) {
+    const r = internal[i];
+    const next = internal[i + 1];
+    const edges: GraphEdge[] = [];
+    let maxCol = r.lane;
+
+    for (let c = 0; c < r.outgoing.length; c++) {
+      const sha = r.outgoing[c];
+      if (sha == null) continue;
+      const bottomLane = next && next.sha === sha ? next.lane : c;
+      const color = colorForLane(c);
+
+      if (r.newLanes.includes(c) && c !== r.lane) {
+        // Brand-new parent lane: a branch-out line from the node.
+        edges.push({ fromLane: r.lane, toLane: bottomLane, color });
+      } else if (r.reusedLanes.includes(c)) {
+        // The node merges into a lane that already existed: draw both the
+        // lane's own continuation and the connector from the node.
+        edges.push({ fromLane: c, toLane: bottomLane, color });
+        edges.push({ fromLane: r.lane, toLane: bottomLane, color });
+      } else {
+        // Pass-through (or first parent continuing in the node's lane).
+        edges.push({ fromLane: c, toLane: bottomLane, color });
+      }
+      maxCol = Math.max(maxCol, c, bottomLane);
+    }
+
+    rows[i].edges = edges;
+    rows[i].laneCount = maxCol + 1;
+  }
+
+  const maxLanes = rows.reduce((m, r) => Math.max(m, r.laneCount), 1);
+  return { rows, maxLanes };
+}

--- a/apps/mobile/components/project/panels/ide/graph/types.ts
+++ b/apps/mobile/components/project/panels/ide/graph/types.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import type { GitGraphCommit, GitRef } from "@shogo/shared-app/hooks";
+
+import type { GraphEdge } from "./graphLayout";
+
+export const ROW_HEIGHT = 30;
+export const LANE_WIDTH = 16;
+export const GRAPH_PAD_LEFT = 14;
+export const NODE_RADIUS = 6;
+
+/** A single rendered row, shared across the branch rail / graph / message columns. */
+export interface DisplayRow {
+  kind: "wip" | "commit";
+  sha: string | null;
+  commit?: GitGraphCommit;
+  lane: number;
+  color: string;
+  /** Edges drawn in the gap below this row. */
+  edges: GraphEdge[];
+  refs: GitRef[];
+  isCheckpoint: boolean;
+  /** Working-dir change count, only for the WIP row. */
+  wipCount?: number;
+}
+
+export function laneCenterX(lane: number): number {
+  return GRAPH_PAD_LEFT + lane * LANE_WIDTH + LANE_WIDTH / 2;
+}
+
+export function graphWidth(maxLanes: number): number {
+  return GRAPH_PAD_LEFT * 2 + Math.max(1, maxLanes) * LANE_WIDTH;
+}

--- a/packages/shared-app/src/hooks/index.ts
+++ b/packages/shared-app/src/hooks/index.ts
@@ -42,3 +42,15 @@ export {
   type RemoteState,
 } from './useRemoteState'
 export { useAgentUrl } from './useAgentUrl'
+export {
+  useGitGraph,
+  type GitGraphState,
+  type GitGraphCommit,
+  type GitGraphBranch,
+  type GitRef,
+  type GitRefType,
+  type GitCoAuthor,
+  type GitCommitDetail,
+  type GitCommitDetailFile,
+  type UseGitGraphOptions,
+} from './useGitGraph'

--- a/packages/shared-app/src/hooks/useGitGraph.ts
+++ b/packages/shared-app/src/hooks/useGitGraph.ts
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * useGitGraph Hook
+ *
+ * Fetches the project workspace's real git history as a DAG for the
+ * GitKraken-style commit-graph view:
+ * - commits with parent SHAs + ref decorations + co-authors
+ * - branch + tag lists, current HEAD
+ * - working-directory status (for the WIP row)
+ * - lazy per-commit detail (files changed, full message, parents)
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import type { GitStatus } from "./useCheckpoints"
+
+export type GitRefType = "head" | "remote" | "tag" | "HEAD"
+
+export interface GitRef {
+  name: string
+  type: GitRefType
+}
+
+export interface GitCoAuthor {
+  name: string
+  email: string
+}
+
+export interface GitGraphCommit {
+  sha: string
+  shortSha: string
+  parents: string[]
+  refs: GitRef[]
+  subject: string
+  body: string
+  author: string
+  authorEmail: string
+  committer: string
+  committerEmail: string
+  date: string
+  coAuthors: GitCoAuthor[]
+}
+
+export interface GitGraphBranch {
+  name: string
+  isCurrent: boolean
+}
+
+export interface GitCommitDetailFile {
+  path: string
+  status: "added" | "modified" | "deleted" | "renamed"
+  additions: number
+  deletions: number
+  oldPath?: string
+}
+
+export interface GitCommitDetail extends GitGraphCommit {
+  files: GitCommitDetailFile[]
+  totalAdditions: number
+  totalDeletions: number
+}
+
+export interface UseGitGraphOptions {
+  baseUrl?: string
+  credentials?: RequestCredentials
+  headers?: () => Record<string, string>
+  /** Commits per page. */
+  pageSize?: number
+}
+
+export interface GitGraphState {
+  commits: GitGraphCommit[]
+  branches: GitGraphBranch[]
+  tags: string[]
+  head: string | null
+  currentBranch: string | null
+  workingStatus: GitStatus | null
+  isLoading: boolean
+  isLoadingMore: boolean
+  hasMore: boolean
+  error: Error | null
+  /** True when the API returned 409 for a folder-linked project. */
+  disabledForExternalMode: boolean
+  loadMore: () => void
+  refetch: () => void
+  /** Lazily fetch (and cache) full detail for one commit. */
+  getCommitDetail: (sha: string) => Promise<GitCommitDetail | null>
+}
+
+export function useGitGraph(
+  projectId: string | undefined,
+  options?: UseGitGraphOptions,
+): GitGraphState {
+  const baseUrl = options?.baseUrl ?? ""
+  const credentials = options?.credentials
+  const extraHeaders = options?.headers
+  const pageSize = options?.pageSize ?? 200
+
+  const [commits, setCommits] = useState<GitGraphCommit[]>([])
+  const [branches, setBranches] = useState<GitGraphBranch[]>([])
+  const [tags, setTags] = useState<string[]>([])
+  const [head, setHead] = useState<string | null>(null)
+  const [currentBranch, setCurrentBranch] = useState<string | null>(null)
+  const [workingStatus, setWorkingStatus] = useState<GitStatus | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [hasMore, setHasMore] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+  const [disabledForExternalMode, setDisabledForExternalMode] = useState(false)
+  const [refetchCounter, setRefetchCounter] = useState(0)
+
+  const detailCache = useRef<Map<string, GitCommitDetail>>(new Map())
+
+  const buildOpts = useCallback((): RequestInit => {
+    const opts: RequestInit = {}
+    if (credentials) opts.credentials = credentials
+    if (extraHeaders) opts.headers = extraHeaders()
+    return opts
+  }, [credentials, extraHeaders])
+
+  useEffect(() => {
+    if (!projectId) {
+      setCommits([])
+      setWorkingStatus(null)
+      return
+    }
+    let cancelled = false
+    detailCache.current.clear()
+
+    const run = async () => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const [graphRes, statusRes] = await Promise.all([
+          fetch(`${baseUrl}/api/projects/${projectId}/git/graph?limit=${pageSize}`, buildOpts()),
+          fetch(`${baseUrl}/api/projects/${projectId}/git/status`, buildOpts()),
+        ])
+        if (cancelled) return
+
+        if (graphRes.ok) {
+          setDisabledForExternalMode(false)
+          const data: any = await graphRes.json()
+          const g = data.graph ?? {}
+          setCommits(g.commits ?? [])
+          setBranches(g.branches ?? [])
+          setTags(g.tags ?? [])
+          setHead(g.head ?? null)
+          setCurrentBranch(g.currentBranch ?? null)
+          setHasMore(Boolean(data.hasMore))
+        } else if (graphRes.status === 409) {
+          let code: string | undefined
+          try {
+            const body: any = await graphRes.json()
+            code = body?.error?.code
+          } catch {
+            /* ignore */
+          }
+          setDisabledForExternalMode(code === "checkpoints_disabled_in_external_mode")
+          setCommits([])
+          setBranches([])
+          setTags([])
+          setHasMore(false)
+        } else {
+          setDisabledForExternalMode(false)
+          setCommits([])
+          setHasMore(false)
+        }
+
+        if (statusRes.ok) {
+          const data: any = await statusRes.json()
+          setWorkingStatus((data?.status ?? null) as GitStatus | null)
+        } else {
+          setWorkingStatus(null)
+        }
+      } catch (err) {
+        if (cancelled) return
+        console.error("[useGitGraph] fetch error:", err)
+        setError(err instanceof Error ? err : new Error("Failed to load git graph"))
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [projectId, refetchCounter, baseUrl, pageSize, buildOpts])
+
+  const loadMore = useCallback(() => {
+    if (!projectId || isLoadingMore || !hasMore) return
+    let cancelled = false
+    const run = async () => {
+      setIsLoadingMore(true)
+      try {
+        const skip = commits.length
+        const res = await fetch(
+          `${baseUrl}/api/projects/${projectId}/git/graph?limit=${pageSize}&skip=${skip}`,
+          buildOpts(),
+        )
+        if (cancelled || !res.ok) return
+        const data: any = await res.json()
+        const more: GitGraphCommit[] = data.graph?.commits ?? []
+        // Skip-based paging can overlap if refs changed; de-dupe by sha.
+        setCommits((prev) => {
+          const seen = new Set(prev.map((c) => c.sha))
+          return [...prev, ...more.filter((c) => !seen.has(c.sha))]
+        })
+        setHasMore(Boolean(data.hasMore))
+      } catch (err) {
+        console.error("[useGitGraph] loadMore error:", err)
+      } finally {
+        if (!cancelled) setIsLoadingMore(false)
+      }
+    }
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [projectId, isLoadingMore, hasMore, commits.length, baseUrl, pageSize, buildOpts])
+
+  const getCommitDetail = useCallback(
+    async (sha: string): Promise<GitCommitDetail | null> => {
+      if (!projectId) return null
+      const cached = detailCache.current.get(sha)
+      if (cached) return cached
+      try {
+        const res = await fetch(
+          `${baseUrl}/api/projects/${projectId}/git/commit/${encodeURIComponent(sha)}`,
+          buildOpts(),
+        )
+        if (!res.ok) return null
+        const data: any = await res.json()
+        const detail = (data?.commit ?? null) as GitCommitDetail | null
+        if (detail) detailCache.current.set(sha, detail)
+        return detail
+      } catch (err) {
+        console.error("[useGitGraph] getCommitDetail error:", err)
+        return null
+      }
+    },
+    [projectId, baseUrl, buildOpts],
+  )
+
+  const refetch = useCallback(() => setRefetchCounter((c) => c + 1), [])
+
+  return useMemo(
+    () => ({
+      commits,
+      branches,
+      tags,
+      head,
+      currentBranch,
+      workingStatus,
+      isLoading,
+      isLoadingMore,
+      hasMore,
+      error,
+      disabledForExternalMode,
+      loadMore,
+      refetch,
+      getCommitDetail,
+    }),
+    [
+      commits,
+      branches,
+      tags,
+      head,
+      currentBranch,
+      workingStatus,
+      isLoading,
+      isLoadingMore,
+      hasMore,
+      error,
+      disabledForExternalMode,
+      loadMore,
+      refetch,
+      getCommitDetail,
+    ],
+  )
+}


### PR DESCRIPTION
## Summary
Adds a full GitKraken-style commit-graph view to the IDE, driven by the project workspace's **real git history** (via the API). Opens as a full main-area tab from the Source Control sidebar ("Open Commit Graph").

- **Three-column layout**: `BRANCH / TAG` rail (ref pills with local/remote/tag icons), a colored **DAG canvas** (SVG bezier lane connectors + avatar nodes, dotted WIP node when the tree is dirty), and the `COMMIT MESSAGE` column.
- **Commit detail panel**: working-dir summary + View Changes, `commit:` sha, message body, author avatar/date/`parent:`, co-authors, Path/Tree file list with status icons, and **Rollback** when the commit is a checkpoint.
- Checkpoint metadata is overlaid by SHA so checkpoint commits offer rollback.

## Changes
- **API** (`git.service.ts`, `checkpoints.ts`): `getGraph` (parents `%P` + ref decorations `%D` + `Co-authored-by:` trailers), `listTags`, `getCommitDetail` (root commit handled via empty-tree diff); new routes `GET /git/graph` and `GET /git/commit/:sha` (ref validated, external-mode 409 preserved).
- **Layout**: pure, unit-tested lane-assignment algorithm (`graphLayout.ts`) — fixed columns, branch forks, merge joins, cycling palette.
- **Hook** (`useGitGraph.ts`): graph + branches/tags + working-dir status + lazy per-commit detail (cached), pagination, filter.
- **UI**: `GraphView` / `CommitGraphCanvas` / `BranchTagRail` / `CommitDetailPanel`, mounted in `Workbench.tsx` as a toggleable full tab.

## Notes
- Targets cloud-managed projects; folder-linked (`external`) projects show the "use your own git" state.
- "Recompose commit with AI" intentionally omitted for now.
- File clicks in the detail panel open in the editor via the primary workspace root.

## Test plan
- [x] `apps/api` — `git-service-graph.test.ts` (linear/parents/HEAD, merges, co-authors, tags, root-commit detail) and existing `checkpoints.test.ts` pass.
- [x] `apps/mobile` — `graphLayout.test.ts` (linear, branch+merge, disjoint roots, colors) passes; new files typecheck clean.
- [ ] Manual: open a cloud project's IDE → Source Control → "Open Commit Graph"; verify graph, selection, detail, WIP row, and rollback on a checkpoint commit.

Made with [Cursor](https://cursor.com)