### PR TITLE
fix(affiliate): resolve referral links via in-app /r route + cookie attribution

### DIFF
--- a/apps/api/src/__tests__/affiliate-signup-attribution.test.ts
+++ b/apps/api/src/__tests__/affiliate-signup-attribution.test.ts
@@ -71,11 +71,13 @@ async function runHookBody(opts: {
       try {
         const visitorId = parseCookieHeader(ctx.request.headers.get('cookie') || '', '__shogo_ref_visitor')
         const code = parseCookieHeader(ctx.request.headers.get('cookie') || '', '__shogo_ref')
-        if (visitorId) {
+        if (visitorId || code) {
           // Stand-in for `await resolveAttributionForUser(...)` —
-          // mirrors the exact shape of the production call.
-          resolveCalls.push([opts.userId, visitorId, code ?? null])
-          await resolveImpl(opts.userId, visitorId, code ?? null)
+          // mirrors the exact shape of the production call. Either the
+          // visitor cookie (click-based) or the code cookie (direct
+          // fallback) is enough to attempt attribution.
+          resolveCalls.push([opts.userId, visitorId ?? null, code ?? null])
+          await resolveImpl(opts.userId, visitorId ?? null, code ?? null)
         }
       } catch (err) {
         // swallow — auth.ts logs but doesn't throw
@@ -107,9 +109,19 @@ describe('signup hook integration', () => {
     expect(resolveCalls.length).toBe(0)
   })
 
-  test('no-ops when visitor cookie is missing', async () => {
+  test('attributes from the code cookie even when the visitor cookie is missing', async () => {
     await runHookBody({
       cookieHeader: '__shogo_ref=alpha',
+      featureFlag: 'true',
+      userId: 'u1',
+    })
+    expect(resolveCalls.length).toBe(1)
+    expect(resolveCalls[0]).toEqual(['u1', null, 'alpha'])
+  })
+
+  test('no-ops when neither referral cookie is present', async () => {
+    await runHookBody({
+      cookieHeader: 'session=abc; other=1',
       featureFlag: 'true',
       userId: 'u1',
     })

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -472,8 +472,12 @@ export const auth = betterAuth({
                 ''
               const visitorId = parseCookieHeader(cookieHeader, '__shogo_ref_visitor')
               const code = parseCookieHeader(cookieHeader, '__shogo_ref')
-              if (visitorId) {
-                await resolveAttributionForUser(user.id, visitorId, code ?? null)
+              // Either signal is enough: the visitor cookie drives
+              // click-based attribution, the code cookie drives the
+              // direct code fallback (resolveAttributionForUser handles
+              // both, including the case where only one is present).
+              if (visitorId || code) {
+                await resolveAttributionForUser(user.id, visitorId ?? null, code ?? null)
               }
             } catch (err) {
               console.error('[Affiliate] attribution on signup failed', err)

--- a/apps/api/src/routes/__tests__/affiliates.test.ts
+++ b/apps/api/src/routes/__tests__/affiliates.test.ts
@@ -639,17 +639,37 @@ describe('POST /api/affiliates/enroll (error branches)', () => {
     expect(j.error.code).toBe('invalid_code')
   })
 
-  test('AffiliateError parent_not_found → 404', async () => {
-    users.set('u_e', { id: 'u_e', email: 'e@x.io', name: 'E' })
+  test('derives parent from the user\'s attribution', async () => {
+    users.set('u_ref', { id: 'u_ref', email: 'ref@x.io', name: 'Ref' })
+    affiliateRows.set('aff_owner', {
+      id: 'aff_owner', userId: 'u_owner', code: 'owner', status: 'active', depth: 1,
+    })
+    attributionRows.set('u_ref', { userId: 'u_ref', affiliateId: 'aff_owner' })
     const app = makeApp()
     const res = await app.request('/api/affiliates/enroll', {
       method: 'POST',
-      headers: { 'content-type': 'application/json', 'x-test-user-id': 'u_e' },
+      headers: { 'content-type': 'application/json', 'x-test-user-id': 'u_ref' },
+      body: JSON.stringify({ termsAccepted: true }),
+    })
+    expect(res.status).toBe(200)
+    const j: any = await res.json()
+    expect(j.affiliate.parentAffiliateId).toBe('aff_owner')
+    expect(j.affiliate.depth).toBe(2)
+  })
+
+  test('ignores a manually supplied parentCode (no longer accepted)', async () => {
+    users.set('u_m', { id: 'u_m', email: 'm@x.io', name: 'M' })
+    const app = makeApp()
+    const res = await app.request('/api/affiliates/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-user-id': 'u_m' },
       body: JSON.stringify({ termsAccepted: true, parentCode: 'ghost' }),
     })
-    expect(res.status).toBe(404)
+    // parentCode is stripped by the schema; enrollment succeeds with no parent.
+    expect(res.status).toBe(200)
     const j: any = await res.json()
-    expect(j.error.code).toBe('parent_not_found')
+    expect(j.ok).toBe(true)
+    expect(j.affiliate.parentAffiliateId ?? null).toBeNull()
   })
 
   test('AffiliateError user_not_found → 404 (user missing in db)', async () => {
@@ -684,6 +704,62 @@ describe('POST /api/affiliates/enroll (error branches)', () => {
       prismaStub.user.findUnique = orig
       console.error = origErr
     }
+  })
+})
+
+// ============================================================================
+// Public browser visit recorder (in-app /r/<code> route)
+// ============================================================================
+describe('POST /api/affiliates/visit (public, no secret)', () => {
+  test('503 when flag off', async () => {
+    delete process.env.SHOGO_AFFILIATES_NATIVE
+    const app = makeApp()
+    const res = await app.request('/api/affiliates/visit', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ code: 'alice', visitorId: 'visitor-123' }),
+    })
+    expect(res.status).toBe(503)
+    process.env.SHOGO_AFFILIATES_NATIVE = 'true'
+  })
+
+  test('records a click without the internal secret', async () => {
+    affiliateRows.set('aff_v', {
+      id: 'aff_v', userId: 'u_v', code: 'alice', status: 'active', depth: 1,
+    })
+    const app = makeApp()
+    const res = await app.request('/api/affiliates/visit', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ code: 'alice', visitorId: 'visitor-123' }),
+    })
+    expect(res.status).toBe(200)
+    const j: any = await res.json()
+    expect(j.ok).toBe(true)
+    expect(typeof j.clickId).toBe('string')
+  })
+
+  test('unknown code → 200 no-op (does not disrupt the redirect)', async () => {
+    const app = makeApp()
+    const res = await app.request('/api/affiliates/visit', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ code: 'ghost', visitorId: 'visitor-123' }),
+    })
+    expect(res.status).toBe(200)
+    const j: any = await res.json()
+    expect(j.ok).toBe(false)
+    expect(j.error.code).toBe('affiliate_not_found')
+  })
+
+  test('invalid body → 400', async () => {
+    const app = makeApp()
+    const res = await app.request('/api/affiliates/visit', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ code: 'alice' }),
+    })
+    expect(res.status).toBe(400)
   })
 })
 

--- a/apps/api/src/routes/affiliates.ts
+++ b/apps/api/src/routes/affiliates.ts
@@ -64,7 +64,8 @@ function affiliateErrorStatus(code: string): number {
 }
 
 const enrollSchema = z.object({
-  parentCode: z.string().trim().min(1).max(64).optional().nullable(),
+  // No `parentCode`: the upline is derived server-side from the user's
+  // AffiliateAttribution (the referral cookie), never manually supplied.
   code: z.string().trim().min(2).max(40).optional().nullable(),
   termsAccepted: z.boolean(),
 })
@@ -80,6 +81,16 @@ const clickSchema = z.object({
   utmCampaign: z.string().nullable().optional(),
   referrer: z.string().nullable().optional(),
   country: z.string().length(2).nullable().optional(),
+})
+
+// Browser-facing visit recorder (no internal secret). Minimal surface:
+// just the code + a client-generated visitor id. Used by the in-app
+// `/r/<code>` route (apps/mobile/app/r/[code].tsx).
+const visitSchema = z.object({
+  code: z.string().min(1).max(64),
+  visitorId: z.string().min(8).max(128),
+  landingPage: z.string().max(2048).nullable().optional(),
+  referrer: z.string().max(2048).nullable().optional(),
 })
 
 export function affiliateRoutes(): Hono {
@@ -154,6 +165,56 @@ export function affiliateRoutes(): Hono {
     })
   })
 
+  /**
+   * POST /api/affiliates/visit
+   * Public, browser-facing click recorder for the in-app `/r/<code>`
+   * route. Unlike `/affiliates/click` this is NOT secret-gated (a browser
+   * can't hold the internal secret); it is analytics-only and tolerant of
+   * bad input. Attribution itself is driven by the `__shogo_ref` cookie at
+   * signup, so a failed/duplicate visit never blocks earning.
+   */
+  router.post('/affiliates/visit', async (c) => {
+    if (!isFlagOn()) {
+      return c.json({ ok: false, error: { code: 'feature_disabled' } }, 503)
+    }
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ ok: false, error: { code: 'bad_request' } }, 400)
+    }
+    const parsed = visitSchema.safeParse(body)
+    if (!parsed.success) {
+      return c.json(
+        { ok: false, error: { code: 'invalid_request', issues: parsed.error.issues } },
+        400,
+      )
+    }
+    const ip =
+      c.req.header('cf-connecting-ip') ||
+      c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||
+      null
+    try {
+      const click = await recordClick({
+        code: parsed.data.code,
+        visitorId: parsed.data.visitorId,
+        ip,
+        userAgent: c.req.header('user-agent') ?? null,
+        landingPage: parsed.data.landingPage ?? null,
+        referrer: parsed.data.referrer ?? null,
+        country: c.req.header('cf-ipcountry') ?? null,
+      })
+      return c.json({ ok: true, clickId: click.id })
+    } catch (err) {
+      if (err instanceof AffiliateError) {
+        // Unknown/inactive code — 200 no-op so the redirect isn't disrupted.
+        return c.json({ ok: false, error: { code: err.code } }, 200)
+      }
+      console.error('[Affiliate visit] failed', err)
+      return c.json({ ok: false, error: { code: 'server_error' } }, 500)
+    }
+  })
+
   // --------------------------------------------------------------------------
   // Authenticated user endpoints
   // --------------------------------------------------------------------------
@@ -209,7 +270,21 @@ export function affiliateRoutes(): Hono {
     if (!userId) return c.json({ ok: false, error: { code: 'unauthorized' } }, 401)
     const summary = await getAffiliateSummary(userId)
     if (!summary) return c.json({ ok: true, enrolled: false })
-    return c.json({ ok: true, enrolled: true, ...summary })
+    // The mobile dashboard (apps/mobile/lib/affiliate-api.ts) reads a
+    // flatter set of field names than the service emits. Expose both:
+    // the raw service shape (consumed by server tests / future clients)
+    // plus the mobile aliases. The running-balance counters live on the
+    // affiliate row, not in the per-status commission sums.
+    return c.json({
+      ok: true,
+      enrolled: true,
+      ...summary,
+      pendingPayoutCents: summary.affiliate?.pendingPayoutCents ?? 0,
+      lifetimePayoutCents: summary.affiliate?.totalPaidOutCents ?? 0,
+      clicksLast30d: summary.clicks30d,
+      signupsLast30d: summary.signups30d,
+      commissionsLast30d: summary.commissions30d,
+    })
   })
 
   /**

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -552,12 +552,15 @@ app.use(
       '/api/instances/heartbeat',
       '/api/instances/ws',
       '/api/vm/',
-      // Native MLM affiliate program — two public surfaces:
+      // Native MLM affiliate program — public surfaces:
       //   /lookup  → marketing site validates a code before redirect
       //   /click   → Cloudflare Pages Function records the click using
       //              SHOGO_INTERNAL_SECRET (auth handled in-route)
+      //   /visit   → in-app /r/<code> route records the click from the
+      //              browser (no secret; analytics-only, validated in-route)
       '/api/affiliates/lookup',
       '/api/affiliates/click',
+      '/api/affiliates/visit',
     ]
     if (publicPrefixes.some((p) => path.startsWith(p))) return next()
     if (isAllowedUnauthWebchatProxyPath(path)) return next()

--- a/apps/api/src/services/__tests__/affiliate.service.test.ts
+++ b/apps/api/src/services/__tests__/affiliate.service.test.ts
@@ -176,6 +176,10 @@ const prismaStub = {
         return true
       })
     },
+    count: async ({ where }: any) => commissions.filter((c) =>
+      (!where.affiliateId || c.affiliateId === where.affiliateId) &&
+      (!where.createdAt?.gte || c.createdAt >= where.createdAt.gte),
+    ).length,
     groupBy: async ({ where, by, _sum }: any) => {
       const filtered = commissions.filter((c) => {
         if (where.status && c.status !== where.status) return false
@@ -422,53 +426,49 @@ describe('enrollAffiliate', () => {
     expect(b.code).toMatch(/^shared-[a-z0-9]{4}$/)
   })
 
-  test('rejects self-referral via parentCode (defensive guard)', async () => {
-    // The enroll-by-userId idempotency check normally short-circuits
-    // before the parent self-referral guard can run. Simulate the
-    // corrupted state — an affiliate row whose code lookup resolves
-    // to `u1` but whose userId lookup is missing — by patching the
-    // mock for one call. (Real-world trigger: a backfill that wrote
-    // a code-only row without a corresponding userId mapping.)
-    seedAffiliate({ id: 'aff_mine', userId: 'u1', code: 'mine' })
-    seedUser('u1', 'a@a.com', 'Ada')
-    const origFindUnique = prismaStub.affiliate.findUnique
-    prismaStub.affiliate.findUnique = (async ({ where }: any) => {
-      if (where.userId === 'u1') return null
-      return origFindUnique({ where })
-    }) as any
-    try {
-      await expect(
-        svc.enrollAffiliate('u1', { parentCode: 'mine', termsAccepted: true }),
-      ).rejects.toMatchObject({ code: 'self_referral' })
-    } finally {
-      prismaStub.affiliate.findUnique = origFindUnique
-    }
-  })
-
-  test('rejects parent_too_deep when chain would exceed max depth', async () => {
-    process.env.SHOGO_AFFILIATE_MAX_DEPTH = '3'
-    seedAffiliate({ userId: 'u-root', code: 'root', depth: 1 })
-    const l2 = seedAffiliate({ userId: 'u-l2', code: 'l2', parentAffiliateId: 'aff_1', depth: 2 })
-    seedAffiliate({ userId: 'u-l3', code: 'l3', parentAffiliateId: l2.id, depth: 3 })
-    seedUser('u-new', 'n@n.com', 'New')
-    await expect(
-      svc.enrollAffiliate('u-new', { parentCode: 'l3', termsAccepted: true }),
-    ).rejects.toMatchObject({ code: 'parent_too_deep' })
-  })
-
-  test('happy path with parent updates depth', async () => {
+  test('derives parent from attribution and sets depth', async () => {
     seedAffiliate({ id: 'aff_root', userId: 'u-root', code: 'root', depth: 1 })
     seedUser('u-child', 'c@c.com', 'Child')
-    const child = await svc.enrollAffiliate('u-child', { parentCode: 'root', termsAccepted: true })
+    attributions.set('u-child', {
+      id: 'attr_child', userId: 'u-child', affiliateId: 'aff_root', attributedAt: new Date(),
+    })
+    const child = await svc.enrollAffiliate('u-child', { termsAccepted: true })
     expect(child.depth).toBe(2)
     expect(child.parentAffiliateId).toBe('aff_root')
   })
 
-  test('unknown parent code throws parent_not_found', async () => {
-    seedUser('u1')
-    await expect(
-      svc.enrollAffiliate('u1', { parentCode: 'who-dis', termsAccepted: true }),
-    ).rejects.toMatchObject({ code: 'parent_not_found' })
+  test('no attribution → enrolls at top of tree (depth 1, no parent)', async () => {
+    seedUser('u-solo', 's@s.com', 'Solo')
+    const row = await svc.enrollAffiliate('u-solo', { termsAccepted: true })
+    expect(row.depth).toBe(1)
+    expect(row.parentAffiliateId).toBeNull()
+  })
+
+  test('skips parent (best-effort, no error) when referrer would exceed max depth', async () => {
+    process.env.SHOGO_AFFILIATE_MAX_DEPTH = '3'
+    seedAffiliate({ id: 'aff_root', userId: 'u-root', code: 'root', depth: 1 })
+    const l2 = seedAffiliate({ userId: 'u-l2', code: 'l2', parentAffiliateId: 'aff_root', depth: 2 })
+    const l3 = seedAffiliate({ userId: 'u-l3', code: 'l3', parentAffiliateId: l2.id, depth: 3 })
+    seedUser('u-new', 'n@n.com', 'New')
+    attributions.set('u-new', { id: 'a', userId: 'u-new', affiliateId: l3.id, attributedAt: new Date() })
+    const row = await svc.enrollAffiliate('u-new', { termsAccepted: true })
+    expect(row.depth).toBe(1)
+    expect(row.parentAffiliateId).toBeNull()
+  })
+
+  test('skips parent (best-effort) when referrer is inactive', async () => {
+    seedAffiliate({ id: 'aff_susp', userId: 'u-susp', code: 'susp', depth: 1, status: 'suspended' })
+    seedUser('u-new', 'n@n.com', 'New')
+    attributions.set('u-new', { id: 'a', userId: 'u-new', affiliateId: 'aff_susp', attributedAt: new Date() })
+    const row = await svc.enrollAffiliate('u-new', { termsAccepted: true })
+    expect(row.parentAffiliateId).toBeNull()
+  })
+
+  test('ignores attribution pointing at a missing affiliate', async () => {
+    seedUser('u-new', 'n@n.com', 'New')
+    attributions.set('u-new', { id: 'a', userId: 'u-new', affiliateId: 'aff_ghost', attributedAt: new Date() })
+    const row = await svc.enrollAffiliate('u-new', { termsAccepted: true })
+    expect(row.parentAffiliateId).toBeNull()
   })
 })
 
@@ -566,6 +566,36 @@ describe('resolveAttributionForUser', () => {
     )
     const attr = await svc.resolveAttributionForUser('u-new', 'v', 'a')
     expect(attr!.affiliateId).toBe('aff_a')
+  })
+
+  test('falls back to code attribution when there is no click row', async () => {
+    seedAffiliate({ id: 'aff_a', userId: 'u-a', code: 'cool-code' })
+    seedUser('u-new')
+    // No clicks recorded; only the __shogo_ref cookie code is known.
+    const attr = await svc.resolveAttributionForUser('u-new', 'visitor-1', 'cool-code')
+    expect(attr).not.toBeNull()
+    expect(attr!.affiliateId).toBe('aff_a')
+    expect(attr!.clickId).toBeNull()
+  })
+
+  test('code fallback works even without a visitorId', async () => {
+    seedAffiliate({ id: 'aff_a', userId: 'u-a', code: 'cool-code' })
+    seedUser('u-new')
+    const attr = await svc.resolveAttributionForUser('u-new', null, 'cool-code')
+    expect(attr!.affiliateId).toBe('aff_a')
+  })
+
+  test('code fallback rejects self-referral', async () => {
+    seedAffiliate({ id: 'aff_self', userId: 'u-new', code: 'mine' })
+    seedUser('u-new')
+    const attr = await svc.resolveAttributionForUser('u-new', null, 'mine')
+    expect(attr).toBeNull()
+  })
+
+  test('returns null when given neither a visitor nor a code', async () => {
+    seedUser('u-new')
+    const attr = await svc.resolveAttributionForUser('u-new', null, null)
+    expect(attr).toBeNull()
   })
 })
 

--- a/apps/api/src/services/affiliate.service.ts
+++ b/apps/api/src/services/affiliate.service.ts
@@ -114,21 +114,20 @@ function deriveSlug(input: string): string {
  * program" — we never auto-enroll. Generates a slug from the user's
  * email if none provided, retries on uniqueness collision.
  *
- * `parentCode` ties this affiliate into someone else's downline (the
- * upline goes through that affiliate at level 1, this affiliate at
- * the new bottom). Rejects:
- *   - self_referral: a user can't list their own future code as parent
- *   - parent_not_found: bad code
- *   - parent_too_deep: would push depth past SHOGO_AFFILIATE_MAX_DEPTH
- *   - cycle: parent is already a descendant of `userId` (paranoid; the
- *     `userId @unique` constraint should already prevent this, but
- *     we keep the explicit guard so future schema changes can't
- *     silently regress)
+ * The upline parent ("referred by") is NOT user-supplied: it is derived
+ * from the enrolling user's own `AffiliateAttribution`, which was locked
+ * at signup from the `__shogo_ref` referral cookie. This guarantees the
+ * tree reflects who actually referred the user, and makes manual
+ * referrer entry impossible.
+ *
+ * Parent attachment is best-effort. If there is no attribution, or the
+ * referrer is inactive, would push depth past SHOGO_AFFILIATE_MAX_DEPTH,
+ * is the user themselves, or would form a cycle, we enroll at the top of
+ * the tree (depth 1, no parent) rather than blocking a legitimate opt-in.
  */
 export async function enrollAffiliate(
   userId: string,
   opts: {
-    parentCode?: string | null
     code?: string | null
     termsAccepted: boolean
     /** For tests: skip uniqueness retries (sync DBs). */
@@ -143,48 +142,46 @@ export async function enrollAffiliate(
   const existing = await prisma.affiliate.findUnique({ where: { userId } })
   if (existing) return existing
 
-  // Resolve parent if provided.
+  // Derive the upline parent from this user's attribution (set at signup
+  // from the referral cookie). Best-effort — invalid/missing referrer
+  // just means a top-of-tree enrollment, never an error.
   let parentAffiliate: any = null
   let depth = 1
-  if (opts.parentCode) {
-    parentAffiliate = await prisma.affiliate.findUnique({
-      where: { code: opts.parentCode.toLowerCase().trim() },
+  const attribution = await prisma.affiliateAttribution.findUnique({ where: { userId } })
+  if (attribution) {
+    const candidateParent = await prisma.affiliate.findUnique({
+      where: { id: attribution.affiliateId },
     })
-    if (!parentAffiliate) {
-      throw new AffiliateError('parent_not_found', `No affiliate found for code "${opts.parentCode}"`)
-    }
-    if (parentAffiliate.userId === userId) {
-      throw new AffiliateError('self_referral', 'You cannot enroll under your own affiliate code')
-    }
-    if (parentAffiliate.status !== 'active') {
-      throw new AffiliateError('parent_inactive', 'Parent affiliate is not active')
-    }
-    depth = parentAffiliate.depth + 1
-    if (depth > getMaxDepth()) {
-      throw new AffiliateError(
-        'parent_too_deep',
-        `Enrolling under ${opts.parentCode} would exceed max depth ${getMaxDepth()}`,
-      )
-    }
-    // Cycle guard: walk up `parentAffiliate.parentAffiliateId` and bail
-    // if we ever encounter `userId`. The new affiliate hasn't been
-    // created yet, so a cycle here can only happen if `userId` is
-    // already an Affiliate sitting upstream — which `userId @unique`
-    // on Affiliate makes impossible — but the guard is cheap and the
-    // failure mode (infinite walk + double-pay loop) is catastrophic.
-    let cursor: any = parentAffiliate
-    const seen = new Set<string>()
-    while (cursor?.parentAffiliateId) {
-      if (seen.has(cursor.parentAffiliateId)) break
-      seen.add(cursor.parentAffiliateId)
-      const next = await prisma.affiliate.findUnique({
-        where: { id: cursor.parentAffiliateId },
-      })
-      if (!next) break
-      if (next.userId === userId) {
-        throw new AffiliateError('cycle', 'Cycle detected in affiliate upline chain')
+    if (
+      candidateParent &&
+      candidateParent.userId !== userId &&
+      candidateParent.status === 'active' &&
+      candidateParent.depth + 1 <= getMaxDepth()
+    ) {
+      // Cycle guard (defensive): bail if `userId` already sits upstream.
+      // The `userId @unique` constraint on Affiliate should make this
+      // impossible, but the failure mode (infinite walk + double-pay
+      // loop) is catastrophic, so the cheap walk stays.
+      let cursor: any = candidateParent
+      const seen = new Set<string>()
+      let cyclic = false
+      while (cursor?.parentAffiliateId) {
+        if (seen.has(cursor.parentAffiliateId)) break
+        seen.add(cursor.parentAffiliateId)
+        const next = await prisma.affiliate.findUnique({
+          where: { id: cursor.parentAffiliateId },
+        })
+        if (!next) break
+        if (next.userId === userId) {
+          cyclic = true
+          break
+        }
+        cursor = next
       }
-      cursor = next
+      if (!cyclic) {
+        parentAffiliate = candidateParent
+        depth = candidateParent.depth + 1
+      }
     }
   }
 
@@ -320,57 +317,26 @@ export async function recordClick(input: RecordClickInput): Promise<any> {
  *
  * Idempotent on the `userId` unique constraint — re-calling never
  * moves an attribution. Returns `null` when nothing matches or when
- * the click would be a self-referral.
+ * the only candidate would be a self-referral.
  *
- * `code` is an optional hint (the value of `__shogo_ref` cookie) used
- * to disambiguate when several affiliates have clicks for the same
- * visitor in the cookie window; it picks the matching one before
- * falling back to "most recent".
+ * Two resolution paths:
+ *   1. Click-based (last-click wins): the most-recent non-expired click
+ *      for `visitorId`; `code` (the `__shogo_ref` cookie) disambiguates
+ *      when several affiliates clicked for the same visitor.
+ *   2. Code fallback: if there's no usable click row but `code` is
+ *      present, attribute directly to that affiliate (clickId null).
+ *      This lets the in-app `/r/<code>` route attribute purely from the
+ *      cookie, without depending on the secret-gated click recorder.
  */
-export async function resolveAttributionForUser(
+async function createAttribution(
   userId: string,
+  affiliateId: string,
   visitorId: string | null,
-  code: string | null = null,
-  now: Date = new Date(),
-): Promise<any | null> {
-  if (!visitorId) return null
-
-  // Existing attribution wins — never overwrite.
-  const existing = await prisma.affiliateAttribution.findUnique({ where: { userId } })
-  if (existing) return existing
-
-  // Find the most recent non-expired click for this visitor. If `code`
-  // is supplied, prefer a click for that affiliate.
-  const clicks: any[] = await prisma.affiliateClick.findMany({
-    where: {
-      visitorId,
-      expiresAt: { gt: now },
-    },
-    orderBy: { createdAt: 'desc' },
-    take: 25,
-    include: { affiliate: true },
-  })
-  if (clicks.length === 0) return null
-
-  let chosen = clicks[0]
-  if (code) {
-    const target = code.toLowerCase().trim()
-    const match = clicks.find((c) => c.affiliate?.code === target)
-    if (match) chosen = match
-  }
-
-  // Self-referral guard: a user cannot attribute to their own affiliate.
-  if (chosen.affiliate?.userId === userId) return null
-  if (chosen.affiliate?.status !== 'active') return null
-
+  clickId: string | null,
+): Promise<any> {
   try {
     return await prisma.affiliateAttribution.create({
-      data: {
-        userId,
-        affiliateId: chosen.affiliateId,
-        visitorId,
-        clickId: chosen.id,
-      },
+      data: { userId, affiliateId, visitorId, clickId },
     })
   } catch (err: any) {
     // Race with a concurrent attribution write — the unique constraint
@@ -380,6 +346,57 @@ export async function resolveAttributionForUser(
     }
     throw err
   }
+}
+
+export async function resolveAttributionForUser(
+  userId: string,
+  visitorId: string | null,
+  code: string | null = null,
+  now: Date = new Date(),
+): Promise<any | null> {
+  // Need at least one signal to attribute.
+  if (!visitorId && !code) return null
+
+  // Existing attribution wins — never overwrite.
+  const existing = await prisma.affiliateAttribution.findUnique({ where: { userId } })
+  if (existing) return existing
+
+  const normalizedCode = code ? code.toLowerCase().trim() : null
+
+  // 1. Click-based attribution.
+  if (visitorId) {
+    const clicks: any[] = await prisma.affiliateClick.findMany({
+      where: {
+        visitorId,
+        expiresAt: { gt: now },
+      },
+      orderBy: { createdAt: 'desc' },
+      take: 25,
+      include: { affiliate: true },
+    })
+    if (clicks.length > 0) {
+      let chosen = clicks[0]
+      if (normalizedCode) {
+        const match = clicks.find((c) => c.affiliate?.code === normalizedCode)
+        if (match) chosen = match
+      }
+      // Self-referral / inactive guard. If the click is unusable we fall
+      // through to the code fallback rather than giving up.
+      if (chosen.affiliate?.userId !== userId && chosen.affiliate?.status === 'active') {
+        return createAttribution(userId, chosen.affiliateId, visitorId, chosen.id)
+      }
+    }
+  }
+
+  // 2. Code fallback (cookie-only, no usable click row).
+  if (normalizedCode) {
+    const affiliate = await prisma.affiliate.findUnique({ where: { code: normalizedCode } })
+    if (affiliate && affiliate.userId !== userId && affiliate.status === 'active') {
+      return createAttribution(userId, affiliate.id, visitorId, null)
+    }
+  }
+
+  return null
 }
 
 // ============================================================================
@@ -897,6 +914,7 @@ export interface AffiliateSummary {
   affiliate: any
   clicks30d: number
   signups30d: number
+  commissions30d: number
   pendingCents: number
   approvedCents: number
   paidCents: number
@@ -910,12 +928,15 @@ export async function getAffiliateSummary(userId: string, now: Date = new Date()
 
   const since = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)
 
-  const [clicks30d, signups30d, commissionStats, downline] = await Promise.all([
+  const [clicks30d, signups30d, commissions30d, commissionStats, downline] = await Promise.all([
     prisma.affiliateClick.count({
       where: { affiliateId: affiliate.id, createdAt: { gte: since } },
     }),
     prisma.affiliateAttribution.count({
       where: { affiliateId: affiliate.id, attributedAt: { gte: since } },
+    }),
+    prisma.affiliateCommission.count({
+      where: { affiliateId: affiliate.id, createdAt: { gte: since } },
     }),
     prisma.affiliateCommission.groupBy({
       by: ['status'],
@@ -952,6 +973,7 @@ export async function getAffiliateSummary(userId: string, now: Date = new Date()
     affiliate,
     clicks30d,
     signups30d,
+    commissions30d,
     pendingCents: byStatus.pending ?? 0,
     approvedCents: byStatus.approved ?? 0,
     paidCents: byStatus.paid ?? 0,

--- a/apps/mobile/app/(app)/affiliate/enroll.tsx
+++ b/apps/mobile/app/(app)/affiliate/enroll.tsx
@@ -34,7 +34,6 @@ function describeError(code: string): string {
 export default function AffiliateEnrollScreen() {
   const router = useRouter()
   const http = useDomainHttp()
-  const [parentCode, setParentCode] = useState('')
   const [code, setCode] = useState('')
   const [accepted, setAccepted] = useState(false)
   const [submitting, setSubmitting] = useState(false)
@@ -50,7 +49,6 @@ export default function AffiliateEnrollScreen() {
     try {
       const res = await affiliateApi.enroll(http, {
         termsAccepted: true,
-        parentCode: parentCode.trim() || undefined,
         code: code.trim() || undefined,
       })
       if (res?.ok) {
@@ -64,7 +62,7 @@ export default function AffiliateEnrollScreen() {
     } finally {
       setSubmitting(false)
     }
-  }, [accepted, code, http, parentCode, router])
+  }, [accepted, code, http, router])
 
   return (
     <View className="flex-1 bg-background">
@@ -91,17 +89,6 @@ export default function AffiliateEnrollScreen() {
             </Text>
           </CardContent>
         </Card>
-
-        <View className="gap-2">
-          <Text className="text-xs uppercase text-muted-foreground tracking-wide">Referred by (optional)</Text>
-          <Input
-            value={parentCode}
-            onChangeText={setParentCode}
-            placeholder="Referrer's code"
-            autoCapitalize="none"
-            autoCorrect={false}
-          />
-        </View>
 
         <View className="gap-2">
           <Text className="text-xs uppercase text-muted-foreground tracking-wide">Custom slug (optional)</Text>

--- a/apps/mobile/app/r/[code].tsx
+++ b/apps/mobile/app/r/[code].tsx
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Affiliate referral landing route: `/r/<code>`.
+ *
+ * This is the in-app handler for shareable referral links built by
+ * `buildReferralLink` (apps/mobile/lib/affiliate-api.ts). On web it sets
+ * the two first-party attribution cookies that the signup hook
+ * (apps/api/src/auth.ts `user.create.after`) reads:
+ *
+ *   - `__shogo_ref`          → the affiliate code
+ *   - `__shogo_ref_visitor`  → a stable visitor UUID
+ *
+ * It then best-effort records the click (POST /api/affiliates/visit) for
+ * the dashboard's "Clicks (30d)" stat and redirects to sign-up. Because
+ * the link points at this same app's origin (per environment), it always
+ * resolves — no more Expo "Unmatched Route".
+ */
+import { useEffect, useRef } from 'react'
+import { View, ActivityIndicator, Platform } from 'react-native'
+import { Redirect, useLocalSearchParams, useRouter } from 'expo-router'
+import { API_URL } from '../../lib/api'
+
+const REF_COOKIE = '__shogo_ref'
+const VISITOR_COOKIE = '__shogo_ref_visitor'
+// Mirrors SHOGO_AFFILIATE_COOKIE_DAYS (server default). The server's
+// attribution lookup enforces its own expiry, so this only needs to be
+// long enough to outlive a browse-then-signup session.
+const COOKIE_MAX_AGE_SECONDS = 60 * 24 * 60 * 60
+
+function readCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null
+  const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`))
+  return match ? decodeURIComponent(match[1]) : null
+}
+
+function setCookie(name: string, value: string): void {
+  if (typeof document === 'undefined') return
+  document.cookie =
+    `${name}=${encodeURIComponent(value)}; path=/; max-age=${COOKIE_MAX_AGE_SECONDS}; SameSite=Lax`
+}
+
+function newVisitorId(): string {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID()
+    }
+  } catch {
+    // fall through to manual generation
+  }
+  return `v_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 12)}`
+}
+
+export default function AffiliateReferralRedirect() {
+  const router = useRouter()
+  const { code } = useLocalSearchParams<{ code?: string }>()
+  const ran = useRef(false)
+
+  useEffect(() => {
+    if (Platform.OS !== 'web') return
+    if (ran.current) return
+    ran.current = true
+
+    const refCode = (Array.isArray(code) ? code[0] : code)?.trim()
+    if (refCode) {
+      const visitorId = readCookie(VISITOR_COOKIE) ?? newVisitorId()
+      setCookie(VISITOR_COOKIE, visitorId)
+      setCookie(REF_COOKIE, refCode)
+
+      // Best-effort click recording; never block the redirect on it.
+      void fetch(`${API_URL}/api/affiliates/visit`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ code: refCode, visitorId }),
+        keepalive: true,
+      }).catch(() => undefined)
+    }
+
+    router.replace('/(auth)/sign-up')
+  }, [code, router])
+
+  // Native (deep link): no cookies to set, just send them to sign-up.
+  if (Platform.OS !== 'web') {
+    return <Redirect href="/(auth)/sign-up" />
+  }
+
+  return (
+    <View className="flex-1 items-center justify-center bg-background">
+      <ActivityIndicator />
+    </View>
+  )
+}

--- a/apps/mobile/lib/__tests__/affiliate-api.test.ts
+++ b/apps/mobile/lib/__tests__/affiliate-api.test.ts
@@ -30,12 +30,14 @@ function makeHttp(scriptedResponses: Record<string, any> = {}) {
 }
 
 describe('buildReferralLink', () => {
+  // Default base comes from EXPO_PUBLIC_WEB_URL, which is unset under test,
+  // so it falls back to the production Studio origin.
   test('uses default base', () => {
-    expect(buildReferralLink('alice')).toBe('https://shogo.ai/r/alice')
+    expect(buildReferralLink('alice')).toBe('https://studio.shogo.ai/r/alice')
   })
 
   test('encodes special characters', () => {
-    expect(buildReferralLink('al ice')).toBe('https://shogo.ai/r/al%20ice')
+    expect(buildReferralLink('al ice')).toBe('https://studio.shogo.ai/r/al%20ice')
   })
 
   test('respects custom base and strips trailing slash', () => {
@@ -77,13 +79,13 @@ describe('affiliateApi.enroll', () => {
       'POST /api/affiliates/enroll': { ok: true, affiliate: { id: 'aff_new' } },
     })
     const res = await affiliateApi.enroll(http, {
-      termsAccepted: true, parentCode: 'alice', code: 'mycode',
+      termsAccepted: true, code: 'mycode',
     })
     expect(res?.ok).toBe(true)
     expect(calls[0]).toEqual({
       method: 'POST',
       url: '/api/affiliates/enroll',
-      body: { termsAccepted: true, parentCode: 'alice', code: 'mycode' },
+      body: { termsAccepted: true, code: 'mycode' },
     })
   })
 })

--- a/apps/mobile/lib/affiliate-api.ts
+++ b/apps/mobile/lib/affiliate-api.ts
@@ -78,7 +78,7 @@ export const affiliateApi = {
 
   async enroll(
     http: HttpClient,
-    body: { termsAccepted: boolean; parentCode?: string | null; code?: string | null },
+    body: { termsAccepted: boolean; code?: string | null },
   ) {
     const res = await http.post<{ ok: boolean; affiliate?: any; error?: any }>(
       '/api/affiliates/enroll',
@@ -126,9 +126,19 @@ export const affiliateApi = {
 }
 
 /**
- * Builds a shareable referral link for the marketing site.
- * Mirrors the Cloudflare Pages Function at shogo-website/functions/r/[code].ts.
+ * Origin the Studio web app is served from, per environment. Mirrors
+ * openWebAppSession.ts so referral links resolve against the same app
+ * that hosts the in-app `/r/[code]` route — and stay within the current
+ * environment (a staging build emits a staging link, not production).
  */
-export function buildReferralLink(code: string, baseUrl = 'https://shogo.ai'): string {
+const REFERRAL_BASE_URL = process.env.EXPO_PUBLIC_WEB_URL ?? 'https://studio.shogo.ai'
+
+/**
+ * Builds a shareable referral link. Defaults to the current
+ * environment's web origin so staging links never point at production;
+ * the `/r/<code>` route (apps/mobile/app/r/[code].tsx) sets the
+ * attribution cookies and redirects to sign-up.
+ */
+export function buildReferralLink(code: string, baseUrl = REFERRAL_BASE_URL): string {
   return `${baseUrl.replace(/\/$/, '')}/r/${encodeURIComponent(code)}`
 }


### PR DESCRIPTION
## Summary

Fixes affiliate referral links that 404'd with Expo's "Unmatched Route", pointed staging users at production, and required manually typing a referrer. Also fixes the `$NaN` on the affiliate dashboard.

- **Environment-correct links**: `buildReferralLink` now defaults to `EXPO_PUBLIC_WEB_URL` (prod `studio.shogo.ai`, staging `studio.staging.shogo.ai`) so staging links stay on staging and point at the app that hosts the route.
- **`/r/<code>` route** (`apps/mobile/app/r/[code].tsx`): sets the `__shogo_ref` / `__shogo_ref_visitor` first-party cookies, best-effort records a click, then redirects to sign-up — no more Unmatched Route.
- **Auto-derived upline**: `enrollAffiliate` derives the parent from the user's `AffiliateAttribution` (the referral cookie), best-effort, instead of a manually typed code. The manual "Referred by" input and `parentCode` are removed.
- **Cookie-based attribution**: `resolveAttributionForUser` falls back to attributing directly from the `__shogo_ref` code cookie when there's no click row; the signup hook fires on either cookie. New public `POST /api/affiliates/visit` records browser clicks without the internal secret.
- **Dashboard `$NaN` fix**: `/api/affiliates/me` now maps the field names the mobile dashboard reads (`pendingPayoutCents`, `lifetimePayoutCents`, `clicksLast30d`, `signupsLast30d`, `commissionsLast30d`).

## Test plan

- [x] `affiliate.service.test.ts` (56) — derived parent, code-cookie fallback, summary
- [x] `affiliates.test.ts` (50) — `/visit` endpoint, enroll without `parentCode`
- [x] `affiliate-signup-attribution.test.ts` (10) — code-only attribution
- [x] All remaining affiliate API suites pass (188 total, run per-file)
- [x] `affiliate-api.test.ts` (11) mobile client — new default link base
- [ ] Manual: visit `/r/<code>` on web → cookies set → redirect to sign-up → signup attributes → enroll shows correct upline
- [ ] Manual: confirm a staging-generated link stays on staging

Note: API test files must be run per-file; running all in one `bun test` invocation triggers a pre-existing cross-file `mock.module` poisoning issue documented in the route test header.

Made with [Cursor](https://cursor.com)