### PR TITLE
fix(web): mirror Monaco /vs bundle in web Docker build so IDE editors load

### DIFF
--- a/apps/mobile/Dockerfile
+++ b/apps/mobile/Dockerfile
@@ -56,10 +56,29 @@ USER appuser
 # generate:routes). Mobile source is shallow enough to copy directly.
 COPY --chown=appuser:appgroup apps/mobile ./apps/mobile
 
+# Mirror Monaco's self-hosted AMD bundle (node_modules/monaco-editor/min/vs)
+# into public/vs BEFORE exporting. `expo export` copies public/ into dist/,
+# so this is what lands `dist/vs/loader.js` at the same origin as the app
+# shell. CodeEditor.tsx pins `@monaco-editor/loader` at `/vs` (not the CDN)
+# to satisfy the desktop CSP and work offline — if /vs is missing, the
+# loader's `/vs/loader.js` request falls through nginx's SPA fallback to
+# index.html, the browser gets HTML for a <script>, and Monaco fails with
+# "Monaco initialization: error: Event" (blank IDE editors). The `build` npm
+# script chains this same step; the Docker build must not drift from it.
+WORKDIR /app/apps/mobile
+RUN node scripts/copy-monaco-vs.mjs
+
 # Build Expo web export (Metro bundler outputs to apps/mobile/dist/).
 # packages/*/dist are already pre-built in workspace-deps.
-WORKDIR /app/apps/mobile
 RUN npx expo export --platform web
+
+# Fail the build loudly if the self-hosted Monaco bundle didn't make it into
+# the export. Mirrors the integrity guard in apps/desktop/scripts/sync-web.mjs
+# so we never ship a Monaco-less web image again (the blank-IDE / "Monaco
+# initialization: error: Event" regression). Catches both a skipped copy step
+# AND a future Expo upgrade that stops copying public/ into dist/.
+RUN test -f dist/vs/loader.js && test -f dist/vs/editor/editor.main.js \
+    || (echo "ERROR: Monaco /vs assets missing from dist/ — IDE editors would be blank. Did scripts/copy-monaco-vs.mjs run and did expo export copy public/?" && exit 1)
 
 # Inject analytics scripts into the exported HTML (Expo "single" mode strips
 # <script> tags from +html.tsx, so we inject them post-export).

--- a/apps/mobile/scripts/copy-monaco-vs.mjs
+++ b/apps/mobile/scripts/copy-monaco-vs.mjs
@@ -31,30 +31,43 @@
  */
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import { createRequire } from 'node:module';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const APP_ROOT = path.resolve(__dirname, '..');
 
-const SOURCE_VS = path.join(APP_ROOT, 'node_modules', 'monaco-editor', 'min', 'vs');
-const SOURCE_PKG = path.join(APP_ROOT, 'node_modules', 'monaco-editor', 'package.json');
-const DEST_VS = path.join(APP_ROOT, 'public', 'vs');
-const VERSION_STAMP = path.join(DEST_VS, '.monaco-editor-version');
-
 function fail(msg) {
   console.error(`[copy-monaco-vs] ${msg}`);
   process.exit(1);
 }
 
-if (!existsSync(SOURCE_VS)) {
-  // `monaco-editor` is a direct dep of @shogo/mobile — if it's missing the
-  // workspace was never installed. Surface that loud instead of silently
-  // shipping an IDE-less build.
-  fail(`source not found: ${SOURCE_VS} — run \`bun install\` from the repo root.`);
+// Resolve `monaco-editor` via Node's module resolution rather than assuming a
+// fixed `apps/mobile/node_modules` layout. Bun's workspace install hoists
+// shared deps to the repo-root `node_modules`, so the package may live at
+// `/app/node_modules/monaco-editor` (root) OR `apps/mobile/node_modules`
+// (symlink). Hard-coding the latter made the Docker web build fail with
+// "source not found" whenever hoisting won — keep it robust by letting the
+// resolver find the real install location.
+const require = createRequire(import.meta.url);
+let SOURCE_PKG;
+try {
+  SOURCE_PKG = require.resolve('monaco-editor/package.json', { paths: [APP_ROOT] });
+} catch {
+  // `monaco-editor` is a direct dep of @shogo/mobile — if it can't be
+  // resolved the workspace was never installed. Surface that loud instead of
+  // silently shipping an IDE-less build.
+  fail('cannot resolve `monaco-editor` — run `bun install` from the repo root.');
 }
-if (!existsSync(SOURCE_PKG)) {
-  fail(`source package.json not found: ${SOURCE_PKG}`);
+
+const MONACO_ROOT = dirname(SOURCE_PKG);
+const SOURCE_VS = path.join(MONACO_ROOT, 'min', 'vs');
+const DEST_VS = path.join(APP_ROOT, 'public', 'vs');
+const VERSION_STAMP = path.join(DEST_VS, '.monaco-editor-version');
+
+if (!existsSync(SOURCE_VS)) {
+  fail(`source not found: ${SOURCE_VS} — reinstall \`monaco-editor\` (\`bun install\`).`);
 }
 
 const monacoVersion = JSON.parse(readFileSync(SOURCE_PKG, 'utf8')).version;


### PR DESCRIPTION
Fixes #735
Jira: [SHOG-703](https://odin-ai.atlassian.net/browse/SHOG-703)

## Summary

IDE file tabs on the deployed web app (e.g. `studio.staging.shogo.ai`) are stuck on **"Loading…"** and the console logs:

```
Monaco initialization: error: Event {type: 'error', target: script, …}
Uncaught (in promise) Event {type: 'error', target: script, …}
```

Both are the same script-load failure for Monaco's AMD loader. The web Docker build was shipping a bundle **without** Monaco's self-hosted `/vs` assets.

## Root cause

`CodeEditor.tsx` pins `@monaco-editor/loader` at the same-origin path `/vs` (not the CDN) to satisfy the desktop CSP and work offline:

```ts
loader.config({ paths: { vs: "/vs" } });
```

`/vs` is gitignored and generated at build time by `scripts/copy-monaco-vs.mjs` (mirrors `node_modules/monaco-editor/min/vs` → `public/vs/`); `expo export` then copies `public/` into `dist/`. The canonical `build` script chains them:

```
"build": "node scripts/copy-monaco-vs.mjs && expo export --platform web"
```

**`apps/mobile/Dockerfile` ran `npx expo export` directly, skipping the copy step**, so `dist/vs/` was never produced. At runtime `/vs/loader.js` falls through nginx's SPA fallback (`try_files $uri /index.html`) and returns HTML; with `X-Content-Type-Options: nosniff` the browser refuses to execute it as a script → the loader rejects → blank editor.

This is the same "Monaco-less bundle" regression previously fixed on the desktop/root build paths (desktop v1.8.12); the web Dockerfile was the last path still drifting from the `build` script.

## Changes

- **`apps/mobile/Dockerfile`**
  - Run `node scripts/copy-monaco-vs.mjs` before `expo export --platform web`.
  - Add a post-export integrity guard asserting `dist/vs/loader.js` and `dist/vs/editor/editor.main.js` exist (mirrors `apps/desktop/scripts/sync-web.mjs`), so a missing `/vs` **fails the build** instead of silently shipping a blank IDE — also catches a future Expo upgrade that stops copying `public/`.
- **`apps/mobile/scripts/copy-monaco-vs.mjs`**
  - Resolve `monaco-editor` via Node module resolution (`createRequire(import.meta.url).resolve('monaco-editor/package.json', { paths: [APP_ROOT] })`) instead of a hard-coded `apps/mobile/node_modules` path. Bun's workspace install hoists shared deps to the repo-root `node_modules`, so the old path could have failed with "source not found" in the container.

No application/runtime code changed — the IDE logic was correct; it was being served a build missing its Monaco assets.

## Why this is the root fix (not a patch)

The bug is build-path drift: two ways to build the web bundle (`build` script vs. Dockerfile) diverged. The fix re-aligns the Dockerfile with the canonical build **and** adds a fail-loud guard so the two can't silently drift again. The script hardening removes a latent hoisting-dependent failure so the guard never trips for the wrong reason.

## Test plan

- [ ] `docker build` the web image and confirm the build runs `copy-monaco-vs` and passes the `/vs` integrity assertion.
- [ ] Confirm `dist/vs/loader.js` + `dist/vs/editor/editor.main.js` are present in the image.
- [ ] Deploy to staging; open a project IDE and a file tab — editor renders, no `Monaco initialization: error` in console.
- [ ] `GET /vs/loader.js` returns `200` with `Content-Type: application/javascript` (not `text/html`).
- [ ] Sanity-check desktop renderer (built from the same web image) still loads Monaco.

## Deploy notes

- Requires rebuild + redeploy of `shogo-web`. CI auto-detects the change (paths under `apps/mobile/` set `web_changed=true` in `deploy.yml`). Editing the Dockerfile busts the layer cache from the export step onward, so the new copy step is guaranteed to run.

Made with [Cursor](https://cursor.com)