### PR TITLE
Fix desktop Workspace Trust controls for local folders

### DIFF
--- a/apps/api/src/__tests__/local-projects-v4.test.ts
+++ b/apps/api/src/__tests__/local-projects-v4.test.ts
@@ -403,3 +403,105 @@ describe('localProjectsRoutes other routes', () => {
     expect([404, 500]).toContain(res.status)
   })
 })
+
+describe('localProjectsRoutes GET /:id', () => {
+  test('401 unauthenticated', async () => {
+    const app = appNoAuth()
+    const res = await app.request('/proj-x')
+    expect(res.status).toBe(401)
+  })
+
+  test('404 when project missing', async () => {
+    const app = appWithAuth()
+    const res = await app.request('/missing-id')
+    expect(res.status).toBe(404)
+  })
+
+  test('200 returns { project } with projectFolders, workingMode, trustLevel', async () => {
+    projects.set('proj-x', {
+      id: 'proj-x',
+      name: 'External One',
+      workingMode: 'external',
+      trustLevel: 'restricted',
+      projectFolders: [{ id: 'folder-1', path: rootDir, isPrimary: true }],
+    })
+    const app = appWithAuth()
+    const res = await app.request('/proj-x')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as any
+    // The folder UI reads `body.project.*` — not the `{ ok, data }`
+    // envelope the generated route uses. Lock that contract in.
+    expect(body.project?.id).toBe('proj-x')
+    expect(body.project?.workingMode).toBe('external')
+    expect(body.project?.trustLevel).toBe('restricted')
+    expect(Array.isArray(body.project?.projectFolders)).toBe(true)
+    expect(body.project.projectFolders[0]?.isPrimary).toBe(true)
+  })
+
+  test('static GET /recent still wins over the /:id param route', async () => {
+    const app = appWithAuth()
+    const res = await app.request('/recent')
+    expect([200, 500]).toContain(res.status)
+    if (res.status === 200) {
+      const body = (await res.json()) as any
+      // /recent returns { projects: [...] }, never a single { project }.
+      expect(Array.isArray(body.projects)).toBe(true)
+      expect(body.project).toBeUndefined()
+    }
+  })
+})
+
+describe('localProjectsRoutes POST /:id/trust write + refresh ping', () => {
+  test('200 flips trustLevel restricted -> trusted and persists', async () => {
+    projects.set('proj-trust', {
+      id: 'proj-trust',
+      workingMode: 'external',
+      trustLevel: 'restricted',
+      projectFolders: [],
+    })
+    const app = appWithAuth()
+    const res = await app.request('/proj-trust/trust', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ trusted: true }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as any
+    expect(body.project?.trustLevel).toBe('trusted')
+    expect(projects.get('proj-trust')?.trustLevel).toBe('trusted')
+  })
+
+  test('200 flips trustLevel trusted -> restricted (revoke)', async () => {
+    projects.set('proj-trust2', {
+      id: 'proj-trust2',
+      workingMode: 'external',
+      trustLevel: 'trusted',
+      projectFolders: [],
+    })
+    const app = appWithAuth()
+    const res = await app.request('/proj-trust2/trust', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ trusted: false }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as any
+    expect(body.project?.trustLevel).toBe('restricted')
+  })
+
+  test('400 when `trusted` is not a boolean', async () => {
+    projects.set('proj-trust3', {
+      id: 'proj-trust3',
+      workingMode: 'external',
+      trustLevel: 'restricted',
+      projectFolders: [],
+    })
+    const app = appWithAuth()
+    const res = await app.request('/proj-trust3/trust', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ trusted: 'yes' }),
+    })
+    expect(res.status).toBe(400)
+  })
+})

--- a/apps/api/src/routes/local-projects.ts
+++ b/apps/api/src/routes/local-projects.ts
@@ -928,6 +928,36 @@ export function localProjectsRoutes(): Hono {
     return c.json({ projects: ranked })
   })
 
+  /**
+   * GET /:id — relation-loaded project for the desktop Folders/Workspace
+   * panel and the project layout's folder hydration.
+   *
+   * Why this exists separately from the generated `GET /api/projects/:id`:
+   * that route returns the bare scalar row wrapped in a `{ ok, data }`
+   * envelope and does NOT honor `?include=projectFolders`, so the folder
+   * UI never sees linked folders and (because callers were reading the
+   * wrong envelope key) mis-read `workingMode` as `undefined` and fell
+   * back to the dead "Managed project" empty state. This route returns
+   * the `projectFolders` relation in the `{ project }` shape the folder /
+   * trust UI already expects, keeping every desktop folder read on one
+   * consistent contract.
+   *
+   * Registered after `/recent` so the static route still wins; Hono
+   * prioritizes static segments over `:id` regardless, but ordering keeps
+   * the intent obvious.
+   */
+  router.get('/:id', async (c) => {
+    const auth = c.get('auth' as never) as { userId?: string } | undefined
+    if (!auth?.userId) return c.json({ error: 'unauthenticated' }, 401)
+    const projectId = c.req.param('id')
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+      include: { projectFolders: true },
+    })
+    if (!project) return c.json({ error: 'not_found' }, 404)
+    return c.json({ project })
+  })
+
   return router
 }
 

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -540,6 +540,84 @@ export default observer(function ProjectLayout() {
     }
   }, [projectId])
 
+  // Top-bar trust toggle: flips between restricted and trusted based on
+  // the current level. Restricted -> trust this folder; trusted ->
+  // restrict it again. Reuses the same /trust route as the prompt and
+  // updates local state from the returned (folder-included) project.
+  const handleToggleTrust = useCallback(async () => {
+    if (!projectId) return
+    const next = projectTrustLevel !== 'trusted'
+    setTrustSubmitting(true)
+    try {
+      const res = await fetch(
+        `${API_URL}/api/local/projects/${encodeURIComponent(projectId)}/trust`,
+        {
+          method: 'POST',
+          credentials: Platform.OS === 'web' ? 'include' : 'omit',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ trusted: next }),
+        },
+      )
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        Alert.alert('Could not update trust', String(body?.error ?? `HTTP ${res.status}`))
+        return
+      }
+      const body = await res.json().catch(() => ({}))
+      if (body?.project) setProject(body.project)
+    } catch (err: any) {
+      Alert.alert('Could not update trust', err?.message ?? String(err))
+    } finally {
+      setTrustSubmitting(false)
+    }
+  }, [projectId, projectTrustLevel])
+
+  // Single source for refreshing the project WITH its projectFolders
+  // relation + current workingMode / trustLevel. The generated
+  // /api/projects/:id route the MST collection store uses omits the
+  // folders relation (and wraps its body in `{ ok, data }`), so we read
+  // the local-projects route — which returns a `{ project }` envelope
+  // including folders — and merge the result into local state.
+  // Best-effort: no-op outside SHOGO_LOCAL_MODE (the route 404s).
+  const refreshLocalProject = useCallback(async () => {
+    if (!projectId) return
+    try {
+      const res = await fetch(
+        `${API_URL}/api/local/projects/${encodeURIComponent(projectId)}`,
+        { credentials: Platform.OS === 'web' ? 'include' : 'omit' },
+      )
+      if (!res.ok) return
+      const body = await res.json().catch(() => null)
+      const lp = body?.project
+      if (!lp) return
+      setProject((prev: any) => {
+        if (!prev) return prev
+        return {
+          ...prev,
+          workingMode: lp.workingMode ?? prev.workingMode,
+          trustLevel: lp.trustLevel ?? prev.trustLevel,
+          projectFolders: Array.isArray(lp.projectFolders)
+            ? lp.projectFolders
+            : prev.projectFolders,
+        }
+      })
+    } catch {
+      /* best-effort; managed/cloud builds have no local-projects route */
+    }
+  }, [projectId])
+
+  // Hydrate projectFolders (and reconcile workingMode/trustLevel) once
+  // the project row has loaded. Without this, `primaryFolderPath` and the
+  // TrustPrompt would see an empty folder list because the collection
+  // store's loadById can't include the relation. Runs once per projectId.
+  const foldersHydratedRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!projectId || !project?.id) return
+    if (foldersHydratedRef.current === projectId) return
+    foldersHydratedRef.current = projectId
+    void refreshLocalProject()
+  }, [projectId, project?.id, refreshLocalProject])
+
   // Auto-show the trust prompt the first time an external + restricted
   // project lands on this layout. We track this with a ref so the modal
   // doesn't re-pop after the user has dismissed it once per session.
@@ -2114,6 +2192,11 @@ export default observer(function ProjectLayout() {
     hiddenTabs,
     canvasEnabled,
     activeMode,
+    // Workspace Trust badge (external/folder-linked projects only).
+    workingMode: isExternalProject ? 'external' as const : 'managed' as const,
+    trustLevel: projectTrustLevel,
+    onToggleTrust: handleToggleTrust,
+    trustBusy: trustSubmitting,
     showChatSessions: isChatFullscreen ? false : showChatSessions,
     isChatCollapsed: isChatFullscreen ? true : chatCollapsed,
     onChatSessionsToggle: isChatFullscreen ? undefined : () => setShowChatSessions((s: boolean) => !s),
@@ -2549,41 +2632,31 @@ export default observer(function ProjectLayout() {
             </PanelErrorBoundary>
             <PanelErrorBoundary panelName="Settings">
               {(() => {
-                // Folders' onChange refreshes the project so workingMode /
-                // trust / folders changes propagate without a full reload.
+                // Folders' onChange refreshes the project (with folders +
+                // workingMode + trustLevel) so trust / folder changes
+                // propagate without a full reload.
                 const reloadProject = () => {
-                  if (!projectId) return
-                  void fetch(
-                    `${API_URL}/api/projects/${encodeURIComponent(projectId)}?include=projectFolders`,
-                    { credentials: Platform.OS === 'web' ? 'include' : 'omit' },
-                  )
-                    .then((r) => (r.ok ? r.json() : null))
-                    .then((data) => {
-                      const next = data?.project ?? data
-                      if (next) setProject(next)
-                    })
-                    .catch(() => {})
+                  void refreshLocalProject()
                 }
                 const workspaceItems: SettingsSectionItem[] = []
-                // Folders is only meaningful for external projects (it lets
-                // the user pick which local directories the agent has
-                // access to). Managed projects don't expose this knob.
-                if (isExternalProject) {
-                  workspaceItems.push({
-                    id: 'folders',
-                    label: 'Folders',
-                    icon: FolderTree,
-                    render: () => (
-                      <PanelErrorBoundary panelName="Folders">
-                        <FoldersPanel
-                          visible
-                          projectId={projectId!}
-                          onChange={reloadProject}
-                        />
-                      </PanelErrorBoundary>
-                    ),
-                  })
-                }
+                // Always expose the Folders/Workspace panel. For external
+                // projects it manages linked folders + the trust toggle;
+                // for managed projects it renders an informational state
+                // with an "Open a folder" CTA instead of a dead end.
+                workspaceItems.push({
+                  id: 'folders',
+                  label: 'Folders',
+                  icon: FolderTree,
+                  render: () => (
+                    <PanelErrorBoundary panelName="Folders">
+                      <FoldersPanel
+                        visible
+                        projectId={projectId!}
+                        onChange={reloadProject}
+                      />
+                    </PanelErrorBoundary>
+                  ),
+                })
                 // Checkpoints on web lives in the IDE's Source Control
                 // activity-bar entry; native users still reach it from
                 // Settings.

--- a/apps/mobile/components/project/ProjectTopBar.tsx
+++ b/apps/mobile/components/project/ProjectTopBar.tsx
@@ -68,6 +68,8 @@ import {
   FolderTree,
   Globe,
   History,
+  ShieldAlert,
+  ShieldCheck,
 } from 'lucide-react-native'
 import { cn, Badge } from '@shogo/shared-ui/primitives'
 import type { UsageWindows } from '@shogo/shared-app/hooks'
@@ -134,6 +136,17 @@ export interface ProjectTopBarProps {
   hiddenTabs?: string[]
   canvasEnabled?: boolean
   activeMode?: 'none' | 'canvas' | 'app'
+  /**
+   * Workspace Trust controls (external / folder-linked projects only).
+   * When `workingMode === 'external'` a persistent shield badge is shown
+   * that flips `trustLevel` via `onToggleTrust`, so users can move
+   * between restricted and trusted after first startup without opening
+   * the Folders panel. Omitted/undefined on managed projects → no badge.
+   */
+  workingMode?: 'managed' | 'external'
+  trustLevel?: 'restricted' | 'trusted'
+  onToggleTrust?: () => void
+  trustBusy?: boolean
   narrowActiveTab?: 'chat' | 'canvas'
   onNarrowTabChange?: (tab: 'chat' | 'canvas') => void
   narrowPreviewTab?: string
@@ -220,6 +233,72 @@ function BarIconButton({
   )
 }
 
+/**
+ * Persistent Workspace Trust badge for external (folder-linked) projects.
+ * Restricted → amber shield + "Restricted"; trusted → emerald shield +
+ * "Trusted". Tapping flips the trust level via `onToggle`.
+ */
+function TrustBadge({
+  trustLevel,
+  onToggle,
+  busy,
+  compact,
+}: {
+  trustLevel: 'restricted' | 'trusted'
+  onToggle: () => void
+  busy?: boolean
+  compact?: boolean
+}) {
+  const restricted = trustLevel === 'restricted'
+  const Icon = restricted ? ShieldAlert : ShieldCheck
+  const label = restricted ? 'Restricted' : 'Trusted'
+  const tip = restricted
+    ? 'Workspace is restricted — tap to trust this folder (enables edits and shell)'
+    : 'Workspace is trusted — tap to restrict (blocks edits and shell)'
+  const tipRef = useWebTitle(tip)
+
+  if (compact) {
+    return (
+      <Pressable
+        ref={tipRef}
+        onPress={onToggle}
+        disabled={busy}
+        className={cn(
+          'h-6 w-6 items-center justify-center rounded-md',
+          busy ? 'opacity-60' : 'active:bg-muted',
+        )}
+        accessibilityLabel={tip}
+      >
+        <Icon size={13} className={restricted ? 'text-amber-500' : 'text-emerald-500'} />
+      </Pressable>
+    )
+  }
+
+  return (
+    <Pressable
+      ref={tipRef}
+      onPress={onToggle}
+      disabled={busy}
+      className={cn(
+        'h-7 flex-row items-center gap-1 px-2 rounded-md border',
+        restricted ? 'border-amber-400/50' : 'border-emerald-400/40',
+        busy ? 'opacity-60' : 'active:bg-muted',
+      )}
+      accessibilityLabel={tip}
+    >
+      <Icon size={12} className={restricted ? 'text-amber-500' : 'text-emerald-500'} />
+      <Text
+        className={cn(
+          'text-[10px] font-medium',
+          restricted ? 'text-amber-600 dark:text-amber-400' : 'text-emerald-600 dark:text-emerald-400',
+        )}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  )
+}
+
 export function ProjectTopBar({
   projectName,
   projectId,
@@ -242,6 +321,10 @@ export function ProjectTopBar({
   hiddenTabs = [],
   canvasEnabled = true,
   activeMode = 'canvas',
+  workingMode,
+  trustLevel,
+  onToggleTrust,
+  trustBusy = false,
   narrowActiveTab,
   onNarrowTabChange,
   narrowPreviewTab,
@@ -311,6 +394,11 @@ export function ProjectTopBar({
   }, [activeChatSessionId, chatRenameValue, onRenameChat])
 
   const isCanvasActive = activeTab === 'canvas'
+
+  // Workspace Trust badge: external (folder-linked) projects only, and
+  // only when the parent wired up a toggle handler + a known trust level.
+  const showTrustBadge =
+    workingMode === 'external' && !!trustLevel && typeof onToggleTrust === 'function'
 
   const visibleTabs = AGENT_TABS.filter(tab => !hiddenTabs.includes(tab.id))
   // Every remaining tab is primary now that secondary controls live behind
@@ -455,6 +543,15 @@ export function ProjectTopBar({
         </View>
 
         <View className="flex-1" />
+
+        {showTrustBadge && (
+          <TrustBadge
+            trustLevel={trustLevel!}
+            onToggle={onToggleTrust!}
+            busy={trustBusy}
+            compact
+          />
+        )}
 
         {onOpenChatSessions && narrowActiveTab === 'chat' && (
           <BarIconButton
@@ -753,7 +850,14 @@ export function ProjectTopBar({
         )}
 
         {/* Right actions */}
-        <View className="flex-row items-center gap-0.5">
+        <View className="flex-row items-center gap-1">
+          {showTrustBadge && (
+            <TrustBadge
+              trustLevel={trustLevel!}
+              onToggle={onToggleTrust!}
+              busy={trustBusy}
+            />
+          )}
           {isCanvasActive && (
             <PublishDropdown projectId={projectId} projectName={projectName} />
           )}

--- a/apps/mobile/components/project/panels/FoldersPanel.tsx
+++ b/apps/mobile/components/project/panels/FoldersPanel.tsx
@@ -8,16 +8,12 @@
  * native picker, mark a folder primary (where `.shogo/` lives), or
  * remove non-primary folders.
  *
- * Banner behaviour:
- *   - When `runtimeEnabled === false`, render an "Enable preview" prompt
- *     explaining that the Vite/Metro dev server is off by default and
- *     offering a switch to opt in. We deliberately don't auto-run
- *     `bun install` for the user — see plan §5, "respect their package
- *     manager".
- *   - When the project isn't external mode at all, render an
- *     informational empty state instead of nothing — saves the user
- *     wondering why the panel is blank if they navigated here from a
- *     managed project.
+ * Also surfaces an "External preview URL" control so users who run their
+ * own dev server (Vite/Metro/etc.) can tell Shogo which local URL the
+ * "Preview" tab should embed. When the project isn't external mode at
+ * all, render an informational empty state instead of nothing — saves
+ * the user wondering why the panel is blank if they navigated here from
+ * a managed project.
  */
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { ActivityIndicator, Platform, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
@@ -32,10 +28,10 @@ import {
   Trash2,
   ShieldAlert,
   ShieldCheck,
-  PlaySquare,
 } from 'lucide-react-native'
 import { useDomainHttp } from '../../../contexts/domain'
 import { API_URL } from '../../../lib/api'
+import { useOpenLocalFolder } from '../useOpenLocalFolder'
 
 interface ProjectFolder {
   id: string
@@ -49,7 +45,6 @@ interface ProjectShape {
   id: string
   name?: string
   workingMode?: 'managed' | 'external'
-  runtimeEnabled?: boolean
   trustLevel?: 'trusted' | 'restricted'
   projectFolders?: ProjectFolder[]
 }
@@ -90,17 +85,28 @@ export function FoldersPanel({ projectId, visible, onChange }: FoldersPanelProps
       | null
   }, [])
 
+  // "Open a folder" flow for the managed-project empty state — creates a
+  // new external (folder-linked) project and navigates to it. workspaceId
+  // is left undefined so the API binds it to the user's personal
+  // workspace (single-tenant local mode).
+  const { openFolder, isPicking, isAvailable: canOpenFolder } = useOpenLocalFolder({
+    workspaceId: undefined,
+  })
+
   const refresh = useCallback(async () => {
     if (!projectId) return
     setIsLoading(true)
     setError(null)
     try {
-      // The generated /api/projects/:id route already returns
-      // projectFolders via the include relation (model registered in
-      // shogo.config.json). We use the raw fetch path to bypass any
-      // collection store caching — folder state must reflect on the
-      // next render.
-      const res = await fetch(`${API_URL}/api/projects/${encodeURIComponent(projectId)}?include=projectFolders`, {
+      // Read from the local-projects route, which returns the
+      // `projectFolders` relation alongside `workingMode` / `trustLevel`
+      // in a `{ project }` envelope. The generated `/api/projects/:id`
+      // route does NOT include the folders relation and wraps its body in
+      // `{ ok, data }` — reading that here is what made an external
+      // project mis-render as "Managed project" (workingMode read as
+      // undefined). Raw fetch (not the collection store) so folder state
+      // reflects on the next render without cache staleness.
+      const res = await fetch(`${API_URL}/api/local/projects/${encodeURIComponent(projectId)}`, {
         credentials: Platform.OS === 'web' ? 'include' : 'omit',
       })
       if (!res.ok) {
@@ -108,7 +114,7 @@ export function FoldersPanel({ projectId, visible, onChange }: FoldersPanelProps
         return
       }
       const data: any = await res.json()
-      setProject(data?.project ?? data ?? null)
+      setProject(data?.project ?? null)
     } catch (err: any) {
       setError(err?.message ?? 'Failed to load folders')
     } finally {
@@ -264,30 +270,6 @@ export function FoldersPanel({ projectId, visible, onChange }: FoldersPanelProps
     [http, projectId, refresh, onChange],
   )
 
-  const handleEnablePreview = useCallback(async () => {
-    setBusy('runtime')
-    try {
-      // No dedicated route yet — flip `runtimeEnabled` via the generated
-      // /api/projects/:id PATCH route (Project model owns the column).
-      await http.patch(`/api/projects/${encodeURIComponent(projectId)}`, {
-        runtimeEnabled: true,
-      })
-      // Kick a runtime start so the agent picks up Vite/Metro on next
-      // chat turn without waiting for the user to send a message.
-      try {
-        await http.post(`/api/projects/${encodeURIComponent(projectId)}/runtime/start`, {})
-      } catch {
-        /* best-effort */
-      }
-      await refresh()
-      onChange?.()
-    } catch (err: any) {
-      setError(err?.message ?? 'Failed to enable preview')
-    } finally {
-      setBusy(null)
-    }
-  }, [http, projectId, refresh, onChange])
-
   const handleToggleTrust = useCallback(async () => {
     if (!project) return
     const next = project.trustLevel === 'trusted' ? false : true
@@ -353,8 +335,31 @@ export function FoldersPanel({ projectId, visible, onChange }: FoldersPanelProps
           </Text>
           <Text className="text-sm text-muted-foreground text-center">
             This project lives in Shogo's managed workspace, not a folder on your machine.
-            Folder linking is available for "Open Folder…" projects only.
+            Folder linking and Workspace Trust apply to "Open Folder…" projects.
           </Text>
+          {canOpenFolder ? (
+            <Pressable
+              onPress={() => void openFolder()}
+              disabled={isPicking}
+              className={cn(
+                'mt-4 flex-row items-center gap-1.5 rounded-lg px-3.5 py-2',
+                isPicking ? 'bg-muted' : 'bg-primary active:opacity-80',
+              )}
+            >
+              <FolderPlus
+                size={14}
+                className={isPicking ? 'text-muted-foreground' : 'text-primary-foreground'}
+              />
+              <Text
+                className={cn(
+                  'text-xs font-medium',
+                  isPicking ? 'text-muted-foreground' : 'text-primary-foreground',
+                )}
+              >
+                {isPicking ? 'Opening\u2026' : 'Open a folder'}
+              </Text>
+            </Pressable>
+          ) : null}
         </View>
       ) : (
         <ScrollView className="flex-1" contentContainerClassName="pb-6">
@@ -378,7 +383,7 @@ export function FoldersPanel({ projectId, visible, onChange }: FoldersPanelProps
                   busy === 'trust' ? 'opacity-60' : 'active:opacity-80',
                 )}
               >
-                <Text className="text-[11px] font-medium text-white">Trust</Text>
+                <Text className="text-[11px] font-medium text-white">Trust folder</Text>
               </Pressable>
             </View>
           ) : (
@@ -392,34 +397,10 @@ export function FoldersPanel({ projectId, visible, onChange }: FoldersPanelProps
                 disabled={busy === 'trust'}
                 className="active:opacity-60"
               >
-                <Text className="text-[11px] text-muted-foreground underline">Revoke</Text>
+                <Text className="text-[11px] text-muted-foreground underline">Restrict</Text>
               </Pressable>
             </View>
           )}
-
-          {/* Preview opt-in banner. */}
-          {project?.runtimeEnabled === false ? (
-            <View className="mx-4 mt-3 rounded-lg border border-border bg-card px-3 py-3 flex-row items-start gap-2">
-              <PlaySquare size={16} className="text-muted-foreground mt-0.5" />
-              <View className="flex-1">
-                <Text className="text-xs font-medium text-foreground">Live preview is off</Text>
-                <Text className="text-[11px] text-muted-foreground mt-0.5">
-                  Shogo won't run Vite or Metro inside your repo unless you opt in. We respect
-                  your existing package manager.
-                </Text>
-              </View>
-              <Pressable
-                onPress={handleEnablePreview}
-                disabled={busy === 'runtime'}
-                className={cn(
-                  'rounded-md bg-primary px-2.5 py-1',
-                  busy === 'runtime' ? 'opacity-60' : 'active:opacity-80',
-                )}
-              >
-                <Text className="text-[11px] font-medium text-primary-foreground">Enable preview</Text>
-              </Pressable>
-            </View>
-          ) : null}
 
           {/* External preview URL — for "I'm running my own dev server"
               workflows. The "Preview" tab embeds whatever URL is saved

--- a/apps/mobile/components/project/panels/__tests__/FoldersPanel.rtl.test.tsx
+++ b/apps/mobile/components/project/panels/__tests__/FoldersPanel.rtl.test.tsx
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * RTL tests for FoldersPanel — the desktop Workspace/Folders panel.
+ *
+ * Locks in the bug fixes from the "Trust folder" work:
+ *   - The panel reads the local-projects `{ project }` envelope (NOT the
+ *     generated `{ ok, data }` shape). An external project must render
+ *     the trust toggle, NOT the dead "Managed project" empty state.
+ *   - The trust toggle posts `{ trusted: true }` to the /trust route.
+ *   - A genuinely managed project still renders the informational state.
+ *
+ * Dependencies that need a live context / router (`useDomainHttp`,
+ * `useOpenLocalFolder`), the API base URL, and the bare `react-native`
+ * import are mocked so the panel can render in isolation (react-native ->
+ * react-native-web, the same renderer used on web/desktop). Its data
+ * fetch is driven via a stubbed global fetch.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import * as ReactNativeWeb from 'react-native-web'
+
+// No Metro/webpack alias in the test runtime, so map the bare
+// 'react-native' specifier to react-native-web before importing the SUT.
+mock.module('react-native', () => ReactNativeWeb)
+
+// lucide-react-native pulls in react-native-svg (which itself imports the
+// flow-typed `react-native` entry that bun can't parse). We don't assert
+// on icons, so stub the named exports FoldersPanel uses with no-ops.
+const StubIcon = () => null
+mock.module('lucide-react-native', () => ({
+  __esModule: true,
+  Folder: StubIcon,
+  FolderPlus: StubIcon,
+  FolderTree: StubIcon,
+  Globe: StubIcon,
+  Star: StubIcon,
+  StarOff: StubIcon,
+  Trash2: StubIcon,
+  ShieldAlert: StubIcon,
+  ShieldCheck: StubIcon,
+  PlaySquare: StubIcon,
+}))
+
+// shared-ui primitives only contributes `cn` here.
+mock.module('@shogo/shared-ui/primitives', () => ({
+  cn: (...args: any[]) => args.filter(Boolean).join(' '),
+}))
+
+const httpPost = mock(async () => ({ data: {} }))
+const httpDelete = mock(async () => ({ data: {} }))
+const httpPatch = mock(async () => ({ data: {} }))
+
+mock.module('../../../../contexts/domain', () => ({
+  useDomainHttp: () => ({
+    post: httpPost,
+    delete: httpDelete,
+    patch: httpPatch,
+    get: mock(async () => ({ data: {} })),
+  }),
+}))
+
+mock.module('../../../../lib/api', () => ({
+  API_URL: 'http://test.local',
+}))
+
+mock.module('../../useOpenLocalFolder', () => ({
+  useOpenLocalFolder: () => ({
+    openFolder: mock(async () => {}),
+    isPicking: false,
+    isAvailable: false,
+  }),
+}))
+
+// Import the SUT AFTER the mocks are registered (top-level await — same
+// ordering guarantee the other mobile lib tests rely on).
+const { FoldersPanel } = await import('../FoldersPanel')
+
+// The project the stubbed fetch returns for GET /api/local/projects/:id.
+let currentProject: any = null
+const origFetch = globalThis.fetch
+
+beforeEach(() => {
+  httpPost.mockClear()
+  httpDelete.mockClear()
+  httpPatch.mockClear()
+  currentProject = null
+  globalThis.fetch = (async (input: any) => {
+    const url = typeof input === 'string' ? input : String(input?.url ?? input)
+    if (url.includes('/external-preview')) {
+      return new Response(JSON.stringify({ savedUrl: null, detectedUrl: null }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    if (url.includes('/api/local/projects/')) {
+      return new Response(JSON.stringify({ project: currentProject }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } })
+  }) as unknown as typeof fetch
+})
+
+afterEach(() => {
+  globalThis.fetch = origFetch
+})
+
+describe('FoldersPanel — envelope parsing + trust toggle', () => {
+  test('external + restricted project renders the Trust toggle, not "Managed project"', async () => {
+    currentProject = {
+      id: 'proj-ext',
+      name: 'My Repo',
+      workingMode: 'external',
+      trustLevel: 'restricted',
+      runtimeEnabled: true,
+      projectFolders: [{ id: 'f1', path: '/Users/me/repo', isPrimary: true }],
+    }
+
+    render(<FoldersPanel projectId="proj-ext" visible />)
+
+    expect(await screen.findByText('Trust folder')).toBeInTheDocument()
+    expect(screen.getByText(/Workspace is restricted/i)).toBeInTheDocument()
+    // The dead "Managed project" empty state must NOT show for an
+    // external project (mis-read envelope -> managed was the bug).
+    expect(screen.queryByText('Managed project')).not.toBeInTheDocument()
+  })
+
+  test('clicking "Trust folder" posts { trusted: true } to the /trust route', async () => {
+    currentProject = {
+      id: 'proj-ext',
+      name: 'My Repo',
+      workingMode: 'external',
+      trustLevel: 'restricted',
+      runtimeEnabled: true,
+      projectFolders: [{ id: 'f1', path: '/Users/me/repo', isPrimary: true }],
+    }
+
+    const user = userEvent.setup()
+    render(<FoldersPanel projectId="proj-ext" visible />)
+
+    await user.click(await screen.findByText('Trust folder'))
+
+    await waitFor(() => {
+      expect(httpPost).toHaveBeenCalled()
+    })
+    const call = httpPost.mock.calls.find(
+      (c: any[]) => typeof c[0] === 'string' && c[0].includes('/trust'),
+    )
+    expect(call).toBeDefined()
+    expect(call?.[0]).toContain('/api/local/projects/proj-ext/trust')
+    expect(call?.[1]).toEqual({ trusted: true })
+  })
+
+  test('trusted project shows the "Restrict" affordance', async () => {
+    currentProject = {
+      id: 'proj-ext',
+      name: 'My Repo',
+      workingMode: 'external',
+      trustLevel: 'trusted',
+      runtimeEnabled: true,
+      projectFolders: [{ id: 'f1', path: '/Users/me/repo', isPrimary: true }],
+    }
+
+    render(<FoldersPanel projectId="proj-ext" visible />)
+
+    expect(await screen.findByText('Restrict')).toBeInTheDocument()
+    expect(screen.getByText(/Workspace trusted/i)).toBeInTheDocument()
+  })
+
+  test('managed project renders the informational "Managed project" state', async () => {
+    currentProject = {
+      id: 'proj-managed',
+      name: 'Sandbox',
+      workingMode: 'managed',
+      trustLevel: 'trusted',
+      runtimeEnabled: true,
+      projectFolders: [],
+    }
+
+    render(<FoldersPanel projectId="proj-managed" visible />)
+
+    expect(await screen.findByText('Managed project')).toBeInTheDocument()
+    expect(screen.queryByText('Trust folder')).not.toBeInTheDocument()
+  })
+})

--- a/packages/agent-runtime/src/__tests__/trust-resolver-refresh.test.ts
+++ b/packages/agent-runtime/src/__tests__/trust-resolver-refresh.test.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Tests for the live trust REFRESH path — the fix for the
+ * "I clicked Trust folder but the agent is still restricted" bug.
+ *
+ * These exercise `refreshTrust()` against a mocked internal `/trust`
+ * endpoint and assert that `assertAllowedPath()` flips from blocked to
+ * allowed once the API reports `trustLevel: 'trusted'`, without any
+ * process restart. This is the end-to-end guarantee that a user toggling
+ * trust in the desktop UI unblocks write / exec tools on the next turn
+ * (or immediately, via the /internal/refresh-trust IPC ping).
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { assertAllowedPath } from '../runtime-trust'
+import { initTrustResolver, refreshTrust, __resetTrustForTests } from '../trust-resolver'
+
+describe('trust-resolver refresh -> assertAllowedPath', () => {
+  let workspaceDir: string
+  const origFetch = globalThis.fetch
+
+  beforeEach(() => {
+    __resetTrustForTests()
+    workspaceDir = mkdtempSync(join(tmpdir(), 'shogo-trust-refresh-'))
+    writeFileSync(join(workspaceDir, 'inside.txt'), 'hi')
+    process.env.SHOGO_API_URL = 'http://127.0.0.1:65500'
+  })
+
+  afterEach(() => {
+    globalThis.fetch = origFetch
+    delete process.env.SHOGO_API_URL
+    rmSync(workspaceDir, { recursive: true, force: true })
+    __resetTrustForTests()
+  })
+
+  // Stub global fetch to answer the internal /trust read with the given
+  // level. Returns a getter so a test can flip the level between calls.
+  function stubTrustEndpoint(getLevel: () => 'restricted' | 'trusted'): void {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          trustLevel: getLevel(),
+          workingMode: 'external',
+          linkedFolders: [],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      )) as unknown as typeof fetch
+  }
+
+  test('cold start (pre-refresh) is fail-closed restricted for external', () => {
+    initTrustResolver({
+      projectId: 'proj-1',
+      workspaceDir,
+      workingMode: 'external',
+      linkedFolders: [],
+    })
+    const w = assertAllowedPath(join(workspaceDir, 'inside.txt'), 'write')
+    expect(w.ok).toBe(false)
+    expect(w.reason).toBe('restricted_mode_write')
+  })
+
+  test('refresh flips restricted -> trusted and unblocks write + exec', async () => {
+    let level: 'restricted' | 'trusted' = 'restricted'
+    stubTrustEndpoint(() => level)
+
+    initTrustResolver({
+      projectId: 'proj-1',
+      workspaceDir,
+      workingMode: 'external',
+      linkedFolders: [],
+    })
+
+    // First refresh: API still reports restricted -> write/exec blocked.
+    await refreshTrust()
+    const blockedWrite = assertAllowedPath(join(workspaceDir, 'inside.txt'), 'write')
+    expect(blockedWrite.ok).toBe(false)
+    expect(blockedWrite.reason).toBe('restricted_mode_write')
+    const blockedExec = assertAllowedPath(join(workspaceDir, 'inside.txt'), 'exec')
+    expect(blockedExec.ok).toBe(false)
+    expect(blockedExec.reason).toBe('restricted_mode_exec')
+
+    // User clicks "Trust folder": DB flips, runtime re-resolves.
+    level = 'trusted'
+    await refreshTrust()
+    expect(assertAllowedPath(join(workspaceDir, 'inside.txt'), 'write').ok).toBe(true)
+    expect(assertAllowedPath(join(workspaceDir, 'inside.txt'), 'exec').ok).toBe(true)
+    // Reads were always allowed.
+    expect(assertAllowedPath(join(workspaceDir, 'inside.txt'), 'read').ok).toBe(true)
+  })
+
+  test('refresh can also revoke: trusted -> restricted re-blocks write', async () => {
+    let level: 'restricted' | 'trusted' = 'trusted'
+    stubTrustEndpoint(() => level)
+
+    initTrustResolver({
+      projectId: 'proj-1',
+      workspaceDir,
+      workingMode: 'external',
+      linkedFolders: [],
+    })
+
+    await refreshTrust()
+    expect(assertAllowedPath(join(workspaceDir, 'inside.txt'), 'write').ok).toBe(true)
+
+    level = 'restricted'
+    await refreshTrust()
+    const w = assertAllowedPath(join(workspaceDir, 'inside.txt'), 'write')
+    expect(w.ok).toBe(false)
+    expect(w.reason).toBe('restricted_mode_write')
+  })
+
+  test('transient fetch failure keeps the last-known trust level', async () => {
+    let level: 'restricted' | 'trusted' = 'trusted'
+    stubTrustEndpoint(() => level)
+    initTrustResolver({
+      projectId: 'proj-1',
+      workspaceDir,
+      workingMode: 'external',
+      linkedFolders: [],
+    })
+    await refreshTrust()
+    expect(assertAllowedPath(join(workspaceDir, 'inside.txt'), 'write').ok).toBe(true)
+
+    // Next refresh throws (network blip) — the resolver must not flap
+    // back to restricted; it keeps the last-known trusted value.
+    globalThis.fetch = (async () => {
+      throw new Error('ECONNREFUSED')
+    }) as unknown as typeof fetch
+    await refreshTrust()
+    expect(assertAllowedPath(join(workspaceDir, 'inside.txt'), 'write').ok).toBe(true)
+
+    void level
+  })
+})

--- a/packages/agent-runtime/src/trust-resolver.ts
+++ b/packages/agent-runtime/src/trust-resolver.ts
@@ -41,7 +41,12 @@
  * managed (which always live inside our sandbox).
  */
 
+import { existsSync } from 'fs'
+
 import { deriveApiUrl, getInternalHeaders } from './internal-api'
+
+/** Same path internal-api.ts uses to detect a Kubernetes service account. */
+const SA_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
 
 export type WorkingMode = 'managed' | 'external'
 export type TrustLevel = 'trusted' | 'restricted'
@@ -149,6 +154,23 @@ export async function refreshTrust(): Promise<void> {
   if (!apiUrl) {
     // No API to ask. Same fallback as above.
     return
+  }
+
+  // Diagnostic for the silent fail-closed case: if we resolved to the
+  // in-cluster service fallback but there's no Kubernetes service-account
+  // token present, this is almost certainly a desktop / local install
+  // whose runtime env is missing SHOGO_API_URL / API_URL. The fetch below
+  // will fail to resolve `api.<ns>.svc.cluster.local`, the resolver keeps
+  // its fail-closed `restricted` default, and "Trust folder" appears to do
+  // nothing. Surface a clear breadcrumb instead of a mysterious hang.
+  if (apiUrl.includes('.svc.cluster.local') && !existsSync(SA_TOKEN_PATH)) {
+    console.warn(
+      `[trust-resolver] deriveApiUrl() resolved to the in-cluster fallback ` +
+        `(${apiUrl}) but no Kubernetes service-account token is present. If this ` +
+        `is a desktop/local install, SHOGO_API_URL was not seeded into the runtime ` +
+        `env — trust cannot be refreshed and will stay fail-closed (restricted). ` +
+        `Ensure the runtime manager sets SHOGO_API_URL (or API_URL) to the local API.`,
+    )
   }
 
   const url = `${apiUrl}/api/internal/projects/${encodeURIComponent(projectId)}/trust`


### PR DESCRIPTION

<img width="1512" height="982" alt="Screenshot 2026-06-01 at 2 23 27 PM" src="https://github.com/user-attachments/assets/4b06f8cd-f9d9-4d96-a5ef-256adfa3a823" />
<img width="1512" height="982" alt="Screenshot 2026-06-01 at 2 23 34 PM" src="https://github.com/user-attachments/assets/4266767e-d73a-4951-94a7-198271911bf0" />
<img width="1512" height="982" alt="Screenshot 2026-06-01 at 2 23 42 PM" src="https://github.com/user-attachments/assets/6312b586-b1ac-402b-a447-695db8ed5724" />
## Summary

Closes #737.

This PR fixes the desktop local-folder Workspace Trust flow so opened host folders hydrate correctly as external projects and users can reliably toggle between restricted and trusted mode after startup.

The main issue was that the desktop Folders panel and project layout were reading the generated `/api/projects/:id` response shape, which did not include `projectFolders` in the `{ project }` envelope expected by the local folder UI. That made external projects mis-render as managed projects and hid the trust controls that should have been available for local folders.

## What Changed

- Added `GET /api/local/projects/:id` for desktop-local project hydration.
  - Returns `{ project }` with `projectFolders`, `workingMode`, and `trustLevel`.
  - Keeps local folder/trust reads on the same envelope contract as the existing local routes.
  - Prevents the Folders panel from falling back to the misleading managed-project empty state.

- Updated project layout hydration.
  - Fetches local project folder/trust data once the project row loads.
  - Merges `workingMode`, `trustLevel`, and `projectFolders` into local state.
  - Wires a persistent top-bar trust toggle through `/api/local/projects/:id/trust`.

- Added a persistent Workspace Trust badge in the project top bar.
  - External projects now show trusted/restricted state outside the settings panel.
  - Users can toggle trusted ↔ restricted without reopening the first-run prompt.

- Improved the Folders panel behavior.
  - Reads the new local `{ project }` response instead of the generated route.
  - Shows explicit "Trust folder" and "Restrict" actions for external projects.
  - Replaces the dead managed-project empty state with an "Open a folder" CTA.
  - Removes the non-functional "Enable preview" button that was wired to a nonexistent generic project PATCH route.
  - Keeps the functional "External preview URL" workflow for user-managed local dev servers.

- Added runtime trust diagnostics.
  - Logs a targeted warning when a desktop/local runtime resolves to the Kubernetes in-cluster API fallback without a service-account token.
  - This makes missing `SHOGO_API_URL` / `API_URL` configuration visible instead of silently staying fail-closed as restricted.

## Why This Is Needed

Workspace Trust is central to local desktop mode: external folders should start restricted, then become trusted only after explicit user consent. Before this change, the UI could lose the external project context after startup, present an empty managed-project state, and make it look like the trust decision did not work.

This PR fixes that root data-flow bug and makes the trust state visible and actionable in the two places users expect: the top bar and the Folders panel.

## Test Plan

Automated tests run/verified:

- `packages/agent-runtime`
  - `bun test src/__tests__/runtime-trust.test.ts src/__tests__/trust-resolver-refresh.test.ts`
  - Result: 28 pass / 0 fail.
  - Covers restricted → trusted refresh unblocking write/exec path checks.

- `apps/api`
  - `bun test src/__tests__/local-projects-v4.test.ts`
  - Result: 38 pass / 0 fail.
  - Covers `GET /api/local/projects/:id` envelope shape and `POST /api/local/projects/:id/trust` toggles.

- `apps/mobile`
  - `bun test components/project/panels/__tests__/FoldersPanel.rtl.test.tsx`
  - Result: 4 pass / 0 fail.
  - Covers external project rendering, trust toggle payload, trusted "Restrict" affordance, and managed-project informational state.

Manual desktop verification:

- Opened a local Git folder in desktop mode.
- Confirmed the project renders as an external folder project rather than a managed empty state.
- Confirmed the top-right trust badge shows `Trusted` after trusting.
- Confirmed the Folders panel shows the linked folder, trusted workspace message, and `Restrict` action.
- Confirmed the reviewed `Add folder` button is functional and useful: it opens the Electron folder picker, posts selected folders to the local API, and linked folders become runtime allowed roots through trust refresh.

Known unrelated test noise:

- `apps/api/src/__tests__/local-projects-routes.expanded.test.ts` currently has three pre-existing `/fs/browse` failures (`body.entries` undefined). I confirmed those still fail with this route change reverted, and they are unrelated to the single-segment `GET /:id` route added here.

## Jira

Related Jira: SHOG-702

Made with [Cursor](https://cursor.com)