### PR TITLE
fix(infra): prevent EU node disk-exhaustion deploy failures

### DIFF
--- a/.github/scripts/check-node-disk-headroom.sh
+++ b/.github/scripts/check-node-disk-headroom.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# .github/scripts/check-node-disk-headroom.sh
+#
+# Deploy-time gate that catches the 2026-06-02 EU incident class: a node
+# disk-exhaustion event BEFORE we patch the api ksvc into it.
+#
+# What happened in EU: the node pool ran 100 GB boot volumes while ~30 GB of
+# stacked 8 GB runtime images sat on each node. The busiest nodes crossed the
+# kubelet DiskPressure threshold (~85%), so the kubelet started evicting pods
+# and garbage-collecting images. The new `api` revision could never reach its
+# initial scale (pods stuck ContainerCreating / failing liveness), and the
+# warm pool churned. The deploy only discovered this 10 minutes later via
+# `ProgressDeadlineExceeded` — by which point the cluster was already in a
+# self-sustaining storm.
+#
+# Running this BEFORE the ksvc patch turns that 10-minute mystery timeout into
+# an immediate, actionable failure ("node X is at 88% disk").
+#
+# Fails the deploy if either:
+#   * any Ready, schedulable node already reports DiskPressure=True, OR
+#   * any such node's root filesystem is at/above THRESHOLD_PCT used.
+#
+# Usage:
+#   .github/scripts/check-node-disk-headroom.sh [threshold_pct]
+# Env:
+#   THRESHOLD_PCT  default 80  (kubelet's default DiskPressure eviction
+#                               soft threshold is imagefs/nodefs available<15%,
+#                               i.e. ~85% used; 80% leaves margin to deploy)
+
+set -euo pipefail
+
+THRESHOLD_PCT="${1:-${THRESHOLD_PCT:-80}}"
+rc=0
+
+echo "Checking node disk headroom (fail at >=${THRESHOLD_PCT}% used or DiskPressure=True)..."
+
+# 1) DiskPressure condition — the authoritative kubelet signal.
+pressured=$(kubectl get nodes -o json | jq -r '
+  [.items[]
+    | select((.status.conditions // [])[] | select(.type == "DiskPressure" and .status == "True"))
+    | .metadata.name
+  ] | join(" ")
+')
+if [[ -n "$pressured" ]]; then
+  echo "::error::check-node-disk-headroom: node(s) under DiskPressure: $pressured"
+  rc=1
+fi
+
+# 2) Root filesystem usage per node via the kubelet stats summary API.
+# Skip unschedulable (cordoned) nodes — they're intentionally drained and
+# shouldn't gate a deploy.
+for node in $(kubectl get nodes -o jsonpath='{range .items[?(@.spec.unschedulable!=true)]}{.metadata.name}{"\n"}{end}'); do
+  summary=$(kubectl get --raw "/api/v1/nodes/${node}/proxy/stats/summary" 2>/dev/null || echo "")
+  if [[ -z "$summary" ]]; then
+    echo "  $node: (stats unavailable, relying on DiskPressure condition)"
+    continue
+  fi
+  pct=$(echo "$summary" | jq -r '
+    (.node.fs.usedBytes // 0) as $u
+    | (.node.fs.capacityBytes // 0) as $c
+    | if $c > 0 then (($u / $c) * 100 | floor) else 0 end
+  ')
+  echo "  $node: ${pct}% used"
+  if [[ "$pct" -ge "$THRESHOLD_PCT" ]]; then
+    echo "::error::check-node-disk-headroom: node $node at ${pct}% disk (>=${THRESHOLD_PCT}%)"
+    rc=1
+  fi
+done
+
+if [[ "$rc" -ne 0 ]]; then
+  echo "::error::Aborting before ksvc patch: a disk-starved cluster cannot roll out a new revision."
+  echo "Remediate node disk first (prune stale runtime images / scale or replace nodes / raise boot volume — see terraform/README.md 'Boot volume remediation')."
+  echo "::group::node images (largest, busiest node)"
+  kubectl get nodes -o json | jq -r '
+    .items
+    | max_by([.status.images[]?.sizeBytes] | add // 0)
+    | .metadata.name as $n
+    | "node \($n): " + (([.status.images[]?.sizeBytes] | add // 0) / 1e9 | tostring) + " GB of images"
+  ' 2>/dev/null || true
+  echo "::endgroup::"
+fi
+
+exit "$rc"

--- a/.github/scripts/check-node-disk-parity.sh
+++ b/.github/scripts/check-node-disk-parity.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# .github/scripts/check-node-disk-parity.sh
+#
+# Cross-region node-pool boot-volume parity guard.
+#
+# The EU 2026-06-02 incident root cause was a silent capacity drift: EU (and
+# India) node pools were bootstrapped at 100 GB boot volumes while US ran
+# 200 GB. The drift was invisible because the oke module ignores in-place
+# boot-volume changes (a deliberate anti-replacement safety), so neither a
+# `terraform plan` nor day-to-day ops surfaced it. EU tipped into DiskPressure
+# under load; India is the same latent exposure.
+#
+# This check queries the LIVE OCI node pools across all production regions and
+# fails if any region's system-pool boot volume is below EXPECTED_GB. Run it in
+# CI (terraform.yml) so the drift can never silently re-open.
+#
+# Usage:
+#   COMPARTMENT_ID=ocid1.compartment... \
+#   EXPECTED_GB=200 \
+#   REGIONS="us-ashburn-1 eu-frankfurt-1 ap-mumbai-1" \
+#   .github/scripts/check-node-disk-parity.sh
+#
+# Requires: oci CLI configured, jq.
+
+set -euo pipefail
+
+COMPARTMENT_ID="${COMPARTMENT_ID:?COMPARTMENT_ID required}"
+EXPECTED_GB="${EXPECTED_GB:-200}"
+REGIONS="${REGIONS:-us-ashburn-1 eu-frankfurt-1 ap-mumbai-1}"
+
+rc=0
+echo "Asserting system node-pool boot volume == ${EXPECTED_GB} GB across: ${REGIONS}"
+
+for region in $REGIONS; do
+  # A region may have multiple clusters; check every node pool in the
+  # production compartment for that region.
+  pools=$(oci ce node-pool list \
+    --region "$region" \
+    --compartment-id "$COMPARTMENT_ID" \
+    --all \
+    --query 'data[].{name:name, gb:"node-source-details"."boot-volume-size-in-gbs"}' \
+    --output json 2>/dev/null || echo '[]')
+
+  count=$(echo "$pools" | jq 'length')
+  if [[ "$count" -eq 0 ]]; then
+    echo "  [$region] no node pools found (skipping)"
+    continue
+  fi
+
+  while IFS= read -r row; do
+    name=$(echo "$row" | jq -r '.name')
+    gb=$(echo "$row" | jq -r '.gb // 0')
+    if [[ "$gb" -lt "$EXPECTED_GB" ]]; then
+      echo "::error::node-disk-parity: [$region] pool '$name' boot volume ${gb} GB < expected ${EXPECTED_GB} GB"
+      rc=1
+    else
+      echo "  [$region] $name: ${gb} GB OK"
+    fi
+  done < <(echo "$pools" | jq -c '.[]')
+done
+
+if [[ "$rc" -ne 0 ]]; then
+  echo "::error::Boot-volume drift detected. Remediate via a controlled node-pool replacement (see terraform/README.md 'Boot volume remediation')."
+fi
+exit "$rc"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -711,6 +711,15 @@ jobs:
           echo "api_image=$(get_image api ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
           echo "docs_image=$(get_image docs ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
 
+      # Pre-rollout gate (2026-06-02 EU incident class): refuse to apply
+      # manifests / patch ksvcs into a disk-starved cluster. A node above the
+      # disk threshold (or already under DiskPressure) cannot bring up a new
+      # revision — the kubelet evicts/GCs instead — so the rollout would only
+      # fail 10 minutes later with ProgressDeadlineExceeded. Fail fast with an
+      # actionable message instead.
+      - name: Check node disk headroom (pre-rollout gate)
+        run: .github/scripts/check-node-disk-headroom.sh 80
+
       - name: Apply Kubernetes manifests
         run: |
           # Render RUNTIME_IMAGE into the api ksvc at apply time, mirroring the
@@ -1169,6 +1178,15 @@ jobs:
           echo "web_image=$(get_image studio ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
           echo "api_image=$(get_image api ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
           echo "docs_image=$(get_image docs ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
+
+      # Pre-rollout gate (2026-06-02 EU incident class): refuse to apply
+      # manifests / patch ksvcs into a disk-starved cluster. A node above the
+      # disk threshold (or already under DiskPressure) cannot bring up a new
+      # revision — the kubelet evicts/GCs instead — so the rollout would only
+      # fail 10 minutes later with ProgressDeadlineExceeded. Fail fast with an
+      # actionable message instead.
+      - name: Check node disk headroom (pre-rollout gate)
+        run: .github/scripts/check-node-disk-headroom.sh 80
 
       - name: Apply Kubernetes manifests
         run: |
@@ -1735,6 +1753,15 @@ jobs:
           echo "api_image=$(get_image api ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
           echo "docs_image=$(get_image docs ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
 
+      # Pre-rollout gate (2026-06-02 EU incident class): refuse to apply
+      # manifests / patch ksvcs into a disk-starved cluster. A node above the
+      # disk threshold (or already under DiskPressure) cannot bring up a new
+      # revision — the kubelet evicts/GCs instead — so the rollout would only
+      # fail 10 minutes later with ProgressDeadlineExceeded. Fail fast with an
+      # actionable message instead.
+      - name: Check node disk headroom (pre-rollout gate)
+        run: .github/scripts/check-node-disk-headroom.sh 80
+
       - name: Apply Kubernetes manifests
         run: |
           # Render RUNTIME_IMAGE into the api ksvc at apply time, mirroring the
@@ -2288,6 +2315,15 @@ jobs:
           echo "web_image=$(get_image studio ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
           echo "api_image=$(get_image api ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
           echo "docs_image=$(get_image docs ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
+
+      # Pre-rollout gate (2026-06-02 EU incident class): refuse to apply
+      # manifests / patch ksvcs into a disk-starved cluster. A node above the
+      # disk threshold (or already under DiskPressure) cannot bring up a new
+      # revision — the kubelet evicts/GCs instead — so the rollout would only
+      # fail 10 minutes later with ProgressDeadlineExceeded. Fail fast with an
+      # actionable message instead.
+      - name: Check node disk headroom (pre-rollout gate)
+        run: .github/scripts/check-node-disk-headroom.sh 80
 
       - name: Apply Kubernetes manifests
         run: |

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -105,6 +105,26 @@ jobs:
       - name: terraform validate
         run: terraform validate -no-color
 
+      # Cross-region node-pool boot-volume parity guard (2026-06-02 EU
+      # incident): EU/India bootstrapped at 100 GB while US ran 200 GB, and
+      # the oke module ignores in-place boot-volume changes, so the drift was
+      # invisible to `terraform plan`. This asserts parity against the LIVE
+      # OCI pools so the gap can never silently re-open.
+      - name: Install OCI CLI
+        run: pip install oci-cli --quiet
+
+      - name: Node disk parity check (cross-region boot volumes)
+        env:
+          OCI_CLI_USER: ${{ secrets.OCI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ secrets.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ secrets.OCI_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_PRIVATE_KEY }}
+          OCI_CLI_REGION: us-ashburn-1
+          COMPARTMENT_ID: ${{ vars.COMPARTMENT_ID }}
+          EXPECTED_GB: "200"
+          REGIONS: "us-ashburn-1 eu-frankfurt-1 ap-mumbai-1"
+        run: "$GITHUB_WORKSPACE/.github/scripts/check-node-disk-parity.sh"
+
       - name: terraform plan
         id: plan
         env:

--- a/k8s/base/warm-pool-monitor.yaml
+++ b/k8s/base/warm-pool-monitor.yaml
@@ -19,6 +19,10 @@
 #       — same incident class, runtime variant.
 #   * warm-pool ksvcs exist but 0 are Ready
 #       — controller alive but every pod broken.
+#   * any node is under DiskPressure
+#       — node disk exhaustion (the 2026-06-02 EU incident class): boot
+#         volume fills with stacked runtime images, kubelet evicts pods and
+#         GCs images, and the warm pool churns. Earliest clear signal.
 #
 # Modeled after k8s/cnpg/logical-replication/replication-monitor.yaml
 # (deliberately the same structure/operator-experience).
@@ -51,6 +55,13 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["pods"]
+    verbs: ["get", "list"]
+  # Node read is required for the DiskPressure check (check #4). The EU
+  # 2026-06-02 incident was a node-disk exhaustion event (100 GB boot
+  # volumes + stacked 8 GB runtime images -> kubelet eviction/image-GC ->
+  # warm-pool churn) that this monitor was blind to.
+  - apiGroups: [""]
+    resources: ["nodes"]
     verbs: ["get", "list"]
   - apiGroups: ["serving.knative.dev"]
     resources: ["services", "revisions"]
@@ -95,7 +106,13 @@ spec:
               # alpine/k8s ships kubectl + jq + a posix shell in a small
               # multi-arch image. Pinned to a specific patch so a
               # registry-side mutation can't change behavior under us.
-              image: alpine/k8s:1.31.5
+              # MUST be fully qualified with the docker.io/ registry prefix:
+              # the OKE nodes run cri-o with `short-name-mode=enforcing`, which
+              # rejects a bare `alpine/k8s:1.31.5` with "short name mode is
+              # enforcing ... returns ambiguous list" (ImageInspectError). That
+              # silently broke this CronJob on every run, so it never fired
+              # during the EU 2026-06-02 incident.
+              image: docker.io/alpine/k8s:1.31.5
               env:
                 - name: API_NS
                   value: shogo-staging-system
@@ -159,6 +176,24 @@ spec:
                   echo "  total=$TOTAL  ready=$READY"
                   if [ "$TOTAL" -gt 0 ] && [ "$READY" -eq 0 ]; then
                     echo "CRITICAL: $TOTAL warm-pool ksvcs but 0 are Ready"
+                    EXIT_RC=1
+                  fi
+
+                  # 4) Node DiskPressure.
+                  # The EU 2026-06-02 incident: 100 GB boot volumes filled with
+                  # stacked 8 GB runtime images -> kubelet set DiskPressure ->
+                  # pod eviction + image GC -> warm-pool churn + a stuck api
+                  # rollout. DiskPressure on ANY node is the earliest, clearest
+                  # signal of that class and must page before the churn starts.
+                  echo "--- node DiskPressure ---"
+                  PRESSURED=$(kubectl get nodes -o json | jq -r '
+                    [.items[]
+                      | select((.status.conditions // [])[] | select(.type == "DiskPressure" and .status == "True"))
+                      | .metadata.name
+                    ] | join("; ")
+                  ')
+                  if [ -n "$PRESSURED" ]; then
+                    echo "CRITICAL: node(s) under DiskPressure: $PRESSURED"
                     EXIT_RC=1
                   fi
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -158,6 +158,34 @@ The same pattern can be reused when adopting `production-eu`,
 `production-india`, and `production-global` — follow the iteration loop
 of plan → diff → set per-env override → repeat until plan is clean.
 
+## Boot volume remediation
+
+`system_node_boot_volume_gb` must be **200 GB and identical across all
+production regions**. EU/India were bootstrapped at 100 GB, which caused the
+2026-06-02 EU DiskPressure incident: ~30 GB of stacked 8 GB runtime images
+pushed the busiest 100 GB nodes past the kubelet DiskPressure threshold,
+triggering pod eviction + image GC, warm-pool churn, and a stuck `api`
+rollout (`ProgressDeadlineExceeded`).
+
+The OKE module **ignores in-place changes** to
+`node_source_details[0].boot_volume_size_in_gbs` (a boot-volume change forces
+a rolling node replacement; the ignore protects already-bootstrapped pools
+from surprise replacement). So bumping `system_node_boot_volume_gb` in an env
+will **not** apply on its own. To remediate a region that is below 200 GB:
+
+1. Confirm the live drift (and that CI's parity check is failing):
+   `EXPECTED_GB=200 COMPARTMENT_ID=<id> .github/scripts/check-node-disk-parity.sh`
+2. Update the node pool's boot volume out-of-band (does not affect running nodes):
+   `oci ce node-pool update --node-pool-id <ocid> --node-source-details '{"sourceType":"IMAGE","imageId":"<id>","bootVolumeSizeInGBs":200}'`
+3. Cycle nodes so they re-provision at 200 GB — drain + terminate a few at a
+   time (cordon, `kubectl drain`, then terminate the instance so the autoscaler
+   replaces it), watching `DiskPressure` and warm-pool readiness between batches.
+4. Re-run the parity check to confirm green.
+
+Day-to-day disk safety is additionally guarded at deploy time by
+`.github/scripts/check-node-disk-headroom.sh` (a pre-rollout gate) and at
+runtime by the `DiskPressure` check in `k8s/base/warm-pool-monitor.yaml`.
+
 ## Configuration
 
 See `environments/*/variables.tf` for configurable options per environment.

--- a/terraform/environments/production-eu/main.tf
+++ b/terraform/environments/production-eu/main.tf
@@ -118,6 +118,15 @@ module "eu" {
   system_pool_min       = 2
   system_pool_max       = 10
 
+  # 200 GB to match production-us. EU was bootstrapped at 100 GB, which
+  # caused the 2026-06-02 DiskPressure incident (stacked 8 GB runtime images
+  # filled the disk -> kubelet eviction/image-GC -> warm-pool churn -> the
+  # api rollout could not reach initial scale). The oke module ignores
+  # in-place boot-volume changes, so applying this requires a one-time
+  # controlled node-pool replacement (see terraform/README.md "Boot volume
+  # remediation"). Until that cycle runs, the live value stays 100 GB.
+  system_node_boot_volume_gb = 200
+
   enable_workload_pool = false
 
   # Observability

--- a/terraform/environments/production-india/main.tf
+++ b/terraform/environments/production-india/main.tf
@@ -129,6 +129,14 @@ module "india" {
   system_pool_min       = 2
   system_pool_max       = 10
 
+  # 200 GB to match production-us. India is currently LIVE at 100 GB — the
+  # same latent exposure that caused the EU 2026-06-02 DiskPressure incident;
+  # India simply hasn't tipped over yet (lower workspace load). As with EU,
+  # the oke module ignores in-place boot-volume changes, so this needs a
+  # one-time controlled node-pool replacement to take effect (see
+  # terraform/README.md "Boot volume remediation").
+  system_node_boot_volume_gb = 200
+
   enable_workload_pool = false
 
   # Data layer points to US primary

--- a/terraform/environments/production-us/main.tf
+++ b/terraform/environments/production-us/main.tf
@@ -135,6 +135,11 @@ module "us" {
   system_pool_min       = 3
   system_pool_max       = 15
 
+  # Live US nodes are already 200 GB (matches the module default). Stated
+  # explicitly so the cross-region parity check has a US baseline to compare
+  # EU/India against (see .github/scripts/check-node-disk-parity.sh).
+  system_node_boot_volume_gb = 200
+
   enable_workload_pool = false
 
   # Autoscaler IAM (tenancy-level — only enable in primary region)

--- a/terraform/modules/oci-region/main.tf
+++ b/terraform/modules/oci-region/main.tf
@@ -114,6 +114,7 @@ module "oke" {
   node_shape     = var.system_node_shape
   node_ocpus     = var.system_node_ocpus
   node_memory_gb = var.system_node_memory_gb
+  boot_volume_gb = var.system_node_boot_volume_gb
   node_pool_size = var.system_pool_size
   node_pool_min  = var.system_pool_min
   node_pool_max  = var.system_pool_max

--- a/terraform/modules/oci-region/variables.tf
+++ b/terraform/modules/oci-region/variables.tf
@@ -92,6 +92,23 @@ variable "system_node_memory_gb" {
   default     = 64
 }
 
+variable "system_node_boot_volume_gb" {
+  # Set explicitly per environment so the value is auditable and a
+  # cross-region drift (e.g. EU bootstrapped at 100 GB while US is 200 GB)
+  # is visible in code, not hidden behind a module default. The EU
+  # 2026-06-02 incident was caused by EU nodes running 100 GB boot volumes:
+  # ~30 GB of stacked 8 GB runtime images pushed them past the kubelet
+  # DiskPressure threshold, triggering eviction/image-GC and warm-pool churn.
+  #
+  # NOTE: the oke module ignores in-place changes to this attribute
+  # (boot volume changes force a rolling node replacement). Raising it on an
+  # already-bootstrapped pool therefore requires a deliberate node-pool
+  # replacement — see terraform/README.md ("Boot volume remediation").
+  description = "Boot volume size (GB) for system nodes. Must match across regions."
+  type        = number
+  default     = 200
+}
+
 variable "system_pool_size" {
   description = "Desired system node count"
   type        = number


### PR DESCRIPTION
## Context

Postmortem fix for the **2026-06-02 EU deploy failure** ([run 26807554374](https://github.com/shogo-labs/shogo-ai/actions/runs/26807554374/job/79033026771)), where the `api` rollout failed with `ksvc/api did not reach Ready within 600s` / `ProgressDeadlineExceeded`.

### Root cause (traced on the live EU cluster)

EU (and India) system node pools run **100 GB boot volumes** vs **200 GB in US**:

| Region | shape | boot vol | nodes | disk used |
|---|---|---|---|---|
| US | A4.Flex | **200 GB** | 3 | 33–66% |
| EU | A2.Flex | **100 GB** | 7 | up to **86% (DiskPressure)** |
| India | A1.Flex | **100 GB** | 4 | (latent) |

Each deploy stamps a new immutable `production-<sha>` tag onto the **8 GB** `shogo-runtime` image; ~4 versions accumulate per node (~20 GB) plus `shogo-api`. On 100 GB EU nodes this crossed the kubelet `DiskPressure` threshold → **pod eviction + image GC → warm-pool churn → VNIC pod-IP exhaustion (`oci-ipvlan: unable to allocate IP`) → the `api` revision could never reach initial scale.** A partially-applied runtime-image reference also left the warm-pool controller recycling every new pod (split-brain) until `api` rolled forward.

The drift was invisible because the `oke` module **ignores in-place boot-volume changes** (anti-replacement safety), so `terraform plan` never showed it.

The commit `852ee93` ("dont use VM by default") was only the trigger — it shifted workspaces from micro-VMs to in-cluster pods, adding disk/IP load that tipped the already-undersized EU nodes over.

> EU was recovered live (scale-out + cordon to clear DiskPressure, deleted orphaned stale-image api pods, rolled `api` forward to a Ready revision). This PR is the durable prevention.

## Changes

- **terraform**: plumb explicit `system_node_boot_volume_gb` through `oci-region`; set all prod regions to **200 GB**. EU/India are live at 100 GB — applying needs a controlled node-pool replacement, documented in `terraform/README.md` → *Boot volume remediation*.
- **ci parity guard**: `check-node-disk-parity.sh` asserts live boot-volume parity across regions, wired into the terraform PR plan job — the drift can't silently re-open.
- **deploy pre-gate**: `check-node-disk-headroom.sh` runs before manifests are applied in every deploy job — fails fast on a disk-starved cluster instead of a 10-minute `ProgressDeadlineExceeded`.
- **warm-pool-monitor**: fully-qualify image to `docker.io/alpine/k8s:1.31.5` (cri-o `short-name-mode=enforcing` was breaking the monitor on **every** run via `ImageInspectError`, so the alert that should have caught this never fired), and add a node `DiskPressure` check (+ nodes RBAC).

## Test plan

- [ ] `terraform fmt -check -recursive terraform/` and `terraform validate` pass
- [ ] Terraform PR plan job runs the parity check (expected: currently RED until EU/India are remediated to 200 GB)
- [ ] `bash -n` both scripts (done locally)
- [ ] Dry-run `check-node-disk-headroom.sh 80` against each region
- [ ] Confirm `warm-pool-monitor` CronJob succeeds (no more `ImageInspectError`) after the image fix lands
- [ ] Schedule the EU + India boot-volume node-pool replacement per the runbook

Made with [Cursor](https://cursor.com)