### PR TITLE
feat(affiliate): per-affiliate commission rate override

### DIFF
--- a/apps/api/src/__tests__/admin-routes.expanded.test.ts
+++ b/apps/api/src/__tests__/admin-routes.expanded.test.ts
@@ -136,6 +136,16 @@ const prisma = {
   signupAttribution: {
     upsert: mock(async () => ({})),
   },
+  affiliate: {
+    findUnique: mock(async ({ where }: any) => (where.id === 'aff-1' ? { id: 'aff-1' } : null)),
+    update: mock(async ({ where, data }: any) => ({
+      id: where.id,
+      userId: 'user-9',
+      code: 'creator',
+      status: 'active',
+      commissionRateBps: data.commissionRateBps,
+    })),
+  },
 }
 
 mock.module('../lib/prisma', () => withPrismaExports({ prisma }))
@@ -389,6 +399,47 @@ describe('PATCH /heartbeats/projects/:projectId — gap-closer branches', () => 
     const lastCall = prisma.agentConfig.update.mock.calls.at(-1)![0]
     expect(lastCall.data.heartbeatEnabled).toBe(false)
     expect(lastCall.data.nextHeartbeatAt).toBeNull()
+  })
+})
+
+describe('PATCH /affiliates/:id — per-affiliate commission-rate override', () => {
+  function patch(id: string, body: unknown) {
+    return adminRoutes().request(`http://api.test/affiliates/${id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  }
+
+  test('sets a valid override rate', async () => {
+    const res = await patch('aff-1', { commissionRateBps: 3000 })
+    expect(res.status).toBe(200)
+    const body = await json(res)
+    expect(body.ok).toBe(true)
+    expect(body.affiliate.commissionRateBps).toBe(3000)
+    expect(prisma.affiliate.update.mock.calls.at(-1)![0].data).toEqual({ commissionRateBps: 3000 })
+  })
+
+  test('clears the override when passed null', async () => {
+    const res = await patch('aff-1', { commissionRateBps: null })
+    expect(res.status).toBe(200)
+    const body = await json(res)
+    expect(body.affiliate.commissionRateBps).toBeNull()
+    expect(prisma.affiliate.update.mock.calls.at(-1)![0].data).toEqual({ commissionRateBps: null })
+  })
+
+  test('rejects out-of-range and non-integer rates', async () => {
+    expect((await patch('aff-1', { commissionRateBps: 10001 })).status).toBe(400)
+    expect((await patch('aff-1', { commissionRateBps: -1 })).status).toBe(400)
+    expect((await patch('aff-1', { commissionRateBps: 12.5 })).status).toBe(400)
+    expect((await patch('aff-1', { commissionRateBps: 'lots' })).status).toBe(400)
+  })
+
+  test('returns 404 for an unknown affiliate', async () => {
+    const res = await patch('ghost', { commissionRateBps: 1000 })
+    expect(res.status).toBe(404)
+    const body = await json(res)
+    expect(body.error.code).toBe('affiliate_not_found')
   })
 })
 

--- a/apps/api/src/__tests__/affiliate-schema.test.ts
+++ b/apps/api/src/__tests__/affiliate-schema.test.ts
@@ -67,6 +67,11 @@ describe('Affiliate schema (PG)', () => {
     expect(block).toMatch(/depth\s+Int\s+@default\(1\)/)
   })
 
+  test('Affiliate has the optional per-affiliate commissionRateBps override', () => {
+    const block = modelBlock(PG_SCHEMA, 'Affiliate')
+    expect(block).toMatch(/commissionRateBps\s+Int\?/)
+  })
+
   test('AffiliateCommission has the (invoice, affiliate, level) idempotency key', () => {
     const block = modelBlock(PG_SCHEMA, 'AffiliateCommission')
     expect(block).toMatch(/@@unique\(\[stripeInvoiceId,\s*affiliateId,\s*level\]\)/)
@@ -136,6 +141,11 @@ describe('Affiliate schema (local SQLite mirror)', () => {
     expect(block).toMatch(/affiliate\s+Affiliate\?/)
     expect(block).toMatch(/affiliateAttribution\s+AffiliateAttribution\?/)
   })
+
+  test('mirrors the per-affiliate commissionRateBps override column', () => {
+    const block = modelBlock(LOCAL_SCHEMA, 'Affiliate')
+    expect(block).toMatch(/commissionRateBps\s+Int\?/)
+  })
 })
 
 describe('Affiliate migrations', () => {
@@ -188,6 +198,20 @@ describe('Affiliate migrations', () => {
     expect(SQLITE_MIGRATION).toMatch(/INSERT OR IGNORE INTO "affiliate_commission_tiers"/)
     expect(SQLITE_MIGRATION).toMatch(/'aff_tier_l1', 1, 2000/)
     expect(SQLITE_MIGRATION).toMatch(/'aff_tier_l3', 3, 200/)
+  })
+
+  test('per-affiliate rate migrations add the commissionRateBps column on both tracks', () => {
+    const pg = readFileSync(
+      resolve(REPO_ROOT, 'prisma/migrations/20260602203002_affiliate_per_affiliate_rate/migration.sql'),
+      'utf-8',
+    )
+    const sqlite = readFileSync(
+      resolve(REPO_ROOT, 'apps/desktop/prisma/migrations/20260602203002_affiliate_per_affiliate_rate/migration.sql'),
+      'utf-8',
+    )
+    const addColumn = /ALTER TABLE "affiliates" ADD COLUMN "commissionRateBps" INTEGER;/
+    expect(pg).toMatch(addColumn)
+    expect(sqlite).toMatch(addColumn)
   })
 
   test('SQLite migration uses TEXT for the would-be enum columns', () => {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -716,6 +716,65 @@ export function adminRoutes(): Hono {
     }
   })
 
+  // --------------------------------------------------------------------------
+  // Affiliate management
+  // --------------------------------------------------------------------------
+
+  /**
+   * PATCH /affiliates/:id - Set or clear an affiliate's per-affiliate
+   * commission-rate override. `commissionRateBps` is in basis points
+   * (2000 = 20.00%), range 0..10000 (0%..100%). Pass `null` to clear the
+   * override and fall back to the per-level `AffiliateCommissionTier` rate.
+   *
+   * The override only affects the affiliate's direct (L1) referral
+   * commissions, applied as a flat rate (the tier's durationDays window and
+   * secondaryRateBps step-down are bypassed). See
+   * apps/api/src/services/affiliate.service.ts:recordCommissionsForInvoice.
+   */
+  router.patch('/affiliates/:id', async (c) => {
+    const id = c.req.param('id')
+    let body: any
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: { code: 'bad_request', message: 'Invalid JSON body' } }, 400)
+    }
+
+    const raw = body?.commissionRateBps
+    let commissionRateBps: number | null
+    if (raw === null) {
+      commissionRateBps = null
+    } else if (typeof raw === 'number' && Number.isInteger(raw) && raw >= 0 && raw <= 10000) {
+      commissionRateBps = raw
+    } else {
+      return c.json(
+        {
+          error: {
+            code: 'invalid_rate',
+            message: 'commissionRateBps must be null or an integer between 0 and 10000 (basis points)',
+          },
+        },
+        400,
+      )
+    }
+
+    try {
+      const existing = await prisma.affiliate.findUnique({ where: { id }, select: { id: true } })
+      if (!existing) {
+        return c.json({ error: { code: 'affiliate_not_found', message: 'Affiliate not found' } }, 404)
+      }
+      const updated = await prisma.affiliate.update({
+        where: { id },
+        data: { commissionRateBps },
+        select: { id: true, userId: true, code: true, status: true, commissionRateBps: true },
+      })
+      return c.json({ ok: true, affiliate: updated })
+    } catch (error: any) {
+      console.error('[Admin] Affiliate rate patch error:', error)
+      return c.json({ error: { code: 'affiliate_update_failed', message: error.message } }, 500)
+    }
+  })
+
   return router
 }
 

--- a/apps/api/src/services/__tests__/affiliate.service.test.ts
+++ b/apps/api/src/services/__tests__/affiliate.service.test.ts
@@ -809,6 +809,55 @@ describe('recordCommissionsForInvoice', () => {
     const created = await svc.recordCommissionsForInvoice(buildInvoice(), makeStripe(), new Date('2026-05-15'))
     expect(created).toBe(0)
   })
+
+  test('per-affiliate L1 override replaces the tier rate as a flat rate', async () => {
+    const { direct } = setupTree()
+    direct.commissionRateBps = 3000 // 30% custom deal
+    const created = await svc.recordCommissionsForInvoice(buildInvoice(), makeStripe(), new Date('2026-05-15'))
+    expect(created).toBe(1)
+    expect(commissions[0].level).toBe(1)
+    expect(commissions[0].rateBps).toBe(3000)
+    expect(commissions[0].amountCents).toBe(3000) // 30% of 10_000
+    expect(affiliates.get('aff_direct')!.pendingPayoutCents).toBe(3000)
+  })
+
+  test('L1 override bypasses the durationDays window and step-down', async () => {
+    const { direct } = setupTree()
+    direct.commissionRateBps = 2500 // 25% flat
+    // Attribution well past the 365-day window — normally L1 would step
+    // down to the tier's secondaryRateBps (1000). The override wins.
+    attributions.set('u-buyer', {
+      id: 'attr_buyer',
+      userId: 'u-buyer',
+      affiliateId: direct.id,
+      attributedAt: new Date('2025-01-01'),
+    })
+    const created = await svc.recordCommissionsForInvoice(buildInvoice(), makeStripe(), new Date('2026-12-15'))
+    expect(created).toBe(1)
+    expect(commissions[0].rateBps).toBe(2500)
+    expect(commissions[0].amountCents).toBe(2500)
+  })
+
+  test('L1 override does not affect L2/L3 (they keep tier rates)', async () => {
+    process.env.SHOGO_AFFILIATE_PAYOUT_MAX_DEPTH = '3'
+    const { direct } = setupTree()
+    direct.commissionRateBps = 3000 // override only the direct referrer
+    const created = await svc.recordCommissionsForInvoice(buildInvoice(), makeStripe(), new Date('2026-05-15'))
+    expect(created).toBe(3)
+    const byAff = Object.fromEntries(commissions.map((c) => [c.affiliateId, c]))
+    expect(byAff.aff_direct.amountCents).toBe(3000) // 30% override
+    expect(byAff.aff_l2.amountCents).toBe(500) // tier 5%
+    expect(byAff.aff_root.amountCents).toBe(200) // tier 2%
+  })
+
+  test('null override falls back to the tier rate', async () => {
+    const { direct } = setupTree()
+    direct.commissionRateBps = null
+    const created = await svc.recordCommissionsForInvoice(buildInvoice(), makeStripe(), new Date('2026-05-15'))
+    expect(created).toBe(1)
+    expect(commissions[0].rateBps).toBe(2000) // unchanged tier rate
+    expect(commissions[0].amountCents).toBe(2000)
+  })
 })
 
 // ===========================================================================

--- a/apps/api/src/services/affiliate.service.ts
+++ b/apps/api/src/services/affiliate.service.ts
@@ -463,6 +463,9 @@ type InvoiceForCommission = {
  *   - excludes overage trust-block line items from the commission basis
  *   - per-level `durationDays` window: skips a level if the attribution
  *     is older than that window
+ *   - per-affiliate L1 override: when the direct referrer has
+ *     `commissionRateBps` set, that flat rate replaces the level-1 tier
+ *     rate (durationDays / secondaryRateBps bypassed for that affiliate)
  *   - upsert keyed on (invoice, affiliate, level) — webhook replays
  *     never produce duplicate rows
  */
@@ -548,6 +551,18 @@ export async function recordCommissionsForInvoice(
   const cap = Math.min(tiers.length, getPayoutMaxDepth())
   const upline = await getUpline(affiliateId, cap)
 
+  // Per-affiliate L1 override. The direct referrer (level 1) is exactly
+  // `affiliateId` (the customer's attributed affiliate). When that affiliate
+  // has a `commissionRateBps` set, it replaces the level-1 tier rate as a
+  // FLAT rate: the tier's durationDays window and secondaryRateBps step-down
+  // are intentionally bypassed for this affiliate's direct referrals. Deeper
+  // upline levels always use tier rates.
+  const directAffiliate = await prisma.affiliate.findUnique({
+    where: { id: affiliateId },
+    select: { commissionRateBps: true },
+  })
+  const l1OverrideBps = directAffiliate?.commissionRateBps ?? null
+
   const refundHoldDays = getRefundHoldDays()
   const eligibleAt = new Date(now.getTime() + refundHoldDays * 24 * 60 * 60 * 1000)
 
@@ -564,7 +579,11 @@ export async function recordCommissionsForInvoice(
     const uplineEntry = upline.find((u) => u.level === level)
     if (!uplineEntry) continue
     let rateBps = tier.rateBps as number
-    if (tier.durationDays != null && attrAgeDays > tier.durationDays) {
+    if (level === 1 && l1OverrideBps != null) {
+      // Flat per-affiliate override for the direct referrer: ignore the
+      // tier's durationDays / secondaryRateBps and always pay this rate.
+      rateBps = l1OverrideBps
+    } else if (tier.durationDays != null && attrAgeDays > tier.durationDays) {
       // This level's primary window has expired. If a step-down rate is
       // configured (e.g. 20% for year one -> 10% forever), keep paying at
       // that reduced rate; otherwise the level stops earning (legacy

--- a/apps/desktop/prisma/migrations/20260602203002_affiliate_per_affiliate_rate/migration.sql
+++ b/apps/desktop/prisma/migrations/20260602203002_affiliate_per_affiliate_rate/migration.sql
@@ -1,0 +1,16 @@
+-- Migration: affiliate_per_affiliate_rate
+-- Source:    prisma/schema.local.prisma
+--
+-- Adds an optional per-affiliate commission-rate override to the `affiliates`
+-- table. When set (basis points; 2000 = 20.00%), it replaces the per-level
+-- `AffiliateCommissionTier` rate for that affiliate's direct (L1) referrals and
+-- is applied as a flat rate — the tier's durationDays window and
+-- secondaryRateBps step-down are bypassed at L1. NULL = use the tier rate.
+-- See apps/api/src/services/affiliate.service.ts:recordCommissionsForInvoice.
+--
+-- Scoped to the affiliate change only; pre-existing ACCEPTED_DRIFT
+-- redefinitions of other tables (see scripts/check-desktop-schema-drift.ts)
+-- are intentionally left out.
+
+-- AlterTable
+ALTER TABLE "affiliates" ADD COLUMN "commissionRateBps" INTEGER;

--- a/prisma/migrations/20260602203002_affiliate_per_affiliate_rate/migration.sql
+++ b/prisma/migrations/20260602203002_affiliate_per_affiliate_rate/migration.sql
@@ -1,0 +1,16 @@
+-- Migration: per-affiliate commission-rate override.
+--
+-- Adds an optional `commissionRateBps` column to `affiliates` (see
+-- prisma/schema.prisma `Affiliate` and the commission engine in
+-- apps/api/src/services/affiliate.service.ts). When set, it replaces the
+-- per-level `AffiliateCommissionTier` rate for THIS affiliate's direct (L1)
+-- referrals and is applied as a flat rate — the tier's `durationDays` window
+-- and `secondaryRateBps` step-down are bypassed at L1. NULL preserves the
+-- default behavior of using the tier rate. Only level 1 is affected; deeper
+-- upline levels always use tier rates.
+--
+-- Basis points: 2000 = 20.00%. No backfill — existing affiliates stay NULL
+-- and continue earning at the tier rate.
+
+-- AlterTable
+ALTER TABLE "affiliates" ADD COLUMN "commissionRateBps" INTEGER;

--- a/prisma/schema.local.prisma
+++ b/prisma/schema.local.prisma
@@ -1944,6 +1944,7 @@ model Affiliate {
   totalEarningsCents       Int       @default(0)
   pendingPayoutCents       Int       @default(0)
   totalPaidOutCents        Int       @default(0)
+  commissionRateBps        Int?
   termsAcceptedAt          DateTime?
   createdAt                DateTime  @default(now())
   updatedAt                DateTime  @updatedAt

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2573,6 +2573,13 @@ model Affiliate {
   /// Sum of `paid` commissions in cents. Differs from totalEarnings only
   /// when clawbacks adjust the running total.
   totalPaidOutCents     Int             @default(0)
+  /// Optional per-affiliate commission-rate override (basis points;
+  /// 2000 = 20.00%). When set, it replaces the `AffiliateCommissionTier`
+  /// rate for THIS affiliate's direct (L1) referrals and is applied as a
+  /// flat rate — the tier's `durationDays` window and `secondaryRateBps`
+  /// step-down are ignored at L1. Null = use the tier rate (default).
+  /// Only affects level 1; deeper upline levels always use tier rates.
+  commissionRateBps     Int?
   /// Set when the user accepted the affiliate terms during enroll.
   termsAcceptedAt       DateTime?
   createdAt             DateTime        @default(now())


### PR DESCRIPTION
## Summary
- Adds an optional `commissionRateBps` column to the `Affiliate` model so an individual affiliate's **direct (L1)** referral commissions can be paid at a custom flat percentage instead of the global per-level `AffiliateCommissionTier` rate.
- `recordCommissionsForInvoice` applies the override at level 1 as a flat rate, intentionally bypassing the tier's `durationDays` window and `secondaryRateBps` step-down. Deeper upline levels (L2/L3) keep using tier rates; `null` (the default) falls back to the tier rate, preserving today's behavior. The actual rate used is stored on `AffiliateCommission.rateBps`, so clawback/audit math stays correct.
- New super-admin endpoint `PATCH /api/admin/affiliates/:id` with body `{ commissionRateBps: number | null }`, validated to an integer `0..10000` bps (0%–100%); `null` clears the override. 404s on unknown affiliate.
- Schema change mirrored on both Prisma tracks with matching PG + SQLite migrations (`20260602203002_affiliate_per_affiliate_rate`), each a single nullable `ADD COLUMN` (no backfill).

## Test plan
- [x] `bun test apps/api/src/services/__tests__/affiliate.service.test.ts` — override applied flat at L1, bypasses durationDays/step-down, does not affect L2/L3, null falls back to tier
- [x] `bun test apps/api/src/__tests__/admin-routes.expanded.test.ts` — set/clear, range validation, 404
- [x] `bun test apps/api/src/__tests__/affiliate-schema.test.ts` — schema column + migration assertions on both tracks
- [x] `bun run check:schema-parity` / `check:desktop-schema-drift` / `check:migrations` all clean for `affiliates`
- [x] No new typecheck errors (the two pre-existing `affiliate.service.ts` errors also exist on `main`)

## Notes
- Scope is L1 only and a single flat % (per product decision); no mobile/dashboard surfacing in this PR.
- PG migration was authored by hand (no local Postgres in this environment); the SQLite migration was generated via `db:migrate:desktop` and trimmed to the affiliate change, matching the prior `affiliate_secondary_rate` precedent. Run `prisma migrate deploy` on the PG track at deploy time.

Made with [Cursor](https://cursor.com)