### PR TITLE
chore(agent-runtime): gate search tool behind SHOGO_SEARCH_ENABLED + 10s timeout

### DIFF
--- a/.github/scripts/check-node-disk-headroom.sh
+++ b/.github/scripts/check-node-disk-headroom.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# .github/scripts/check-node-disk-headroom.sh
+#
+# Deploy-time gate that catches the 2026-06-02 EU incident class: a node
+# disk-exhaustion event BEFORE we patch the api ksvc into it.
+#
+# What happened in EU: the node pool ran 100 GB boot volumes while ~30 GB of
+# stacked 8 GB runtime images sat on each node. The busiest nodes crossed the
+# kubelet DiskPressure threshold (~85%), so the kubelet started evicting pods
+# and garbage-collecting images. The new `api` revision could never reach its
+# initial scale (pods stuck ContainerCreating / failing liveness), and the
+# warm pool churned. The deploy only discovered this 10 minutes later via
+# `ProgressDeadlineExceeded` — by which point the cluster was already in a
+# self-sustaining storm.
+#
+# Running this BEFORE the ksvc patch turns that 10-minute mystery timeout into
+# an immediate, actionable failure ("node X is at 88% disk").
+#
+# Fails the deploy if either:
+#   * any Ready, schedulable node already reports DiskPressure=True, OR
+#   * any such node's root filesystem is at/above THRESHOLD_PCT used.
+#
+# Usage:
+#   .github/scripts/check-node-disk-headroom.sh [threshold_pct]
+# Env:
+#   THRESHOLD_PCT  default 80  (kubelet's default DiskPressure eviction
+#                               soft threshold is imagefs/nodefs available<15%,
+#                               i.e. ~85% used; 80% leaves margin to deploy)
+
+set -euo pipefail
+
+THRESHOLD_PCT="${1:-${THRESHOLD_PCT:-80}}"
+rc=0
+
+echo "Checking node disk headroom (fail at >=${THRESHOLD_PCT}% used or DiskPressure=True)..."
+
+# 1) DiskPressure condition — the authoritative kubelet signal.
+pressured=$(kubectl get nodes -o json | jq -r '
+  [.items[]
+    | select((.status.conditions // [])[] | select(.type == "DiskPressure" and .status == "True"))
+    | .metadata.name
+  ] | join(" ")
+')
+if [[ -n "$pressured" ]]; then
+  echo "::error::check-node-disk-headroom: node(s) under DiskPressure: $pressured"
+  rc=1
+fi
+
+# 2) Root filesystem usage per node via the kubelet stats summary API.
+# Skip unschedulable (cordoned) nodes — they're intentionally drained and
+# shouldn't gate a deploy.
+for node in $(kubectl get nodes -o jsonpath='{range .items[?(@.spec.unschedulable!=true)]}{.metadata.name}{"\n"}{end}'); do
+  summary=$(kubectl get --raw "/api/v1/nodes/${node}/proxy/stats/summary" 2>/dev/null || echo "")
+  if [[ -z "$summary" ]]; then
+    echo "  $node: (stats unavailable, relying on DiskPressure condition)"
+    continue
+  fi
+  pct=$(echo "$summary" | jq -r '
+    (.node.fs.usedBytes // 0) as $u
+    | (.node.fs.capacityBytes // 0) as $c
+    | if $c > 0 then (($u / $c) * 100 | floor) else 0 end
+  ')
+  echo "  $node: ${pct}% used"
+  if [[ "$pct" -ge "$THRESHOLD_PCT" ]]; then
+    echo "::error::check-node-disk-headroom: node $node at ${pct}% disk (>=${THRESHOLD_PCT}%)"
+    rc=1
+  fi
+done
+
+if [[ "$rc" -ne 0 ]]; then
+  echo "::error::Aborting before ksvc patch: a disk-starved cluster cannot roll out a new revision."
+  echo "Remediate node disk first (prune stale runtime images / scale or replace nodes / raise boot volume — see terraform/README.md 'Boot volume remediation')."
+  echo "::group::node images (largest, busiest node)"
+  kubectl get nodes -o json | jq -r '
+    .items
+    | max_by([.status.images[]?.sizeBytes] | add // 0)
+    | .metadata.name as $n
+    | "node \($n): " + (([.status.images[]?.sizeBytes] | add // 0) / 1e9 | tostring) + " GB of images"
+  ' 2>/dev/null || true
+  echo "::endgroup::"
+fi
+
+exit "$rc"

--- a/.github/scripts/check-node-disk-parity.sh
+++ b/.github/scripts/check-node-disk-parity.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# .github/scripts/check-node-disk-parity.sh
+#
+# Cross-region node-pool boot-volume parity guard.
+#
+# The EU 2026-06-02 incident root cause was a silent capacity drift: EU (and
+# India) node pools were bootstrapped at 100 GB boot volumes while US ran
+# 200 GB. The drift was invisible because the oke module ignores in-place
+# boot-volume changes (a deliberate anti-replacement safety), so neither a
+# `terraform plan` nor day-to-day ops surfaced it. EU tipped into DiskPressure
+# under load; India is the same latent exposure.
+#
+# This check queries the LIVE OCI node pools across all production regions and
+# fails if any region's system-pool boot volume is below EXPECTED_GB. Run it in
+# CI (terraform.yml) so the drift can never silently re-open.
+#
+# Usage:
+#   COMPARTMENT_ID=ocid1.compartment... \
+#   EXPECTED_GB=200 \
+#   REGIONS="us-ashburn-1 eu-frankfurt-1 ap-mumbai-1" \
+#   .github/scripts/check-node-disk-parity.sh
+#
+# Requires: oci CLI configured, jq.
+
+set -euo pipefail
+
+COMPARTMENT_ID="${COMPARTMENT_ID:?COMPARTMENT_ID required}"
+EXPECTED_GB="${EXPECTED_GB:-200}"
+REGIONS="${REGIONS:-us-ashburn-1 eu-frankfurt-1 ap-mumbai-1}"
+
+rc=0
+echo "Asserting system node-pool boot volume == ${EXPECTED_GB} GB across: ${REGIONS}"
+
+for region in $REGIONS; do
+  # A region may have multiple clusters; check every node pool in the
+  # production compartment for that region.
+  pools=$(oci ce node-pool list \
+    --region "$region" \
+    --compartment-id "$COMPARTMENT_ID" \
+    --all \
+    --query 'data[].{name:name, gb:"node-source-details"."boot-volume-size-in-gbs"}' \
+    --output json 2>/dev/null || echo '[]')
+
+  count=$(echo "$pools" | jq 'length')
+  if [[ "$count" -eq 0 ]]; then
+    echo "  [$region] no node pools found (skipping)"
+    continue
+  fi
+
+  while IFS= read -r row; do
+    name=$(echo "$row" | jq -r '.name')
+    gb=$(echo "$row" | jq -r '.gb // 0')
+    if [[ "$gb" -lt "$EXPECTED_GB" ]]; then
+      echo "::error::node-disk-parity: [$region] pool '$name' boot volume ${gb} GB < expected ${EXPECTED_GB} GB"
+      rc=1
+    else
+      echo "  [$region] $name: ${gb} GB OK"
+    fi
+  done < <(echo "$pools" | jq -c '.[]')
+done
+
+if [[ "$rc" -ne 0 ]]; then
+  echo "::error::Boot-volume drift detected. Remediate via a controlled node-pool replacement (see terraform/README.md 'Boot volume remediation')."
+fi
+exit "$rc"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -711,6 +711,15 @@ jobs:
           echo "api_image=$(get_image api ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
           echo "docs_image=$(get_image docs ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
 
+      # Pre-rollout gate (2026-06-02 EU incident class): refuse to apply
+      # manifests / patch ksvcs into a disk-starved cluster. A node above the
+      # disk threshold (or already under DiskPressure) cannot bring up a new
+      # revision — the kubelet evicts/GCs instead — so the rollout would only
+      # fail 10 minutes later with ProgressDeadlineExceeded. Fail fast with an
+      # actionable message instead.
+      - name: Check node disk headroom (pre-rollout gate)
+        run: .github/scripts/check-node-disk-headroom.sh 80
+
       - name: Apply Kubernetes manifests
         run: |
           # Render RUNTIME_IMAGE into the api ksvc at apply time, mirroring the
@@ -1169,6 +1178,15 @@ jobs:
           echo "web_image=$(get_image studio ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
           echo "api_image=$(get_image api ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
           echo "docs_image=$(get_image docs ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
+
+      # Pre-rollout gate (2026-06-02 EU incident class): refuse to apply
+      # manifests / patch ksvcs into a disk-starved cluster. A node above the
+      # disk threshold (or already under DiskPressure) cannot bring up a new
+      # revision — the kubelet evicts/GCs instead — so the rollout would only
+      # fail 10 minutes later with ProgressDeadlineExceeded. Fail fast with an
+      # actionable message instead.
+      - name: Check node disk headroom (pre-rollout gate)
+        run: .github/scripts/check-node-disk-headroom.sh 80
 
       - name: Apply Kubernetes manifests
         run: |
@@ -1735,6 +1753,15 @@ jobs:
           echo "api_image=$(get_image api ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
           echo "docs_image=$(get_image docs ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
 
+      # Pre-rollout gate (2026-06-02 EU incident class): refuse to apply
+      # manifests / patch ksvcs into a disk-starved cluster. A node above the
+      # disk threshold (or already under DiskPressure) cannot bring up a new
+      # revision — the kubelet evicts/GCs instead — so the rollout would only
+      # fail 10 minutes later with ProgressDeadlineExceeded. Fail fast with an
+      # actionable message instead.
+      - name: Check node disk headroom (pre-rollout gate)
+        run: .github/scripts/check-node-disk-headroom.sh 80
+
       - name: Apply Kubernetes manifests
         run: |
           # Render RUNTIME_IMAGE into the api ksvc at apply time, mirroring the
@@ -2288,6 +2315,15 @@ jobs:
           echo "web_image=$(get_image studio ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
           echo "api_image=$(get_image api ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
           echo "docs_image=$(get_image docs ${{ env.NS_SYSTEM }})" >> $GITHUB_OUTPUT
+
+      # Pre-rollout gate (2026-06-02 EU incident class): refuse to apply
+      # manifests / patch ksvcs into a disk-starved cluster. A node above the
+      # disk threshold (or already under DiskPressure) cannot bring up a new
+      # revision — the kubelet evicts/GCs instead — so the rollout would only
+      # fail 10 minutes later with ProgressDeadlineExceeded. Fail fast with an
+      # actionable message instead.
+      - name: Check node disk headroom (pre-rollout gate)
+        run: .github/scripts/check-node-disk-headroom.sh 80
 
       - name: Apply Kubernetes manifests
         run: |

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -105,6 +105,26 @@ jobs:
       - name: terraform validate
         run: terraform validate -no-color
 
+      # Cross-region node-pool boot-volume parity guard (2026-06-02 EU
+      # incident): EU/India bootstrapped at 100 GB while US ran 200 GB, and
+      # the oke module ignores in-place boot-volume changes, so the drift was
+      # invisible to `terraform plan`. This asserts parity against the LIVE
+      # OCI pools so the gap can never silently re-open.
+      - name: Install OCI CLI
+        run: pip install oci-cli --quiet
+
+      - name: Node disk parity check (cross-region boot volumes)
+        env:
+          OCI_CLI_USER: ${{ secrets.OCI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ secrets.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ secrets.OCI_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_PRIVATE_KEY }}
+          OCI_CLI_REGION: us-ashburn-1
+          COMPARTMENT_ID: ${{ vars.COMPARTMENT_ID }}
+          EXPECTED_GB: "200"
+          REGIONS: "us-ashburn-1 eu-frankfurt-1 ap-mumbai-1"
+        run: "$GITHUB_WORKSPACE/.github/scripts/check-node-disk-parity.sh"
+
       - name: terraform plan
         id: plan
         env:

--- a/apps/api/src/__tests__/admin-routes.expanded.test.ts
+++ b/apps/api/src/__tests__/admin-routes.expanded.test.ts
@@ -136,6 +136,16 @@ const prisma = {
   signupAttribution: {
     upsert: mock(async () => ({})),
   },
+  affiliate: {
+    findUnique: mock(async ({ where }: any) => (where.id === 'aff-1' ? { id: 'aff-1' } : null)),
+    update: mock(async ({ where, data }: any) => ({
+      id: where.id,
+      userId: 'user-9',
+      code: 'creator',
+      status: 'active',
+      commissionRateBps: data.commissionRateBps,
+    })),
+  },
 }
 
 mock.module('../lib/prisma', () => withPrismaExports({ prisma }))
@@ -389,6 +399,47 @@ describe('PATCH /heartbeats/projects/:projectId — gap-closer branches', () => 
     const lastCall = prisma.agentConfig.update.mock.calls.at(-1)![0]
     expect(lastCall.data.heartbeatEnabled).toBe(false)
     expect(lastCall.data.nextHeartbeatAt).toBeNull()
+  })
+})
+
+describe('PATCH /affiliates/:id — per-affiliate commission-rate override', () => {
+  function patch(id: string, body: unknown) {
+    return adminRoutes().request(`http://api.test/affiliates/${id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  }
+
+  test('sets a valid override rate', async () => {
+    const res = await patch('aff-1', { commissionRateBps: 3000 })
+    expect(res.status).toBe(200)
+    const body = await json(res)
+    expect(body.ok).toBe(true)
+    expect(body.affiliate.commissionRateBps).toBe(3000)
+    expect(prisma.affiliate.update.mock.calls.at(-1)![0].data).toEqual({ commissionRateBps: 3000 })
+  })
+
+  test('clears the override when passed null', async () => {
+    const res = await patch('aff-1', { commissionRateBps: null })
+    expect(res.status).toBe(200)
+    const body = await json(res)
+    expect(body.affiliate.commissionRateBps).toBeNull()
+    expect(prisma.affiliate.update.mock.calls.at(-1)![0].data).toEqual({ commissionRateBps: null })
+  })
+
+  test('rejects out-of-range and non-integer rates', async () => {
+    expect((await patch('aff-1', { commissionRateBps: 10001 })).status).toBe(400)
+    expect((await patch('aff-1', { commissionRateBps: -1 })).status).toBe(400)
+    expect((await patch('aff-1', { commissionRateBps: 12.5 })).status).toBe(400)
+    expect((await patch('aff-1', { commissionRateBps: 'lots' })).status).toBe(400)
+  })
+
+  test('returns 404 for an unknown affiliate', async () => {
+    const res = await patch('ghost', { commissionRateBps: 1000 })
+    expect(res.status).toBe(404)
+    const body = await json(res)
+    expect(body.error.code).toBe('affiliate_not_found')
   })
 })
 

--- a/apps/api/src/__tests__/affiliate-schema.test.ts
+++ b/apps/api/src/__tests__/affiliate-schema.test.ts
@@ -67,6 +67,11 @@ describe('Affiliate schema (PG)', () => {
     expect(block).toMatch(/depth\s+Int\s+@default\(1\)/)
   })
 
+  test('Affiliate has the optional per-affiliate commissionRateBps override', () => {
+    const block = modelBlock(PG_SCHEMA, 'Affiliate')
+    expect(block).toMatch(/commissionRateBps\s+Int\?/)
+  })
+
   test('AffiliateCommission has the (invoice, affiliate, level) idempotency key', () => {
     const block = modelBlock(PG_SCHEMA, 'AffiliateCommission')
     expect(block).toMatch(/@@unique\(\[stripeInvoiceId,\s*affiliateId,\s*level\]\)/)
@@ -136,6 +141,11 @@ describe('Affiliate schema (local SQLite mirror)', () => {
     expect(block).toMatch(/affiliate\s+Affiliate\?/)
     expect(block).toMatch(/affiliateAttribution\s+AffiliateAttribution\?/)
   })
+
+  test('mirrors the per-affiliate commissionRateBps override column', () => {
+    const block = modelBlock(LOCAL_SCHEMA, 'Affiliate')
+    expect(block).toMatch(/commissionRateBps\s+Int\?/)
+  })
 })
 
 describe('Affiliate migrations', () => {
@@ -188,6 +198,20 @@ describe('Affiliate migrations', () => {
     expect(SQLITE_MIGRATION).toMatch(/INSERT OR IGNORE INTO "affiliate_commission_tiers"/)
     expect(SQLITE_MIGRATION).toMatch(/'aff_tier_l1', 1, 2000/)
     expect(SQLITE_MIGRATION).toMatch(/'aff_tier_l3', 3, 200/)
+  })
+
+  test('per-affiliate rate migrations add the commissionRateBps column on both tracks', () => {
+    const pg = readFileSync(
+      resolve(REPO_ROOT, 'prisma/migrations/20260602203002_affiliate_per_affiliate_rate/migration.sql'),
+      'utf-8',
+    )
+    const sqlite = readFileSync(
+      resolve(REPO_ROOT, 'apps/desktop/prisma/migrations/20260602203002_affiliate_per_affiliate_rate/migration.sql'),
+      'utf-8',
+    )
+    const addColumn = /ALTER TABLE "affiliates" ADD COLUMN "commissionRateBps" INTEGER;/
+    expect(pg).toMatch(addColumn)
+    expect(sqlite).toMatch(addColumn)
   })
 
   test('SQLite migration uses TEXT for the would-be enum columns', () => {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -716,6 +716,65 @@ export function adminRoutes(): Hono {
     }
   })
 
+  // --------------------------------------------------------------------------
+  // Affiliate management
+  // --------------------------------------------------------------------------
+
+  /**
+   * PATCH /affiliates/:id - Set or clear an affiliate's per-affiliate
+   * commission-rate override. `commissionRateBps` is in basis points
+   * (2000 = 20.00%), range 0..10000 (0%..100%). Pass `null` to clear the
+   * override and fall back to the per-level `AffiliateCommissionTier` rate.
+   *
+   * The override only affects the affiliate's direct (L1) referral
+   * commissions, applied as a flat rate (the tier's durationDays window and
+   * secondaryRateBps step-down are bypassed). See
+   * apps/api/src/services/affiliate.service.ts:recordCommissionsForInvoice.
+   */
+  router.patch('/affiliates/:id', async (c) => {
+    const id = c.req.param('id')
+    let body: any
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: { code: 'bad_request', message: 'Invalid JSON body' } }, 400)
+    }
+
+    const raw = body?.commissionRateBps
+    let commissionRateBps: number | null
+    if (raw === null) {
+      commissionRateBps = null
+    } else if (typeof raw === 'number' && Number.isInteger(raw) && raw >= 0 && raw <= 10000) {
+      commissionRateBps = raw
+    } else {
+      return c.json(
+        {
+          error: {
+            code: 'invalid_rate',
+            message: 'commissionRateBps must be null or an integer between 0 and 10000 (basis points)',
+          },
+        },
+        400,
+      )
+    }
+
+    try {
+      const existing = await prisma.affiliate.findUnique({ where: { id }, select: { id: true } })
+      if (!existing) {
+        return c.json({ error: { code: 'affiliate_not_found', message: 'Affiliate not found' } }, 404)
+      }
+      const updated = await prisma.affiliate.update({
+        where: { id },
+        data: { commissionRateBps },
+        select: { id: true, userId: true, code: true, status: true, commissionRateBps: true },
+      })
+      return c.json({ ok: true, affiliate: updated })
+    } catch (error: any) {
+      console.error('[Admin] Affiliate rate patch error:', error)
+      return c.json({ error: { code: 'affiliate_update_failed', message: error.message } }, 500)
+    }
+  })
+
   return router
 }
 

--- a/apps/api/src/services/__tests__/affiliate.service.test.ts
+++ b/apps/api/src/services/__tests__/affiliate.service.test.ts
@@ -809,6 +809,55 @@ describe('recordCommissionsForInvoice', () => {
     const created = await svc.recordCommissionsForInvoice(buildInvoice(), makeStripe(), new Date('2026-05-15'))
     expect(created).toBe(0)
   })
+
+  test('per-affiliate L1 override replaces the tier rate as a flat rate', async () => {
+    const { direct } = setupTree()
+    direct.commissionRateBps = 3000 // 30% custom deal
+    const created = await svc.recordCommissionsForInvoice(buildInvoice(), makeStripe(), new Date('2026-05-15'))
+    expect(created).toBe(1)
+    expect(commissions[0].level).toBe(1)
+    expect(commissions[0].rateBps).toBe(3000)
+    expect(commissions[0].amountCents).toBe(3000) // 30% of 10_000
+    expect(affiliates.get('aff_direct')!.pendingPayoutCents).toBe(3000)
+  })
+
+  test('L1 override bypasses the durationDays window and step-down', async () => {
+    const { direct } = setupTree()
+    direct.commissionRateBps = 2500 // 25% flat
+    // Attribution well past the 365-day window — normally L1 would step
+    // down to the tier's secondaryRateBps (1000). The override wins.
+    attributions.set('u-buyer', {
+      id: 'attr_buyer',
+      userId: 'u-buyer',
+      affiliateId: direct.id,
+      attributedAt: new Date('2025-01-01'),
+    })
+    const created = await svc.recordCommissionsForInvoice(buildInvoice(), makeStripe(), new Date('2026-12-15'))
+    expect(created).toBe(1)
+    expect(commissions[0].rateBps).toBe(2500)
+    expect(commissions[0].amountCents).toBe(2500)
+  })
+
+  test('L1 override does not affect L2/L3 (they keep tier rates)', async () => {
+    process.env.SHOGO_AFFILIATE_PAYOUT_MAX_DEPTH = '3'
+    const { direct } = setupTree()
+    direct.commissionRateBps = 3000 // override only the direct referrer
+    const created = await svc.recordCommissionsForInvoice(buildInvoice(), makeStripe(), new Date('2026-05-15'))
+    expect(created).toBe(3)
+    const byAff = Object.fromEntries(commissions.map((c) => [c.affiliateId, c]))
+    expect(byAff.aff_direct.amountCents).toBe(3000) // 30% override
+    expect(byAff.aff_l2.amountCents).toBe(500) // tier 5%
+    expect(byAff.aff_root.amountCents).toBe(200) // tier 2%
+  })
+
+  test('null override falls back to the tier rate', async () => {
+    const { direct } = setupTree()
+    direct.commissionRateBps = null
+    const created = await svc.recordCommissionsForInvoice(buildInvoice(), makeStripe(), new Date('2026-05-15'))
+    expect(created).toBe(1)
+    expect(commissions[0].rateBps).toBe(2000) // unchanged tier rate
+    expect(commissions[0].amountCents).toBe(2000)
+  })
 })
 
 // ===========================================================================

--- a/apps/api/src/services/affiliate.service.ts
+++ b/apps/api/src/services/affiliate.service.ts
@@ -463,6 +463,9 @@ type InvoiceForCommission = {
  *   - excludes overage trust-block line items from the commission basis
  *   - per-level `durationDays` window: skips a level if the attribution
  *     is older than that window
+ *   - per-affiliate L1 override: when the direct referrer has
+ *     `commissionRateBps` set, that flat rate replaces the level-1 tier
+ *     rate (durationDays / secondaryRateBps bypassed for that affiliate)
  *   - upsert keyed on (invoice, affiliate, level) — webhook replays
  *     never produce duplicate rows
  */
@@ -548,6 +551,18 @@ export async function recordCommissionsForInvoice(
   const cap = Math.min(tiers.length, getPayoutMaxDepth())
   const upline = await getUpline(affiliateId, cap)
 
+  // Per-affiliate L1 override. The direct referrer (level 1) is exactly
+  // `affiliateId` (the customer's attributed affiliate). When that affiliate
+  // has a `commissionRateBps` set, it replaces the level-1 tier rate as a
+  // FLAT rate: the tier's durationDays window and secondaryRateBps step-down
+  // are intentionally bypassed for this affiliate's direct referrals. Deeper
+  // upline levels always use tier rates.
+  const directAffiliate = await prisma.affiliate.findUnique({
+    where: { id: affiliateId },
+    select: { commissionRateBps: true },
+  })
+  const l1OverrideBps = directAffiliate?.commissionRateBps ?? null
+
   const refundHoldDays = getRefundHoldDays()
   const eligibleAt = new Date(now.getTime() + refundHoldDays * 24 * 60 * 60 * 1000)
 
@@ -564,7 +579,11 @@ export async function recordCommissionsForInvoice(
     const uplineEntry = upline.find((u) => u.level === level)
     if (!uplineEntry) continue
     let rateBps = tier.rateBps as number
-    if (tier.durationDays != null && attrAgeDays > tier.durationDays) {
+    if (level === 1 && l1OverrideBps != null) {
+      // Flat per-affiliate override for the direct referrer: ignore the
+      // tier's durationDays / secondaryRateBps and always pay this rate.
+      rateBps = l1OverrideBps
+    } else if (tier.durationDays != null && attrAgeDays > tier.durationDays) {
       // This level's primary window has expired. If a step-down rate is
       // configured (e.g. 20% for year one -> 10% forever), keep paying at
       // that reduced rate; otherwise the level stops earning (legacy

--- a/apps/desktop/prisma/migrations/20260602203002_affiliate_per_affiliate_rate/migration.sql
+++ b/apps/desktop/prisma/migrations/20260602203002_affiliate_per_affiliate_rate/migration.sql
@@ -1,0 +1,16 @@
+-- Migration: affiliate_per_affiliate_rate
+-- Source:    prisma/schema.local.prisma
+--
+-- Adds an optional per-affiliate commission-rate override to the `affiliates`
+-- table. When set (basis points; 2000 = 20.00%), it replaces the per-level
+-- `AffiliateCommissionTier` rate for that affiliate's direct (L1) referrals and
+-- is applied as a flat rate — the tier's durationDays window and
+-- secondaryRateBps step-down are bypassed at L1. NULL = use the tier rate.
+-- See apps/api/src/services/affiliate.service.ts:recordCommissionsForInvoice.
+--
+-- Scoped to the affiliate change only; pre-existing ACCEPTED_DRIFT
+-- redefinitions of other tables (see scripts/check-desktop-schema-drift.ts)
+-- are intentionally left out.
+
+-- AlterTable
+ALTER TABLE "affiliates" ADD COLUMN "commissionRateBps" INTEGER;

--- a/k8s/base/warm-pool-monitor.yaml
+++ b/k8s/base/warm-pool-monitor.yaml
@@ -19,6 +19,10 @@
 #       — same incident class, runtime variant.
 #   * warm-pool ksvcs exist but 0 are Ready
 #       — controller alive but every pod broken.
+#   * any node is under DiskPressure
+#       — node disk exhaustion (the 2026-06-02 EU incident class): boot
+#         volume fills with stacked runtime images, kubelet evicts pods and
+#         GCs images, and the warm pool churns. Earliest clear signal.
 #
 # Modeled after k8s/cnpg/logical-replication/replication-monitor.yaml
 # (deliberately the same structure/operator-experience).
@@ -51,6 +55,13 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["pods"]
+    verbs: ["get", "list"]
+  # Node read is required for the DiskPressure check (check #4). The EU
+  # 2026-06-02 incident was a node-disk exhaustion event (100 GB boot
+  # volumes + stacked 8 GB runtime images -> kubelet eviction/image-GC ->
+  # warm-pool churn) that this monitor was blind to.
+  - apiGroups: [""]
+    resources: ["nodes"]
     verbs: ["get", "list"]
   - apiGroups: ["serving.knative.dev"]
     resources: ["services", "revisions"]
@@ -95,7 +106,13 @@ spec:
               # alpine/k8s ships kubectl + jq + a posix shell in a small
               # multi-arch image. Pinned to a specific patch so a
               # registry-side mutation can't change behavior under us.
-              image: alpine/k8s:1.31.5
+              # MUST be fully qualified with the docker.io/ registry prefix:
+              # the OKE nodes run cri-o with `short-name-mode=enforcing`, which
+              # rejects a bare `alpine/k8s:1.31.5` with "short name mode is
+              # enforcing ... returns ambiguous list" (ImageInspectError). That
+              # silently broke this CronJob on every run, so it never fired
+              # during the EU 2026-06-02 incident.
+              image: docker.io/alpine/k8s:1.31.5
               env:
                 - name: API_NS
                   value: shogo-staging-system
@@ -159,6 +176,24 @@ spec:
                   echo "  total=$TOTAL  ready=$READY"
                   if [ "$TOTAL" -gt 0 ] && [ "$READY" -eq 0 ]; then
                     echo "CRITICAL: $TOTAL warm-pool ksvcs but 0 are Ready"
+                    EXIT_RC=1
+                  fi
+
+                  # 4) Node DiskPressure.
+                  # The EU 2026-06-02 incident: 100 GB boot volumes filled with
+                  # stacked 8 GB runtime images -> kubelet set DiskPressure ->
+                  # pod eviction + image GC -> warm-pool churn + a stuck api
+                  # rollout. DiskPressure on ANY node is the earliest, clearest
+                  # signal of that class and must page before the churn starts.
+                  echo "--- node DiskPressure ---"
+                  PRESSURED=$(kubectl get nodes -o json | jq -r '
+                    [.items[]
+                      | select((.status.conditions // [])[] | select(.type == "DiskPressure" and .status == "True"))
+                      | .metadata.name
+                    ] | join("; ")
+                  ')
+                  if [ -n "$PRESSURED" ]; then
+                    echo "CRITICAL: node(s) under DiskPressure: $PRESSURED"
                     EXIT_RC=1
                   fi
 

--- a/packages/agent-runtime/src/gateway-tools.ts
+++ b/packages/agent-runtime/src/gateway-tools.ts
@@ -4330,7 +4330,9 @@ export function createTools(ctx: ToolContext, extraTools?: AgentTool[]): AgentTo
     g(createWriteFileTool(ctx), 'file_write'),
     g(createEditFileTool(ctx), 'file_write'),
     g(createDeleteFileTool(ctx), 'file_delete'),
-    g(createSearchTool(ctx), 'file_read'),
+    // search is disabled while local indexing is off (reindex-on-query hangs).
+    // Re-enable with SHOGO_SEARCH_ENABLED=1 (also pre-warms the index — see gateway.ts start()).
+    ...(process.env.SHOGO_SEARCH_ENABLED === '1' ? [g(createSearchTool(ctx), 'file_read')] : []),
     g(createImpactRadiusTool(ctx), 'file_read'),
     g(createDetectChangesTool(ctx), 'file_read'),
     g(createReviewContextTool(ctx), 'file_read'),
@@ -4775,6 +4777,8 @@ function createDeleteFileTool(ctx: ToolContext): AgentTool {
   }
 }
 
+const SEARCH_TIMEOUT_MS = 10_000
+
 function createSearchTool(ctx: ToolContext): AgentTool {
   return {
     name: 'search',
@@ -4797,7 +4801,26 @@ function createSearchTool(ctx: ToolContext): AgentTool {
       }
       const engine = getOrCreateIndex(ctx)
       const searchSource = source === 'all' || !source ? undefined : source
-      const results = await engine.search(query, { source: searchSource, limit, pathFilter: path_filter, extensions: file_extensions })
+      // The first query triggers a lazy full reindex (see IndexEngine.search),
+      // which on a large/cold workspace can run for minutes. Cap it so the tool
+      // fails fast with a clear message instead of hanging the turn.
+      let results: Awaited<ReturnType<typeof engine.search>>
+      try {
+        results = await Promise.race([
+          engine.search(query, { source: searchSource, limit, pathFilter: path_filter, extensions: file_extensions }),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error('SEARCH_TIMEOUT')), SEARCH_TIMEOUT_MS)),
+        ])
+      } catch (err) {
+        if (err instanceof Error && err.message === 'SEARCH_TIMEOUT') {
+          return textResult({
+            error: `Search timed out after ${SEARCH_TIMEOUT_MS / 1000}s. The workspace index may be cold or still building — try again shortly or narrow the query with path_filter/file_extensions.`,
+            query,
+            source: source ?? 'all',
+          })
+        }
+        throw err
+      }
       return textResult({
         query,
         source: source ?? 'all',

--- a/packages/agent-runtime/src/gateway.ts
+++ b/packages/agent-runtime/src/gateway.ts
@@ -839,7 +839,12 @@ export class AgentGateway {
     // from CanvasFileWatcher events plus a persisted "last scan"
     // timestamp so subsequent boots skip the full re-walk — is
     // tracked separately.
-    const prewarm = (process.env.SHOGO_INDEX_PREWARM ?? '').trim() === '1'
+    // Pre-warm when explicitly requested, or whenever the search tool is
+    // enabled — otherwise the first `search` call would trigger a multi-minute
+    // lazy reindex and (now) hit the 10s tool timeout instead of returning hits.
+    const prewarm =
+      (process.env.SHOGO_INDEX_PREWARM ?? '').trim() === '1' ||
+      (process.env.SHOGO_SEARCH_ENABLED ?? '').trim() === '1'
     const indexDelayMs = parseInt(process.env.SHOGO_INDEX_START_DELAY_MS ?? '3000', 10)
     if (prewarm) {
       setTimeout(() => this.initIndexEngine({ prewarm: true }), Math.max(0, indexDelayMs))

--- a/prisma/migrations/20260602203002_affiliate_per_affiliate_rate/migration.sql
+++ b/prisma/migrations/20260602203002_affiliate_per_affiliate_rate/migration.sql
@@ -1,0 +1,16 @@
+-- Migration: per-affiliate commission-rate override.
+--
+-- Adds an optional `commissionRateBps` column to `affiliates` (see
+-- prisma/schema.prisma `Affiliate` and the commission engine in
+-- apps/api/src/services/affiliate.service.ts). When set, it replaces the
+-- per-level `AffiliateCommissionTier` rate for THIS affiliate's direct (L1)
+-- referrals and is applied as a flat rate — the tier's `durationDays` window
+-- and `secondaryRateBps` step-down are bypassed at L1. NULL preserves the
+-- default behavior of using the tier rate. Only level 1 is affected; deeper
+-- upline levels always use tier rates.
+--
+-- Basis points: 2000 = 20.00%. No backfill — existing affiliates stay NULL
+-- and continue earning at the tier rate.
+
+-- AlterTable
+ALTER TABLE "affiliates" ADD COLUMN "commissionRateBps" INTEGER;

--- a/prisma/schema.local.prisma
+++ b/prisma/schema.local.prisma
@@ -1944,6 +1944,7 @@ model Affiliate {
   totalEarningsCents       Int       @default(0)
   pendingPayoutCents       Int       @default(0)
   totalPaidOutCents        Int       @default(0)
+  commissionRateBps        Int?
   termsAcceptedAt          DateTime?
   createdAt                DateTime  @default(now())
   updatedAt                DateTime  @updatedAt

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2573,6 +2573,13 @@ model Affiliate {
   /// Sum of `paid` commissions in cents. Differs from totalEarnings only
   /// when clawbacks adjust the running total.
   totalPaidOutCents     Int             @default(0)
+  /// Optional per-affiliate commission-rate override (basis points;
+  /// 2000 = 20.00%). When set, it replaces the `AffiliateCommissionTier`
+  /// rate for THIS affiliate's direct (L1) referrals and is applied as a
+  /// flat rate — the tier's `durationDays` window and `secondaryRateBps`
+  /// step-down are ignored at L1. Null = use the tier rate (default).
+  /// Only affects level 1; deeper upline levels always use tier rates.
+  commissionRateBps     Int?
   /// Set when the user accepted the affiliate terms during enroll.
   termsAcceptedAt       DateTime?
   createdAt             DateTime        @default(now())

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -158,6 +158,34 @@ The same pattern can be reused when adopting `production-eu`,
 `production-india`, and `production-global` — follow the iteration loop
 of plan → diff → set per-env override → repeat until plan is clean.
 
+## Boot volume remediation
+
+`system_node_boot_volume_gb` must be **200 GB and identical across all
+production regions**. EU/India were bootstrapped at 100 GB, which caused the
+2026-06-02 EU DiskPressure incident: ~30 GB of stacked 8 GB runtime images
+pushed the busiest 100 GB nodes past the kubelet DiskPressure threshold,
+triggering pod eviction + image GC, warm-pool churn, and a stuck `api`
+rollout (`ProgressDeadlineExceeded`).
+
+The OKE module **ignores in-place changes** to
+`node_source_details[0].boot_volume_size_in_gbs` (a boot-volume change forces
+a rolling node replacement; the ignore protects already-bootstrapped pools
+from surprise replacement). So bumping `system_node_boot_volume_gb` in an env
+will **not** apply on its own. To remediate a region that is below 200 GB:
+
+1. Confirm the live drift (and that CI's parity check is failing):
+   `EXPECTED_GB=200 COMPARTMENT_ID=<id> .github/scripts/check-node-disk-parity.sh`
+2. Update the node pool's boot volume out-of-band (does not affect running nodes):
+   `oci ce node-pool update --node-pool-id <ocid> --node-source-details '{"sourceType":"IMAGE","imageId":"<id>","bootVolumeSizeInGBs":200}'`
+3. Cycle nodes so they re-provision at 200 GB — drain + terminate a few at a
+   time (cordon, `kubectl drain`, then terminate the instance so the autoscaler
+   replaces it), watching `DiskPressure` and warm-pool readiness between batches.
+4. Re-run the parity check to confirm green.
+
+Day-to-day disk safety is additionally guarded at deploy time by
+`.github/scripts/check-node-disk-headroom.sh` (a pre-rollout gate) and at
+runtime by the `DiskPressure` check in `k8s/base/warm-pool-monitor.yaml`.
+
 ## Configuration
 
 See `environments/*/variables.tf` for configurable options per environment.

--- a/terraform/environments/production-eu/main.tf
+++ b/terraform/environments/production-eu/main.tf
@@ -118,6 +118,15 @@ module "eu" {
   system_pool_min       = 2
   system_pool_max       = 10
 
+  # 200 GB to match production-us. EU was bootstrapped at 100 GB, which
+  # caused the 2026-06-02 DiskPressure incident (stacked 8 GB runtime images
+  # filled the disk -> kubelet eviction/image-GC -> warm-pool churn -> the
+  # api rollout could not reach initial scale). The oke module ignores
+  # in-place boot-volume changes, so applying this requires a one-time
+  # controlled node-pool replacement (see terraform/README.md "Boot volume
+  # remediation"). Until that cycle runs, the live value stays 100 GB.
+  system_node_boot_volume_gb = 200
+
   enable_workload_pool = false
 
   # Observability

--- a/terraform/environments/production-india/main.tf
+++ b/terraform/environments/production-india/main.tf
@@ -129,6 +129,14 @@ module "india" {
   system_pool_min       = 2
   system_pool_max       = 10
 
+  # 200 GB to match production-us. India is currently LIVE at 100 GB — the
+  # same latent exposure that caused the EU 2026-06-02 DiskPressure incident;
+  # India simply hasn't tipped over yet (lower workspace load). As with EU,
+  # the oke module ignores in-place boot-volume changes, so this needs a
+  # one-time controlled node-pool replacement to take effect (see
+  # terraform/README.md "Boot volume remediation").
+  system_node_boot_volume_gb = 200
+
   enable_workload_pool = false
 
   # Data layer points to US primary

--- a/terraform/environments/production-us/main.tf
+++ b/terraform/environments/production-us/main.tf
@@ -135,6 +135,11 @@ module "us" {
   system_pool_min       = 3
   system_pool_max       = 15
 
+  # Live US nodes are already 200 GB (matches the module default). Stated
+  # explicitly so the cross-region parity check has a US baseline to compare
+  # EU/India against (see .github/scripts/check-node-disk-parity.sh).
+  system_node_boot_volume_gb = 200
+
   enable_workload_pool = false
 
   # Autoscaler IAM (tenancy-level — only enable in primary region)

--- a/terraform/modules/oci-region/main.tf
+++ b/terraform/modules/oci-region/main.tf
@@ -114,6 +114,7 @@ module "oke" {
   node_shape     = var.system_node_shape
   node_ocpus     = var.system_node_ocpus
   node_memory_gb = var.system_node_memory_gb
+  boot_volume_gb = var.system_node_boot_volume_gb
   node_pool_size = var.system_pool_size
   node_pool_min  = var.system_pool_min
   node_pool_max  = var.system_pool_max

--- a/terraform/modules/oci-region/variables.tf
+++ b/terraform/modules/oci-region/variables.tf
@@ -92,6 +92,23 @@ variable "system_node_memory_gb" {
   default     = 64
 }
 
+variable "system_node_boot_volume_gb" {
+  # Set explicitly per environment so the value is auditable and a
+  # cross-region drift (e.g. EU bootstrapped at 100 GB while US is 200 GB)
+  # is visible in code, not hidden behind a module default. The EU
+  # 2026-06-02 incident was caused by EU nodes running 100 GB boot volumes:
+  # ~30 GB of stacked 8 GB runtime images pushed them past the kubelet
+  # DiskPressure threshold, triggering eviction/image-GC and warm-pool churn.
+  #
+  # NOTE: the oke module ignores in-place changes to this attribute
+  # (boot volume changes force a rolling node replacement). Raising it on an
+  # already-bootstrapped pool therefore requires a deliberate node-pool
+  # replacement — see terraform/README.md ("Boot volume remediation").
+  description = "Boot volume size (GB) for system nodes. Must match across regions."
+  type        = number
+  default     = 200
+}
+
 variable "system_pool_size" {
   description = "Desired system node count"
   type        = number


### PR DESCRIPTION
## Summary

Local index pre-warm is gated off by default, so the agent `search` tool runs a lazy full reindex on its first call (`IndexEngine.search()`), which on a large/cold workspace can take minutes — and the searches time out.

This PR:
- **Disables the `search` tool by default.** It is only registered when `SHOGO_SEARCH_ENABLED=1`. Because the tool is built once in `createTools()` and both the main agent and all subagents (`explore`, `code-reviewer`) derive their tool sets from that list, gating the single registration point removes it everywhere.
- **Folds prewarm into the same flag.** `SHOGO_SEARCH_ENABLED=1` also turns on index pre-warm in `AgentGateway.start()`, so re-enabling search never leaves a cold index that just times out. `SHOGO_INDEX_PREWARM` still works independently to warm the index for the HTTP `/agent/workspace/search` API without exposing the agent tool.
- **Adds a 10s timeout** around `engine.search()` in the tool's `execute`, so once re-enabled a cold/slow reindex fails fast with a clear message instead of hanging the turn.

### Behavior matrix

| `SHOGO_SEARCH_ENABLED` | `SHOGO_INDEX_PREWARM` | search tool | index prewarm |
|---|---|---|---|
| unset (default) | unset | hidden | off |
| `1` | (any) | exposed (10s timeout) | on |
| unset | `1` | hidden | on (HTTP API only) |

## Test plan

- [ ] Default (no env): agent does not see the `search` tool; gateway logs pre-warm disabled.
- [ ] `SHOGO_SEARCH_ENABLED=1`: `search` tool is available and the index pre-warms on startup.
- [ ] Simulate a slow/cold reindex and confirm the tool returns the timeout message after ~10s rather than hanging.
- [ ] `SHOGO_INDEX_PREWARM=1` alone still pre-warms for `/agent/workspace/search` without exposing the agent tool.

Made with [Cursor](https://cursor.com)