### PR TITLE
fix(cli): resolve 4 bugs blocking worker startup on npm-installed CLI

### DIFF
--- a/apps/mobile/components/chat/EnvironmentPicker.tsx
+++ b/apps/mobile/components/chat/EnvironmentPicker.tsx
@@ -33,7 +33,6 @@ import { useInstancePicker, type Instance } from "@shogo/shared-app/hooks"
 import { useActiveWorkspace } from "../../hooks/useActiveWorkspace"
 import { API_URL } from "../../lib/api"
 import { authClient } from "../../lib/auth-client"
-import { usePlatformConfig } from "../../lib/platform-config"
 
 function getAuthHeaders(): Record<string, string> {
   if (Platform.OS === "web") return {}
@@ -72,7 +71,6 @@ export interface EnvironmentPickerProps {
 
 export function EnvironmentPicker({ disabled }: EnvironmentPickerProps) {
   const [open, setOpen] = useState(false)
-  const { localMode } = usePlatformConfig()
   const workspace = useActiveWorkspace()
   const { instance: activeInstance, setInstance, clearInstance } = useActiveInstance()
 
@@ -97,19 +95,6 @@ export function EnvironmentPicker({ disabled }: EnvironmentPickerProps) {
   const triggerIcon = activeInstance
     ? <Laptop className="h-3.5 w-3.5 text-emerald-500" size={14} />
     : <Cloud className="h-3.5 w-3.5 text-muted-foreground" size={14} />
-
-  if (localMode) {
-    return (
-      <WebTooltip label="Environment: Local">
-        <View
-          accessibilityLabel="Environment: Local"
-          className="h-[22px] w-[22px] items-center justify-center rounded-md"
-        >
-          <Laptop className="h-3.5 w-3.5 text-muted-foreground" size={14} />
-        </View>
-      </WebTooltip>
-    )
-  }
 
   return (
     <Popover

--- a/packages/shogo-worker/src/commands/start.ts
+++ b/packages/shogo-worker/src/commands/start.ts
@@ -261,13 +261,18 @@ function buildChildArgv(flags: StartFlags): string[] {
  *   2. The compiled binary at /usr/local/bin/shogo on PATH (best-effort).
  *   3. The bin shim shipped with this package.
  */
-function resolveSelfEntry(): { entry: string; runner: 'bun' | 'node' } {
+function resolveSelfEntry(): { entry: string; runner: 'bun' | 'node' | 'tsx' } {
   // process.execPath is the bun/node binary; argv[1] is the script.
   const execPath = process.execPath;
   const isBun = /\bbun(?:-[^/\\]*)?$/.test(execPath) || typeof (globalThis as any).Bun !== 'undefined';
   const argvScript = process.argv[1];
   if (argvScript && existsSync(argvScript)) {
-    return { entry: argvScript, runner: isBun ? 'bun' : 'node' };
+    // When spawned via tsx (from the bin shim), process.execPath is still
+    // `node` because tsx runs on top of Node. Detect a .ts entry and route
+    // through tsx so the detached child can handle TypeScript natively.
+    const isTs = /\.ts$/.test(argvScript);
+    const runner = isBun ? 'bun' : (isTs ? 'tsx' : 'node');
+    return { entry: argvScript, runner };
   }
   // Fallback: the compiled bin shim shipped with the package.
   // Resolved relative to this file via import.meta.url so it works

--- a/packages/shogo-worker/src/commands/start.ts
+++ b/packages/shogo-worker/src/commands/start.ts
@@ -124,9 +124,17 @@ export async function runStart(flags: StartFlags): Promise<void> {
   }
   console.log('');
 
+  // Derive the AI proxy URL from the cloud URL so the agent-runtime
+  // routes LLM calls through Shogo Cloud's proxy instead of requiring
+  // direct API keys on the machine.  The proxy endpoint lives at
+  // <cloudUrl>/api/ai/v1 — the same base the desktop app uses.
+  const aiProxyUrl = `${cfg.cloudUrl.replace(/\/+$/, '')}/api/ai/v1`;
+
   const defaultSpawnConfig: ProjectSpawnConfig = {
     cloudUrl: cfg.cloudUrl,
     apiKey: cfg.apiKey,
+    aiProxyUrl,
+    aiProxyToken: cfg.apiKey,
     // No projectDir up front — the runtime manager's `maybeAutoPull`
     // sets PROJECT_DIR per-project to <projectsDir>/<projectId>/ once
     // the clone completes. CWD defaults to that same directory.

--- a/packages/shogo-worker/src/lib/process-manager.ts
+++ b/packages/shogo-worker/src/lib/process-manager.ts
@@ -20,7 +20,7 @@ import { PID_FILE, WORKER_LOG, WORKER_ERR, ensureHome } from './paths.ts';
 
 export interface SpawnOpts {
   entry: string;
-  runner: 'bun' | 'node';
+  runner: 'bun' | 'node' | 'tsx';
   env: NodeJS.ProcessEnv;
   cwd: string;
   detach?: boolean;

--- a/packages/shogo-worker/src/lib/runtime-install.ts
+++ b/packages/shogo-worker/src/lib/runtime-install.ts
@@ -60,7 +60,7 @@ export type Channel = 'stable' | 'beta' | 'nightly';
  * Layout assumed by `buildAssetUrls()`:
  *   ${baseUrl}/v${version}/${assetName}
  */
-export const DEFAULT_RELEASES_BASE_URL = 'https://github.com/shogo-ai/shogo/releases/download';
+export const DEFAULT_RELEASES_BASE_URL = 'https://github.com/shogo-labs/shogo-ai/releases/download';
 
 export interface InstallOptions {
   /** Specific version to install (e.g. "0.1.0"). Default: latest in channel. */

--- a/packages/shogo-worker/src/lib/tunnel.ts
+++ b/packages/shogo-worker/src/lib/tunnel.ts
@@ -102,7 +102,7 @@ type TunnelWebSocketConstructor = new (url: string, init: TunnelWebSocketInit) =
 
 type RuntimeWithBunWebSocketHeaders = typeof globalThis & {
   Bun?: unknown;
-  process?: { versions?: { bun?: string } };
+  process?: { versions?: { bun?: string; node?: string } };
 };
 
 interface HeartbeatResponse {
@@ -116,8 +116,8 @@ export class TunnelWebSocketHeaderSupportError extends Error {
   code = 'TUNNEL_WS_HEADERS_UNSUPPORTED' as const;
   constructor() {
     super(
-      'Tunnel WebSocket auth requires Bun WebSocket header support. ' +
-        'This runtime does not advertise Bun, so Authorization headers may be dropped.',
+      'Tunnel WebSocket auth requires a runtime with WebSocket header support (Bun or Node >= 21). ' +
+        'Current runtime does not support WebSocket constructor headers.',
     );
     this.name = 'TunnelWebSocketHeaderSupportError';
   }
@@ -231,7 +231,15 @@ export class WorkerTunnel {
   private supportsWebSocketConstructorHeaders(
     runtime: RuntimeWithBunWebSocketHeaders = globalThis as RuntimeWithBunWebSocketHeaders,
   ): boolean {
-    return typeof runtime.Bun !== 'undefined' || typeof runtime.process?.versions?.bun === 'string';
+    if (typeof runtime.Bun !== 'undefined' || typeof runtime.process?.versions?.bun === 'string') return true;
+    // Node 21+ ships WebSocket (via undici) with header support in the constructor.
+    // Detect by checking for Node >= 21 (the version that made WebSocket a global).
+    const nodeVersion = runtime.process?.versions?.node;
+    if (nodeVersion) {
+      const major = parseInt(nodeVersion.split('.')[0] ?? '0', 10);
+      if (major >= 21) return true;
+    }
+    return false;
   }
 
   private createTunnelWebSocket(


### PR DESCRIPTION
## Updated PR Description

This PR now contains **6 fixes** across 3 packages that resolve multiple blocking issues with the `@shogo-ai/worker` CLI.

---

### Commit 1: `fix(worker): include dist/cli.mjs in npm package to fix tsx ENOENT`

**Error:** `Error: spawn tsx ENOENT`

**Root Cause:** The `files` array in `packages/shogo-worker/package.json` listed `["bin", "src", "README.md"]` — `"dist"` was missing. The `bin/shogo.mjs` shim had a fallback chain:
1. `dist/shogo` (compiled binary) — doesn't exist
2. `dist/cli.mjs` (Node ESM bundle) — **not included in npm package** ❌
3. `src/cli.ts` (TypeScript source) — requires `tsx` → not installed → ENOENT 💥

**Fix:** Added `"dist"` to the `files` array and updated `prepublishOnly` to run `bun run build:js` before publishing.

---

### Commit 2: `fix(worker): detect tsx runner for detached child process`

**Error:** `Unknown file extension ".ts"` when the worker detaches into background.

**Root Cause:** `resolveSelfEntry()` in `start.ts` only checked for Bun runtime. When running under tsx (npm install path), `process.execPath` is still `node`, so the detached child was spawned with `runner: 'node'` on a `.ts` file — Node can't run TypeScript directly.

**Fix:** Added `.ts` extension detection to `resolveSelfEntry()` and widened `SpawnOpts.runner` type from `'bun' | 'node'` to `'bun' | 'node' | 'tsx'`.

---

### Commit 3: `fix(worker): correct GitHub releases URL for runtime install`

**Error:** `GitHub API 404 for https://api.github.com/repos/shogo-ai/shogo/releases/latest`

**Root Cause:** `DEFAULT_RELEASES_BASE_URL` was set to `https://github.com/shogo-ai/shogo/releases/download` — wrong owner (`shogo-ai` → `shogo-labs`) and wrong repo (`shogo` → `shogo-ai`). The regex-derived API URL hit a non-existent repo.

**Fix:** Updated to `https://github.com/shogo-labs/shogo-ai/releases/download`.

---

### Commit 4: `fix(worker): allow Node 21+ WebSocket for tunnel auth headers`

**Error:** `WebSocket is not defined` (Node 20) or tunnel connection rejected (Node 22).

**Root Cause:** `supportsWebSocketConstructorHeaders()` only checked for Bun runtime. Node 22 ships WebSocket via undici with full header support, but the guard threw preemptively.

**Fix:** Added Node version detection (`>=21.0.0`) to the WebSocket support check.

---

### Commit 5: `fix(worker): route LLM calls through cloud AI proxy for CLI workers`

**Error:** `AI provider error: No API key for provider: openai`

**Root Cause:** The `defaultSpawnConfig` in the CLI worker only included `cloudUrl` and `apiKey`. When the agent-runtime was spawned on the VPS, it had no `AI_PROXY_URL` or `AI_PROXY_TOKEN` env vars, so it fell back to direct provider calls that fail without local API keys.

**Fix:** Derived `aiProxyUrl` from `cfg.cloudUrl + '/api/ai/v1'` and set `aiProxyToken` to `cfg.apiKey` in the default spawn config. The runtime manager passes these as `AI_PROXY_URL` and `AI_PROXY_TOKEN` to the child process, routing all LLM traffic through Shogo Cloud's proxy (which has API keys configured server-side).

---

### Commit 6: `fix(mobile): instance picker icon now opens popover in local mode`

**Bug:** The laptop/instance icon in the chat input bar was non-clickable in the desktop app.

**Root Cause:** `EnvironmentPicker` had a `localMode` early return that rendered a plain `<View>` (not `<Pressable>`) with no `onPress` handler. The icon was visible but completely non-interactive.

**Fix:** Removed the `localMode` early return and unused `usePlatformConfig` import. The component always renders the full `<Popover>` with trigger/content wiring.

---

## Testing

All 6 fixes were tested on:
- macOS (local development)
- Ubuntu 24.04 VPS (remote worker)

Key verification:
- `npm pack` confirmed `dist/cli.mjs` (81KB) is included
- VPS worker starts without `ERR_UNKNOWN_FILE_EXTENSION`
- VPS worker connects to cloud without `WebSocket is not defined`
- LLM calls route through cloud proxy (no local API keys needed)
- Instance picker icon opens the popover in desktop app
