### PR TITLE
feat(mobile): download files from the IDE file tree right-click menu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,12 @@ RUNTIME_DOMAIN_SUFFIX=localhost
 VITE_RUNTIME_BASE=5200
 VITE_RUNTIME_END=5209
 VITE_DEV_PORT=5173
+# Merged-root WORKSPACE runtime (multi-project, workspace-scoped chat).
+# When 'true', /api/workspaces/:id/chat resolves + proxies a merged-root
+# agent-runtime; when off it returns 501. Must agree with the client flag
+# EXPO_PUBLIC_WORKSPACE_RUNTIME for the home "workspace chat" flow to work.
+# Default off preserves the per-project chat behavior.
+SHOGO_WORKSPACE_RUNTIME=false
 
 # -----------------------------------------------------------------------------
 # Local Docker port mapping

--- a/apps/api/src/__tests__/runtime-manager-startWorkspace.test.ts
+++ b/apps/api/src/__tests__/runtime-manager-startWorkspace.test.ts
@@ -10,14 +10,19 @@ import { join } from 'node:path'
 
 // Stub the workspace env builder so the spawn path never touches the DB.
 mock.module('../lib/runtime/build-workspace-env', () => ({
-  buildWorkspaceEnv: async (workspaceId: string, attachedProjectIds: string[]) => ({
+  buildWorkspaceEnv: async (
+    workspaceId: string,
+    attachedProjectIds: string[],
+    opts?: { anchorProjectId?: string },
+  ) => ({
     WORKSPACE_ID: workspaceId,
     WORKSPACE_PROJECT_IDS: attachedProjectIds.join(','),
+    ...(opts?.anchorProjectId ? { WORKSPACE_ANCHOR_PROJECT_ID: opts.anchorProjectId } : {}),
     AGENT_NAME: 'Test WS',
   }),
 }))
 
-const { RuntimeManager, workspaceRuntimeKey } = await import('../lib/runtime/manager')
+const { RuntimeManager, workspaceRuntimeKey, projectWorkspaceRuntimeKey } = await import('../lib/runtime/manager')
 
 let dirs: string[] = []
 const origEnv = { ...process.env }
@@ -45,6 +50,13 @@ function makeManager(opts: { agentStatus?: any; agentThrows?: Error } = {}) {
   rm.allocatePortAsync = mock(async () => 37100)
   rm.buildUrl = (_id: string, port: number) => `http://localhost:${port}`
   rm.startHealthCheck = mock(() => {})
+  // Hermetic seeding: create the member project dir without the real
+  // template-copy + `bun install` so the merged-root symlinks resolve.
+  rm.ensureProjectDirectory = mock(async (id: string) => {
+    const d = join(workspacesDir, id)
+    mkdirSync(d, { recursive: true })
+    return d
+  })
   rm.agentManager = {
     ensureRunning: mock(async () => {
       if (opts.agentThrows) throw opts.agentThrows
@@ -58,7 +70,7 @@ function makeManager(opts: { agentStatus?: any; agentThrows?: Error } = {}) {
 }
 
 describe('RuntimeManager.startWorkspace', () => {
-  test('spawns a workspace runtime rooted at the workspaces parent', async () => {
+  test('spawns a workspace runtime rooted at the per-workspace merged root', async () => {
     const { rm, workspacesDir } = makeManager()
     const res = await rm.startWorkspace('ws-1', { attachedProjectIds: ['p1', 'p2'] })
 
@@ -68,11 +80,21 @@ describe('RuntimeManager.startWorkspace', () => {
     const call = rm.agentManager.ensureRunning.mock.calls[0]
     expect(call[0]).toBe(workspaceRuntimeKey('ws-1')) // key = ws:ws-1
     const spawnConfig = call[1]
-    expect(spawnConfig.projectDir).toBe(workspacesDir)
+    // projectDir is now the per-workspace merged root (symlinks to the
+    // attached projects), NOT the shared workspaces parent.
+    const mergedRoot = join(workspacesDir, '.workspace-roots', 'ws-1')
+    expect(spawnConfig.projectDir).toBe(mergedRoot)
     expect(spawnConfig.workspaceId).toBe('ws-1')
     expect(spawnConfig.extraEnv.WORKSPACE_RUNTIME).toBe('true')
     expect(spawnConfig.extraEnv.WORKING_MODE).toBe('managed')
     expect(spawnConfig.extraEnv.WORKSPACE_PROJECT_IDS).toBe('p1,p2')
+    // The merged root holds one symlink per attached project, and the real
+    // dirs are shipped as LINKED_FOLDERS for path-allowance.
+    expect(existsSync(join(mergedRoot, 'p1'))).toBe(true)
+    expect(existsSync(join(mergedRoot, 'p2'))).toBe(true)
+    const linked = JSON.parse(spawnConfig.extraEnv.LINKED_FOLDERS)
+    expect(linked).toContain(join(workspacesDir, 'p1'))
+    expect(linked).toContain(join(workspacesDir, 'p2'))
   })
 
   test('keys the runtime under ws:<id> (no collision with a project of same id)', async () => {
@@ -136,5 +158,73 @@ describe('RuntimeManager.startWorkspace', () => {
     expect(rm.runtimes.has('ws:ws-1')).toBe(true)
     await rm.stopAll()
     expect(rm.runtimes.size).toBe(0)
+  })
+})
+
+describe('RuntimeManager.startProjectWorkspace (anchor-keyed merged root)', () => {
+  test('keys the runtime by the anchor project (ws:proj:<anchor>)', async () => {
+    const { rm } = makeManager()
+    await rm.startProjectWorkspace('anchor-1', {
+      workspaceId: 'ws-1',
+      attachedProjectIds: ['p2'],
+    })
+    expect(rm.runtimes.has(projectWorkspaceRuntimeKey('anchor-1'))).toBe(true)
+    // Distinct from both the plain project key and the workspace-session key.
+    expect(rm.runtimes.has('anchor-1')).toBe(false)
+    expect(rm.runtimes.has('ws:ws-1')).toBe(false)
+  })
+
+  test('mounts the anchor first plus its attachments as subfolders', async () => {
+    const { rm, workspacesDir } = makeManager()
+    await rm.startProjectWorkspace('anchor-1', {
+      workspaceId: 'ws-1',
+      attachedProjectIds: ['anchor-1', 'p2'], // anchor duplicated → deduped
+    })
+    const call = rm.agentManager.ensureRunning.mock.calls[0]
+    expect(call[0]).toBe(projectWorkspaceRuntimeKey('anchor-1'))
+    const spawnConfig = call[1]
+    const mergedRoot = join(workspacesDir, '.workspace-roots', 'proj-anchor-1')
+    expect(spawnConfig.projectDir).toBe(mergedRoot)
+    expect(existsSync(join(mergedRoot, 'anchor-1'))).toBe(true)
+    expect(existsSync(join(mergedRoot, 'p2'))).toBe(true)
+    expect(spawnConfig.extraEnv.WORKSPACE_ANCHOR_PROJECT_ID).toBe('anchor-1')
+    expect(spawnConfig.extraEnv.WORKSPACE_PROJECT_IDS).toBe('anchor-1,p2')
+  })
+
+  test('symlinks linked local folders by basename and ships them as LINKED_FOLDERS', async () => {
+    const { rm, workspacesDir } = makeManager()
+    const localFolder = join(workspacesDir, '..', 'my-local-folder')
+    mkdirSync(localFolder, { recursive: true })
+    await rm.startProjectWorkspace('anchor-1', {
+      workspaceId: 'ws-1',
+      attachedProjectIds: [],
+      localFolders: [localFolder],
+    })
+    const mergedRoot = join(workspacesDir, '.workspace-roots', 'proj-anchor-1')
+    expect(existsSync(join(mergedRoot, 'my-local-folder'))).toBe(true)
+    const spawnConfig = rm.agentManager.ensureRunning.mock.calls[0][1]
+    const linked = JSON.parse(spawnConfig.extraEnv.LINKED_FOLDERS)
+    expect(linked.some((p: string) => p.endsWith('my-local-folder'))).toBe(true)
+  })
+
+  test('emits READONLY_ROOTS for read-only attachments', async () => {
+    const { rm, workspacesDir } = makeManager()
+    await rm.startProjectWorkspace('anchor-1', {
+      workspaceId: 'ws-1',
+      attachedProjectIds: ['p2', 'p3'],
+      readonlyProjectIds: ['p3'],
+    })
+    const spawnConfig = rm.agentManager.ensureRunning.mock.calls[0][1]
+    const readonly = JSON.parse(spawnConfig.extraEnv.READONLY_ROOTS)
+    expect(readonly).toEqual([join(workspacesDir, 'p3')])
+    // The anchor + read-write attachment are NOT read-only.
+    expect(readonly).not.toContain(join(workspacesDir, 'anchor-1'))
+    expect(readonly).not.toContain(join(workspacesDir, 'p2'))
+  })
+
+  test('requires an anchorProjectId and a workspaceId', async () => {
+    const { rm } = makeManager()
+    await expect(rm.startProjectWorkspace('', { workspaceId: 'ws-1' })).rejects.toThrow(/anchorProjectId is required/)
+    await expect(rm.startProjectWorkspace('anchor-1', { workspaceId: '' })).rejects.toThrow(/workspaceId is required/)
   })
 })

--- a/apps/api/src/lib/resolve-workspace-runtime-url.ts
+++ b/apps/api/src/lib/resolve-workspace-runtime-url.ts
@@ -60,6 +60,19 @@ export interface ResolveWorkspaceRuntimeOpts {
   /** Attached project ids this runtime should mount. */
   attachedProjectIds: string[]
 
+  /**
+   * For the universal project-anchored path: the anchor project id. When
+   * set, host mode spawns a PROJECT-anchored merged runtime
+   * (`startProjectWorkspace`, keyed `ws:proj:<anchor>`) that mounts the
+   * anchor + attachments + linked folders, instead of the workspace-session
+   * runtime keyed by workspaceId. Cloud (k8s/vm) is not yet anchor-aware.
+   */
+  anchorProjectId?: string
+  /** Linked local host folders to mount (project-anchored host path only). */
+  localFolders?: string[]
+  /** Subset of attached projects mounted read-only (write-denied). */
+  readonlyProjectIds?: string[]
+
   /** Log tag included in fallback/error log lines. */
   logTag?: string
 
@@ -79,6 +92,17 @@ export interface ResolveWorkspaceRuntimeOpts {
   _hostStart?: (
     workspaceId: string,
     attachedProjectIds: string[],
+    manager?: IRuntimeManager,
+  ) => Promise<IProjectRuntime>
+  /** Test-only override for the project-anchored host spawn. */
+  _hostStartProject?: (
+    anchorProjectId: string,
+    opts: {
+      workspaceId: string
+      attachedProjectIds: string[]
+      localFolders: string[]
+      readonlyProjectIds: string[]
+    },
     manager?: IRuntimeManager,
   ) => Promise<IProjectRuntime>
 
@@ -127,6 +151,31 @@ async function defaultHostStart(
 }
 
 /**
+ * Default host spawn for the project-anchored path. Delegates to
+ * `RuntimeManager.startProjectWorkspace`, keyed `ws:proj:<anchor>`.
+ */
+async function defaultHostStartProject(
+  anchorProjectId: string,
+  opts: {
+    workspaceId: string
+    attachedProjectIds: string[]
+    localFolders: string[]
+    readonlyProjectIds: string[]
+  },
+  manager?: IRuntimeManager,
+): Promise<IProjectRuntime> {
+  const m: any =
+    manager ?? (await import('./runtime/index')).getRuntimeManager()
+  if (typeof m.startProjectWorkspace !== 'function') {
+    throw new Error(
+      `[WorkspaceRuntime] host spawn unavailable: this RuntimeManager has no startProjectWorkspace(). ` +
+        `Expected on the desktop/local RuntimeManager (apps/api/src/lib/runtime/manager.ts).`,
+    )
+  }
+  return m.startProjectWorkspace(anchorProjectId, opts)
+}
+
+/**
  * Resolve the agent-runtime URL for a workspace, honouring the
  * k8s/vm/host hierarchy. Throws `WorkspaceRuntimeNotEnabledError` when
  * the feature flag is off.
@@ -149,6 +198,16 @@ export async function resolveWorkspaceRuntimeUrl(
   }
   if (!isEnabled()) {
     throw new WorkspaceRuntimeNotEnabledError(workspaceId)
+  }
+
+  // Cloud (k8s/vm) is keyed by workspaceId Service and is not yet
+  // anchor-aware. Fail loudly rather than silently mounting the wrong tree
+  // when a project-anchored runtime is requested in cloud.
+  if (opts.anchorProjectId && (isKubernetes() || isVMIsolation())) {
+    throw new Error(
+      `[${tag}] project-anchored workspace runtime (anchor=${opts.anchorProjectId}) is not yet ` +
+        `supported in cloud (k8s/vm). It is currently host/desktop-only.`,
+    )
   }
 
   if (isKubernetes()) {
@@ -178,8 +237,23 @@ export async function resolveWorkspaceRuntimeUrl(
   }
 
   // Host mode.
-  const start = opts._hostStart ?? defaultHostStart
-  const runtime = await start(workspaceId, attachedProjectIds, opts.runtimeManager)
+  let runtime: IProjectRuntime
+  if (opts.anchorProjectId) {
+    const startProject = opts._hostStartProject ?? defaultHostStartProject
+    runtime = await startProject(
+      opts.anchorProjectId,
+      {
+        workspaceId,
+        attachedProjectIds,
+        localFolders: opts.localFolders ?? [],
+        readonlyProjectIds: opts.readonlyProjectIds ?? [],
+      },
+      opts.runtimeManager,
+    )
+  } else {
+    const start = opts._hostStart ?? defaultHostStart
+    runtime = await start(workspaceId, attachedProjectIds, opts.runtimeManager)
+  }
 
   let host = 'localhost'
   try {

--- a/apps/api/src/lib/runtime/build-workspace-env.ts
+++ b/apps/api/src/lib/runtime/build-workspace-env.ts
@@ -6,8 +6,10 @@
  * The workspace-scoped sibling of `build-project-env.ts`. Where
  * `buildProjectEnv` assembles the env for a single-project pod, this
  * assembles the env for a runtime that mounts several attached projects
- * as subfolders under one `WORKSPACE_DIR` (the parent `workspaces/`
- * directory). It carries:
+ * as subfolders under one `WORKSPACE_DIR` (a per-workspace MERGED ROOT
+ * built by RuntimeManager.buildWorkspaceMergedRoot — on host that's a
+ * dir of symlinks to the real `workspaces/<id>` project dirs; in cloud
+ * it's the pod volume that holds only the attached projects). It carries:
  *
  *   - WORKSPACE_ID / WORKSPACE_RUNTIME — mode markers the agent-runtime
  *     boot reads to switch into merged-root mode.
@@ -22,10 +24,13 @@
  *   - AI proxy URLs / S3 config / model overrides — identical to the
  *     project builder so cloud, desktop and host behave the same.
  *
- * Note: file-tool path allowance does not need LINKED_FOLDERS here —
- * every attached project is a child of `WORKSPACE_DIR`, and
- * `getAllowedRoots()` (packages/agent-runtime/src/runtime-trust.ts)
- * already admits descendants of the workspace dir.
+ * Note: on host the merged root holds symlinks, and path allowance
+ * (`assertAllowedPath`) realpath-resolves symlinks back to the real
+ * `workspaces/<id>` dirs — so RuntimeManager.doStartWorkspace ships those
+ * real dirs as `LINKED_FOLDERS` to keep them admitted as allowed roots.
+ * That wiring lives in the manager, not here, because only it knows the
+ * on-disk layout. In cloud (real subfolders, no symlinks) the descendant
+ * rule under `WORKSPACE_DIR` suffices and LINKED_FOLDERS is unset.
  */
 
 import { generateProxyToken } from '../ai-proxy-token'
@@ -34,6 +39,13 @@ import { deriveWorkspaceRuntimeToken } from '../workspace-runtime-token'
 
 export interface BuildWorkspaceEnvOpts {
   logPrefix?: string
+  /**
+   * For project-anchored merged runtimes: the anchor project id. Exposed to
+   * the runtime as `WORKSPACE_ANCHOR_PROJECT_ID` so it can pick a sensible
+   * default preview target (`/p/<anchor>`) and label the merged root. Unset
+   * for workspace-session runtimes (no single anchor).
+   */
+  anchorProjectId?: string
   /**
    * Test-only injection seams. Production callers omit these and the
    * builder resolves prisma / owner lookup / token mint lazily, exactly
@@ -82,6 +94,9 @@ export async function buildWorkspaceEnv(
     WORKSPACE_ID: workspaceId,
     WORKSPACE_RUNTIME: 'true',
     WORKSPACE_PROJECT_IDS: attachedProjectIds.join(','),
+  }
+  if (opts.anchorProjectId) {
+    env.WORKSPACE_ANCHOR_PROJECT_ID = opts.anchorProjectId
   }
 
   // Workspace identity carries the base agent persona; per-project

--- a/apps/api/src/lib/runtime/manager.ts
+++ b/apps/api/src/lib/runtime/manager.ts
@@ -8,8 +8,8 @@
  */
 
 import { execSync, type ChildProcess } from 'child_process'
-import { existsSync, cpSync, mkdirSync, writeFileSync, readFileSync, unlinkSync, rmSync } from 'fs'
-import { join, dirname, resolve } from 'path'
+import { existsSync, cpSync, mkdirSync, writeFileSync, readFileSync, unlinkSync, rmSync, symlinkSync, lstatSync } from 'fs'
+import { join, dirname, resolve, basename } from 'path'
 import { fileURLToPath } from 'url'
 import { pkg, isMobileTechStack, stackSeedsItself } from '@shogo/shared-runtime'
 import {
@@ -72,6 +72,18 @@ export function workspaceRuntimeKey(workspaceId: string): string {
   return `ws:${workspaceId}`
 }
 
+/**
+ * Internal runtimes-map key for a PROJECT-ANCHORED merged-root runtime —
+ * the universal "every project runs on the workspace runtime" path. Keyed
+ * by the anchor project id (not the workspace id) so two projects in the
+ * same workspace with different attachment sets never collide on one
+ * merged root. Distinct prefix from both the plain project key (`<id>`)
+ * and the workspace-session key (`ws:<workspaceId>`).
+ */
+export function projectWorkspaceRuntimeKey(anchorProjectId: string): string {
+  return `ws:proj:${anchorProjectId}`
+}
+
 /** Default configuration values */
 const DEFAULT_CONFIG: IRuntimeConfig = {
   basePort: PORT_RANGE_START,
@@ -107,6 +119,17 @@ export class RuntimeManager implements IRuntimeManager {
   private usedPorts: Set<number> = new Set()
   private healthCheckTimers: Map<string, NodeJS.Timeout> = new Map()
   private startingPromises: Map<string, Promise<IProjectRuntime>> = new Map()
+  /**
+   * Monotonic "boot generation" per merged-root runtime key. Bumped every
+   * time a NEW agent process is spawned for that key (cold start or restart —
+   * NOT a reuse). Env-coupled changes like `READONLY_ROOTS` (read-only
+   * attachments) only take effect on a fresh boot, so the generation is how
+   * callers observe "the runtime has actually restarted with my new config":
+   * attach/detach/mode-change bumps it, and the mobile composer / e2e poll
+   * {@link getProjectWorkspaceReadiness} until the generation advances and the
+   * runtime reports healthy.
+   */
+  private workspaceRuntimeGeneration: Map<string, number> = new Map()
   /**
    * Embedded MIT WorkerRuntimeManager that owns the agent-runtime
    * spawn lifecycle (port allocation in its own range, env injection,
@@ -169,10 +192,26 @@ export class RuntimeManager implements IRuntimeManager {
       // server.ts (agent-proxy) and routes/ai-proxy.ts (AI proxy)
       // refresh `lastUsedAt` on every chunk forwarded and every model
       // call from the agent, so cloud's 15-min reaper now only fires
-      // on a genuinely-idle slot. Local mode additionally disables
-      // the reaper outright as a belt-and-suspenders since there is
-      // no resource motivation to ever reap there.
-      idleMs: process.env.SHOGO_LOCAL_MODE === 'true' ? 0 : undefined,
+      // on a genuinely-idle slot.
+      //
+      // We used to disable the reaper outright in local mode (`idleMs: 0`),
+      // but that let runtimes accumulate forever — every project the
+      // heartbeat or UI ever touched left a permanent ~700MB agent-runtime
+      // tree, with nothing to reclaim it. We instead use a generous local
+      // window (default 45 min via RUNTIME_LOCAL_IDLE_MS) so genuinely-idle
+      // projects are eventually reaped while the touch hooks keep active
+      // chat streams alive. Set RUNTIME_LOCAL_IDLE_MS=0 to opt back into
+      // the old never-reap behaviour.
+      idleMs:
+        process.env.SHOGO_LOCAL_MODE === 'true'
+          ? parseInt(process.env.RUNTIME_LOCAL_IDLE_MS || String(45 * 60 * 1000), 10)
+          : undefined,
+      // Hard ceiling on concurrent runtimes. Without this the worker only
+      // ever reaped on idle, so a busy multi-project session (or a disabled
+      // idle window) could exceed the intended cap unbounded. The worker
+      // LRU-evicts the least-recently-used non-streaming slot once this is
+      // exceeded. Mirrors `this.config.maxRuntimes` (RUNTIME_MAX_COUNT).
+      maxRuntimes: this.config.maxRuntimes,
     })
   }
 
@@ -903,6 +942,16 @@ export class ShogoErrorBoundary extends Component<Props, State> {
         log('rm-node_modules', { ms: Date.now() - tRm })
       }
 
+      // Materialize `@shogo-ai/* : workspace:*` pins to a concrete version
+      // before installing. A freshly-seeded project dir lives at
+      // `workspaces/<id>` and is NOT a member of the monorepo's bun
+      // workspace graph, so `bun install` cannot resolve `workspace:*`
+      // (fails with "Workspace dependency @shogo-ai/sdk not found"). The
+      // shipped/desktop template is already materialized at build time, so
+      // this is a no-op there; it only does work in monorepo/host dev where
+      // the bundled template still carries `workspace:*`.
+      this.materializeWorkspaceDeps(projectDir, projectId)
+
       const cmdName = pkg.isWindows ? 'npm.cmd' : pkg.bunBinary
       console.log(`[RuntimeManager] Installing dependencies for ${projectId} (${cmdName})...`)
       const tInstall = Date.now()
@@ -925,6 +974,81 @@ export class ShogoErrorBoundary extends Component<Props, State> {
 
     log('done', { projectDir })
     return projectDir
+  }
+
+  /**
+   * Rewrite `@shogo-ai/* : workspace:*` specifiers in a freshly-seeded
+   * project's `package.json` to a concrete `^X.Y.Z` so `bun install`
+   * resolves them standalone. Mirrors
+   * `scripts/materialize-runtime-template.ts`, but offline: in host/desktop
+   * mode the monorepo's `packages/<pkg>` is present, so we pin to its
+   * in-repo version (no network, deterministic). No-op when the template
+   * was already materialized at build time (no `workspace:*` deps left).
+   */
+  private materializeWorkspaceDeps(projectDir: string, projectId: string): void {
+    const pkgPath = join(projectDir, 'package.json')
+    if (!existsSync(pkgPath)) return
+
+    let manifest: any
+    let raw: string
+    try {
+      raw = readFileSync(pkgPath, 'utf8')
+      manifest = JSON.parse(raw)
+    } catch {
+      return
+    }
+
+    const DEP_KEYS = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']
+    let changed = false
+    for (const key of DEP_KEYS) {
+      const deps = manifest[key]
+      if (!deps || typeof deps !== 'object') continue
+      for (const [name, spec] of Object.entries(deps)) {
+        if (typeof spec !== 'string' || !spec.startsWith('workspace:')) continue
+        if (!name.startsWith('@shogo-ai/')) continue
+        const version = this.resolveInRepoPackageVersion(name)
+        if (version) {
+          deps[name] = `^${version}`
+        } else {
+          // No in-repo package to pin against (e.g. a partial bundle).
+          // Fall back to the published `latest` so the install can still
+          // resolve rather than dying on the `workspace:` protocol.
+          console.warn(
+            `[RuntimeManager] No in-repo version for ${name} while seeding ${projectId} — pinning to "latest"`,
+          )
+          deps[name] = 'latest'
+        }
+        changed = true
+      }
+    }
+
+    if (!changed) return
+    try {
+      const trailing = raw.endsWith('\n') ? '\n' : ''
+      writeFileSync(pkgPath, JSON.stringify(manifest, null, 2) + trailing)
+      console.log(`[RuntimeManager] Materialized @shogo-ai/* workspace deps for ${projectId}`)
+    } catch (err: any) {
+      console.warn(
+        `[RuntimeManager] Failed to materialize workspace deps for ${projectId}:`,
+        err?.message ?? err,
+      )
+    }
+  }
+
+  /**
+   * Best-effort in-repo version for an `@shogo-ai/<pkg>` package, read from
+   * `<repo>/packages/<pkg>/package.json`. Returns null if not present.
+   */
+  private resolveInRepoPackageVersion(name: string): string | null {
+    const short = name.replace(/^@shogo-ai\//, '')
+    const candidate = join(PROJECT_ROOT, 'packages', short, 'package.json')
+    if (!existsSync(candidate)) return null
+    try {
+      const version = JSON.parse(readFileSync(candidate, 'utf8'))?.version
+      return typeof version === 'string' ? version : null
+    } catch {
+      return null
+    }
   }
 
   private async getProjectInfo(projectId: string): Promise<{
@@ -1083,7 +1207,68 @@ export class ShogoErrorBoundary extends Component<Props, State> {
     }
   }
 
+  /**
+   * Resolve the project-anchored spawn options for an anchor project: its
+   * workspace id plus the current attachment / linked-folder / read-only
+   * sets. Mirrors the lookup in `local-projects.ts:restartAnchorRuntime`
+   * so the bare-key `start()` path and the attach/restart path build the
+   * identical merged root.
+   *
+   * Returns `null` when the project has no `workspaceId` (it cannot be
+   * anchored), so callers fall back to the legacy single-project path.
+   *
+   * Uses dynamic imports to keep prisma / the attachment service off this
+   * module's static dependency graph — `manager.ts` is imported very early
+   * and `restartAnchorRuntime` already lazy-imports the same modules.
+   */
+  private async resolveAnchorSpawnOpts(anchorProjectId: string): Promise<{
+    workspaceId: string
+    attachedProjectIds: string[]
+    localFolders: string[]
+    readonlyProjectIds: string[]
+  } | null> {
+    const [{ prisma }, attachmentSvc] = await Promise.all([
+      import('../prisma'),
+      import('../../services/project-attachment.service'),
+    ])
+
+    const anchor = await prisma.project.findUnique({
+      where: { id: anchorProjectId },
+      select: { workspaceId: true },
+    })
+    if (!anchor?.workspaceId) return null
+
+    // Keep the pinned workspace session in lockstep, then collect the
+    // current member + folder + readonly set for the spawn.
+    await attachmentSvc.syncPinnedSessionAttachments(anchorProjectId).catch(() => {})
+    const attachments = await attachmentSvc.listAttachments(anchorProjectId)
+    const localFolders = await attachmentSvc.getAnchorLocalFolders(anchorProjectId)
+    const attachedProjectIds = attachments.map((a) => a.attachedProjectId)
+    const readonlyProjectIds = attachments
+      .filter((a) => a.attachMode === 'readonly')
+      .map((a) => a.attachedProjectId)
+
+    return { workspaceId: anchor.workspaceId, attachedProjectIds, localFolders, readonlyProjectIds }
+  }
+
   async start(projectId: string): Promise<IProjectRuntime> {
+    // Universal workspace-runtime model: when SHOGO_WORKSPACE_RUNTIME is
+    // enabled, every project runs on its project-anchored merged-root
+    // runtime (`ws:proj:<id>`). The legacy single-project runtime keyed by
+    // the bare `<projectId>` would otherwise be spawned *in addition* to
+    // the anchored one — prewarm + heartbeat take this `start()` path while
+    // chat / attach take `startProjectWorkspace` — giving two agent-runtime
+    // trees per project that never dedup against each other. Delegating here
+    // collapses them onto one key so prewarm, heartbeat, chat and attach all
+    // share a single runtime.
+    if (process.env.SHOGO_WORKSPACE_RUNTIME === 'true') {
+      const anchorOpts = await this.resolveAnchorSpawnOpts(projectId)
+      if (anchorOpts) {
+        return this.startProjectWorkspace(projectId, anchorOpts)
+      }
+      // No workspaceId — cannot anchor; fall through to the legacy path.
+    }
+
     // Check if already running
     const existing = this.runtimes.get(projectId)
     if (existing && existing.status === 'running') {
@@ -1166,7 +1351,14 @@ export class ShogoErrorBoundary extends Component<Props, State> {
       }
     }
 
-    const promise = this.doStartWorkspace(workspaceId, opts.attachedProjectIds ?? [])
+    const promise = this.doStartMergedRuntime({
+      key,
+      rootName: workspaceId,
+      workspaceId,
+      memberProjectIds: opts.attachedProjectIds ?? [],
+      localFolders: [],
+      logLabel: workspaceId.slice(0, 8),
+    })
     this.startingPromises.set(key, promise)
     try {
       return await promise
@@ -1175,25 +1367,139 @@ export class ShogoErrorBoundary extends Component<Props, State> {
     }
   }
 
-  private async doStartWorkspace(
-    workspaceId: string,
-    attachedProjectIds: string[],
+  /**
+   * Start (or join an in-flight start of) a PROJECT-ANCHORED merged-root
+   * runtime — the universal "every project runs on the workspace runtime"
+   * path. Keyed by the anchor project id, it mounts the anchor plus its
+   * attached projects (as subfolders) and its linked local folders. A plain
+   * project is simply an anchor with no extra members.
+   */
+  async startProjectWorkspace(
+    anchorProjectId: string,
+    opts: {
+      workspaceId: string
+      attachedProjectIds?: string[]
+      localFolders?: string[]
+      readonlyProjectIds?: string[]
+    },
   ): Promise<IProjectRuntime> {
-    const key = workspaceRuntimeKey(workspaceId)
+    if (!anchorProjectId) {
+      throw new Error('[RuntimeManager] startProjectWorkspace: anchorProjectId is required')
+    }
+    if (!opts.workspaceId) {
+      throw new Error('[RuntimeManager] startProjectWorkspace: workspaceId is required')
+    }
+    const key = projectWorkspaceRuntimeKey(anchorProjectId)
+
+    // Anchor is always the first member; attachments follow (deduped).
+    const memberProjectIds = [anchorProjectId, ...(opts.attachedProjectIds ?? [])].filter(
+      (id, i, arr) => id && arr.indexOf(id) === i,
+    )
+
+    const existing = this.runtimes.get(key)
+    if (existing && existing.status === 'running' && existing.agentPort) {
+      // The merged root is built once at process start. A project (or linked
+      // folder) attached AFTER the runtime came up would otherwise never get
+      // symlinked into the root, so a reused runtime would not "see" it. The
+      // agent reads its merged-root WORKSPACE_DIR live, so re-running the
+      // (idempotent) symlink builder here makes new members appear without a
+      // full restart. Env-coupled changes (READONLY_ROOTS) still need a
+      // restart, which the attach route triggers explicitly.
+      try {
+        const workspacesDir = resolve(this.config.workspacesDir || join(PROJECT_ROOT, 'workspaces'))
+        await this.buildWorkspaceMergedRoot(workspacesDir, `proj-${anchorProjectId}`, memberProjectIds, {
+          localFolders: opts.localFolders ?? [],
+          readonlyProjectIds: opts.readonlyProjectIds ?? [],
+        })
+      } catch (err: any) {
+        console.warn(
+          `[RuntimeManager] startProjectWorkspace(${key}): merged-root refresh on reuse failed: ${err?.message ?? err}`,
+        )
+      }
+      return this.toPublicRuntime(existing)
+    }
+
+    const inflight = this.startingPromises.get(key)
+    if (inflight) {
+      console.log(`[RuntimeManager] Waiting on in-flight project-workspace start for ${key}`)
+      return inflight
+    }
+
+    if (existing && (existing.status === 'error' || existing.status === 'starting')) {
+      try {
+        await this.stop(key)
+      } catch (err: any) {
+        console.warn(`[RuntimeManager] startProjectWorkspace(${key}): pre-respawn stop failed: ${err?.message ?? err}`)
+      }
+    }
+
+    const promise = this.doStartMergedRuntime({
+      key,
+      rootName: `proj-${anchorProjectId}`,
+      workspaceId: opts.workspaceId,
+      anchorProjectId,
+      memberProjectIds,
+      localFolders: opts.localFolders ?? [],
+      readonlyProjectIds: opts.readonlyProjectIds ?? [],
+      logLabel: `proj:${anchorProjectId.slice(0, 8)}`,
+    })
+    this.startingPromises.set(key, promise)
+    try {
+      return await promise
+    } finally {
+      this.startingPromises.delete(key)
+    }
+  }
+
+  /**
+   * Shared boot path for every merged-root runtime, whether keyed by a
+   * workspace session (`ws:<workspaceId>`) or anchored on a project
+   * (`ws:proj:<anchorId>`). It builds the per-runtime merged root (symlinks
+   * to each member project + linked local folder), assembles the workspace
+   * env (per-project AI proxy tokens, manifest, READONLY_ROOTS for
+   * read-only attachments), and spawns the agent-runtime in WORKSPACE mode.
+   */
+  private async doStartMergedRuntime(spec: {
+    key: string
+    rootName: string
+    workspaceId: string
+    memberProjectIds: string[]
+    localFolders: string[]
+    anchorProjectId?: string
+    readonlyProjectIds?: string[]
+    logLabel: string
+  }): Promise<IProjectRuntime> {
+    const { key, rootName, workspaceId, memberProjectIds, localFolders } = spec
     const startedAtMs = Date.now()
     const phase = (name: string, extra?: Record<string, unknown>) => {
       console.log(
-        `[RuntimeManager:doStartWorkspace:${workspaceId.slice(0, 8)}] ${name} ` +
+        `[RuntimeManager:doStartMergedRuntime:${spec.logLabel}] ${name} ` +
           `(+${Date.now() - startedAtMs}ms${extra ? ' ' + JSON.stringify(extra) : ''})`,
       )
     }
-    phase('begin', { attachedProjectIds: attachedProjectIds.length })
+    phase('begin', { members: memberProjectIds.length, folders: localFolders.length, anchor: spec.anchorProjectId })
 
-    // The workspace runtime is rooted at the workspaces PARENT; each
-    // attached project is an existing subfolder. We never seed/template
-    // here — the merged-root boot skips that (workspace-runtime-mode.ts).
+    // A fresh agent process is about to spawn for this key — bump the boot
+    // generation so readiness pollers can tell this boot apart from the one it
+    // replaced (env-coupled config like READONLY_ROOTS only applies per boot).
+    this.workspaceRuntimeGeneration.set(key, (this.workspaceRuntimeGeneration.get(key) ?? 0) + 1)
+
+    // The runtime is rooted at a per-runtime MERGED ROOT that contains only
+    // this runtime's members (as symlinks to their real `workspaces/<id>`
+    // dirs) plus any linked local folders. Rooting directly at the shared
+    // `workspaces/` pool would expose every project + template on the host
+    // to the agent. The merged root scopes `ls`, the agent CWD, and
+    // path-allowance to just the members.
     const workspacesDir = resolve(this.config.workspacesDir || join(PROJECT_ROOT, 'workspaces'))
     if (!existsSync(workspacesDir)) mkdirSync(workspacesDir, { recursive: true })
+
+    const { dir: mergedRootDir, linkedFolders, readonlyFolders } = await this.buildWorkspaceMergedRoot(
+      workspacesDir,
+      rootName,
+      memberProjectIds,
+      { localFolders, readonlyProjectIds: spec.readonlyProjectIds },
+    )
+    phase('merged-root:ready', { mergedRootDir, links: linkedFolders.length, readonly: readonlyFolders.length })
 
     const port = await this.allocatePortAsync()
     const agentPort = port + AGENT_PORT_OFFSET
@@ -1218,16 +1524,30 @@ export class ShogoErrorBoundary extends Component<Props, State> {
         throw new Error(`[RuntimeManager] Runtime server not found at ${runtimeServerPath}`)
       }
 
-      // Base workspace env (WORKSPACE_ID, attached ids, per-project AI
+      // Base workspace env (WORKSPACE_ID, member ids, per-project AI
       // proxy tokens, workspace runtime token, proxy URLs, S3, Composio
       // scope). Layer the host-dev-only keys on top.
-      const runtimeEnv = await buildWorkspaceEnv(workspaceId, attachedProjectIds, {
-        logPrefix: 'doStartWorkspace',
+      const runtimeEnv = await buildWorkspaceEnv(workspaceId, memberProjectIds, {
+        logPrefix: 'doStartMergedRuntime',
+        anchorProjectId: spec.anchorProjectId,
       })
       runtimeEnv.WORKSPACE_RUNTIME = 'true'
       runtimeEnv.WORKING_MODE = 'managed'
       runtimeEnv.NODE_ENV = 'development'
       runtimeEnv.SCHEMAS_PATH = join(workspacesDir, '..', '.schemas')
+      // The merged root holds symlinks to the real `workspaces/<id>` dirs.
+      // The runtime's path-allowance (assertAllowedPath) realpath-resolves
+      // symlinks, so reads/writes through `mergedRoot/<id>/...` resolve to
+      // `workspaces/<id>/...` — which must be admitted as an allowed root.
+      // Ship the real project dirs as LINKED_FOLDERS so they are.
+      if (linkedFolders.length > 0) {
+        runtimeEnv.LINKED_FOLDERS = JSON.stringify(linkedFolders)
+      }
+      // Read-only attachments: their real dirs are allowed for reads but
+      // denied for writes by assertAllowedPath (see runtime-trust.ts).
+      if (readonlyFolders.length > 0) {
+        runtimeEnv.READONLY_ROOTS = JSON.stringify(readonlyFolders)
+      }
 
       const apiPort = process.env.API_PORT || '8002'
       const apiBase = `http://localhost:${apiPort}`
@@ -1242,8 +1562,9 @@ export class ShogoErrorBoundary extends Component<Props, State> {
       const spawnConfig: ProjectSpawnConfig = {
         cloudUrl: getShogoCloudUrl(),
         apiKey: process.env.SHOGO_API_KEY || '',
-        // projectDir becomes WORKSPACE_DIR in the child — the parent dir.
-        projectDir: workspacesDir,
+        // projectDir becomes WORKSPACE_DIR in the child — the per-runtime
+        // merged root that contains only this runtime's members.
+        projectDir: mergedRootDir,
         name: runtimeEnv.AGENT_NAME,
         workspaceId,
         extraEnv: runtimeEnv,
@@ -1275,6 +1596,121 @@ export class ShogoErrorBoundary extends Component<Props, State> {
       }
       throw err
     }
+  }
+
+  /**
+   * Build (or refresh) the per-runtime MERGED ROOT directory that a
+   * merged-root runtime is rooted at. It lives at
+   * `workspaces/.workspace-roots/<rootName>` (dot-prefixed so it's never
+   * mistaken for a project) and contains one symlink per member project
+   * (pointing at its real `workspaces/<projectId>` dir) plus one symlink per
+   * linked local folder (by basename), and nothing else.
+   *
+   * Each member project's real dir is seeded first (template + deps via
+   * `ensureProjectDirectory`, idempotent) so the merged tree actually
+   * contains a working project rather than a dangling link.
+   *
+   * Returns the merged-root path, the list of all real member dirs (for
+   * LINKED_FOLDERS path-allowance), and the subset that is read-only (for
+   * READONLY_ROOTS write-denial — see the caller). Symlinks are recreated
+   * on every start so attach/detach/folder changes reflect after a restart.
+   */
+  private async buildWorkspaceMergedRoot(
+    workspacesDir: string,
+    rootName: string,
+    memberProjectIds: string[],
+    opts: { localFolders?: string[]; readonlyProjectIds?: string[] } = {},
+  ): Promise<{ dir: string; linkedFolders: string[]; readonlyFolders: string[] }> {
+    const mergedRoot = join(workspacesDir, '.workspace-roots', rootName)
+    mkdirSync(mergedRoot, { recursive: true })
+
+    const linkType = pkg.isWindows ? 'junction' : 'dir'
+    const linkedFolders: string[] = []
+    const readonlyFolders: string[] = []
+    const readonlySet = new Set(opts.readonlyProjectIds ?? [])
+    const expectedLinkNames = new Set<string>()
+
+    // (Re)create a single symlink `<mergedRoot>/<linkName> -> <absTarget>`,
+    // replacing whatever is currently there. Records the name so the prune
+    // pass below keeps it.
+    const linkInto = (absTarget: string, linkName: string) => {
+      expectedLinkNames.add(linkName)
+      const linkPath = join(mergedRoot, linkName)
+      try {
+        const st = lstatSync(linkPath)
+        if (st.isSymbolicLink()) unlinkSync(linkPath)
+        else rmSync(linkPath, { recursive: true, force: true })
+      } catch {
+        /* nothing at linkPath yet */
+      }
+      try {
+        symlinkSync(absTarget, linkPath, linkType)
+      } catch (err: any) {
+        console.warn(
+          `[RuntimeManager] buildWorkspaceMergedRoot: failed to link ${linkName} -> ${absTarget}: ${err?.message ?? err}`,
+        )
+      }
+    }
+
+    // Member projects (anchor + attachments) — symlinked by project id.
+    for (const projectId of memberProjectIds) {
+      // Seed the real project dir (template + deps). Idempotent — the
+      // install is sentinel-gated, so repeat starts are cheap.
+      let realProjectDir: string
+      try {
+        realProjectDir = await this.ensureProjectDirectory(projectId)
+      } catch (err: any) {
+        console.warn(
+          `[RuntimeManager] buildWorkspaceMergedRoot: failed to seed member project ${projectId}: ${err?.message ?? err}`,
+        )
+        realProjectDir = join(workspacesDir, projectId)
+      }
+      if (!existsSync(realProjectDir)) {
+        console.warn(
+          `[RuntimeManager] buildWorkspaceMergedRoot: member project ${projectId} has no directory at ${realProjectDir} — skipping link`,
+        )
+        continue
+      }
+      const absProjectDir = resolve(realProjectDir)
+      linkedFolders.push(absProjectDir)
+      if (readonlySet.has(projectId)) readonlyFolders.push(absProjectDir)
+      linkInto(absProjectDir, projectId)
+    }
+
+    // Linked local host folders — symlinked by basename (collision-safe).
+    for (const folder of opts.localFolders ?? []) {
+      const abs = resolve(folder)
+      if (!existsSync(abs)) {
+        console.warn(`[RuntimeManager] buildWorkspaceMergedRoot: linked folder missing on disk: ${abs} — skipping`)
+        continue
+      }
+      const base = basename(abs) || 'folder'
+      let name = base
+      let i = 2
+      while (expectedLinkNames.has(name)) name = `${base}-${i++}`
+      linkedFolders.push(abs)
+      linkInto(abs, name)
+    }
+
+    // Prune stale links no longer expected so detached projects / removed
+    // folders stop appearing in the merged tree after a restart.
+    try {
+      const { readdirSync } = await import('fs')
+      for (const entry of readdirSync(mergedRoot)) {
+        if (expectedLinkNames.has(entry)) continue
+        const entryPath = join(mergedRoot, entry)
+        try {
+          const st = lstatSync(entryPath)
+          if (st.isSymbolicLink()) unlinkSync(entryPath)
+        } catch {
+          /* ignore */
+        }
+      }
+    } catch {
+      /* merged root just created / unreadable — nothing to prune */
+    }
+
+    return { dir: mergedRoot, linkedFolders, readonlyFolders }
   }
 
   private async doStart(projectId: string): Promise<IProjectRuntime> {
@@ -2102,8 +2538,44 @@ export class ShogoErrorBoundary extends Component<Props, State> {
   }
 
   status(projectId: string): IProjectRuntime | null {
+    // Universal workspace-runtime model: when the flag is on, a project
+    // runs on its anchored merged-root runtime (`ws:proj:<id>`), so a bare
+    // `<projectId>` lookup would miss it and make callers (e.g. the local
+    // heartbeat scheduler) believe nothing is running and cold-start a
+    // duplicate. Prefer the anchored key, falling back to the bare key for
+    // any legacy runtime started before the flag was enabled.
+    if (process.env.SHOGO_WORKSPACE_RUNTIME === 'true') {
+      const anchored = this.runtimes.get(projectWorkspaceRuntimeKey(projectId))
+      if (anchored) return this.toPublicRuntime(anchored)
+    }
     const runtime = this.runtimes.get(projectId)
     return runtime ? this.toPublicRuntime(runtime) : null
+  }
+
+  /**
+   * Observable readiness of a project's anchor merged-root runtime
+   * (`ws:proj:<anchorId>`). `generation` is the boot counter (see
+   * {@link workspaceRuntimeGeneration}); `ready` means the agent process is up
+   * and the runtime answers a health probe. Callers poll this after an
+   * attach/detach/mode-change so they only send (or assert read-only
+   * enforcement) once the runtime has rebooted with the new config.
+   */
+  async getProjectWorkspaceReadiness(anchorProjectId: string): Promise<{
+    running: boolean
+    ready: boolean
+    generation: number
+    agentPort?: number
+  }> {
+    const key = projectWorkspaceRuntimeKey(anchorProjectId)
+    const generation = this.workspaceRuntimeGeneration.get(key) ?? 0
+    const runtime = this.runtimes.get(key)
+    if (!runtime) return { running: false, ready: false, generation }
+    const running = runtime.status === 'running' && !!runtime.agentPort
+    if (!running) {
+      return { running: false, ready: false, generation, agentPort: runtime.agentPort || undefined }
+    }
+    const health = await this.getHealth(key).catch(() => ({ healthy: false }) as IHealthStatus)
+    return { running, ready: !!health.healthy, generation, agentPort: runtime.agentPort || undefined }
   }
 
   async getHealth(projectId: string): Promise<IHealthStatus> {

--- a/apps/api/src/routes/local-projects.ts
+++ b/apps/api/src/routes/local-projects.ts
@@ -34,6 +34,13 @@ import { cpSync } from 'fs'
 import { dirname, isAbsolute, join, resolve, sep } from 'path'
 import os from 'os'
 import { prisma } from '../lib/prisma'
+import {
+  attachProjectToProject,
+  detachProjectFromProject,
+  getOrCreatePinnedWorkspaceSession,
+  listAttachments,
+  ProjectAttachmentError,
+} from '../services/project-attachment.service'
 
 // =============================================================================
 // Runtime pre-warm
@@ -83,6 +90,66 @@ function prewarmRuntimeBackground(projectId: string, hint: string): void {
     .catch((err) => {
       console.warn(`[local-projects] prewarm: import of runtime/manager failed: ${err?.message ?? err}`)
     })
+}
+
+/**
+ * Fire-and-forget: tear down and re-warm the ANCHOR merged-root runtime
+ * (`ws:proj:<anchorId>`) so a just-changed attachment / linked-folder set is
+ * remounted. `LINKED_FOLDERS` / `READONLY_ROOTS` are parsed once at runtime
+ * boot, so the set only takes effect after a restart.
+ *
+ * No-op (swallowed) when `SHOGO_WORKSPACE_RUNTIME` is off — in that case the
+ * project still runs on the legacy single-project runtime and attachments
+ * are inert until the flag is enabled.
+ */
+async function restartAnchorRuntime(anchorProjectId: string, hint: string): Promise<void> {
+  const [{ getRuntimeManager, projectWorkspaceRuntimeKey }, resolveMod] = await Promise.all([
+    import('../lib/runtime/manager'),
+    import('../lib/resolve-workspace-runtime-url'),
+  ])
+
+  const manager: any = getRuntimeManager()
+
+  // Single source of truth for the anchor's merged-root spawn options
+  // (workspaceId + the current attachment / linked-folder / readonly sets).
+  // Shared with `RuntimeManager.start()`'s dedup path so a restart rebuilds
+  // the exact same root the bare-key callers would. Returns null when the
+  // project has no workspaceId (nothing to anchor).
+  const spawnOpts = await manager.resolveAnchorSpawnOpts(anchorProjectId)
+  if (!spawnOpts) return
+
+  try {
+    await manager.stop(projectWorkspaceRuntimeKey(anchorProjectId))
+  } catch {
+    /* not running — nothing to tear down */
+  }
+
+  // Await the resolve so the new boot (with the updated READONLY_ROOTS /
+  // member set) is actually up by the time this resolves — that's what makes
+  // the runtime-status generation bump observable to a polling client.
+  await resolveMod
+    .resolveWorkspaceRuntimeUrl(spawnOpts.workspaceId, {
+      anchorProjectId,
+      attachedProjectIds: spawnOpts.attachedProjectIds,
+      localFolders: spawnOpts.localFolders,
+      readonlyProjectIds: spawnOpts.readonlyProjectIds,
+      logTag: 'AnchorRestart',
+      runtimeManager: manager,
+    })
+    .catch((err: any) => {
+      if (err instanceof resolveMod.WorkspaceRuntimeNotEnabledError) return
+      console.warn(
+        `[local-projects] anchor restart (${hint}) for ${anchorProjectId} failed: ${err?.message ?? err}`,
+      )
+    })
+}
+
+function restartAnchorRuntimeBackground(anchorProjectId: string, hint: string): void {
+  void restartAnchorRuntime(anchorProjectId, hint).catch((err: any) => {
+    console.warn(
+      `[local-projects] anchor restart (${hint}) for ${anchorProjectId} threw: ${err?.message ?? err}`,
+    )
+  })
 }
 
 /**
@@ -731,20 +798,24 @@ export function localProjectsRoutes(): Hono {
       include: { projectFolders: true },
     })
     if (!project) return c.json({ error: 'not_found' }, 404)
-    if (project.workingMode !== 'external') {
-      return c.json({ error: 'not_external_project' }, 409)
-    }
+    // Managed projects may now link local folders too (they mount into the
+    // anchor merged-root runtime). Only EXTERNAL projects use the primary
+    // folder to host `.shogo/`, so a managed project's linked folders are
+    // never primary.
     if (project.projectFolders.some((f) => f.path === validated.path)) {
       return c.json({ error: 'folder_already_linked' }, 409)
     }
 
+    const isExternal = project.workingMode === 'external'
     const folder = await prisma.projectFolder.create({
       data: {
         projectId,
         path: validated.path!,
-        isPrimary: project.projectFolders.length === 0,
+        isPrimary: isExternal && project.projectFolders.length === 0,
       },
     })
+    // Remount the merged-root runtime so the agent sees the new folder.
+    restartAnchorRuntimeBackground(projectId, 'folder-add')
     return c.json({ folder }, 201)
   })
 
@@ -774,6 +845,7 @@ export function localProjectsRoutes(): Hono {
       )
     }
     await prisma.projectFolder.delete({ where: { id: folderId } })
+    restartAnchorRuntimeBackground(projectId, 'folder-remove')
     return c.json({ ok: true })
   })
 
@@ -955,10 +1027,118 @@ export function localProjectsRoutes(): Hono {
       include: { projectFolders: true },
     })
     if (!project) return c.json({ error: 'not_found' }, 404)
-    return c.json({ project })
+    // Persistent project-to-project attachments (the anchor merged-root
+    // runtime mounts these as subfolders). Folded into the project payload
+    // so the Folders panel can render both sections from one fetch.
+    const attachments = await listAttachments(projectId)
+    return c.json({ project, attachments })
+  })
+
+  /**
+   * POST /:id/workspace-session — get (or create) the project-pinned
+   * workspace chat session for this project. Opening the project routes its
+   * chat through this session so the agent runs on the anchor merged-root
+   * runtime (mounting the project + its attachments + linked folders).
+   */
+  router.post('/:id/workspace-session', async (c) => {
+    const auth = c.get('auth' as never) as { userId?: string } | undefined
+    if (!auth?.userId) return c.json({ error: 'unauthenticated' }, 401)
+    const projectId = c.req.param('id')
+    try {
+      const session = await getOrCreatePinnedWorkspaceSession(projectId)
+      const attachments = await listAttachments(projectId)
+      return c.json({
+        session: { id: session.id, workspaceId: session.workspaceId },
+        attachments,
+      })
+    } catch (err) {
+      return mapAttachmentError(c, err)
+    }
+  })
+
+  /**
+   * POST /:id/attachments { attachedProjectId, attachMode? } — attach
+   * GET /:id/workspace-runtime-status — observable readiness of this
+   * project's anchor merged-root runtime. Returns `{ running, ready,
+   * generation }`. The mobile Folders panel polls this after attach/detach/
+   * mode-change (which trigger an env-coupled restart) so the
+   * "Restarting context…" indicator clears on real readiness, and the e2e
+   * gates its read-only write assertion on the generation bump instead of a
+   * fixed sleep.
+   */
+  router.get('/:id/workspace-runtime-status', async (c) => {
+    const auth = c.get('auth' as never) as { userId?: string } | undefined
+    if (!auth?.userId) return c.json({ error: 'unauthenticated' }, 401)
+    const projectId = c.req.param('id')
+    try {
+      const { getRuntimeManager } = await import('../lib/runtime/manager')
+      const manager: any = getRuntimeManager()
+      const readiness = await manager.getProjectWorkspaceReadiness(projectId)
+      return c.json(readiness)
+    } catch (err: any) {
+      console.warn(
+        `[local-projects] workspace-runtime-status for ${projectId} failed: ${err?.message ?? err}`,
+      )
+      return c.json({ running: false, ready: false, generation: 0 })
+    }
+  })
+
+  /**
+   * another Shogo project (same workspace) to this anchor. Idempotent.
+   */
+  router.post('/:id/attachments', async (c) => {
+    const auth = c.get('auth' as never) as { userId?: string } | undefined
+    if (!auth?.userId) return c.json({ error: 'unauthenticated' }, 401)
+    const projectId = c.req.param('id')
+
+    let body: { attachedProjectId?: string; attachMode?: string }
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'invalid_json' }, 400)
+    }
+    const attachedProjectId = body.attachedProjectId
+    if (!attachedProjectId || typeof attachedProjectId !== 'string') {
+      return c.json({ error: 'attachedProjectId_required' }, 400)
+    }
+    const attachMode = body.attachMode === 'readonly' ? 'readonly' : 'readwrite'
+
+    try {
+      const attachment = await attachProjectToProject(projectId, attachedProjectId, attachMode)
+      restartAnchorRuntimeBackground(projectId, 'attach')
+      return c.json({ attachment }, 201)
+    } catch (err) {
+      return mapAttachmentError(c, err)
+    }
+  })
+
+  /**
+   * DELETE /:id/attachments/:attachedProjectId — detach a project. No-op if
+   * it wasn't attached.
+   */
+  router.delete('/:id/attachments/:attachedProjectId', async (c) => {
+    const auth = c.get('auth' as never) as { userId?: string } | undefined
+    if (!auth?.userId) return c.json({ error: 'unauthenticated' }, 401)
+    const projectId = c.req.param('id')
+    const attachedProjectId = c.req.param('attachedProjectId')
+
+    const removed = await detachProjectFromProject(projectId, attachedProjectId)
+    if (removed) restartAnchorRuntimeBackground(projectId, 'detach')
+    return c.json({ ok: true, removed })
   })
 
   return router
+}
+
+/** Map a ProjectAttachmentError to an HTTP response. */
+function mapAttachmentError(c: any, err: unknown): Response {
+  if (err instanceof ProjectAttachmentError) {
+    const status =
+      err.code === 'project_not_found' ? 404 : err.code === 'self_attach' ? 400 : 409
+    return c.json({ error: err.code, message: err.message }, status)
+  }
+  console.error('[local-projects] attachment error:', err)
+  return c.json({ error: 'internal_error' }, 500)
 }
 
 // =============================================================================

--- a/apps/api/src/routes/workspace-chat.ts
+++ b/apps/api/src/routes/workspace-chat.ts
@@ -22,6 +22,9 @@ import { join, resolve } from 'path'
 import { Hono } from 'hono'
 
 import type { IRuntimeManager } from '../lib/runtime'
+import { prisma } from '../lib/prisma'
+import * as billingService from '../services/billing.service'
+import { getModelTier, resolveModelId } from '@shogo/model-catalog'
 import { hasWorkspaceAccess } from '../services/workspace.service'
 import { autoCheckpointWorkspaceProjects } from '../services/workspace-checkpoint.service'
 import {
@@ -38,6 +41,9 @@ import {
   WorkspaceRuntimeNotEnabledError,
 } from '../lib/resolve-workspace-runtime-url'
 import { deriveWorkspaceRuntimeToken } from '../lib/workspace-runtime-token'
+import { setProjectUser } from '../lib/project-user-context'
+import { openSession, closeSession } from '../lib/proxy-billing-session'
+import { trackUsageFromStream } from './project-chat'
 
 // Same resolution as project-chat.ts / RuntimeManager: the `workspaces/`
 // parent where each project lives at `<dir>/<projectId>`. Auto-checkpoints
@@ -63,6 +69,65 @@ function mapSessionError(c: any, err: unknown) {
   throw err
 }
 
+/**
+ * Anchor-aware runtime resolution opts for a session.
+ *
+ * A workspace session can be PROJECT-PINNED: its `contextId` is the anchor
+ * project of an anchor-keyed merged-root runtime (the universal "every
+ * project runs on the workspace runtime" path). When pinned we tell the
+ * resolver the anchor (so it keys `ws:proj:<anchor>` + adds the anchor's
+ * linked folders) and which attached projects are read-only. Home/workspace
+ * sessions (no `contextId`) resolve the workspace-keyed runtime as before.
+ */
+async function anchorRuntimeOpts(
+  sessionId: string,
+  attached: { projectId: string; attachMode: AttachMode }[],
+): Promise<{ anchorProjectId?: string; localFolders?: string[]; readonlyProjectIds?: string[] }> {
+  let anchorProjectId: string | undefined
+  try {
+    const session = (await prisma.chatSession.findUnique({
+      where: { id: sessionId },
+      select: { contextId: true } as any,
+    })) as { contextId?: string | null } | null
+    anchorProjectId = session?.contextId ?? undefined
+  } catch {
+    anchorProjectId = undefined
+  }
+  if (!anchorProjectId) return {}
+
+  const readonlyProjectIds = attached
+    .filter((a) => a.attachMode === 'readonly')
+    .map((a) => a.projectId)
+
+  let localFolders: string[] = []
+  try {
+    const folders = (await prisma.projectFolder.findMany({
+      where: { projectId: anchorProjectId },
+      select: { path: true },
+    })) as Array<{ path: string }>
+    localFolders = folders.map((f) => f.path).filter((p) => typeof p === 'string' && p.length > 0)
+  } catch {
+    localFolders = []
+  }
+
+  return { anchorProjectId, localFolders, readonlyProjectIds }
+}
+
+/**
+ * Load the runtime resolution inputs for a session: the attached project
+ * ids plus the anchor-aware extras (anchor, linked folders, read-only set).
+ * One call so every route resolves the same merged-root runtime.
+ */
+async function loadRuntimeArgs(sessionId: string): Promise<{
+  attachedProjectIds: string[]
+  extra: { anchorProjectId?: string; localFolders?: string[]; readonlyProjectIds?: string[] }
+}> {
+  const attached = await getAttachedProjects(sessionId)
+  const attachedProjectIds = attached.map((a) => a.projectId)
+  const extra = await anchorRuntimeOpts(sessionId, attached)
+  return { attachedProjectIds, extra }
+}
+
 export function workspaceChatRoutes(config: WorkspaceChatRoutesConfig): Hono {
   const router = new Hono()
   const { resolveUserId, runtimeManager } = config
@@ -82,6 +147,70 @@ export function workspaceChatRoutes(config: WorkspaceChatRoutesConfig): Hono {
       return { res: c.json({ error: { code: 'forbidden', message: 'No access to this workspace' } }, 403) }
     }
     return { userId }
+  }
+
+  /**
+   * Resolve the workspace runtime URL, mapping the disabled-flag case to a
+   * clean 501. Returns the resolved url/mode, or `{ res }` with the 501
+   * response for the caller to return directly.
+   */
+  async function resolveOr501(
+    c: any,
+    workspaceId: string,
+    attachedProjectIds: string[],
+    logTag: string,
+    extra?: { anchorProjectId?: string; localFolders?: string[]; readonlyProjectIds?: string[] },
+  ): Promise<{ url: string; mode: string } | { res: Response }> {
+    try {
+      const resolved = await resolveWorkspaceRuntimeUrl(workspaceId, {
+        attachedProjectIds,
+        logTag,
+        runtimeManager,
+        ...extra,
+      })
+      return { url: resolved.url, mode: resolved.mode }
+    } catch (err) {
+      if (err instanceof WorkspaceRuntimeNotEnabledError) {
+        return {
+          res: c.json(
+            {
+              error: {
+                code: 'workspace_runtime_unavailable',
+                message:
+                  'Workspace runtimes are not yet available in this environment. ' +
+                  'Multi-project chat lands with the merged-root runtime (Phase 2b).',
+              },
+            },
+            501,
+          ),
+        }
+      }
+      throw err
+    }
+  }
+
+  /**
+   * Authenticated fetch against the workspace runtime. Resolves the runtime
+   * URL fresh (host `startWorkspace` dedupes) and injects the workspace
+   * runtime token. Used by the resume hook + turn/stream/stop routes.
+   */
+  async function fetchFromWorkspaceRuntime(
+    workspaceId: string,
+    attachedProjectIds: string[],
+    path: string,
+    init?: RequestInit,
+    extra?: { anchorProjectId?: string; localFolders?: string[]; readonlyProjectIds?: string[] },
+  ): Promise<Response> {
+    const resolved = await resolveWorkspaceRuntimeUrl(workspaceId, {
+      attachedProjectIds,
+      logTag: 'WorkspaceRuntime',
+      runtimeManager,
+      ...extra,
+    })
+    const headers = new Headers(init?.headers)
+    if (!headers.has('Content-Type')) headers.set('Content-Type', 'application/json')
+    headers.set('x-runtime-token', deriveWorkspaceRuntimeToken(workspaceId))
+    return fetch(`${resolved.url}${path}`, { ...init, headers })
   }
 
   // List workspace-scoped chat sessions.
@@ -162,8 +291,11 @@ export function workspaceChatRoutes(config: WorkspaceChatRoutesConfig): Hono {
     const projectId = c.req.param('projectId')
 
     let attachedProjectIds: string[]
+    let runtimeExtra: { anchorProjectId?: string; localFolders?: string[]; readonlyProjectIds?: string[] } = {}
     try {
-      attachedProjectIds = (await getAttachedProjects(sessionId)).map((a) => a.projectId)
+      const args = await loadRuntimeArgs(sessionId)
+      attachedProjectIds = args.attachedProjectIds
+      runtimeExtra = args.extra
     } catch (err) {
       return mapSessionError(c, err)
     }
@@ -185,6 +317,7 @@ export function workspaceChatRoutes(config: WorkspaceChatRoutesConfig): Hono {
         attachedProjectIds,
         logTag: 'WorkspacePreview',
         runtimeManager,
+        ...runtimeExtra,
       })
     } catch (err) {
       if (err instanceof WorkspaceRuntimeNotEnabledError) {
@@ -234,91 +367,649 @@ export function workspaceChatRoutes(config: WorkspaceChatRoutesConfig): Hono {
     return c.json({ stopped: true })
   })
 
-  // Proxy chat to the workspace runtime.
-  router.post('/workspaces/:workspaceId/chat', async (c) => {
+  // Preemptively warm a workspace runtime so the merged-root pod is being
+  // claimed / cold-started while the user is still composing. The attached
+  // project set (resolved from `attachProjectIds` in the body, or from a
+  // `sessionId`'s attachments) drives which subfolders the runtime mounts.
+  // Returns 202 immediately and resolves in the background (idempotent — host
+  // `startWorkspace` dedupes concurrent starts). The SHOGO_WORKSPACE_RUNTIME
+  // gate is honoured silently in the background resolve, so a prewarm in an
+  // environment without the flag is simply a no-op rather than an error.
+  router.post('/workspaces/:workspaceId/runtime/prewarm', async (c) => {
+    const auth = await authorize(c)
+    if ('res' in auth) return auth.res
+    const workspaceId = c.req.param('workspaceId')
+    const body = await c.req.json().catch(() => ({} as any))
+
+    let attachedProjectIds: string[] = Array.isArray(body?.attachProjectIds)
+      ? body.attachProjectIds.filter((x: unknown): x is string => typeof x === 'string')
+      : []
+    let runtimeExtra: { anchorProjectId?: string; localFolders?: string[]; readonlyProjectIds?: string[] } = {}
+    if (typeof body?.sessionId === 'string' && body.sessionId) {
+      try {
+        const args = await loadRuntimeArgs(body.sessionId)
+        if (attachedProjectIds.length === 0) attachedProjectIds = args.attachedProjectIds
+        runtimeExtra = args.extra
+      } catch {
+        // Session may not exist yet / not a workspace session — warm with an
+        // empty set rather than failing the (best-effort) prewarm.
+      }
+    }
+
+    // Fire-and-forget: don't await so the client gets a snappy 202 and the
+    // pod warms while the user keeps composing. Swallow the disabled-flag
+    // case (prewarm is best-effort); log everything else.
+    void resolveWorkspaceRuntimeUrl(workspaceId, {
+      attachedProjectIds,
+      logTag: 'WorkspacePrewarm',
+      runtimeManager,
+      ...runtimeExtra,
+    }).catch((err) => {
+      if (!(err instanceof WorkspaceRuntimeNotEnabledError)) {
+        console.error(
+          `[WorkspaceChat] Background prewarm failed for ${workspaceId}:`,
+          err?.message ?? err,
+        )
+      }
+    })
+
+    return c.json({ success: true, workspaceId, status: 'warming' }, 202)
+  })
+
+  // Preemptively warm a workspace runtime. Returns 202 immediately and
+  // resolves the runtime in the background, so a merged-root pod is being
+  // claimed/cold-started while the user composes their first message. The
+  // homepage calls this on Send (the workspace-aware sibling of the
+  // per-project /runtime/prewarm). Body accepts `sessionId` and/or
+  // `attachProjectIds` to determine which subfolders the runtime mounts.
+  router.post('/workspaces/:workspaceId/runtime/prewarm', async (c) => {
     const auth = await authorize(c)
     if ('res' in auth) return auth.res
     const workspaceId = c.req.param('workspaceId')
 
     const body = await c.req.json().catch(() => ({} as any))
-    const sessionId: string | undefined = body?.sessionId
-    if (!sessionId) {
-      return c.json({ error: { code: 'bad_request', message: 'sessionId is required' } }, 400)
+    let attachedProjectIds: string[] = Array.isArray(body?.attachProjectIds)
+      ? body.attachProjectIds.filter((x: unknown) => typeof x === 'string')
+      : []
+    let runtimeExtra: { anchorProjectId?: string; localFolders?: string[]; readonlyProjectIds?: string[] } = {}
+    if (typeof body?.sessionId === 'string' && body.sessionId) {
+      try {
+        const args = await loadRuntimeArgs(body.sessionId)
+        if (attachedProjectIds.length === 0) attachedProjectIds = args.attachedProjectIds
+        runtimeExtra = args.extra
+      } catch {
+        /* best-effort */
+      }
+    }
+
+    // Fire-and-forget: resolve (and thus spawn/claim) the workspace runtime.
+    // Swallow the disabled-flag 501 and transient errors — this is a warm-up
+    // hint, not a correctness path.
+    void resolveWorkspaceRuntimeUrl(workspaceId, {
+      attachedProjectIds,
+      logTag: 'WorkspacePrewarm',
+      runtimeManager,
+      ...runtimeExtra,
+    }).catch((err) => {
+      if (err instanceof WorkspaceRuntimeNotEnabledError) return
+      console.warn(
+        `[WorkspaceChat] Prewarm failed for ${workspaceId} (non-blocking):`,
+        err?.message ?? err,
+      )
+    })
+
+    return c.json({ accepted: true }, 202)
+  })
+
+  // Proxy chat to the workspace runtime.
+  //
+  // Parity with project-chat.ts POST /projects/:projectId/chat: workspace
+  // membership auth (above), a usage-balance gate, model-tier downgrade for
+  // non-advanced plans, a per-turn billing session keyed on the billing
+  // anchor project (first attached, since the AI proxy + runtime default
+  // token are project-scoped), decoupled upstream streaming so a client
+  // disconnect never aborts the runtime, and trackUsageFromStream for
+  // persistence + server-side auto-resume + billing close. Runtime
+  // resolution stays gated behind SHOGO_WORKSPACE_RUNTIME (501 when off).
+  router.post('/workspaces/:workspaceId/chat', async (c) => {
+    const auth = await authorize(c)
+    if ('res' in auth) return auth.res
+    const workspaceId = c.req.param('workspaceId')
+
+    // Usage gate (workspace-level balance) — mirrors project-chat.
+    if (!(await billingService.hasBalance(workspaceId))) {
+      return c.json(
+        {
+          error: {
+            code: 'usage_limit_reached',
+            message:
+              "You've reached your usage limit. Enable usage-based pricing or upgrade your plan to continue.",
+          },
+        },
+        402,
+      )
+    }
+
+    let body = await c.req.text()
+    let parsedBody: any = {}
+    try {
+      parsedBody = JSON.parse(body)
+    } catch {
+      /* not JSON, that's fine */
+    }
+
+    // chat-session id is REQUIRED. Header takes precedence, then
+    // `sessionId` / `chatSessionId` in the body. The runtime keys its
+    // in-memory SessionManager + durable turn buffer on this id, and the
+    // billing session below is opened under it.
+    const sessionId: string | null =
+      c.req.header('X-Chat-Session-Id') ||
+      parsedBody?.sessionId ||
+      parsedBody?.chatSessionId ||
+      null
+    if (!sessionId || typeof sessionId !== 'string' || sessionId.trim() === '') {
+      return c.json(
+        {
+          error: {
+            code: 'chat_session_id_required',
+            message:
+              'sessionId is required — send it as the X-Chat-Session-Id header or as `sessionId` in the JSON body',
+          },
+        },
+        400,
+      )
+    }
+
+    // Normalize the body so the runtime reads the same session id from
+    // `chatSessionId` (its durable buffer + resume key) that we billed under.
+    if (parsedBody.chatSessionId !== sessionId) {
+      parsedBody.chatSessionId = sessionId
+      body = JSON.stringify(parsedBody)
     }
 
     let attachedProjectIds: string[]
+    let runtimeExtra: { anchorProjectId?: string; localFolders?: string[]; readonlyProjectIds?: string[] } = {}
     try {
-      attachedProjectIds = (await getAttachedProjects(sessionId)).map((a) => a.projectId)
+      const args = await loadRuntimeArgs(sessionId)
+      attachedProjectIds = args.attachedProjectIds
+      runtimeExtra = args.extra
     } catch (err) {
       return mapSessionError(c, err)
     }
 
-    let resolved
+    // Billing anchor: the AI proxy accumulates usage keyed by projectId, and
+    // build-workspace-env mints the first attached project's token as the
+    // runtime's default AI_PROXY_TOKEN, so we anchor billing on the first
+    // attached project. Per-call multi-project attribution is Phase 2b.
+    const billingProjectId: string | null = attachedProjectIds[0] ?? null
+
+    // Model-tier guard: downgrade non-economy models for workspaces without
+    // advanced access (server-side enforcement, same as project chat).
+    if (parsedBody.agentMode) {
+      const resolvedModel = resolveModelId(parsedBody.agentMode)
+      if (getModelTier(resolvedModel) !== 'economy') {
+        if (!(await billingService.hasAdvancedModelAccess(workspaceId))) {
+          parsedBody.agentMode = 'claude-haiku-4-5-20251001'
+          body = JSON.stringify(parsedBody)
+        }
+      }
+    }
+
+    // Resolve the workspace runtime (501 when SHOGO_WORKSPACE_RUNTIME off).
+    const runtimeRes = await resolveOr501(c, workspaceId, attachedProjectIds, 'WorkspaceChat', runtimeExtra)
+    if ('res' in runtimeRes) return runtimeRes.res
+    let podUrl = runtimeRes.url
+
+    // The caller already passed hasWorkspaceAccess, so attribute billing +
+    // Composio identity to the authenticated user.
+    const billingUserId =
+      parsedBody?.userId || c.req.header('X-Billing-User-Id') || auth.userId
+    if (billingProjectId && billingUserId && billingUserId !== 'system') {
+      setProjectUser(billingProjectId, billingUserId)
+    }
+
+    // Open the billing session (anchor project) so the AI proxy accumulates
+    // tokens across the agentic loop instead of charging per-call. Only when
+    // we have an anchor project; a zero-attachment session degrades to a bare
+    // proxy. trackUsageFromStream closes the session after the stream ends;
+    // the finally guard closes an orphaned session on early exit.
+    let billingSessionHandedOff = false
+    if (billingProjectId) {
+      openSession(billingProjectId, workspaceId, billingUserId || 'system', sessionId)
+    }
     try {
-      resolved = await resolveWorkspaceRuntimeUrl(workspaceId, {
-        attachedProjectIds,
-        logTag: 'WorkspaceChat',
-        runtimeManager,
-      })
-    } catch (err) {
-      if (err instanceof WorkspaceRuntimeNotEnabledError) {
-        return c.json(
-          {
-            error: {
-              code: 'workspace_runtime_unavailable',
-              message:
-                'Workspace runtimes are not yet available in this environment. ' +
-                'Multi-project chat lands with the merged-root runtime (Phase 2b).',
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      headers['x-runtime-token'] = deriveWorkspaceRuntimeToken(workspaceId)
+
+      const authHeader = c.req.header('Authorization')
+      if (authHeader) headers['Authorization'] = authHeader
+      const sessHeader = c.req.header('X-Session-Id')
+      if (sessHeader) headers['X-Session-Id'] = sessHeader
+      if (billingUserId && billingUserId !== 'system') {
+        headers['X-Billing-User-Id'] = billingUserId
+      }
+      // The caller passed workspace membership above, so X-User-Id is trusted.
+      headers['X-User-Id'] = auth.userId
+      // Runtime keys its durable-turn + billing state on the chat session id.
+      headers['x-chat-session-id'] = sessionId
+
+      const MAX_RETRIES = 30
+      const BASE_DELAY_MS = 500
+      const MAX_DELAY_MS = 4000
+      const FETCH_TIMEOUT_MS = parseInt(
+        process.env.CHAT_UPSTREAM_FETCH_TIMEOUT_MS || '14400000',
+        10,
+      )
+      // A client disconnect must NOT abort the upstream fetch — the runtime
+      // keeps the agent running so the client can resume, and
+      // trackUsageFromStream needs the full stream for billing/persistence.
+      const clientSignal = c.req.raw.signal
+      const fetchSignal = AbortSignal.timeout(FETCH_TIMEOUT_MS)
+      let lastError: Error | null = null
+
+      for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+        if (clientSignal?.aborted) {
+          return new Response(null, { status: 499 })
+        }
+        try {
+          const upstream = await fetch(`${podUrl}/agent/chat`, {
+            method: 'POST',
+            headers,
+            body,
+            signal: fetchSignal,
+          })
+
+          if (!upstream.ok) {
+            const errorText = await upstream.text()
+            console.error(
+              `[WorkspaceChat] Runtime returned error: ${upstream.status} ${errorText}`,
+            )
+            const isTransient =
+              upstream.status === 401 ||
+              upstream.status === 403 ||
+              upstream.status === 404 ||
+              upstream.status >= 500
+            if (isTransient && attempt < MAX_RETRIES) {
+              const delay = Math.min(BASE_DELAY_MS * Math.pow(2, attempt - 1), MAX_DELAY_MS)
+              await new Promise((r) => setTimeout(r, delay))
+              // Re-resolve in case the runtime port/host changed mid-retry.
+              try {
+                const refreshed = await resolveWorkspaceRuntimeUrl(workspaceId, {
+                  attachedProjectIds,
+                  logTag: 'WorkspaceChat',
+                  runtimeManager,
+                  ...runtimeExtra,
+                })
+                podUrl = refreshed.url
+              } catch {
+                /* keep old url */
+              }
+              continue
+            }
+            return c.json(
+              {
+                error: {
+                  code: 'runtime_error',
+                  message: `Runtime error: ${upstream.status}`,
+                  detail: errorText.slice(0, 200),
+                },
+              },
+              upstream.status as any,
+            )
+          }
+
+          // Copy response headers (minus hop-by-hop), add CORS + expose the
+          // turn-ledger headers so the browser can read them cross-origin.
+          const responseHeaders = new Headers()
+          upstream.headers.forEach((value, key) => {
+            if (
+              !['content-length', 'transfer-encoding', 'connection'].includes(key.toLowerCase())
+            ) {
+              responseHeaders.set(key, value)
+            }
+          })
+          responseHeaders.set('Access-Control-Allow-Origin', '*')
+          responseHeaders.set('Access-Control-Allow-Methods', 'POST, OPTIONS')
+          responseHeaders.set(
+            'Access-Control-Allow-Headers',
+            'Content-Type, Authorization, X-Session-Id',
+          )
+          responseHeaders.set(
+            'Access-Control-Expose-Headers',
+            'X-Turn-Id, X-Chat-Session-Id, X-Last-Seq, X-Turn-Status',
+          )
+
+          if (!upstream.body) {
+            return new Response(null, { status: upstream.status, headers: responseHeaders })
+          }
+
+          // Decoupled fan-out (same pattern as project-chat): read the
+          // upstream body in a background loop and independently push chunks
+          // to both the client stream and a tracking queue, so billing +
+          // persistence always see the full stream even if the client drops.
+          const bgReader = upstream.body.getReader()
+          const trackingChunks: Uint8Array[] = []
+          let trackingDone = false
+          let trackingNotify: (() => void) | null = null
+          const trackingWait = () =>
+            new Promise<void>((res) => {
+              trackingNotify = res
+            })
+          const trackingStream = new ReadableStream<Uint8Array>({
+            async pull(controller) {
+              while (trackingChunks.length === 0 && !trackingDone) {
+                await trackingWait()
+              }
+              if (trackingChunks.length > 0) {
+                controller.enqueue(trackingChunks.shift()!)
+                return
+              }
+              controller.close()
             },
-          },
-          501,
+            cancel() {
+              trackingDone = true
+              trackingNotify?.()
+              trackingNotify = null
+            },
+          })
+
+          const clientStream = new ReadableStream<Uint8Array>({
+            start(controller) {
+              const keepaliveChunk = new TextEncoder().encode(': proxy-keep-alive\n\n')
+              const proxyKeepalive = setInterval(() => {
+                try {
+                  controller.enqueue(keepaliveChunk)
+                } catch {
+                  clearInterval(proxyKeepalive)
+                }
+              }, 15_000)
+              ;(async () => {
+                try {
+                  while (true) {
+                    const { done, value } = await bgReader.read()
+                    if (done) break
+                    trackingChunks.push(value)
+                    trackingNotify?.()
+                    trackingNotify = null
+                    try {
+                      controller.enqueue(value)
+                    } catch {
+                      /* client gone — stream continues for tracking */
+                    }
+                  }
+                } catch (err: any) {
+                  try {
+                    controller.error(err)
+                  } catch {
+                    /* client gone */
+                  }
+                } finally {
+                  clearInterval(proxyKeepalive)
+                  trackingDone = true
+                  trackingNotify?.()
+                  trackingNotify = null
+                  try {
+                    controller.close()
+                  } catch {
+                    /* already closed */
+                  }
+                }
+              })()
+            },
+          })
+
+          if (billingProjectId) {
+            // trackUsageFromStream owns billing close + persistence + the
+            // anchor project's auto-checkpoint.
+            billingSessionHandedOff = true
+            trackUsageFromStream(
+              trackingStream,
+              parsedBody,
+              { id: billingProjectId, workspaceId },
+              {
+                chatSessionId: sessionId,
+                resume: async (fromSeq) => {
+                  try {
+                    return await fetchFromWorkspaceRuntime(
+                      workspaceId,
+                      attachedProjectIds,
+                      `/agent/chat/${encodeURIComponent(sessionId)}/stream?fromSeq=${fromSeq}`,
+                      { method: 'GET' },
+                      runtimeExtra,
+                    )
+                  } catch (err: any) {
+                    console.warn(
+                      `[WorkspaceChat] Resume fetch failed for ${workspaceId}/${sessionId}:`,
+                      err?.message || err,
+                    )
+                    return null
+                  }
+                },
+              },
+            ).catch((err) => console.error('[WorkspaceChat] Usage tracking error:', err))
+          } else {
+            // No anchor project → no billing/persistence anchor; drain the
+            // tracking stream so the background fan-out doesn't stall.
+            void (async () => {
+              try {
+                const r = trackingStream.getReader()
+                // eslint-disable-next-line no-empty
+                while (!(await r.read()).done) {}
+              } catch {
+                /* noop */
+              }
+            })()
+          }
+
+          // Multi-project auto-checkpoint for the NON-anchor attached projects
+          // (the anchor is checkpointed by trackUsageFromStream). Best-effort,
+          // fires on clean client-stream close.
+          const checkpointTargets = attachedProjectIds.filter((id) => id !== billingProjectId)
+          let outBody: ReadableStream<Uint8Array> = clientStream
+          if (checkpointTargets.length > 0) {
+            const checkpointWatcher = new TransformStream<Uint8Array, Uint8Array>({
+              flush() {
+                autoCheckpointWorkspaceProjects(checkpointTargets, {
+                  workspacesDir: WORKSPACES_DIR,
+                  message: `AI: workspace turn (session ${sessionId.slice(0, 8)})`,
+                }).catch((err) =>
+                  console.warn(
+                    '[WorkspaceChat] Auto-checkpoint failed (non-blocking):',
+                    err?.message ?? err,
+                  ),
+                )
+              },
+            })
+            outBody = clientStream.pipeThrough(checkpointWatcher)
+          }
+
+          return new Response(outBody, { status: upstream.status, headers: responseHeaders })
+        } catch (fetchError: any) {
+          lastError = fetchError
+          const isClientAbort = fetchError.name === 'AbortError' && clientSignal?.aborted
+          if (isClientAbort) return new Response(null, { status: 499 })
+
+          const isTransient =
+            fetchError.code === 'ECONNREFUSED' ||
+            fetchError.code === 'ECONNRESET' ||
+            fetchError.code === 'ETIMEDOUT' ||
+            fetchError.cause?.code === 'ECONNREFUSED' ||
+            fetchError.cause?.code === 'ECONNRESET' ||
+            fetchError.cause?.code === 'ETIMEDOUT' ||
+            fetchError.name === 'TimeoutError'
+          if (isTransient && attempt < MAX_RETRIES) {
+            const delay = Math.min(BASE_DELAY_MS * Math.pow(2, attempt - 1), MAX_DELAY_MS)
+            try {
+              const refreshed = await resolveWorkspaceRuntimeUrl(workspaceId, {
+                attachedProjectIds,
+                logTag: 'WorkspaceChat',
+                runtimeManager,
+                ...runtimeExtra,
+              })
+              podUrl = refreshed.url
+            } catch {
+              /* keep old url */
+            }
+            await new Promise((r) => setTimeout(r, delay))
+            continue
+          }
+          throw fetchError
+        }
+      }
+
+      return c.json(
+        { error: { code: 'proxy_error', message: lastError?.message || 'Max retries exceeded' } },
+        503,
+      )
+    } catch (error: any) {
+      console.error('[WorkspaceChat] Proxy error:', error)
+      return c.json(
+        { error: { code: 'proxy_error', message: error.message || 'Proxy failed' } },
+        500,
+      )
+    } finally {
+      // Guard: close the billing session if trackUsageFromStream never took
+      // ownership (retry exhaustion, client disconnect, thrown error).
+      if (billingProjectId && !billingSessionHandedOff) {
+        closeSession(billingProjectId, { chatSessionId: sessionId }).catch((err) =>
+          console.error(
+            `[WorkspaceChat] Failed to close orphaned billing session for ${billingProjectId}:`,
+            err,
+          ),
         )
       }
-      throw err
     }
+  })
 
-    // Runtime is enabled: proxy the chat through. Full billing/usage
-    // parity with project-chat.ts is wired in Phase 2b; this is the
-    // minimal forward so the merged-root runtime can be exercised once
-    // SHOGO_WORKSPACE_RUNTIME is on.
-    const headers = new Headers({ 'Content-Type': 'application/json' })
-    headers.set('x-runtime-token', deriveWorkspaceRuntimeToken(workspaceId))
-    // The runtime keys its durable-turn + billing state on the chat
-    // session id, read from this header (or `chatSessionId` in the body).
-    // Forward the workspace session id so it has one.
-    headers.set('x-chat-session-id', sessionId)
-    const upstream = await fetch(`${resolved.url}/agent/chat`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(body),
-      signal: c.req.raw.signal,
-    })
+  // Resume an active workspace turn stream (AI SDK resume URL pattern:
+  // ${chatPostUrl}/${sessionId}/stream). Optional ?fromSeq=N for delta replay.
+  router.get('/workspaces/:workspaceId/chat/:sessionId/stream', async (c) => {
+    const auth = await authorize(c)
+    if ('res' in auth) return auth.res
+    const workspaceId = c.req.param('workspaceId')
+    const sessionId = c.req.param('sessionId')
+    const fromSeq = c.req.query('fromSeq')
 
-    // Per-project auto-checkpoint: when the agent turn's stream completes
-    // cleanly, snapshot each attached project that changed (see
-    // workspace-checkpoint.service.ts — dirtiness-based, per-project git
-    // repo at workspaces/<id>). We tee the stream so the snapshot fires on
-    // normal close; if the client aborts mid-turn the upstream errors and
-    // `flush` never runs, so we don't checkpoint a torn-off turn. Snapshots
-    // are best-effort and never block the response.
-    if (!upstream.body || attachedProjectIds.length === 0) {
-      return new Response(upstream.body, { status: upstream.status, headers: upstream.headers })
+    let attachedProjectIds: string[]
+    let runtimeExtra: { anchorProjectId?: string; localFolders?: string[]; readonlyProjectIds?: string[] } = {}
+    try {
+      const args = await loadRuntimeArgs(sessionId)
+      attachedProjectIds = args.attachedProjectIds
+      runtimeExtra = args.extra
+    } catch (err) {
+      return mapSessionError(c, err)
     }
-    const projectsForCheckpoint = attachedProjectIds
-    const checkpointWatcher = new TransformStream({
-      flush() {
-        autoCheckpointWorkspaceProjects(projectsForCheckpoint, {
-          workspacesDir: WORKSPACES_DIR,
-          message: `AI: workspace turn (session ${sessionId.slice(0, 8)})`,
-        }).catch((err) => {
-          console.warn('[WorkspaceChat] Auto-checkpoint failed (non-blocking):', err?.message ?? err)
-        })
-      },
-    })
-    return new Response(upstream.body.pipeThrough(checkpointWatcher), {
-      status: upstream.status,
-      headers: upstream.headers,
-    })
+    const runtimeRes = await resolveOr501(c, workspaceId, attachedProjectIds, 'WorkspaceResume', runtimeExtra)
+    if ('res' in runtimeRes) return runtimeRes.res
+
+    const runtimePath =
+      fromSeq !== undefined && fromSeq !== ''
+        ? `/agent/chat/${encodeURIComponent(sessionId)}/stream?fromSeq=${encodeURIComponent(fromSeq)}`
+        : `/agent/chat/${encodeURIComponent(sessionId)}/stream`
+    try {
+      const response = await fetchFromWorkspaceRuntime(workspaceId, attachedProjectIds, runtimePath, {
+        method: 'GET',
+      }, runtimeExtra)
+      if (response.status === 204 || !response.body) {
+        return new Response(null, { status: 204 })
+      }
+      const responseHeaders = new Headers()
+      response.headers.forEach((value, key) => {
+        if (!['content-length', 'transfer-encoding', 'connection'].includes(key.toLowerCase())) {
+          responseHeaders.set(key, value)
+        }
+      })
+      responseHeaders.set('Access-Control-Allow-Origin', '*')
+      responseHeaders.set('Access-Control-Expose-Headers', 'X-Turn-Id, X-Last-Seq, X-Turn-Status')
+      responseHeaders.set('X-Accel-Buffering', 'no')
+      return new Response(response.body, { status: response.status, headers: responseHeaders })
+    } catch (err: any) {
+      console.warn(
+        `[WorkspaceChat] resume proxy error for ${workspaceId}/${sessionId}:`,
+        err?.message || err,
+      )
+      return new Response(null, { status: 204 })
+    }
+  })
+
+  // Read-only durable turn snapshot (poll without opening a stream).
+  router.get('/workspaces/:workspaceId/chat/:sessionId/turn', async (c) => {
+    const auth = await authorize(c)
+    if ('res' in auth) return auth.res
+    const workspaceId = c.req.param('workspaceId')
+    const sessionId = c.req.param('sessionId')
+
+    let attachedProjectIds: string[]
+    let runtimeExtra: { anchorProjectId?: string; localFolders?: string[]; readonlyProjectIds?: string[] } = {}
+    try {
+      const args = await loadRuntimeArgs(sessionId)
+      attachedProjectIds = args.attachedProjectIds
+      runtimeExtra = args.extra
+    } catch (err) {
+      return mapSessionError(c, err)
+    }
+    const runtimeRes = await resolveOr501(c, workspaceId, attachedProjectIds, 'WorkspaceTurn', runtimeExtra)
+    if ('res' in runtimeRes) return runtimeRes.res
+    try {
+      const response = await fetchFromWorkspaceRuntime(
+        workspaceId,
+        attachedProjectIds,
+        `/agent/chat/${encodeURIComponent(sessionId)}/turn`,
+        { method: 'GET' },
+        runtimeExtra,
+      )
+      if (response.status === 404) return c.json({ status: 'unknown' as const }, 404)
+      const data = await response.json()
+      return c.json(data, response.status as any)
+    } catch (err: any) {
+      console.warn(
+        `[WorkspaceChat] turn snapshot proxy error for ${workspaceId}/${sessionId}:`,
+        err?.message || err,
+      )
+      return c.json({ status: 'unknown' as const }, 404)
+    }
+  })
+
+  // Stop/interrupt active generation on the workspace runtime.
+  router.post('/workspaces/:workspaceId/chat/stop', async (c) => {
+    const auth = await authorize(c)
+    if ('res' in auth) return auth.res
+    const workspaceId = c.req.param('workspaceId')
+
+    const body = await c.req.text()
+    let parsed: any = {}
+    try {
+      parsed = JSON.parse(body || '{}')
+    } catch {
+      /* noop */
+    }
+    // sessionId resolves the attached project set for runtime resolution.
+    const sessionId: string | undefined =
+      c.req.header('X-Chat-Session-Id') || parsed?.sessionId || parsed?.chatSessionId
+    let attachedProjectIds: string[] = []
+    let runtimeExtra: { anchorProjectId?: string; localFolders?: string[]; readonlyProjectIds?: string[] } = {}
+    if (sessionId) {
+      try {
+        const args = await loadRuntimeArgs(sessionId)
+        attachedProjectIds = args.attachedProjectIds
+        runtimeExtra = args.extra
+      } catch {
+        /* noop */
+      }
+    }
+    const runtimeRes = await resolveOr501(c, workspaceId, attachedProjectIds, 'WorkspaceStop', runtimeExtra)
+    if ('res' in runtimeRes) return runtimeRes.res
+    try {
+      const response = await fetchFromWorkspaceRuntime(workspaceId, attachedProjectIds, '/agent/stop', {
+        method: 'POST',
+        body: body || '{}',
+      }, runtimeExtra)
+      const result = await response.json()
+      return c.json(result)
+    } catch (error: any) {
+      console.error('[WorkspaceChat] Stop error:', error)
+      return c.json({ success: false, error: error.message }, 500)
+    }
   })
 
   return router

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1383,8 +1383,10 @@ app.route('/api', remoteAuditRoutes())
 // Sync engine — Phase 2 event-driven bidirectional sync
 app.route('/api', syncRoutes())
 // Workspace-scoped chat + session management (multi-project / parent-folder
-// model). Session CRUD is live; the /chat proxy returns 501 until the
-// merged-root workspace runtime (Phase 2b) is enabled via SHOGO_WORKSPACE_RUNTIME.
+// model). Session CRUD is live; the /chat proxy (+ turn/stream/stop) reaches
+// project-chat parity (billing, persistence, auto-resume) but the merged-root
+// workspace runtime it proxies to is gated behind SHOGO_WORKSPACE_RUNTIME —
+// runtime resolution returns 501 until that flag is enabled.
 app.route('/api', workspaceChatRoutes({ resolveUserId: getAuthUserId, runtimeManager: getRuntimeManager() }))
 startTunnelHeartbeat()
 

--- a/apps/api/src/services/__tests__/project-attachment.service.test.ts
+++ b/apps/api/src/services/__tests__/project-attachment.service.test.ts
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+//
+// project-attachment.service — persistent project↔project attachments and
+// the per-project pinned workspace session that materializes them.
+
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+interface ProjectRow {
+  id: string
+  workspaceId: string
+  name?: string | null
+}
+
+interface State {
+  projects: Map<string, ProjectRow>
+  attachments: Array<{ id: string; projectId: string; attachedProjectId: string; attachMode: string }>
+  pinnedSession: { id: string; contextId: string } | null
+  sessionProjects: Array<{ sessionId: string; projectId: string; attachMode: string }>
+  folders: Array<{ projectId: string; path: string }>
+}
+
+const s: State = {
+  projects: new Map(),
+  attachments: [],
+  pinnedSession: null,
+  sessionProjects: [],
+  folders: [],
+}
+
+let idSeq = 0
+
+mock.module('../../lib/prisma', () => ({
+  prisma: {
+    project: {
+      findUnique: async (args: any) => s.projects.get(args.where.id) ?? null,
+    },
+    projectAttachment: {
+      findMany: async (args: any) => {
+        const rows = s.attachments.filter((a) => a.projectId === args.where.projectId)
+        if (args.include?.attached) {
+          return rows.map((r) => ({
+            ...r,
+            attached: { id: r.attachedProjectId, name: s.projects.get(r.attachedProjectId)?.name ?? null },
+          }))
+        }
+        return rows
+      },
+      upsert: async (args: any) => {
+        const { projectId, attachedProjectId } = args.where.projectId_attachedProjectId
+        let row = s.attachments.find((a) => a.projectId === projectId && a.attachedProjectId === attachedProjectId)
+        if (row) {
+          row.attachMode = args.update.attachMode
+        } else {
+          row = { id: `att-${++idSeq}`, ...args.create }
+          s.attachments.push(row)
+        }
+        return {
+          ...row,
+          attached: { id: row.attachedProjectId, name: s.projects.get(row.attachedProjectId)?.name ?? null },
+        }
+      },
+      deleteMany: async (args: any) => {
+        const before = s.attachments.length
+        s.attachments = s.attachments.filter(
+          (a) => !(a.projectId === args.where.projectId && a.attachedProjectId === args.where.attachedProjectId),
+        )
+        return { count: before - s.attachments.length }
+      },
+    },
+    projectFolder: {
+      findMany: async (args: any) => s.folders.filter((f) => f.projectId === args.where.projectId),
+    },
+    chatSession: {
+      findFirst: async (_args: any) => s.pinnedSession,
+      create: async (args: any) => {
+        s.pinnedSession = { id: `sess-${++idSeq}`, contextId: args.data.contextId }
+        return { id: s.pinnedSession.id }
+      },
+    },
+    chatSessionProject: {
+      findMany: async (args: any) => s.sessionProjects.filter((p) => p.sessionId === args.where.sessionId),
+      deleteMany: async (args: any) => {
+        const ids: string[] = args.where.projectId.in
+        const before = s.sessionProjects.length
+        s.sessionProjects = s.sessionProjects.filter(
+          (p) => !(p.sessionId === args.where.sessionId && ids.includes(p.projectId)),
+        )
+        return { count: before - s.sessionProjects.length }
+      },
+      upsert: async (args: any) => {
+        const { sessionId, projectId } = args.where.sessionId_projectId
+        let row = s.sessionProjects.find((p) => p.sessionId === sessionId && p.projectId === projectId)
+        if (row) row.attachMode = args.update.attachMode
+        else s.sessionProjects.push({ sessionId, projectId, attachMode: args.create.attachMode })
+        return {}
+      },
+    },
+  },
+}))
+
+const svc = await import('../project-attachment.service')
+
+beforeEach(() => {
+  s.projects = new Map([
+    ['anchor', { id: 'anchor', workspaceId: 'ws1', name: 'Anchor' }],
+    ['b', { id: 'b', workspaceId: 'ws1', name: 'Project B' }],
+    ['c', { id: 'c', workspaceId: 'ws1', name: 'Project C' }],
+    ['other-ws', { id: 'other-ws', workspaceId: 'ws2', name: 'Foreign' }],
+  ])
+  s.attachments = []
+  s.pinnedSession = null
+  s.sessionProjects = []
+  s.folders = []
+  idSeq = 0
+})
+
+describe('attachProjectToProject', () => {
+  it('rejects self-attach', async () => {
+    await expect(svc.attachProjectToProject('anchor', 'anchor')).rejects.toMatchObject({ code: 'self_attach' })
+  })
+
+  it('rejects cross-workspace attach', async () => {
+    await expect(svc.attachProjectToProject('anchor', 'other-ws')).rejects.toMatchObject({ code: 'cross_workspace' })
+  })
+
+  it('rejects unknown attached project', async () => {
+    await expect(svc.attachProjectToProject('anchor', 'nope')).rejects.toMatchObject({ code: 'project_not_found' })
+  })
+
+  it('attaches and seeds the pinned session with [anchor, attached]', async () => {
+    const row = await svc.attachProjectToProject('anchor', 'b', 'readonly')
+    expect(row.attachedProjectId).toBe('b')
+    expect(row.attachMode).toBe('readonly')
+    // Pinned session created + synced: anchor (readwrite) + b (readonly).
+    expect(s.pinnedSession).not.toBeNull()
+    const sid = s.pinnedSession!.id
+    const rows = s.sessionProjects.filter((p) => p.sessionId === sid)
+    expect(rows.find((r) => r.projectId === 'anchor')?.attachMode).toBe('readwrite')
+    expect(rows.find((r) => r.projectId === 'b')?.attachMode).toBe('readonly')
+  })
+
+  it('is idempotent — re-attach updates attachMode', async () => {
+    await svc.attachProjectToProject('anchor', 'b', 'readwrite')
+    await svc.attachProjectToProject('anchor', 'b', 'readonly')
+    expect(s.attachments.filter((a) => a.attachedProjectId === 'b')).toHaveLength(1)
+    expect(s.attachments[0].attachMode).toBe('readonly')
+  })
+})
+
+describe('detachProjectFromProject', () => {
+  it('removes the attachment and resyncs the session', async () => {
+    await svc.attachProjectToProject('anchor', 'b')
+    await svc.attachProjectToProject('anchor', 'c')
+    const removed = await svc.detachProjectFromProject('anchor', 'b')
+    expect(removed).toBe(true)
+    const sid = s.pinnedSession!.id
+    const ids = s.sessionProjects.filter((p) => p.sessionId === sid).map((p) => p.projectId).sort()
+    expect(ids).toEqual(['anchor', 'c'])
+  })
+
+  it('returns false when nothing was attached', async () => {
+    expect(await svc.detachProjectFromProject('anchor', 'b')).toBe(false)
+  })
+})
+
+describe('getOrCreatePinnedWorkspaceSession', () => {
+  it('creates once then returns the same session', async () => {
+    const first = await svc.getOrCreatePinnedWorkspaceSession('anchor')
+    expect(first.workspaceId).toBe('ws1')
+    const second = await svc.getOrCreatePinnedWorkspaceSession('anchor')
+    expect(second.id).toBe(first.id)
+  })
+})
+
+describe('getAnchorLocalFolders', () => {
+  it('returns the anchor folder paths', async () => {
+    s.folders = [
+      { projectId: 'anchor', path: '/Users/me/data' },
+      { projectId: 'b', path: '/Users/me/other' },
+    ]
+    expect(await svc.getAnchorLocalFolders('anchor')).toEqual(['/Users/me/data'])
+  })
+})

--- a/apps/api/src/services/project-attachment.service.ts
+++ b/apps/api/src/services/project-attachment.service.ts
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Project Attachment Service
+ *
+ * Persistent project-to-project attachments (`ProjectAttachment`) and the
+ * per-project PINNED workspace chat session that materializes them.
+ *
+ * Model: every project is the ANCHOR of an anchor-keyed merged-root
+ * workspace runtime (see apps/api/src/lib/runtime/manager.ts
+ * `startProjectWorkspace`). The Folders panel writes durable attachments on
+ * the Project; this service keeps a single workspace `ChatSession`
+ * (contextType='workspace', `contextId`=anchor) in lockstep with those
+ * attachments so opening the project boots the merged runtime mounting
+ * `[anchor + attached projects + linked folders]`.
+ *
+ * Attachments are validated to live in the same org workspace as the anchor
+ * (reuse of `assertProjectsInWorkspace` semantics), and self-attach is
+ * rejected.
+ */
+
+import { prisma } from '../lib/prisma'
+import type { AttachMode } from './workspace-session.service'
+
+export interface ProjectAttachmentRow {
+  id: string
+  attachedProjectId: string
+  attachedProjectName: string | null
+  attachMode: AttachMode
+}
+
+function normalizeAttachMode(mode: string | undefined | null): AttachMode {
+  return mode === 'readonly' ? 'readonly' : 'readwrite'
+}
+
+export type ProjectAttachmentErrorCode =
+  | 'project_not_found'
+  | 'self_attach'
+  | 'cross_workspace'
+
+export class ProjectAttachmentError extends Error {
+  constructor(public code: ProjectAttachmentErrorCode, message: string) {
+    super(message)
+    this.name = 'ProjectAttachmentError'
+  }
+}
+
+/** List the persistent attachments on an anchor project. */
+export async function listAttachments(anchorProjectId: string): Promise<ProjectAttachmentRow[]> {
+  const rows = (await prisma.projectAttachment.findMany({
+    where: { projectId: anchorProjectId },
+    orderBy: { createdAt: 'asc' },
+    include: { attached: { select: { id: true, name: true } } } as any,
+  })) as any[]
+  return rows.map((r) => ({
+    id: r.id,
+    attachedProjectId: r.attachedProjectId,
+    attachedProjectName: r.attached?.name ?? null,
+    attachMode: normalizeAttachMode(r.attachMode),
+  }))
+}
+
+/**
+ * Attach `attachedProjectId` to `anchorProjectId` (idempotent — a repeat
+ * attach updates the attachMode). Validates both projects exist in the same
+ * workspace and rejects self-attach, then re-syncs the pinned session.
+ */
+export async function attachProjectToProject(
+  anchorProjectId: string,
+  attachedProjectId: string,
+  attachMode: AttachMode = 'readwrite',
+): Promise<ProjectAttachmentRow> {
+  if (anchorProjectId === attachedProjectId) {
+    throw new ProjectAttachmentError('self_attach', 'A project cannot be attached to itself')
+  }
+  const anchor = await prisma.project.findUnique({
+    where: { id: anchorProjectId },
+    select: { id: true, workspaceId: true },
+  })
+  if (!anchor) {
+    throw new ProjectAttachmentError('project_not_found', `Anchor project ${anchorProjectId} not found`)
+  }
+  const attached = await prisma.project.findUnique({
+    where: { id: attachedProjectId },
+    select: { id: true, workspaceId: true },
+  })
+  if (!attached) {
+    throw new ProjectAttachmentError('project_not_found', `Attached project ${attachedProjectId} not found`)
+  }
+  if (attached.workspaceId !== anchor.workspaceId) {
+    throw new ProjectAttachmentError(
+      'cross_workspace',
+      `Project ${attachedProjectId} is not in the same workspace as ${anchorProjectId}`,
+    )
+  }
+
+  const mode = normalizeAttachMode(attachMode)
+  const row = (await prisma.projectAttachment.upsert({
+    where: { projectId_attachedProjectId: { projectId: anchorProjectId, attachedProjectId } } as any,
+    create: { projectId: anchorProjectId, attachedProjectId, attachMode: mode },
+    update: { attachMode: mode },
+    include: { attached: { select: { id: true, name: true } } } as any,
+  })) as any
+
+  await syncPinnedSessionAttachments(anchorProjectId)
+
+  return {
+    id: row.id,
+    attachedProjectId: row.attachedProjectId,
+    attachedProjectName: row.attached?.name ?? null,
+    attachMode: normalizeAttachMode(row.attachMode),
+  }
+}
+
+/** Detach a project. No-op if it wasn't attached. Returns whether removed. */
+export async function detachProjectFromProject(
+  anchorProjectId: string,
+  attachedProjectId: string,
+): Promise<boolean> {
+  const res = (await prisma.projectAttachment.deleteMany({
+    where: { projectId: anchorProjectId, attachedProjectId },
+  })) as { count: number }
+  if (res.count > 0) {
+    await syncPinnedSessionAttachments(anchorProjectId)
+  }
+  return res.count > 0
+}
+
+/** Linked local host folders on the anchor (reused `ProjectFolder` rows). */
+export async function getAnchorLocalFolders(anchorProjectId: string): Promise<string[]> {
+  const rows = (await prisma.projectFolder.findMany({
+    where: { projectId: anchorProjectId },
+    select: { path: true },
+  })) as Array<{ path: string }>
+  return rows.map((r) => r.path).filter((p) => typeof p === 'string' && p.length > 0)
+}
+
+/**
+ * Find (or create) the project-pinned workspace session for an anchor —
+ * a `contextType='workspace'` ChatSession whose `contextId` is the anchor.
+ * Seeds its attached-project set on creation.
+ */
+export async function getOrCreatePinnedWorkspaceSession(
+  anchorProjectId: string,
+): Promise<{ id: string; workspaceId: string }> {
+  const anchor = await prisma.project.findUnique({
+    where: { id: anchorProjectId },
+    select: { id: true, workspaceId: true, name: true },
+  })
+  if (!anchor) {
+    throw new ProjectAttachmentError('project_not_found', `Anchor project ${anchorProjectId} not found`)
+  }
+
+  const existing = (await prisma.chatSession.findFirst({
+    where: { contextType: 'workspace', contextId: anchorProjectId } as any,
+    select: { id: true },
+  })) as { id: string } | null
+
+  if (existing) {
+    return { id: existing.id, workspaceId: anchor.workspaceId }
+  }
+
+  const session = (await prisma.chatSession.create({
+    data: {
+      contextType: 'workspace',
+      contextId: anchorProjectId,
+      workspaceId: anchor.workspaceId,
+      inferredName: anchor.name ?? 'Project workspace',
+    } as any,
+    select: { id: true },
+  })) as { id: string }
+
+  await syncPinnedSessionAttachments(anchorProjectId, session.id)
+  return { id: session.id, workspaceId: anchor.workspaceId }
+}
+
+/**
+ * Reconcile the pinned session's `ChatSessionProject` rows to exactly
+ * `[anchor (readwrite), ...ProjectAttachment (mode)]`. Called on create and
+ * on every attach/detach so "every chat opened in this project includes the
+ * attached projects/folders".
+ */
+export async function syncPinnedSessionAttachments(
+  anchorProjectId: string,
+  sessionId?: string,
+): Promise<void> {
+  const sid = sessionId ?? (await getOrCreatePinnedWorkspaceSession(anchorProjectId)).id
+
+  const attachments = (await prisma.projectAttachment.findMany({
+    where: { projectId: anchorProjectId },
+    select: { attachedProjectId: true, attachMode: true },
+  })) as Array<{ attachedProjectId: string; attachMode: string }>
+
+  // Desired set: anchor first (always read-write), then attachments.
+  const desired = new Map<string, AttachMode>()
+  desired.set(anchorProjectId, 'readwrite')
+  for (const a of attachments) {
+    desired.set(a.attachedProjectId, normalizeAttachMode(a.attachMode))
+  }
+
+  const current = (await prisma.chatSessionProject.findMany({
+    where: { sessionId: sid },
+    select: { projectId: true, attachMode: true },
+  })) as Array<{ projectId: string; attachMode: string }>
+  const currentMap = new Map(current.map((c) => [c.projectId, normalizeAttachMode(c.attachMode)]))
+
+  // Remove rows no longer desired.
+  const toRemove = current.filter((c) => !desired.has(c.projectId)).map((c) => c.projectId)
+  if (toRemove.length > 0) {
+    await prisma.chatSessionProject.deleteMany({
+      where: { sessionId: sid, projectId: { in: toRemove } },
+    })
+  }
+
+  // Upsert desired rows (create missing / update changed attachMode).
+  for (const [projectId, mode] of desired) {
+    if (currentMap.get(projectId) === mode) continue
+    await prisma.chatSessionProject.upsert({
+      where: { sessionId_projectId: { sessionId: sid, projectId } } as any,
+      create: { sessionId: sid, projectId, attachMode: mode },
+      update: { attachMode: mode },
+    })
+  }
+}

--- a/apps/desktop/prisma/migrations/20260602224926_add_project_attachments/migration.sql
+++ b/apps/desktop/prisma/migrations/20260602224926_add_project_attachments/migration.sql
@@ -1,0 +1,28 @@
+-- Migration: add_project_attachments
+-- Generated: 2026-06-02T22:49:27.208Z by scripts/db-migrate-desktop.ts
+-- Source:    prisma/schema.local.prisma
+--
+-- Persistent project-to-project attachment. The anchor project's merged-root
+-- workspace runtime mounts each attached project as an additional member root.
+-- (Trimmed to the new table only; unrelated pre-existing schema drift emitted
+-- by `migrate diff` was removed so this migration is scoped to its change.)
+
+-- CreateTable
+CREATE TABLE "project_attachments" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "projectId" TEXT NOT NULL,
+    "attachedProjectId" TEXT NOT NULL,
+    "attachMode" TEXT NOT NULL DEFAULT 'readwrite',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "project_attachments_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "projects" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "project_attachments_attachedProjectId_fkey" FOREIGN KEY ("attachedProjectId") REFERENCES "projects" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "project_attachments_projectId_idx" ON "project_attachments"("projectId");
+
+-- CreateIndex
+CREATE INDEX "project_attachments_attachedProjectId_idx" ON "project_attachments"("attachedProjectId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "project_attachments_projectId_attachedProjectId_key" ON "project_attachments"("projectId", "attachedProjectId");

--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -1,1 +1,9 @@
 # Trigger web rebuild for EXPO_PUBLIC_API_URL fix
+
+# Route new "home" chats through the workspace-aware (merged-root) runtime:
+# a workspace-scoped chat session with the project attached, chatting against
+# /api/workspaces/:id/chat instead of the per-project runtime. Opt-in; the API
+# independently gates the runtime behind SHOGO_WORKSPACE_RUNTIME, so BOTH must
+# be 'true' for workspace chat to function. Default off preserves the existing
+# per-project create flow.
+# EXPO_PUBLIC_WORKSPACE_RUNTIME=false

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -41,7 +41,7 @@ import { useActiveWorkspace } from '../../hooks/useActiveWorkspace'
 import { workspaceProjectFilter } from '../../lib/project-load'
 import { getActiveWorkspaceId } from '../../lib/workspace-store'
 import { useBillingData } from '@shogo/shared-app/hooks'
-import { usePlatformConfig } from '../../lib/platform-config'
+import { usePlatformConfig, isWorkspaceRuntimeEnabled } from '../../lib/platform-config'
 import { api, getOnboardingMessage } from '../../lib/api'
 import { EVENTS, trackEvent } from '../../lib/analytics'
 import { safeGetItem, safeRemoveItem } from '../../lib/safe-storage'
@@ -257,17 +257,25 @@ const HomeScreen = observer(function HomeScreen() {
   const [isCreating, setIsCreating] = useState(false)
 
   /**
-   * Draft project the homepage opens behind the scenes as soon as the
-   * user starts composing (typing or tapping the mic for EZ Mode).
+   * Draft project the homepage opens behind the scenes for a creation
+   * gesture (pressing Send or tapping the mic for EZ Mode). It is NOT
+   * created while the user is merely typing — see `handlePromptChange`.
    * Reused by both submit and the Shogo voice entry point so we never
-   * create two projects for one creation gesture, and so a runtime pod
-   * is being warmed while the user is still composing.
+   * create two projects for one creation gesture.
    */
-  type HomeDraft = { projectId: string; chatSessionId: string }
+  type HomeDraft = {
+    projectId: string
+    chatSessionId: string
+    /**
+     * Whether `chatSessionId` is a workspace-scoped session (the project is
+     * attached to it) chatting against the merged-root runtime, or a legacy
+     * per-project session. Drives the route param + ChatPanel scope.
+     */
+    chatScope: 'project' | 'workspace'
+  }
   const draftRef = useRef<HomeDraft | null>(null)
   const draftPromiseRef = useRef<Promise<HomeDraft | null> | null>(null)
   const draftPrewarmedRef = useRef<Set<string>>(new Set())
-  const draftTypeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [loadingTemplate, setLoadingTemplate] = useState<string | null>(null)
   // APP_MODE_DISABLED: homeAppTemplates state removed
   const [activeTab, setActiveTab] = useState<'projects' | 'shared'>('projects')
@@ -438,23 +446,65 @@ const HomeScreen = observer(function HomeScreen() {
         : undefined
 
   /**
+   * Create the chat session for a freshly-created home project. When the
+   * workspace runtime is enabled (client + server agree), this is a
+   * workspace-scoped session with the project attached; otherwise it's the
+   * legacy per-project session. Returns the draft descriptor.
+   */
+  const createHomeDraftSession = useCallback(
+    async (projectId: string, workspaceId: string): Promise<HomeDraft> => {
+      if (isWorkspaceRuntimeEnabled()) {
+        const session = await api.createWorkspaceSession(http, workspaceId, {
+          inferredName: 'Untitled',
+          attachProjectIds: [projectId],
+          attachMode: 'readwrite',
+        })
+        return { projectId, chatSessionId: session.id, chatScope: 'workspace' }
+      }
+      const chatSession = await actions.createChatSession({
+        inferredName: 'Untitled',
+        contextType: 'project',
+        contextId: projectId,
+      })
+      return { projectId, chatSessionId: chatSession.id, chatScope: 'project' }
+    },
+    [actions, http],
+  )
+
+  /** Fire-and-forget warm the runtime that backs a draft (workspace or project). */
+  const prewarmHomeDraft = useCallback(
+    (draft: HomeDraft, workspaceId: string) => {
+      if (draft.chatScope === 'workspace') {
+        void api.prewarmWorkspaceRuntime(http, workspaceId, {
+          sessionId: draft.chatSessionId,
+          attachProjectIds: [draft.projectId],
+        })
+      } else {
+        void api.prewarmProjectRuntime(http, draft.projectId)
+      }
+    },
+    [http],
+  )
+
+  /**
    * Single-flight: create the draft project + chat session for the home
    * composer, kick off a runtime prewarm, and return them. Concurrent
-   * callers (typing debounce + submit + mic) all join the same in-flight
-   * promise so we never duplicate creation. Once a draft exists, future
-   * calls resolve to the same draft until it has been consumed by a
-   * navigation away from the home screen.
+   * callers (submit + mic) all join the same in-flight promise so we never
+   * duplicate creation. Once a draft exists, future calls resolve to the
+   * same draft until it has been consumed by a navigation away from the
+   * home screen.
    */
   const ensureDraftProject = useCallback(async (): Promise<HomeDraft | null> => {
     if (draftRef.current) return draftRef.current
     if (draftPromiseRef.current) return draftPromiseRef.current
     if (!user?.id || !currentWorkspace?.id) return null
 
+    const workspaceId = currentWorkspace.id
     const promise = (async (): Promise<HomeDraft | null> => {
       try {
         const newProject = await actions.createProject(
           'New Project',
-          currentWorkspace.id,
+          workspaceId,
           undefined,
           user.id,
         )
@@ -464,15 +514,7 @@ const HomeScreen = observer(function HomeScreen() {
         // marketplace install path is the source of tech-stack-aware
         // seeding. The runtime defaults to react-app for projects with
         // no settings.techStackId, matching the old fallback.
-        const chatSession = await actions.createChatSession({
-          inferredName: 'Untitled',
-          contextType: 'project',
-          contextId: newProject.id,
-        })
-        const draft: HomeDraft = {
-          projectId: newProject.id,
-          chatSessionId: chatSession.id,
-        }
+        const draft = await createHomeDraftSession(newProject.id, workspaceId)
         draftRef.current = draft
 
         // Fire-and-forget runtime prewarm. The API returns 202 and warms
@@ -482,7 +524,7 @@ const HomeScreen = observer(function HomeScreen() {
         // per project id locally.
         if (!draftPrewarmedRef.current.has(draft.projectId)) {
           draftPrewarmedRef.current.add(draft.projectId)
-          void api.prewarmProjectRuntime(http, draft.projectId)
+          prewarmHomeDraft(draft, workspaceId)
         }
 
         return draft
@@ -496,27 +538,16 @@ const HomeScreen = observer(function HomeScreen() {
 
     draftPromiseRef.current = promise
     return promise
-  }, [actions, currentWorkspace?.id, http, user?.id])
+  }, [actions, createHomeDraftSession, currentWorkspace?.id, prewarmHomeDraft, user?.id])
 
-  /** Wrap `setPrompt` so the homepage starts warming as soon as there's real input. */
+  /**
+   * Home composer input handler. Updates local state only — project and
+   * chat-session creation is deferred to the actual creation gesture
+   * (Send -> `createProjectFromPrompt`, mic -> `handleStartVoiceProjectCreation`)
+   * so we never open a stray project while the user is still typing.
+   */
   const handlePromptChange = useCallback((next: string) => {
     setPrompt(next)
-    if (next.trim().length < 3) return
-    if (draftRef.current || draftPromiseRef.current) return
-    if (draftTypeTimerRef.current) clearTimeout(draftTypeTimerRef.current)
-    // Tiny debounce so a single keystroke doesn't trigger creation, but
-    // we still kick off well before submit so warm-pool claim has time
-    // to land.
-    draftTypeTimerRef.current = setTimeout(() => {
-      draftTypeTimerRef.current = null
-      void ensureDraftProject()
-    }, 250)
-  }, [ensureDraftProject])
-
-  useEffect(() => {
-    return () => {
-      if (draftTypeTimerRef.current) clearTimeout(draftTypeTimerRef.current)
-    }
   }, [])
 
   const createProjectFromPrompt = useCallback(async (
@@ -549,16 +580,11 @@ const HomeScreen = observer(function HomeScreen() {
             undefined,
             user.id,
           )
-          const chatSession = await actions.createChatSession({
-            inferredName: 'Untitled',
-            contextType: 'project',
-            contextId: newProject.id,
-          })
-          draft = { projectId: newProject.id, chatSessionId: chatSession.id }
+          draft = await createHomeDraftSession(newProject.id, currentWorkspace.id)
           draftRef.current = draft
           if (!draftPrewarmedRef.current.has(draft.projectId)) {
             draftPrewarmedRef.current.add(draft.projectId)
-            void api.prewarmProjectRuntime(http, draft.projectId)
+            prewarmHomeDraft(draft, currentWorkspace.id)
           }
         } catch (err: any) {
           const detail = err?.message || err?.details?.error?.message || String(err)
@@ -588,6 +614,7 @@ const HomeScreen = observer(function HomeScreen() {
         params: {
           id: consumed.projectId,
           chatSessionId: consumed.chatSessionId,
+          chatScope: consumed.chatScope,
           initialMessage: text,
           initialInteractionMode: submissionInteractionMode,
         },
@@ -596,10 +623,17 @@ const HomeScreen = observer(function HomeScreen() {
       // Fire-and-forget: replace heuristic name with AI-generated name
       const pid = consumed.projectId
       const sid = consumed.chatSessionId
+      const sidScope = consumed.chatScope
       api.generateProjectName(http, text, currentWorkspace.id).then(({ name, description }) => {
         if (name && name !== projectName) {
           actions.updateProject(pid, { name, description: description || undefined })
-          actions.updateChatSession(sid, { inferredName: name })
+          // Only project-scoped sessions live in the local MST collection.
+          // Workspace sessions are created server-side (api.createWorkspaceSession)
+          // and aren't in `chatSessionCollection`, so updateChatSession would
+          // throw "Item not found" — skip the local rename for them.
+          if (sidScope === 'project') {
+            actions.updateChatSession(sid, { inferredName: name })
+          }
         }
       }).catch((err) => {
         console.warn('[Home] AI project name generation failed, keeping heuristic name:', err)
@@ -609,11 +643,13 @@ const HomeScreen = observer(function HomeScreen() {
     }
   }, [
     actions,
+    createHomeDraftSession,
     currentWorkspace?.id,
     ensureDraftProject,
     http,
     interactionMode,
     posthog,
+    prewarmHomeDraft,
     projects,
     router,
     user?.id,
@@ -650,6 +686,7 @@ const HomeScreen = observer(function HomeScreen() {
         params: {
           id: consumed.projectId,
           chatSessionId: consumed.chatSessionId,
+          chatScope: consumed.chatScope,
           initialInteractionMode: interactionMode,
           startEzMode: '1',
           autoStartVoice: '1',
@@ -863,9 +900,10 @@ const HomeScreen = observer(function HomeScreen() {
                 // point. Sits at the leftmost edge of the toolbar so it
                 // reads as "what am I creating?" before model + mode.
                 // Selecting "Blank" is a no-op (the composer itself IS
-                // the blank-project surface — Send creates one); "Open
-                // folder" / "Import" fire their flows immediately and
-                // route into the resulting project.
+                // the blank-project surface — the project is created on
+                // Send, not while typing); "Open folder" / "Import" fire
+                // their flows immediately and route into the resulting
+                // project.
                 leadingControls={
                   <ProjectSourceMenu
                     workspaceId={currentWorkspace?.id}

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -4,8 +4,6 @@ import { useState, useEffect, useCallback, useMemo, useRef, memo } from 'react'
 import {
   View,
   Text,
-  Pressable,
-  ScrollView,
   Platform,
   Alert,
   useWindowDimensions,
@@ -13,10 +11,7 @@ import {
 import { useRouter } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { observer } from 'mobx-react-lite'
-import { ArrowRight } from 'lucide-react-native'
 import Svg, { Defs, RadialGradient, Stop, Ellipse } from 'react-native-svg'
-import { ProjectCard } from '../../components/home/ProjectCard'
-import { cn } from '@shogo/shared-ui/primitives'
 import { Button } from '@shogo/shared-ui/primitives'
 import { usePostHogSafe } from '../../contexts/posthog'
 import { useAuth } from '../../contexts/auth'
@@ -27,7 +22,6 @@ import {
   useDomainActions,
   useDomainHttp,
 } from '../../contexts/domain'
-import type { IProject, IMember, IWorkspace } from '../../contexts/domain'
 import { CompactChatInput } from '../../components/chat/CompactChatInput'
 import type { FileAttachment, InteractionMode } from '../../components/chat/ChatInput'
 import { DEFAULT_MODEL_PRO, DEFAULT_MODEL_FREE } from '../../components/chat/ChatInput'
@@ -39,7 +33,6 @@ import { loadModelPreference, saveModelPreference } from '../../lib/agent-mode-p
 import { setPendingFiles } from '../../lib/pending-image-store'
 import { useActiveWorkspace } from '../../hooks/useActiveWorkspace'
 import { workspaceProjectFilter } from '../../lib/project-load'
-import { getActiveWorkspaceId } from '../../lib/workspace-store'
 import { useBillingData } from '@shogo/shared-app/hooks'
 import { usePlatformConfig, isWorkspaceRuntimeEnabled } from '../../lib/platform-config'
 import { api, getOnboardingMessage } from '../../lib/api'
@@ -205,26 +198,12 @@ const LovableGradient = memo(function LovableGradient({ isDark }: { isDark: bool
 // (apps/mobile/components/project/useOpenLocalFolder.ts), shared with
 // the `/projects` page's "New project" menu so both surfaces stay in sync.
 
-// Tab descriptors are static — keep them at module scope so the array
-// reference doesn't churn on every render of HomeScreen.
-//
-// The "Templates" tab was removed when built-in templates were folded
-// into the marketplace; the surface the user sees is now exclusively
-// their own projects, plus shared. Marketplace browsing happens on
-// the dedicated `/marketplace` route and via the marketing-site
-// `pending_template_id` deep-link below.
-const TAB_ITEMS = [
-  { key: 'projects' as const, label: 'My projects' },
-  { key: 'shared' as const, label: 'Shared with me' },
-]
-
 // Static style fragments. The composer-wrapper variants below are a
 // per-theme ✕ per-platform decision tree, so we precompute the four
 // possibilities once and pick by index instead of building a new object
 // literal on every render.
-const TAB_BAR_CONTENT_STYLE = { alignItems: 'center' as const, gap: 2 }
-const SCROLL_VIEW_CONTENT_STYLE = { flexGrow: 1 }
 const COMPOSER_WRAPPER_NATIVE = { maxWidth: 680 }
+const CONTENT_MAX_WIDTH = { maxWidth: 680 } as const
 const COMPOSER_WRAPPER_WEB_LIGHT = {
   maxWidth: 680,
   boxShadow:
@@ -249,7 +228,6 @@ const HomeScreen = observer(function HomeScreen() {
   const isDark = useDarkMode()
   const { width: screenWidth } = useWindowDimensions()
   const isMobile = screenWidth < 640
-  const gridColumns = screenWidth < 640 ? 2 : screenWidth < 1024 ? 2 : 3
 
   const [prompt, setPrompt] = useState('')
   const [interactionMode, setInteractionMode] = useState<InteractionMode>('agent')
@@ -278,7 +256,6 @@ const HomeScreen = observer(function HomeScreen() {
   const draftPrewarmedRef = useRef<Set<string>>(new Set())
   const [loadingTemplate, setLoadingTemplate] = useState<string | null>(null)
   // APP_MODE_DISABLED: homeAppTemplates state removed
-  const [activeTab, setActiveTab] = useState<'projects' | 'shared'>('projects')
 
   const [workspaceError, setWorkspaceError] = useState(false)
 
@@ -382,46 +359,6 @@ const HomeScreen = observer(function HomeScreen() {
   }, [currentWorkspace?.id, user?.id, router])
 
   // APP_MODE_DISABLED: pending_app_template deep-link removed
-
-  const myProjects = useMemo((): IProject[] => {
-    try {
-      const all = projects?.all
-      const workspaceId = currentWorkspace?.id ?? getActiveWorkspaceId()
-      return [...(Array.isArray(all) ? all : [])]
-        .filter((p) => !workspaceId || p.workspaceId === workspaceId)
-        .sort((a: any, b: any) => {
-          const aTime = a.updatedAt ? new Date(a.updatedAt).getTime() : 0
-          const bTime = b.updatedAt ? new Date(b.updatedAt).getTime() : 0
-          return bTime - aTime
-        })
-    } catch {
-      return []
-    }
-  }, [projects?.all, currentWorkspace?.id])
-
-  const sharedProjects = useMemo((): IProject[] => {
-    if (!user?.id) return []
-    try {
-      const userMembers = membersColl.all.filter((m: IMember) => m.userId === user.id)
-      const sharedWsIds = new Set(
-        workspaces.all
-          .filter((ws: IWorkspace) => {
-            const membership = userMembers.find((m: IMember) => m.workspaceId === ws.id)
-            return membership && membership.role !== 'owner'
-          })
-          .map((ws: IWorkspace) => ws.id)
-      )
-      return [...(projects?.all ?? [])]
-        .filter((p) => sharedWsIds.has(p.workspaceId))
-        .sort((a, b) => {
-          const aTime = a.updatedAt ? new Date(a.updatedAt).getTime() : 0
-          const bTime = b.updatedAt ? new Date(b.updatedAt).getTime() : 0
-          return bTime - aTime
-        })
-    } catch {
-      return []
-    }
-  }, [user?.id, projects?.all, membersColl.all, workspaces.all])
 
   const firstName = useMemo(() => {
     const name = user?.name || 'there'
@@ -770,18 +707,6 @@ const HomeScreen = observer(function HomeScreen() {
   // boundaries, so caching them gives every memoized child the same
   // identity-equal style across renders driven by other state (input
   // value, mobx ticks, etc.).
-  const heroOuterStyle = useMemo(
-    () => ({ minHeight: isMobile ? 340 : 420 }),
-    [isMobile],
-  )
-  const heroInnerStyle = useMemo(
-    () => ({
-      paddingHorizontal: isMobile ? 16 : 24,
-      paddingTop: isMobile ? 48 : 64,
-      paddingBottom: isMobile ? 32 : 48,
-    }),
-    [isMobile],
-  )
   const heroTitleStyle = useMemo(
     () => ({
       fontSize: isMobile ? 26 : 36,
@@ -800,35 +725,6 @@ const HomeScreen = observer(function HomeScreen() {
         ? COMPOSER_WRAPPER_WEB_DARK
         : COMPOSER_WRAPPER_WEB_LIGHT
       : COMPOSER_WRAPPER_NATIVE
-  const bottomSectionStyle = useMemo(
-    () => ({
-      marginTop: -24,
-      paddingTop: 20,
-      marginLeft: isMobile ? 8 : 20,
-      marginRight: isMobile ? 8 : 20,
-    }),
-    [isMobile],
-  )
-  const tabBarRowStyle = useMemo(
-    () => ({ paddingHorizontal: isMobile ? 12 : 24, gap: 4 }),
-    [isMobile],
-  )
-  const tabContentPaddingStyle = useMemo(
-    () => ({ paddingHorizontal: isMobile ? 12 : 24, paddingBottom: 40 }),
-    [isMobile],
-  )
-  const gridContainerStyle = useMemo(
-    () =>
-      Platform.OS === 'web'
-        ? ({
-            display: 'grid' as any,
-            gridTemplateColumns: `repeat(${gridColumns}, 1fr)`,
-            gap: isMobile ? 10 : 16,
-            width: '100%',
-          } as any)
-        : {},
-    [gridColumns, isMobile],
-  )
 
   if (!isAuthenticated) {
     if (localMode) {
@@ -852,171 +748,63 @@ const HomeScreen = observer(function HomeScreen() {
 
   return (
     <View className="flex-1 bg-background">
-      <ScrollView className="flex-1" contentContainerStyle={SCROLL_VIEW_CONTENT_STYLE}>
-        {/* Hero section with gradient */}
-        <View className="relative" style={heroOuterStyle}>
-          <LovableGradient isDark={isDark} />
+      <View className="relative flex-1 items-center justify-center px-4">
+        <LovableGradient isDark={isDark} />
 
-          <View
-            className="relative items-center justify-center"
-            style={heroInnerStyle}
-          >
-            <Text
-              className="text-center font-bold mb-2 text-foreground"
-              style={heroTitleStyle}
-            >
-              What's on your mind, {firstName}?
-            </Text>
-            <Text
-              className="text-center mb-8 text-muted-foreground"
-              style={heroSubtitleStyle}
-            >
-              Build agents by chatting with AI
-            </Text>
-
-            <View
-              className="w-full rounded-2xl"
-              style={composerWrapperStyle}
-            >
-              <CompactChatInput
-                onSubmit={handlePromptSubmit}
-                isLoading={isCreating}
-                placeholder={homeComposerPlaceholder}
-                agentPlaceholderActive={interactionMode === 'agent'}
-                value={prompt}
-                onChange={handlePromptChange}
-                interactionMode={interactionMode}
-                onInteractionModeChange={handleHomeInteractionModeChange}
-                selectedModel={selectedModel}
-                onModelChange={handleHomeModelChange}
-                isPro={hasAdvancedModelAccess}
-                onUpgradeClick={() => router.push('/billing')}
-                onStartVoiceProjectCreation={
-                  Platform.OS === 'web' && features.ezMode
-                    ? handleStartVoiceProjectCreation
-                    : undefined
-                }
-                // Consolidated "where does this project come from?" entry
-                // point. Sits at the leftmost edge of the toolbar so it
-                // reads as "what am I creating?" before model + mode.
-                // Selecting "Blank" is a no-op (the composer itself IS
-                // the blank-project surface — the project is created on
-                // Send, not while typing); "Open folder" / "Import" fire
-                // their flows immediately and route into the resulting
-                // project.
-                leadingControls={
-                  <ProjectSourceMenu
-                    workspaceId={currentWorkspace?.id}
-                    variant="chip"
-                  />
-                }
-              />
-            </View>
-          </View>
-        </View>
-
-        {/* Bottom section: tab bar + template cards */}
         <View
-          className="flex-1 rounded-t-3xl bg-card border-t border-border"
-          style={bottomSectionStyle}
+          className="relative w-full items-center justify-center"
+          style={CONTENT_MAX_WIDTH}
         >
-          <View
-            className="flex-row items-center mb-5"
-            style={tabBarRowStyle}
+          <Text
+            className="text-center font-bold mb-2 text-foreground"
+            style={heroTitleStyle}
           >
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              contentContainerStyle={TAB_BAR_CONTENT_STYLE}
-              className="flex-1"
-            >
-              {TAB_ITEMS.map((tab) => (
-                <Pressable
-                  key={tab.key}
-                  onPress={() => setActiveTab(tab.key)}
-                  className={cn(
-                    'px-3 py-2 rounded-lg',
-                    activeTab === tab.key && 'bg-muted',
-                  )}
-                >
-                  <Text
-                    className={cn(
-                      'text-[13px]',
-                      activeTab === tab.key
-                        ? 'text-foreground font-semibold'
-                        : 'text-muted-foreground'
-                    )}
-                    numberOfLines={1}
-                  >
-                    {tab.label}
-                  </Text>
-                </Pressable>
-              ))}
-            </ScrollView>
+            What's on your mind, {firstName}?
+          </Text>
+          <Text
+            className="text-center mb-8 text-muted-foreground"
+            style={heroSubtitleStyle}
+          >
+            Build agents by chatting with AI
+          </Text>
 
-            {activeTab === 'shared' && (
-              <Pressable
-                onPress={() => router.push('/(app)/shared' as any)}
-                className="flex-row items-center gap-1 active:opacity-70 flex-shrink-0"
-              >
-                <Text className="text-[13px] font-medium text-foreground">
-                  View all
-                </Text>
-                <ArrowRight size={14} className="text-foreground" />
-              </Pressable>
-            )}
-          </View>
-
-          <View style={tabContentPaddingStyle}>
-            {activeTab === 'projects' && (
-              myProjects.length > 0 ? (
-                <View className="gap-3" style={gridContainerStyle}>
-                  {myProjects.map((project) => (
-                    <ProjectCard
-                      key={project.id}
-                      name={String(project.name || 'Untitled')}
-                      description={typeof project.description === 'string' ? project.description : undefined}
-                      updatedAt={project.updatedAt}
-                      createdAt={project.createdAt}
-                      onPress={() => router.push(`/(app)/projects/${project.id}`)}
-                      isDark={isDark}
-                      compact={isMobile}
-                    />
-                  ))}
-                </View>
-              ) : (
-                <View className="items-center py-12">
-                  <Text className="text-muted-foreground text-sm">No projects yet — create one above!</Text>
-                </View>
-              )
-            )}
-
-            {activeTab === 'shared' && (
-              sharedProjects.length > 0 ? (
-                <View className="gap-3" style={gridContainerStyle}>
-                  {sharedProjects.map((project) => (
-                    <ProjectCard
-                      key={project.id}
-                      name={String(project.name || 'Untitled')}
-                      description={typeof project.description === 'string' ? project.description : undefined}
-                      updatedAt={project.updatedAt}
-                      createdAt={project.createdAt}
-                      onPress={() => router.push(`/(app)/projects/${project.id}`)}
-                      isDark={isDark}
-                      badge="Shared"
-                      compact={isMobile}
-                    />
-                  ))}
-                </View>
-              ) : (
-                <View className="items-center py-12">
-                  <Text className="text-muted-foreground text-sm">No shared projects</Text>
-                </View>
-              )
-            )}
+          <View className="w-full rounded-2xl" style={composerWrapperStyle}>
+            <CompactChatInput
+              onSubmit={handlePromptSubmit}
+              isLoading={isCreating}
+              placeholder={homeComposerPlaceholder}
+              agentPlaceholderActive={interactionMode === 'agent'}
+              value={prompt}
+              onChange={handlePromptChange}
+              interactionMode={interactionMode}
+              onInteractionModeChange={handleHomeInteractionModeChange}
+              selectedModel={selectedModel}
+              onModelChange={handleHomeModelChange}
+              isPro={hasAdvancedModelAccess}
+              onUpgradeClick={() => router.push('/billing')}
+              onStartVoiceProjectCreation={
+                Platform.OS === 'web' && features.ezMode
+                  ? handleStartVoiceProjectCreation
+                  : undefined
+              }
+              // Consolidated "where does this project come from?" entry
+              // point. Sits at the leftmost edge of the toolbar so it
+              // reads as "what am I creating?" before model + mode.
+              // Selecting "Blank" is a no-op (the composer itself IS
+              // the blank-project surface — the project is created on
+              // Send, not while typing); "Open folder" / "Import" fire
+              // their flows immediately and route into the resulting
+              // project.
+              leadingControls={
+                <ProjectSourceMenu
+                  workspaceId={currentWorkspace?.id}
+                  variant="chip"
+                />
+              }
+            />
           </View>
         </View>
-      </ScrollView>
+      </View>
     </View>
   )
 })

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -244,6 +244,13 @@ export default observer(function ProjectLayout() {
   const params = useLocalSearchParams<{
     id: string
     chatSessionId?: string
+    /**
+     * Routing scope for the initial chat session: 'workspace' means
+     * `chatSessionId` is a workspace-scoped session (the project is attached)
+     * that chats against the merged-root runtime; absent/'project' is the
+     * legacy per-project session. Only applies to the initial tab.
+     */
+    chatScope?: string
     initialMessage?: string
     initialInteractionMode?: string
     appTemplateName?: string
@@ -274,6 +281,12 @@ export default observer(function ProjectLayout() {
   // The session ID that should receive these one-time props (only the first tab).
   const [initialPropsSessionId] = useState(() => params.chatSessionId ?? null)
   const [capturedInitialMessage] = useState(() => params.initialMessage ?? undefined)
+  // Scope of the initial session tab. Only the tab matching
+  // `initialPropsSessionId` chats in workspace scope; tabs created later are
+  // ordinary per-project sessions.
+  const [capturedChatScope] = useState<'project' | 'workspace'>(() =>
+    params.chatScope === 'workspace' ? 'workspace' : 'project'
+  )
   const [capturedInitialInteractionMode] = useState<InteractionMode | undefined>(() => {
     const raw = params.initialInteractionMode
     const m = Array.isArray(raw) ? raw[0] : raw
@@ -301,6 +314,25 @@ export default observer(function ProjectLayout() {
   const [chatSessionId, setChatSessionId] = useState<string | null>(
     () => params.chatSessionId ?? null
   )
+
+  // Universal workspace-runtime rollout gate. When on, a project's chat runs
+  // on its anchor-keyed merged-root runtime via a single project-pinned
+  // workspace session (mounting the project + its attachments + linked
+  // folders). Strictly flag-gated so flag-off behavior is byte-identical to
+  // the legacy single-project runtime + project-scoped chat.
+  const workspaceRuntimeEnabled = process.env.EXPO_PUBLIC_WORKSPACE_RUNTIME === 'true'
+  // The project-pinned workspace session id (resolved from the API when the
+  // flag is on). Tabs whose id is this session chat in 'workspace' scope.
+  const [pinnedWorkspaceSessionId, setPinnedWorkspaceSessionId] = useState<string | null>(null)
+  // Whether the pinned-session resolve has settled (success OR failure). Used
+  // to gate the chat render: while unresolved (flag on, no deep-link) we show a
+  // loading state rather than the legacy empty/project-tab chat, so there is no
+  // async swap/re-mount race. On failure we fall through to the legacy chat.
+  const [pinnedResolveFailed, setPinnedResolveFailed] = useState(false)
+  // Tracks whether we've already promoted the pinned session to the active
+  // chat for the current project, so we only force it once (the user can
+  // switch tabs afterwards).
+  const pinnedSessionAppliedRef = useRef(false)
 
   // Project state
   const [project, setProject] = useState<any>(null)
@@ -694,6 +726,55 @@ export default observer(function ProjectLayout() {
   }, [remoteAgentBaseUrl, projectId])
   const agentUrl = remoteProjectAgentBaseUrl ?? resolvedAgentUrl
 
+  // Resolve (or create) the project-pinned workspace session once, when the
+  // workspace-runtime flag is on. This session is what routes the project's
+  // chat through the anchor merged-root runtime. Gated so flag-off does
+  // nothing. Best-effort: a failure simply leaves the project on the legacy
+  // project-scoped chat.
+  useEffect(() => {
+    if (!workspaceRuntimeEnabled || !projectId) return
+    // New project → re-pin from scratch.
+    pinnedSessionAppliedRef.current = false
+    setPinnedWorkspaceSessionId(null)
+    setPinnedResolveFailed(false)
+    let cancelled = false
+    void (async () => {
+      const res = await api.getProjectWorkspaceSession(http, projectId)
+      if (cancelled) return
+      if (res.session?.id) {
+        setPinnedWorkspaceSessionId(res.session.id)
+      } else {
+        // Resolve failed: drop the loading gate so the project falls back to
+        // the legacy project-scoped chat instead of hanging on a spinner.
+        console.warn(
+          `[ProjectLayout] pinned workspace session resolve failed: ${res.error ?? 'unknown'}`,
+        )
+        setPinnedResolveFailed(true)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [workspaceRuntimeEnabled, projectId, http])
+
+  // Make the pinned workspace session the project's canonical chat (flag-on
+  // only). Under the "always workspace runtime" model every project is driven
+  // by its anchor merged-root runtime, so the active chat must be the
+  // anchor-pinned workspace session (seeded with [anchor + attachments]) — not
+  // a project-scoped session that would boot the legacy single-project
+  // runtime. We apply this once per project load (tracked by a ref) so the
+  // user can still switch tabs afterwards, and we defer to an explicit
+  // deep-linked `chatSessionId`. Mirrors the home flow's workspace-session
+  // seeding; the "ensure active session in tabs" effect adds it to the
+  // open-tabs list and ChatPanel renders it in 'workspace' scope.
+  useEffect(() => {
+    if (!workspaceRuntimeEnabled || !pinnedWorkspaceSessionId) return
+    if (params.chatSessionId) return
+    if (pinnedSessionAppliedRef.current) return
+    pinnedSessionAppliedRef.current = true
+    setChatSessionId(pinnedWorkspaceSessionId)
+  }, [workspaceRuntimeEnabled, pinnedWorkspaceSessionId, params.chatSessionId])
+
   // APP_MODE_DISABLED: app template copy effect removed
 
   // Shared model selection — shared between ChatPanel and CapabilitiesPanel
@@ -899,6 +980,18 @@ export default observer(function ProjectLayout() {
   // Restore open tabs from AsyncStorage on mount
   useEffect(() => {
     if (!projectId || openTabsRestoredRef.current) return
+    // Under the always-on workspace runtime, a project has exactly one chat:
+    // its anchor-pinned workspace session. Restoring previously-open
+    // project-scoped tabs here would (a) mount hidden sibling ChatPanels on the
+    // legacy single-project runtime and (b) make `openChatTabIds` non-empty
+    // before the pinned session resolves, defeating the loading gate. So when
+    // the flag is on and we're not following an explicit deep-link, skip the
+    // restore entirely and let the pinned-session promotion seed the sole tab.
+    if (workspaceRuntimeEnabled && !params.chatSessionId) {
+      openTabsRestoredRef.current = true
+      setTabsHydration('fresh')
+      return
+    }
     AsyncStorage.getItem(`shogo:chatTabs:${projectId}`).then((raw) => {
       if (raw === null) {
         openTabsRestoredRef.current = true
@@ -1022,6 +1115,13 @@ export default observer(function ProjectLayout() {
       }
 
       if (chatSessionId) return
+      // Under the always-on workspace runtime, the project-pinned workspace
+      // session owns active-session selection (see the pinned-session
+      // promotion effect). Auto-selecting / auto-creating a project-scoped
+      // session here would race that promotion and strand the visible chat on
+      // the wrong (project) session — and boot the legacy single-project
+      // runtime instead of the anchor merged root.
+      if (workspaceRuntimeEnabled) return
       // Wait for restore to finish so we know which branch to take.
       if (tabsHydration === 'loading') return
       // Only auto-select / auto-create on a truly fresh visit. On
@@ -1071,6 +1171,8 @@ export default observer(function ProjectLayout() {
   const pickedFromRestoreRef = useRef<Set<string>>(new Set())
   useEffect(() => {
     if (!projectId) return
+    // Flag-on: pinned workspace session owns selection (see above).
+    if (workspaceRuntimeEnabled) return
     if (pickedFromRestoreRef.current.has(projectId)) return
     if (tabsHydration !== 'restored-with-tabs') return
     if (chatSessionId) {
@@ -1590,6 +1692,17 @@ export default observer(function ProjectLayout() {
   }, [store?.chatSessionCollection?.all, sessionNames, projectId, _sessionFieldsKey])
 
   const handleCreateNewSession = useCallback(async () => {
+    // Flag-on: a project has exactly one chat — its anchor-pinned workspace
+    // session. A "new chat" must not mint a project-scoped session (that would
+    // strand the project on the legacy single-project runtime). Just re-select
+    // the pinned session instead.
+    if (workspaceRuntimeEnabled && pinnedWorkspaceSessionId) {
+      setOpenChatTabIds((prev) =>
+        prev.includes(pinnedWorkspaceSessionId) ? prev : [...prev, pinnedWorkspaceSessionId],
+      )
+      setChatSessionId(pinnedWorkspaceSessionId)
+      return
+    }
     try {
       const newSession = await actions.createChatSession({
         inferredName: 'Untitled',
@@ -1603,7 +1716,7 @@ export default observer(function ProjectLayout() {
     } catch (err) {
       console.error('[ProjectLayout] Failed to create chat session:', err)
     }
-  }, [actions, projectId])
+  }, [actions, projectId, workspaceRuntimeEnabled, pinnedWorkspaceSessionId])
 
   // ─── Canvas-error → "Debug" toast ───────────────────────────────────────
   // The canvas iframe (and its ShogoErrorBoundary) postMessage `canvas-error`
@@ -2061,7 +2174,22 @@ export default observer(function ProjectLayout() {
    * `tabsHydration === 'loading'` we render nothing extra to avoid flashing
    * the empty state for one frame on every mount.
    */
-  const showEmptyChatState = tabsHydration !== 'loading' && openChatTabIds.length === 0
+  // Flag-on loading gate: while the anchor-pinned workspace session is still
+  // resolving (and we aren't following an explicit deep-link), render a single
+  // loading state and mount no ChatPanel. This makes the pinned session the
+  // chat from first paint — no async swap, no fill-wipe re-mount, no lingering
+  // project-session sibling tabs. Once the pinned session resolves it becomes
+  // the sole open tab (so `openChatTabIds.length > 0` clears the gate); on
+  // resolve failure `pinnedResolveFailed` clears it and we fall back to the
+  // legacy empty-chat list.
+  const workspaceChatLoading =
+    workspaceRuntimeEnabled &&
+    !params.chatSessionId &&
+    !pinnedResolveFailed &&
+    openChatTabIds.length === 0
+
+  const showEmptyChatState =
+    !workspaceChatLoading && tabsHydration !== 'loading' && openChatTabIds.length === 0
 
   const renderEmptyChatList = (onSelectClose?: () => void) => (
     <ChatSessionSidebar
@@ -2110,6 +2238,13 @@ export default observer(function ProjectLayout() {
                 userId={user?.id}
                 projectId={projectId}
                 projectType="unified"
+                chatScope={
+                  workspaceRuntimeEnabled && tabId === pinnedWorkspaceSessionId
+                    ? 'workspace'
+                    : isInitialSession
+                      ? capturedChatScope
+                      : 'project'
+                }
                 isActive={isActive}
                 localAgentUrl={remoteProjectAgentBaseUrl ?? undefined}
                 initialMessage={isInitialSession ? capturedInitialMessage : (debugSeed ?? undefined)}
@@ -2444,11 +2579,22 @@ export default observer(function ProjectLayout() {
                   >
                     <View
                       className="absolute inset-0"
-                      style={showEmptyChatState || narrowChatPickerOpen ? { opacity: 0 } : undefined}
-                      pointerEvents={showEmptyChatState || narrowChatPickerOpen ? 'none' : 'auto'}
+                      style={showEmptyChatState || narrowChatPickerOpen || workspaceChatLoading ? { opacity: 0 } : undefined}
+                      pointerEvents={showEmptyChatState || narrowChatPickerOpen || workspaceChatLoading ? 'none' : 'auto'}
                     >
                       <EzModeAwareChatPanels>{chatPanels}</EzModeAwareChatPanels>
                     </View>
+                    {workspaceChatLoading && (
+                      <View
+                        testID="workspace-chat-loading"
+                        className="absolute inset-0 bg-background items-center justify-center"
+                      >
+                        <ActivityIndicator size="large" />
+                        <Text className="text-sm text-muted-foreground mt-3 text-center">
+                          Starting workspace…
+                        </Text>
+                      </View>
+                    )}
                     {showEmptyChatState && (
                       isChatFullscreen || showSidebar ? (
                         <View className="absolute inset-0 bg-background items-center justify-center px-8">

--- a/apps/mobile/components/canvas/CanvasWebView.tsx
+++ b/apps/mobile/components/canvas/CanvasWebView.tsx
@@ -177,6 +177,8 @@ function CanvasIframe({ url, agentUrl, themeMessage, onCanvasError, onCanvasCapa
       <iframe
         ref={iframeRef}
         src={url}
+        data-testid="canvas-preview-iframe"
+        title="Project preview"
         style={{
           width: '100%',
           height: '100%',

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -1157,6 +1157,7 @@ function ChatInputImpl({
           }}
           placeholder={placeholder}
           placeholderTextColor="#9ca3af"
+          testID="project-composer-input"
           accessibilityLabel="Chat message input"
           editable={!disabled && !voiceInput.isRecording}
           multiline

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -256,6 +256,14 @@ export interface ChatPanelProps {
   workspaceId?: string
   userId?: string
   projectId?: string
+  /**
+   * Chat routing scope. `'project'` (default) chats against the per-project
+   * runtime (`/api/projects/:projectId/chat`); `'workspace'` chats against
+   * the merged-root workspace runtime (`/api/workspaces/:workspaceId/chat`)
+   * using `chatSessionId` as a workspace-scoped session id. The workspace
+   * path requires `workspaceId`.
+   */
+  chatScope?: "project" | "workspace"
   localAgentUrl?: string | null
   children?: React.ReactNode
   className?: string
@@ -675,6 +683,7 @@ export const ChatPanel = observer(function ChatPanel({
   workspaceId,
   userId,
   projectId,
+  chatScope = "project",
   localAgentUrl,
   children,
   className,
@@ -1223,9 +1232,16 @@ export const ChatPanel = observer(function ChatPanel({
   // the user taps Stop before the model produced any text or tool calls.
   const userInitiatedStopRef = useRef(false)
 
+  // Workspace-scoped chat routes to `/api/workspaces/:workspaceId/chat`
+  // instead of the per-project endpoint. Only set when this panel is
+  // operating in workspace scope and we actually have a workspace id.
+  const chatWorkspaceId =
+    chatScope === "workspace" && workspaceId ? workspaceId : undefined
+
   const transportConfig = useChatTransportConfig({
     apiBaseUrl: API_URL!,
     projectId,
+    workspaceId: chatWorkspaceId,
     localAgentUrl,
     credentials: Platform.OS === 'web' ? 'include' : 'omit',
     headers: nativeHeaders,
@@ -2428,6 +2444,7 @@ export const ChatPanel = observer(function ChatPanel({
     const req = buildStopRequest({
       localAgentUrl,
       projectId,
+      workspaceId: chatWorkspaceId,
       apiBaseUrl: API_URL!,
       platform: Platform.OS,
       getCookie: () => authClient.getCookie(),
@@ -2439,7 +2456,7 @@ export const ChatPanel = observer(function ChatPanel({
         console.warn("[ChatPanel] Failed to send stop signal to backend:", err)
       })
     }
-  }, [stop, projectId, localAgentUrl, expoFetch, currentSessionId])
+  }, [stop, projectId, chatWorkspaceId, localAgentUrl, expoFetch, currentSessionId])
 
   // Keep the shared subagent-stop helper pointed at the current API/runtime
   // so SubagentCard (chat) and AgentEntry (agents panel) can cancel without
@@ -2871,6 +2888,7 @@ export const ChatPanel = observer(function ChatPanel({
           projectId,
           localAgentUrl,
           loadSessionId,
+          chatWorkspaceId,
         )
         void probeChatTurnStatus({
           url: turnUrl,

--- a/apps/mobile/components/layout/AppSidebar.tsx
+++ b/apps/mobile/components/layout/AppSidebar.tsx
@@ -8,21 +8,14 @@
  *
  * Sections:
  *  - Logo row: gradient "S" badge + "Shogo" text + collapse toggle
- *  - Workspace switcher
- *  - Primary nav: Home + Search (Cmd+K)
- *  - PROJECTS section: Recent (5 projects), All Projects (with New Folder), Starred, Shared
- *  - RESOURCES section: Marketplace, Instance Picker, API Keys, Docs (external)
- *
- * Templates were folded into the marketplace — every former built-in
- * template is now a `MarketplaceListing` row owned by the official
- * "Shogo" creator. The standalone Templates nav entry was removed
- * once that consolidation landed; users discover and install the same
- * content through Marketplace.
+ *  - Primary nav: Home + Search (Cmd+K) [+ Meetings in local mode]
+ *  - PROJECTS tree: every project, each expandable to reveal its chats
  *  - Upgrade to Pro CTA
- *  - User avatar + Sign Out
+ *  - Consolidated account button (workspace switcher + resource links +
+ *    user/profile/sign-out) anchored at the bottom
  */
 
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import {
   View,
   Text,
@@ -51,8 +44,6 @@ import { observer } from 'mobx-react-lite'
 import {
   Home,
   Search,
-  Clock,
-  LayoutGrid,
   Star,
   Users,
   User,
@@ -60,8 +51,8 @@ import {
   ChevronDown,
   ChevronRight,
   PanelLeftClose,
-  PanelLeft,
-  FolderPlus,
+  Folder,
+  MessageSquare,
   Plus,
   X,
   LogOut,
@@ -82,14 +73,12 @@ import {
 import { cn } from '@shogo/shared-ui/primitives'
 import { Avatar } from '@shogo/shared-ui/primitives'
 import { CommandPalette, useCommandPalette } from './CommandPalette'
-import { InstancePicker } from './InstancePicker'
 import { useActiveInstance } from '../../contexts/active-instance'
 import { ShogoLogoMark } from '../branding/ShogoLogoMark'
 import { useAuth } from '../../contexts/auth'
 import {
   useProjectCollection,
   useWorkspaceCollection,
-  useFolderCollection,
   useDomainActions,
   useDomainHttp,
 } from '../../contexts/domain'
@@ -111,18 +100,6 @@ function getInitials(name: string | null | undefined): string {
     .join('')
     .toUpperCase()
     .slice(0, 2)
-}
-
-function isRouteActive(pathname: string, href: string): boolean {
-  if (href === '/') {
-    return pathname === '/' || pathname === '/(app)' || pathname === '/(app)/index'
-  }
-  const normalizedPathname = pathname.replace('/(app)', '')
-  const normalizedHref = href.replace('/(app)', '')
-  if (normalizedHref === '/projects') {
-    return normalizedPathname === '/projects' || normalizedPathname.startsWith('/projects/')
-  }
-  return normalizedPathname === normalizedHref || normalizedPathname.startsWith(normalizedHref + '/')
 }
 
 // ─── NavItem ───────────────────────────────────────────────
@@ -206,85 +183,124 @@ function NavItem({
   )
 }
 
-// ─── NavSection (collapsible) ──────────────────────────────
+// ─── ChatTreeItem (a single chat nested under a project) ────
 
-interface NavSectionProps {
-  title: string
-  collapsed?: boolean
-  children: React.ReactNode
-  defaultExpanded?: boolean
+function chatLabel(session: any): string {
+  const name = typeof session.name === 'string' ? session.name.trim() : ''
+  if (name) return name
+  if (session.inferredName) return session.inferredName
+  const created = session.createdAt ? new Date(session.createdAt) : new Date()
+  return `Chat · ${created.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}`
 }
 
-function NavSection({ title, collapsed, children, defaultExpanded = true }: NavSectionProps) {
-  const [expanded, setExpanded] = useState(defaultExpanded)
-
-  if (collapsed) return <>{children}</>
+function ChatTreeItem({
+  session,
+  projectId,
+  onNavPress,
+}: {
+  session: any
+  projectId: string
+  onNavPress?: () => void
+}) {
+  const router = useRouter()
 
   return (
-    <View className="mt-4">
-      <Pressable
-        onPress={() => setExpanded(!expanded)}
-        className="flex-row items-center gap-1 px-3 py-1"
-      >
-        {expanded ? (
-          <ChevronDown size={12} className="text-muted-foreground" />
-        ) : (
-          <ChevronRight size={12} className="text-muted-foreground" />
-        )}
-        <Text className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-          {title}
-        </Text>
-      </Pressable>
-      {expanded && children}
-    </View>
+    <Pressable
+      onPress={() => {
+        router.push({
+          pathname: '/(app)/projects/[id]',
+          params: { id: projectId, chatSessionId: session.id },
+        } as any)
+        onNavPress?.()
+      }}
+      role="link"
+      accessibilityLabel={`Chat: ${chatLabel(session)}`}
+      className="flex-row items-center gap-2 rounded-md px-2 py-1.5 active:bg-accent/50"
+    >
+      <MessageSquare size={13} className="text-muted-foreground" />
+      <Text className="text-sm text-muted-foreground flex-1" numberOfLines={1}>
+        {chatLabel(session)}
+      </Text>
+    </Pressable>
   )
 }
 
-// ─── ExpandableNavItem ─────────────────────────────────────
+// ─── ProjectTreeItem (a project + its nested chats) ─────────
 
-interface ExpandableNavItemProps {
-  icon: React.ElementType
-  label: string
-  href?: string
-  active?: boolean
-  collapsed?: boolean
-  defaultExpanded?: boolean
-  children?: React.ReactNode
-  onNavPress?: () => void
-}
-
-function ExpandableNavItem({
-  icon: Icon,
-  label,
-  href,
-  active,
+const ProjectTreeItem = observer(function ProjectTreeItem({
+  project,
   collapsed,
-  defaultExpanded = true,
-  children,
   onNavPress,
-}: ExpandableNavItemProps) {
-  const [expanded, setExpanded] = useState(defaultExpanded)
+}: {
+  project: any
+  collapsed?: boolean
+  onNavPress?: () => void
+}) {
   const router = useRouter()
+  const pathname = usePathname()
+  const http = useDomainHttp()
+  const [expanded, setExpanded] = useState(false)
+  // Chats are fetched directly into local state (rather than the shared
+  // chat-session collection) because the collection's loaders prune items
+  // from other contexts — expanding a second project would otherwise wipe
+  // the first project's chats out of the cache.
+  const [sessions, setSessions] = useState<any[]>([])
+  const [loaded, setLoaded] = useState(false)
+  const seededRef = useRef(false)
 
-  const handlePress = useCallback(() => {
-    if (href) {
-      router.push(href as any)
-      onNavPress?.()
+  const isActive = pathname.includes(project.id)
+
+  const loadChats = useCallback(async () => {
+    if (seededRef.current || !http) return
+    seededRef.current = true
+    try {
+      const res = await http.get<{ ok: boolean; items?: any[] }>(
+        `/api/chat-sessions?contextId=${encodeURIComponent(project.id)}&limit=50`,
+      )
+      const items = Array.isArray(res.data?.items) ? res.data!.items! : []
+      const normalized = items
+        .map((s: any) => ({
+          id: s.id,
+          name: typeof s.name === 'string' ? s.name : '',
+          inferredName: s.inferredName ?? '',
+          createdAt: s.createdAt ? new Date(s.createdAt).getTime() : 0,
+          activity: new Date(s.lastActiveAt || s.updatedAt || s.createdAt || 0).getTime(),
+        }))
+        .sort((a, b) => b.activity - a.activity)
+      setSessions(normalized)
+    } catch (e) {
+      console.error('[AppSidebar] Failed to load chats:', e)
+      seededRef.current = false
+    } finally {
+      setLoaded(true)
     }
-  }, [href, router, onNavPress])
+  }, [http, project.id])
+
+  const toggleExpanded = useCallback(() => {
+    setExpanded((prev) => {
+      const next = !prev
+      if (next) void loadChats()
+      return next
+    })
+  }, [loadChats])
+
+  const openProject = useCallback(() => {
+    router.push(`/(app)/projects/${project.id}` as any)
+    onNavPress?.()
+  }, [router, project.id, onNavPress])
 
   if (collapsed) {
     return (
       <Pressable
-        onPress={handlePress}
+        onPress={openProject}
         role="link"
-        accessibilityLabel={label}
+        accessibilityLabel={`Project: ${project.name || 'Untitled'}`}
         className={cn(
           'items-center justify-center rounded-md px-2 py-2',
-          active ? 'bg-accent' : 'active:bg-accent/50'
+          isActive ? 'bg-accent' : 'active:bg-accent/50',
         )}
       >
-        <Icon size={16} className={active ? 'text-foreground' : 'text-muted-foreground'} />
+        <Folder size={16} className={isActive ? 'text-foreground' : 'text-muted-foreground'} />
       </Pressable>
     )
   }
@@ -293,81 +309,62 @@ function ExpandableNavItem({
     <View>
       <View
         className={cn(
-          'flex-row items-center gap-3 rounded-md px-3 py-2',
-          active ? 'bg-accent' : ''
+          'flex-row items-center gap-1.5 rounded-md pr-2 py-1.5',
+          isActive ? 'bg-accent' : '',
         )}
       >
-        <Pressable onPress={handlePress} role="link" accessibilityLabel={label} className="flex-1 flex-row items-center gap-3 active:opacity-70">
-          <Icon
-            size={16}
-            className={active ? 'text-foreground' : 'text-muted-foreground'}
-          />
-          <Text
-            className={cn('text-sm flex-1', active ? 'text-foreground' : 'text-muted-foreground')}
-            numberOfLines={1}
-          >
-            {label}
-          </Text>
-        </Pressable>
-        <Pressable onPress={() => setExpanded(!expanded)} role="button" accessibilityLabel={`${expanded ? 'Collapse' : 'Expand'} ${label}`} className="p-1 -mr-1 active:opacity-70">
+        <Pressable
+          onPress={toggleExpanded}
+          role="button"
+          accessibilityLabel={`${expanded ? 'Collapse' : 'Expand'} ${project.name || 'Untitled'}`}
+          className="p-1 active:opacity-70"
+        >
           {expanded ? (
             <ChevronDown size={14} className="text-muted-foreground" />
           ) : (
             <ChevronRight size={14} className="text-muted-foreground" />
           )}
         </Pressable>
+        <Pressable
+          onPress={openProject}
+          role="link"
+          accessibilityLabel={`Project: ${project.name || 'Untitled'}`}
+          className="flex-1 flex-row items-center gap-2 active:opacity-70"
+        >
+          <Folder size={15} className={isActive ? 'text-foreground' : 'text-muted-foreground'} />
+          <Text
+            className={cn('text-sm flex-1', isActive ? 'text-foreground' : 'text-foreground')}
+            numberOfLines={1}
+          >
+            {project.name || 'Untitled'}
+          </Text>
+        </Pressable>
       </View>
       {expanded && (
         <View className="ml-6 mt-0.5">
-          {children}
+          {sessions.length === 0 ? (
+            <View className="px-2 py-1.5">
+              <Text className="text-xs text-muted-foreground" numberOfLines={1}>
+                {loaded ? 'No chats yet' : 'Loading…'}
+              </Text>
+            </View>
+          ) : (
+            sessions.map((s: any) => (
+              <ChatTreeItem
+                key={s.id}
+                session={s}
+                projectId={project.id}
+                onNavPress={onNavPress}
+              />
+            ))
+          )}
         </View>
       )}
     </View>
   )
-}
+})
 
-// ─── ProjectItem ───────────────────────────────────────────
-
-function ProjectItem({
-  name,
-  projectId,
-  onNavPress,
-}: {
-  name: string
-  projectId: string
-  onNavPress?: () => void
-}) {
-  const router = useRouter()
-  const pathname = usePathname()
-  const isActive = pathname.includes(projectId)
-
-  return (
-    <Pressable
-      onPress={() => {
-        router.push(`/(app)/projects/${projectId}` as any)
-        onNavPress?.()
-      }}
-      role="link"
-      accessibilityLabel={`Project: ${name}`}
-      className={cn(
-        'flex-row items-center rounded-md px-2 py-1.5',
-        isActive ? 'bg-accent' : 'active:bg-accent/50'
-      )}
-    >
-      <Text
-        className={cn(
-          'text-sm',
-          isActive ? 'text-foreground' : 'text-muted-foreground'
-        )}
-        numberOfLines={1}
-      >
-        {name}
-      </Text>
-    </Pressable>
-  )
-}
-
-// ─── UserMenu (popover anchored to avatar) ─────────────────
+// ─── UserMenuContent (user section of the account menu) ────
 
 interface UserMenuProps {
   user: { name?: string | null; email?: string | null; image?: string | null } | null
@@ -502,54 +499,350 @@ function UserMenuContent({
   )
 }
 
-function UserMenu({ user, onSignOut, onNavigate, isSuperAdmin, isWide = true, bottomInset = 0, collapsed }: UserMenuProps) {
+// ─── WorkspaceMenuSection (workspace block inside the account menu) ─
+
+interface WorkspaceMenuSectionProps {
+  workspaces: any[]
+  currentWorkspace: any
+  billingData: any
+  workspacePlan: { planId: string; status: string | null } | null
+  allPlans: Record<string, { planId: string; status: string | null }>
+  showBilling: boolean
+  onNavigate: (href: string) => void
+  onSwitchWorkspace: (workspaceId: string) => void
+  onCreateWorkspace: () => void
+  localMode?: boolean
+  onClose: () => void
+}
+
+function WorkspaceMenuSection({
+  workspaces,
+  currentWorkspace,
+  billingData,
+  workspacePlan,
+  allPlans,
+  showBilling,
+  onNavigate,
+  onSwitchWorkspace,
+  onCreateWorkspace,
+  localMode,
+  onClose,
+}: WorkspaceMenuSectionProps) {
+  const posthog = usePostHogSafe()
+
+  const wsInitial = currentWorkspace?.name?.[0]?.toUpperCase() ?? 'W'
+  const resolvedPlanId = (billingData.hasActiveSubscription && billingData.subscription?.planId)
+    || workspacePlan?.planId
+    || 'free'
+  const planType = getPlanDisplayName(resolvedPlanId !== 'free' ? resolvedPlanId : undefined)
+
+  return (
+    <>
+      {currentWorkspace && (
+        <View className="px-4 py-3">
+          <View className="flex-row items-start gap-3">
+            <View className="h-10 w-10 rounded-lg bg-primary/10 items-center justify-center">
+              <Text className="text-sm font-medium text-primary">{wsInitial}</Text>
+            </View>
+            <View className="flex-1 min-w-0">
+              <Text className="font-medium text-foreground" numberOfLines={1}>
+                {currentWorkspace.name}
+              </Text>
+              {showBilling && (
+                <Text className="text-xs text-muted-foreground">
+                  {planType} Plan {'\u00B7'} 1 member
+                </Text>
+              )}
+            </View>
+          </View>
+        </View>
+      )}
+
+      {currentWorkspace && (
+        <View className="px-3 pb-2 flex-row gap-2">
+          <Pressable
+            onPress={() => { onNavigate('/(app)/settings'); onClose() }}
+            className="flex-1 flex-row items-center justify-center gap-1.5 h-8 rounded-md border border-border active:bg-muted"
+          >
+            <Settings size={14} className="text-muted-foreground" />
+            <Text className="text-xs text-foreground">Settings</Text>
+          </Pressable>
+          {!localMode && (
+            <Pressable
+              onPress={() => { onNavigate('/(app)/settings?tab=people'); onClose() }}
+              className="flex-1 flex-row items-center justify-center gap-1.5 h-8 rounded-md border border-border active:bg-muted"
+            >
+              <Users size={14} className="text-muted-foreground" />
+              <Text className="text-xs text-foreground">Invite</Text>
+            </Pressable>
+          )}
+        </View>
+      )}
+
+      {showBilling && currentWorkspace && (
+        <>
+          <View className="h-px bg-border" />
+          <View className="px-4 py-3 gap-2">
+            <Text className="text-sm text-muted-foreground">Usage</Text>
+            <CompactUsageWindows windows={billingData.usageWindows} />
+          </View>
+        </>
+      )}
+
+      {showBilling && currentWorkspace && planType === 'Free' && (
+        <View className="px-3 py-2">
+          <Pressable
+            onPress={() => { trackEvent(posthog, EVENTS.UPGRADE_CLICKED); onNavigate('/(app)/billing'); onClose() }}
+            className="flex-row items-center justify-center gap-2 h-9 rounded-md"
+            style={Platform.OS === 'web'
+              ? { backgroundImage: 'linear-gradient(to right, #3b82f6, #9333ea)' } as any
+              : { backgroundColor: '#7c3aed' }}
+          >
+            <Zap size={16} className="text-white" />
+            <Text className="text-sm font-medium text-white">Upgrade to Pro</Text>
+          </Pressable>
+        </View>
+      )}
+
+      <View className="h-px bg-border" />
+
+      <View className="py-1">
+        <Text className="px-4 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+          All workspaces
+        </Text>
+        {workspaces.map((ws: any) => {
+          const isCurrent = ws.id === currentWorkspace?.id
+          return (
+            <Pressable
+              key={ws.id}
+              onPress={() => {
+                if (!isCurrent) {
+                  onSwitchWorkspace(ws.id)
+                }
+                onClose()
+              }}
+              className="flex-row items-center gap-2 px-4 py-2 active:bg-muted"
+            >
+              <View className="h-6 w-6 rounded bg-primary/10 items-center justify-center">
+                <Text className="text-[10px] font-medium text-primary">
+                  {ws.name?.[0]?.toUpperCase() ?? 'W'}
+                </Text>
+              </View>
+              <Text className="text-sm text-foreground flex-1" numberOfLines={1}>
+                {ws.name}
+              </Text>
+              {showBilling && (() => {
+                const wsPlanId = (allPlans[ws.id]?.planId
+                  ?? (ws.id === currentWorkspace?.id && billingData.subscription?.planId))
+                  || 'free'
+                const isPaid = wsPlanId !== 'free'
+                const label = isPaid
+                  ? wsPlanId.charAt(0).toUpperCase() + wsPlanId.slice(1)
+                  : 'Free'
+                return (
+                  <View className={cn('rounded px-1.5 py-0.5', isPaid ? 'bg-primary/10' : 'bg-muted')}>
+                    <Text className={cn('text-[10px]', isPaid ? 'text-primary font-medium' : 'text-muted-foreground')}>{label}</Text>
+                  </View>
+                )
+              })()}
+              {isCurrent && (
+                <Check size={16} className="text-primary" />
+              )}
+            </Pressable>
+          )
+        })}
+
+        {!localMode && (
+          <Pressable
+            onPress={() => { onClose(); onCreateWorkspace() }}
+            className="flex-row items-center gap-2 px-4 py-2 rounded-md active:bg-muted"
+          >
+            <Plus size={16} className="text-muted-foreground" />
+            <Text className="text-sm text-foreground">Create new workspace</Text>
+          </Pressable>
+        )}
+      </View>
+    </>
+  )
+}
+
+// ─── AccountNavLinks (resources/links moved into the account menu) ─
+
+function AccountNavLinks({
+  features,
+  localMode,
+  onNavigate,
+  onClose,
+}: {
+  features: { marketplace?: boolean }
+  localMode?: boolean
+  onNavigate: (href: string) => void
+  onClose: () => void
+}) {
+  const items: Array<{ icon: React.ElementType; label: string; href: string }> = [
+    { icon: Star, label: 'Starred', href: '/(app)/starred' },
+    ...(!localMode ? [{ icon: Users, label: 'Shared with me', href: '/(app)/shared' }] : []),
+    ...(features.marketplace ? [{ icon: Store, label: 'Marketplace', href: '/(app)/marketplace' }] : []),
+    { icon: Monitor, label: 'Remote Control', href: '/(app)/remote-control' },
+    ...(!localMode ? [{ icon: Key, label: 'API Keys', href: '/(app)/api-keys' }] : []),
+  ]
+
+  return (
+    <View role="menu" className="py-1">
+      {items.map(({ icon: Icon, label, href }) => (
+        <Pressable
+          key={label}
+          onPress={() => { onNavigate(href); onClose() }}
+          role="menuitem"
+          accessibilityLabel={label}
+          className="flex-row items-center gap-3 px-4 py-3 active:bg-muted"
+        >
+          <Icon size={18} className="text-muted-foreground" />
+          <Text className="text-sm text-foreground">{label}</Text>
+        </Pressable>
+      ))}
+      <Pressable
+        onPress={() => { Linking.openURL('https://docs.shogo.ai/'); onClose() }}
+        role="menuitem"
+        accessibilityLabel="Docs"
+        className="flex-row items-center gap-3 px-4 py-3 active:bg-muted"
+      >
+        <ExternalLink size={18} className="text-muted-foreground" />
+        <Text className="text-sm text-foreground">Docs</Text>
+      </Pressable>
+    </View>
+  )
+}
+
+// ─── AccountMenu (consolidated workspace + user button) ─────
+
+interface AccountMenuProps extends UserMenuProps {
+  workspaces: any[]
+  currentWorkspace: any
+  billingData: any
+  workspacePlan: { planId: string; status: string | null } | null
+  allPlans: Record<string, { planId: string; status: string | null }>
+  showBilling: boolean
+  onSwitchWorkspace: (workspaceId: string) => void
+  onCreateWorkspace: () => void
+  localMode?: boolean
+  features: { marketplace?: boolean }
+}
+
+function AccountMenu({
+  user,
+  onSignOut,
+  onNavigate,
+  isSuperAdmin,
+  isWide = true,
+  bottomInset = 0,
+  collapsed,
+  workspaces,
+  currentWorkspace,
+  billingData,
+  workspacePlan,
+  allPlans,
+  showBilling,
+  onSwitchWorkspace,
+  onCreateWorkspace,
+  localMode,
+  features,
+}: AccountMenuProps) {
   const [isOpen, setIsOpen] = useState(false)
+  const close = useCallback(() => setIsOpen(false), [])
+
+  const triggerInner = (
+    <>
+      <View className="h-7 w-7 rounded bg-primary/20 items-center justify-center">
+        <Text className="text-[11px] font-bold text-primary">
+          {currentWorkspace?.name?.[0]?.toUpperCase() || 'W'}
+        </Text>
+      </View>
+      {!collapsed && (
+        <View className="flex-1 min-w-0">
+          <Text className="text-sm text-foreground" numberOfLines={1} ellipsizeMode="tail">
+            {currentWorkspace?.name || 'Workspace'}
+          </Text>
+          <Text className="text-xs text-muted-foreground" numberOfLines={1} ellipsizeMode="tail">
+            {user?.name || 'User'}
+          </Text>
+        </View>
+      )}
+      {!collapsed && (
+        <Avatar fallback={getInitials(user?.name)} src={user?.image} size="sm" />
+      )}
+    </>
+  )
+
+  const menuSections = (
+    <>
+      <WorkspaceMenuSection
+        workspaces={workspaces}
+        currentWorkspace={currentWorkspace}
+        billingData={billingData}
+        workspacePlan={workspacePlan}
+        allPlans={allPlans}
+        showBilling={showBilling}
+        onNavigate={onNavigate}
+        onSwitchWorkspace={onSwitchWorkspace}
+        onCreateWorkspace={onCreateWorkspace}
+        localMode={localMode}
+        onClose={close}
+      />
+      <View className="h-px bg-border" />
+      <AccountNavLinks
+        features={features}
+        localMode={localMode}
+        onNavigate={onNavigate}
+        onClose={close}
+      />
+      <View className="h-px bg-border" />
+      <UserMenuContent
+        user={user}
+        onSignOut={onSignOut}
+        onNavigate={onNavigate}
+        isSuperAdmin={isSuperAdmin}
+        onClose={close}
+      />
+    </>
+  )
 
   if (isWide) {
     return (
       <Popover
         placement="top"
-        size="xs"
+        size="sm"
         className="flex-1 min-w-0 w-auto h-auto items-stretch"
         isOpen={isOpen}
         onOpen={() => setIsOpen(true)}
-        onClose={() => setIsOpen(false)}
+        onClose={close}
         trigger={(triggerProps) => (
           <Pressable
             {...triggerProps}
             role="button"
-            accessibilityLabel={`${user?.name || 'User'} — open user menu`}
-            accessibilityHint="Opens menu with profile, appearance, and sign out options"
+            accessibilityLabel={`${currentWorkspace?.name || 'Workspace'}, ${user?.name || 'User'} — open account menu`}
+            accessibilityHint="Opens menu to switch workspace, navigate, and manage your account"
             accessibilityState={{ expanded: isOpen }}
-            className="flex-row items-center gap-2 active:opacity-80 flex-1 min-w-0"
-          >
-            <Avatar
-              fallback={getInitials(user?.name)}
-              src={user?.image}
-              size="sm"
-            />
-            {!collapsed && (
-              <Text
-                className="text-sm text-foreground flex-1 min-w-0"
-                numberOfLines={1}
-                ellipsizeMode="tail"
-              >
-                {user?.name || 'User'}
-              </Text>
+            className={cn(
+              'flex-row items-center gap-2 active:opacity-80 flex-1 min-w-0',
+              collapsed && 'justify-center',
             )}
+          >
+            {triggerInner}
           </Pressable>
         )}
       >
         <PopoverBackdrop />
-        <PopoverContent className="w-[280px] max-w-[320px] p-0">
+        <PopoverContent className="w-[300px] max-w-[340px] p-0">
           <PopoverBody>
-            <UserMenuContent
-              user={user}
-              onSignOut={onSignOut}
-              onNavigate={onNavigate}
-              isSuperAdmin={isSuperAdmin}
-              onClose={() => setIsOpen(false)}
-            />
+            <ScrollView
+              className="max-h-[520px]"
+              showsVerticalScrollIndicator={false}
+              bounces={false}
+              overScrollMode="never"
+            >
+              {menuSections}
+            </ScrollView>
           </PopoverBody>
         </PopoverContent>
       </Popover>
@@ -561,37 +854,24 @@ function UserMenu({ user, onSignOut, onNavigate, isSuperAdmin, isWide = true, bo
       <Pressable
         onPress={() => setIsOpen(true)}
         role="button"
-        accessibilityLabel={`${user?.name || 'User'} — open user menu`}
-        accessibilityHint="Opens menu with profile, appearance, and sign out options"
+        accessibilityLabel={`${currentWorkspace?.name || 'Workspace'}, ${user?.name || 'User'} — open account menu`}
+        accessibilityHint="Opens menu to switch workspace, navigate, and manage your account"
         accessibilityState={{ expanded: isOpen }}
-        className="flex-row items-center gap-2 active:opacity-80 flex-1 min-w-0"
-      >
-        <Avatar
-          fallback={getInitials(user?.name)}
-          src={user?.image}
-          size="sm"
-        />
-        {!collapsed && (
-          <Text
-            className="text-sm text-foreground flex-1 min-w-0"
-            numberOfLines={1}
-            ellipsizeMode="tail"
-          >
-            {user?.name || 'User'}
-          </Text>
+        className={cn(
+          'flex-row items-center gap-2 active:opacity-80 flex-1 min-w-0',
+          collapsed && 'justify-center',
         )}
+      >
+        {triggerInner}
       </Pressable>
       <Modal
         visible={isOpen}
         transparent
         animationType="slide"
         statusBarTranslucent
-        onRequestClose={() => setIsOpen(false)}
+        onRequestClose={close}
       >
-        <Pressable
-          className="flex-1 bg-black/50 justify-end"
-          onPress={() => setIsOpen(false)}
-        >
+        <Pressable className="flex-1 bg-black/50 justify-end" onPress={close}>
           <Pressable
             onPress={(e) => e.stopPropagation()}
             className="bg-card border-t border-border rounded-t-2xl shadow-2xl"
@@ -600,316 +880,13 @@ function UserMenu({ user, onSignOut, onNavigate, isSuperAdmin, isWide = true, bo
             <View className="items-center pt-2 pb-1">
               <View className="w-10 h-1 rounded-full bg-muted-foreground/30" />
             </View>
-            <UserMenuContent
-              user={user}
-              onSignOut={onSignOut}
-              onNavigate={onNavigate}
-              isSuperAdmin={isSuperAdmin}
-              onClose={() => setIsOpen(false)}
-            />
+            <ScrollView className="max-h-[480px]" showsVerticalScrollIndicator={false}>
+              {menuSections}
+            </ScrollView>
           </Pressable>
         </Pressable>
       </Modal>
     </>
-  )
-}
-
-// ─── WorkspaceSwitcher (popover anchored to workspace button) ─
-
-interface WorkspaceSwitcherProps {
-  collapsed: boolean
-  workspaces: any[]
-  currentWorkspace: any
-  billingData: any
-  workspacePlan: { planId: string; status: string | null } | null
-  allPlans: Record<string, { planId: string; status: string | null }>
-  showBilling: boolean
-  onNavigate: (href: string) => void
-  onSwitchWorkspace: (workspaceId: string) => void
-  onCreateWorkspace: () => void
-  localMode?: boolean
-}
-
-function WorkspaceSwitcher({
-  collapsed,
-  workspaces,
-  currentWorkspace,
-  billingData,
-  workspacePlan,
-  allPlans,
-  showBilling,
-  onNavigate,
-  onSwitchWorkspace,
-  onCreateWorkspace,
-  localMode,
-}: WorkspaceSwitcherProps) {
-  const posthog = usePostHogSafe()
-  const [isOpen, setIsOpen] = useState(false)
-
-  const wsInitial = currentWorkspace?.name?.[0]?.toUpperCase() ?? 'W'
-  const resolvedPlanId = (billingData.hasActiveSubscription && billingData.subscription?.planId)
-    || workspacePlan?.planId
-    || 'free'
-  const planType = getPlanDisplayName(resolvedPlanId !== 'free' ? resolvedPlanId : undefined)
-
-  return (
-    <Popover
-      placement="bottom"
-      size="sm"
-      isOpen={isOpen}
-      onOpen={() => setIsOpen(true)}
-      onClose={() => setIsOpen(false)}
-      trigger={(triggerProps) => (
-        <Pressable
-          {...triggerProps}
-          className={cn(
-            'flex-row items-center gap-2 rounded-md px-2 py-1.5 active:bg-muted',
-            collapsed && 'justify-center px-0'
-          )}
-        >
-          <View className="h-6 w-6 rounded bg-primary/20 items-center justify-center">
-            <Text className="text-[10px] font-bold text-primary">
-              {currentWorkspace?.name?.[0]?.toUpperCase() || 'W'}
-            </Text>
-          </View>
-          {!collapsed && (
-            <>
-              <Text className="text-sm text-foreground flex-1" numberOfLines={1}>
-                {currentWorkspace?.name || 'Workspace'}
-              </Text>
-              <ChevronDown size={14} className="text-muted-foreground" />
-            </>
-          )}
-        </Pressable>
-      )}
-    >
-      <PopoverBackdrop />
-      <PopoverContent className="max-w-[280px] p-0">
-        <View className="flex-col overflow-hidden max-h-[480px]">
-          {/* ── Pinned top: workspace header + actions ── */}
-          {currentWorkspace && (
-            <View className="px-4 py-3">
-              <View className="flex-row items-start gap-3">
-                <View className="h-10 w-10 rounded-lg bg-primary/10 items-center justify-center">
-                  <Text className="text-sm font-medium text-primary">{wsInitial}</Text>
-                </View>
-                <View className="flex-1 min-w-0">
-                  <Text className="font-medium text-foreground" numberOfLines={1}>
-                    {currentWorkspace.name}
-                  </Text>
-                  {showBilling && (
-                    <Text className="text-xs text-muted-foreground">
-                      {planType} Plan {'\u00B7'} 1 member
-                    </Text>
-                  )}
-                </View>
-              </View>
-            </View>
-          )}
-
-          {currentWorkspace && (
-            <View className="px-3 pb-2 flex-row gap-2">
-              <Pressable
-                onPress={() => { onNavigate('/(app)/settings'); setIsOpen(false) }}
-                className="flex-1 flex-row items-center justify-center gap-1.5 h-8 rounded-md border border-border active:bg-muted"
-              >
-                <Settings size={14} className="text-muted-foreground" />
-                <Text className="text-xs text-foreground">Settings</Text>
-              </Pressable>
-              {!localMode && (
-                <Pressable
-                  onPress={() => { onNavigate('/(app)/settings?tab=people'); setIsOpen(false) }}
-                  className="flex-1 flex-row items-center justify-center gap-1.5 h-8 rounded-md border border-border active:bg-muted"
-                >
-                  <Users size={14} className="text-muted-foreground" />
-                  <Text className="text-xs text-foreground">Invite</Text>
-                </Pressable>
-              )}
-            </View>
-          )}
-
-          <View className="h-px bg-border" />
-
-          {/* ── Scrollable middle ── */}
-          <ScrollView
-            className="shrink"
-            showsVerticalScrollIndicator={false}
-            bounces={false}
-            overScrollMode="never"
-          >
-            {/* Usage */}
-            {showBilling && currentWorkspace && (
-              <>
-                <View className="px-4 py-3 gap-2">
-                  <Text className="text-sm text-muted-foreground">Usage</Text>
-                  <CompactUsageWindows windows={billingData.usageWindows} />
-                </View>
-
-                <View className="h-px bg-border" />
-              </>
-            )}
-
-            {/* Upgrade CTA */}
-            {showBilling && currentWorkspace && planType === 'Free' && (
-              <>
-                <View className="px-3 py-2">
-                  <Pressable
-                    onPress={() => { trackEvent(posthog, EVENTS.UPGRADE_CLICKED); onNavigate('/(app)/billing'); setIsOpen(false) }}
-                    className="flex-row items-center justify-center gap-2 h-9 rounded-md"
-                    style={Platform.OS === 'web'
-                      ? { backgroundImage: 'linear-gradient(to right, #3b82f6, #9333ea)' } as any
-                      : { backgroundColor: '#7c3aed' }}
-                  >
-                    <Zap size={16} className="text-white" />
-                    <Text className="text-sm font-medium text-white">Upgrade to Pro</Text>
-                  </Pressable>
-                </View>
-
-                <View className="h-px bg-border" />
-              </>
-            )}
-
-            {/* All workspaces */}
-            <View className="py-1">
-              <Text className="px-4 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-                All workspaces
-              </Text>
-              {workspaces.map((ws: any) => {
-                const isCurrent = ws.id === currentWorkspace?.id
-                return (
-                  <Pressable
-                    key={ws.id}
-                    onPress={() => {
-                      if (!isCurrent) {
-                        onSwitchWorkspace(ws.id)
-                      }
-                      setIsOpen(false)
-                    }}
-                    className="flex-row items-center gap-2 px-4 py-2 active:bg-muted"
-                  >
-                    <View className="h-6 w-6 rounded bg-primary/10 items-center justify-center">
-                      <Text className="text-[10px] font-medium text-primary">
-                        {ws.name?.[0]?.toUpperCase() ?? 'W'}
-                      </Text>
-                    </View>
-                    <Text className="text-sm text-foreground flex-1" numberOfLines={1}>
-                      {ws.name}
-                    </Text>
-                    {showBilling && (() => {
-                      const wsPlanId = (allPlans[ws.id]?.planId
-                        ?? (ws.id === currentWorkspace?.id && billingData.subscription?.planId))
-                        || 'free'
-                      const isPaid = wsPlanId !== 'free'
-                      const label = isPaid
-                        ? wsPlanId.charAt(0).toUpperCase() + wsPlanId.slice(1)
-                        : 'Free'
-                      return (
-                        <View className={cn('rounded px-1.5 py-0.5', isPaid ? 'bg-primary/10' : 'bg-muted')}>
-                          <Text className={cn('text-[10px]', isPaid ? 'text-primary font-medium' : 'text-muted-foreground')}>{label}</Text>
-                        </View>
-                      )
-                    })()}
-                    {isCurrent && (
-                      <Check size={16} className="text-primary" />
-                    )}
-                  </Pressable>
-                )
-              })}
-            </View>
-          </ScrollView>
-
-          <View className="h-px bg-border" />
-
-          {/* ── Pinned bottom: create workspace ── */}
-          {!localMode && (
-            <View className="p-1">
-              <Pressable
-                onPress={() => {
-                  setIsOpen(false)
-                  onCreateWorkspace()
-                }}
-                className="flex-row items-center gap-2 px-4 py-2 rounded-md active:bg-muted"
-              >
-                <Plus size={16} className="text-muted-foreground" />
-                <Text className="text-sm text-foreground">Create new workspace</Text>
-              </Pressable>
-            </View>
-          )}
-        </View>
-      </PopoverContent>
-    </Popover>
-  )
-}
-
-// ─── CreateFolderModal ─────────────────────────────────────
-
-function CreateFolderModal({
-  visible,
-  onClose,
-  onSubmit,
-}: {
-  visible: boolean
-  onClose: () => void
-  onSubmit: (name: string) => void
-}) {
-  const [name, setName] = useState('')
-
-  const handleSubmit = useCallback(() => {
-    if (name.trim()) {
-      onSubmit(name.trim())
-      setName('')
-      onClose()
-    }
-  }, [name, onSubmit, onClose])
-
-  return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
-      <Pressable className="flex-1 bg-black/50 items-center justify-center" onPress={onClose}>
-        <Pressable
-          className="bg-card rounded-xl p-6 w-80 border border-border"
-          onPress={(e) => e.stopPropagation()}
-        >
-          <View className="flex-row items-center justify-between mb-1">
-            <Text className="text-base font-semibold text-foreground">Create new folder</Text>
-            <Pressable onPress={onClose} className="p-1">
-              <X size={20} className="text-muted-foreground" />
-            </Pressable>
-          </View>
-          <Text className="text-sm text-muted-foreground mb-4">
-            Create a new folder to organize your projects
-          </Text>
-          <TextInput
-            value={name}
-            onChangeText={setName}
-            placeholder="Enter folder name"
-            placeholderTextColor="#9ca3af"
-            className="border border-border rounded-md px-3 py-2 text-sm text-foreground bg-background mb-4"
-            autoFocus
-            onSubmitEditing={handleSubmit}
-          />
-          <View className="flex-row gap-2 justify-end">
-            <Pressable
-              onPress={onClose}
-              className="px-4 py-2 rounded-md border border-border active:bg-muted"
-            >
-              <Text className="text-sm text-foreground">Cancel</Text>
-            </Pressable>
-            <Pressable
-              onPress={handleSubmit}
-              className={cn(
-                'px-4 py-2 rounded-md',
-                name.trim() ? 'bg-primary active:bg-primary/80' : 'bg-muted'
-              )}
-              disabled={!name.trim()}
-            >
-              <Text className={cn('text-sm', name.trim() ? 'text-primary-foreground' : 'text-muted-foreground')}>
-                Create folder
-              </Text>
-            </Pressable>
-          </View>
-        </Pressable>
-      </Pressable>
-    </Modal>
   )
 }
 
@@ -1111,25 +1088,22 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
 
   const [allPlans, setAllPlans] = useState<Record<string, { planId: string; status: string | null }>>({})
 
-  let recentProjects: any[]
+  let workspaceProjects: any[]
   try {
     const all = projects?.all ?? []
     const workspaceScoped = activeWorkspaceId
       ? all.filter((p: any) => p.workspaceId === activeWorkspaceId)
       : all
-    recentProjects = [...workspaceScoped]
-      .sort((a: any, b: any) => {
-        const aTime = a.lastMessageAt || a.updatedAt || 0
-        const bTime = b.lastMessageAt || b.updatedAt || 0
-        return bTime - aTime
-      })
-      .slice(0, 5)
+    workspaceProjects = [...workspaceScoped].sort((a: any, b: any) => {
+      const aTime = a.lastMessageAt || a.updatedAt || 0
+      const bTime = b.lastMessageAt || b.updatedAt || 0
+      return bTime - aTime
+    })
   } catch {
-    recentProjects = []
+    workspaceProjects = []
   }
 
   const [collapsed, setCollapsed] = useState(false)
-  const [createFolderOpen, setCreateFolderOpen] = useState(false)
   const [createWorkspaceOpen, setCreateWorkspaceOpen] = useState(false)
   const { open: commandPaletteOpen, setOpen: setCommandPaletteOpen } = useCommandPalette()
   const { instance: activeRemoteInstance } = useActiveInstance()
@@ -1151,19 +1125,6 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
   const isPaidPlan = billingData.hasActiveSubscription || (workspacePlan?.planId !== 'free' && workspacePlan?.status === 'active')
 
   const toggleCollapse = useCallback(() => setCollapsed((c) => !c), [])
-
-  const handleCreateFolder = useCallback(
-    async (name: string) => {
-      if (currentWorkspace?.id) {
-        try {
-          await actions.createFolder(name, currentWorkspace.id, null)
-        } catch (e) {
-          console.warn('Failed to create folder:', e)
-        }
-      }
-    },
-    [actions, currentWorkspace]
-  )
 
   const handleSwitchWorkspace = useCallback(
     (workspaceId: string) => {
@@ -1229,7 +1190,6 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
   }, [setCommandPaletteOpen])
 
   const isHomePage = pathname === '/' || pathname === '/(app)' || pathname === '/(app)/index'
-  const isProjectsPage = pathname.startsWith('/projects') || pathname.startsWith('/(app)/projects')
   const isMeetingsPage = pathname.startsWith('/meetings') || pathname.startsWith('/(app)/meetings')
 
   const sidebarContent = (
@@ -1278,26 +1238,6 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
         </View>
       )}
 
-      {/* ── Workspace Switcher ── */}
-      <View className={cn('p-2 border-b border-border', collapsed && 'px-1')}>
-        <WorkspaceSwitcher
-          collapsed={collapsed}
-          workspaces={allWorkspaces}
-          currentWorkspace={currentWorkspace}
-          billingData={billingData}
-          workspacePlan={workspacePlan}
-          allPlans={allPlans}
-          showBilling={features.billing}
-          onNavigate={(href) => {
-            if (!isWide) onClose?.()
-            router.push(href as any)
-          }}
-          onSwitchWorkspace={handleSwitchWorkspace}
-          onCreateWorkspace={handleCreateWorkspace}
-          localMode={localMode}
-        />
-      </View>
-
       {/* ── Main Navigation (scrollable) ── */}
       <ScrollView className="flex-1 py-2" showsVerticalScrollIndicator={false}>
         {/* Primary nav */}
@@ -1329,105 +1269,30 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
           )}
         </View>
 
-        {/* PROJECTS section */}
-        <NavSection title="Projects" collapsed={collapsed}>
-          <View className="px-2">
-            <ExpandableNavItem
-              icon={Clock}
-              label="Recent"
-              collapsed={collapsed}
-              defaultExpanded={true}
-            >
-              {recentProjects.map((project: any) => (
-                <ProjectItem
-                  key={project.id}
-                  name={project.name}
-                  projectId={project.id}
-                  onNavPress={onNavPress}
-                />
-              ))}
-            </ExpandableNavItem>
-
-            <ExpandableNavItem
-              icon={LayoutGrid}
-              label="All projects"
-              href="/(app)/projects"
-              active={isProjectsPage && !isHomePage}
-              collapsed={collapsed}
-              defaultExpanded={true}
-              onNavPress={onNavPress}
-            >
-              {!collapsed && (
-                <Pressable
-                  onPress={() => setCreateFolderOpen(true)}
-                  className="flex-row items-center gap-2 px-2 py-1.5 rounded-md active:bg-accent/50"
-                >
-                  <FolderPlus size={14} className="text-muted-foreground" />
-                  <Text className="text-sm text-muted-foreground">New folder</Text>
-                </Pressable>
-              )}
-            </ExpandableNavItem>
-
-            <NavItem
-              icon={Star}
-              label="Starred"
-              href="/(app)/starred"
-              active={isRouteActive(pathname, '/(app)/starred')}
-              collapsed={collapsed}
-              onNavPress={onNavPress}
-            />
-            {!localMode && (
-              <NavItem
-                icon={Users}
-                label="Shared with me"
-                href="/(app)/shared"
-                active={isRouteActive(pathname, '/(app)/shared')}
+        {/* PROJECTS tree — each project expands to show its chats */}
+        <View className="mt-4 px-2">
+          {!collapsed && (
+            <Text className="px-1 pb-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Projects
+            </Text>
+          )}
+          {workspaceProjects.length === 0 ? (
+            !collapsed && (
+              <View className="px-2 py-2">
+                <Text className="text-xs text-muted-foreground">No projects yet</Text>
+              </View>
+            )
+          ) : (
+            workspaceProjects.map((project: any) => (
+              <ProjectTreeItem
+                key={project.id}
+                project={project}
                 collapsed={collapsed}
                 onNavPress={onNavPress}
               />
-            )}
-          </View>
-        </NavSection>
-
-        {/* RESOURCES section */}
-        <NavSection title="Resources" collapsed={collapsed}>
-          <View className="px-2">
-            {features.marketplace && (
-              <NavItem
-                icon={Store}
-                label="Marketplace"
-                href="/(app)/marketplace"
-                active={isRouteActive(pathname, '/(app)/marketplace')}
-                collapsed={collapsed}
-                onNavPress={onNavPress}
-              />
-            )}
-            <NavItem
-              icon={Monitor}
-              label="Remote Control"
-              href="/(app)/remote-control"
-              active={isRouteActive(pathname, '/(app)/remote-control')}
-              collapsed={collapsed}
-              onNavPress={onNavPress}
-            />
-            {!localMode && (
-              <NavItem
-                icon={Key}
-                label="API Keys"
-                href="/(app)/api-keys"
-                active={isRouteActive(pathname, '/(app)/api-keys')}
-                collapsed={collapsed}
-                onNavPress={onNavPress}
-              />
-            )}
-            <NavItem
-              icon={ExternalLink}
-              label="Docs"
-              externalHref="https://docs.shogo.ai/"
-              collapsed={collapsed}
-            />
-          </View>
-        </NavSection>
+            ))
+          )}
+        </View>
       </ScrollView>
 
       {/* ── Bottom Section ── */}
@@ -1453,7 +1318,7 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
           </View>
         )}
 
-        {/* User row */}
+        {/* Consolidated workspace + user row */}
         <View
           className={cn(
             'flex-row items-center gap-2 p-2 border-t border-border',
@@ -1461,14 +1326,24 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
           )}
         >
           <View className={cn('min-w-0', !collapsed && 'flex-1')}>
-            <UserMenu
+            <AccountMenu
               user={user}
               onSignOut={handleSignOut}
-              onNavigate={(href) => { router.push(href as any); onNavPress() }}
+              onNavigate={(href) => { if (!isWide) onClose?.(); router.push(href as any); onNavPress() }}
               isSuperAdmin={isSuperAdmin}
               isWide={isWide}
               bottomInset={insets.bottom}
               collapsed={collapsed}
+              workspaces={allWorkspaces}
+              currentWorkspace={currentWorkspace}
+              billingData={billingData}
+              workspacePlan={workspacePlan}
+              allPlans={allPlans}
+              showBilling={features.billing}
+              onSwitchWorkspace={handleSwitchWorkspace}
+              onCreateWorkspace={handleCreateWorkspace}
+              localMode={localMode}
+              features={features}
             />
           </View>
 
@@ -1609,11 +1484,6 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
       </Modal>
 
       {/* Modals (true dialogs that are fine as centered overlays) */}
-      <CreateFolderModal
-        visible={createFolderOpen}
-        onClose={() => setCreateFolderOpen(false)}
-        onSubmit={handleCreateFolder}
-      />
       <CreateWorkspaceModal
         visible={createWorkspaceOpen}
         onClose={() => setCreateWorkspaceOpen(false)}

--- a/apps/mobile/components/project/ProjectTopBar.tsx
+++ b/apps/mobile/components/project/ProjectTopBar.tsx
@@ -206,12 +206,14 @@ function BarIconButton({
   active,
   title,
   size = 12,
+  testID,
 }: {
   icon: React.ElementType
   onPress: () => void
   active?: boolean
   title?: string
   size?: number
+  testID?: string
 }) {
   const tipRef = useWebTitle(title)
 
@@ -219,6 +221,7 @@ function BarIconButton({
     <Pressable
       ref={tipRef}
       onPress={onPress}
+      testID={testID}
       className={cn(
         'h-6 w-6 items-center justify-center rounded-md',
         active ? 'bg-primary' : 'active:bg-muted',
@@ -475,6 +478,7 @@ export function ProjectTopBar({
                   isNativePhone ? { maxWidth: nativeNarrowTitleMaxWidth } : undefined,
                 ]}
                 accessibilityLabel="Switch project"
+                testID="project-switcher-trigger"
               >
                 <Text
                   className="text-xs font-semibold text-foreground"
@@ -660,6 +664,7 @@ export function ProjectTopBar({
                   isNativePhone ? { maxWidth: 180 } : undefined,
                 ]}
                 accessibilityLabel="Switch project"
+                testID="project-switcher-trigger"
               >
                 <Text
                   className="text-xs font-semibold text-foreground"
@@ -809,6 +814,7 @@ export function ProjectTopBar({
               onPress={() => handleTabPress(tab.id)}
               active={getTabActive(tab.id)}
               title={tab.label}
+              testID={`project-tab-${tab.id}`}
             />
           ))}
         </View>
@@ -1197,6 +1203,7 @@ function ProjectMenuView({
         <Pressable
           onPress={onSwitchProject}
           className="px-4 py-3 active:bg-muted"
+          testID="project-switcher-open"
         >
           <View className="flex-row items-center gap-2.5">
             <View className="h-8 w-8 rounded-lg bg-primary items-center justify-center">
@@ -1678,6 +1685,7 @@ function ProjectSwitcherView({
                 <Pressable
                   key={project.id}
                   onPress={() => onSelect(project.id)}
+                  testID={`project-switcher-item-${project.id}`}
                   className={cn(
                     'flex-row items-center gap-2.5 px-3 py-2.5 active:bg-muted',
                     isCurrent && 'bg-accent/50',

--- a/apps/mobile/components/project/panels/FoldersPanel.tsx
+++ b/apps/mobile/components/project/panels/FoldersPanel.tsx
@@ -3,35 +3,42 @@
 /**
  * FoldersPanel
  *
- * VS Code-style folder management for external (workingMode='external')
- * projects. Lists every linked folder, lets the user add more via the
- * native picker, mark a folder primary (where `.shogo/` lives), or
- * remove non-primary folders.
+ * Project context manager. Two sections, available for every project:
  *
- * Also surfaces an "External preview URL" control so users who run their
- * own dev server (Vite/Metro/etc.) can tell Shogo which local URL the
- * "Preview" tab should embed. When the project isn't external mode at
- * all, render an informational empty state instead of nothing — saves
- * the user wondering why the panel is blank if they navigated here from
- * a managed project.
+ *   - Linked folders — local host folders mounted into the project's
+ *     anchor merged-root runtime (add via the desktop native picker,
+ *     remove non-primary). External projects also use the primary folder to
+ *     host `.shogo/` and can promote folders.
+ *   - Attached projects — other Shogo projects (same workspace) mounted as
+ *     subfolders of the same merged-root runtime so the agent can read /
+ *     (optionally) edit across them. Add via the project picker; detach
+ *     per-row; read-only attachments are write-protected by the runtime.
+ *
+ * Changing either set restarts the anchor merged-root runtime server-side
+ * (LINKED_FOLDERS / READONLY_ROOTS are parsed once at boot), so the panel
+ * shows a transient "Restarting context…" state after a change.
+ *
+ * External projects also get Workspace Trust + an "External preview URL"
+ * control (their own dev server).
  */
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ActivityIndicator, Platform, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import { cn } from '@shogo/shared-ui/primitives'
 import {
+  Boxes,
   Folder,
   FolderPlus,
   FolderTree,
   Globe,
+  Plus,
   Star,
   StarOff,
   Trash2,
   ShieldAlert,
   ShieldCheck,
 } from 'lucide-react-native'
-import { useDomainHttp } from '../../../contexts/domain'
-import { API_URL } from '../../../lib/api'
-import { useOpenLocalFolder } from '../useOpenLocalFolder'
+import { useDomainHttp, useProjectCollection } from '../../../contexts/domain'
+import { api, API_URL } from '../../../lib/api'
 
 interface ProjectFolder {
   id: string
@@ -44,40 +51,45 @@ interface ProjectFolder {
 interface ProjectShape {
   id: string
   name?: string
+  workspaceId?: string
   workingMode?: 'managed' | 'external'
   trustLevel?: 'trusted' | 'restricted'
   projectFolders?: ProjectFolder[]
+}
+
+interface AttachmentShape {
+  id: string
+  attachedProjectId: string
+  attachedProjectName: string | null
+  attachMode: 'readwrite' | 'readonly'
 }
 
 interface FoldersPanelProps {
   projectId: string
   visible: boolean
   /**
-   * Called when the user changes folder state so the parent (project
-   * page) can re-query and refresh peripheral UI (file tree, etc.).
-   * Optional — the panel does its own state sync regardless.
+   * Called when the user changes folder/attachment state so the parent
+   * (project page) can re-query and refresh peripheral UI (file tree, etc.).
    */
   onChange?: () => void
 }
 
 export function FoldersPanel({ projectId, visible, onChange }: FoldersPanelProps) {
   const http = useDomainHttp()
+  const projectCollection = useProjectCollection()
   const [project, setProject] = useState<ProjectShape | null>(null)
+  const [attachments, setAttachments] = useState<AttachmentShape[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [busy, setBusy] = useState<string | null>(null)
+  const [restarting, setRestarting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [pickerOpen, setPickerOpen] = useState(false)
 
-  // Preview URL state — separate fetch from project, lives on
-  // Project.settings.externalPreview.savedUrl. We surface both the
-  // saved URL and the most recent detected URL so the user can either
-  // pick the auto-detected one or type their own.
   const [previewSavedUrl, setPreviewSavedUrl] = useState<string | null>(null)
   const [previewDetectedUrl, setPreviewDetectedUrl] = useState<string | null>(null)
   const [previewDraft, setPreviewDraft] = useState<string>('')
 
-  // Native picker handle. Only present in Electron. We capture it
-  // lazily so the panel works in a regular browser (the buttons are
-  // disabled with a hint instead of crashing).
+  // Native picker handle. Only present in Electron desktop.
   const desktop = useMemo(() => {
     if (Platform.OS !== 'web' || typeof window === 'undefined') return null
     return (window as any).shogoDesktop as
@@ -85,42 +97,20 @@ export function FoldersPanel({ projectId, visible, onChange }: FoldersPanelProps
       | null
   }, [])
 
-  // "Open a folder" flow for the managed-project empty state — creates a
-  // new external (folder-linked) project and navigates to it. workspaceId
-  // is left undefined so the API binds it to the user's personal
-  // workspace (single-tenant local mode).
-  const { openFolder, isPicking, isAvailable: canOpenFolder } = useOpenLocalFolder({
-    workspaceId: undefined,
-  })
-
   const refresh = useCallback(async () => {
     if (!projectId) return
     setIsLoading(true)
     setError(null)
     try {
-      // Read from the local-projects route, which returns the
-      // `projectFolders` relation alongside `workingMode` / `trustLevel`
-      // in a `{ project }` envelope. The generated `/api/projects/:id`
-      // route does NOT include the folders relation and wraps its body in
-      // `{ ok, data }` — reading that here is what made an external
-      // project mis-render as "Managed project" (workingMode read as
-      // undefined). Raw fetch (not the collection store) so folder state
-      // reflects on the next render without cache staleness.
-      const res = await fetch(`${API_URL}/api/local/projects/${encodeURIComponent(projectId)}`, {
-        credentials: Platform.OS === 'web' ? 'include' : 'omit',
-      })
-      if (!res.ok) {
-        setError(`HTTP ${res.status}`)
-        return
-      }
-      const data: any = await res.json()
-      setProject(data?.project ?? null)
+      const { project: p, attachments: att } = await api.getLocalProjectWithAttachments(http, projectId)
+      setProject(p)
+      setAttachments(att)
     } catch (err: any) {
       setError(err?.message ?? 'Failed to load folders')
     } finally {
       setIsLoading(false)
     }
-  }, [projectId])
+  }, [http, projectId])
 
   useEffect(() => {
     if (visible) void refresh()
@@ -129,8 +119,50 @@ export function FoldersPanel({ projectId, visible, onChange }: FoldersPanelProps
   const isExternal = project?.workingMode === 'external'
   const folders = project?.projectFolders ?? []
 
-  // Poll the external-preview state alongside the folder data. Cheap:
-  // one GET every 5 s while the panel is open. Stops on hide.
+  // Signal that the merged-root runtime is being remounted, then clear when it
+  // reports healthy again. A read-only attach (and any member change) triggers
+  // an env-coupled restart on the server; rather than guess with a fixed
+  // timer, poll the runtime-status endpoint until `ready` so the indicator
+  // reflects actual readiness. A token guards against overlapping restarts
+  // (the latest one owns the indicator).
+  const restartTokenRef = useRef(0)
+  const flagRestart = useCallback(() => {
+    if (!projectId) return
+    const token = ++restartTokenRef.current
+    setRestarting(true)
+    void (async () => {
+      const deadline = Date.now() + 20_000
+      // Let the server tear the old runtime down first so we don't observe the
+      // pre-restart 'ready' and clear too early.
+      await new Promise((r) => setTimeout(r, 800))
+      while (restartTokenRef.current === token && Date.now() < deadline) {
+        const status = await api.getWorkspaceRuntimeStatus(http, projectId)
+        if (status.ready) break
+        await new Promise((r) => setTimeout(r, 700))
+      }
+      if (restartTokenRef.current === token) setRestarting(false)
+    })()
+  }, [http, projectId])
+
+  // Candidate projects for the "Add project" picker: same workspace, not
+  // this project, not already attached.
+  const attachCandidates = useMemo(() => {
+    let all: Array<{ id: string; name: string; workspaceId: string }> = []
+    try {
+      all = (projectCollection?.all?.slice() ?? []) as any[]
+    } catch {
+      all = []
+    }
+    const attachedIds = new Set(attachments.map((a) => a.attachedProjectId))
+    return all.filter(
+      (p) =>
+        p.id !== projectId &&
+        attachedIds.has(p.id) === false &&
+        (!project?.workspaceId || p.workspaceId === project.workspaceId),
+    )
+  }, [projectCollection?.all, attachments, projectId, project?.workspaceId])
+
+  // ─── Preview URL polling (external only) ───────────────────────────
   useEffect(() => {
     if (!visible || !isExternal || !projectId) return
     let cancelled = false
@@ -147,8 +179,6 @@ export function FoldersPanel({ projectId, visible, onChange }: FoldersPanelProps
         const detected = typeof body?.detectedUrl === 'string' ? body.detectedUrl : null
         setPreviewSavedUrl(saved)
         setPreviewDetectedUrl(detected)
-        // Seed the draft from saved-or-detected the first time, but
-        // don't overwrite while the user is actively editing.
         setPreviewDraft((prev) => prev || saved || detected || '')
       } catch {
         /* best-effort */
@@ -203,10 +233,7 @@ export function FoldersPanel({ projectId, visible, onChange }: FoldersPanelProps
     try {
       const res = await fetch(
         `${API_URL}/api/projects/${encodeURIComponent(projectId)}/external-preview`,
-        {
-          method: 'DELETE',
-          credentials: Platform.OS === 'web' ? 'include' : 'omit',
-        },
+        { method: 'DELETE', credentials: Platform.OS === 'web' ? 'include' : 'omit' },
       )
       if (res.ok) {
         setPreviewSavedUrl(null)
@@ -220,30 +247,35 @@ export function FoldersPanel({ projectId, visible, onChange }: FoldersPanelProps
     }
   }, [projectId, onChange])
 
-  const handleAdd = useCallback(async () => {
+  // ─── Linked folders ────────────────────────────────────────────────
+  const handleAddFolder = useCallback(async () => {
     if (!desktop?.pickFolders) return
-    setBusy('add')
+    setBusy('add-folder')
     try {
       const picked = await desktop.pickFolders({ multi: true })
       if (!picked?.ok || !Array.isArray(picked.paths)) return
       for (const path of picked.paths) {
-        await http.post(`/api/local/projects/${encodeURIComponent(projectId)}/folders`, { path })
+        const r = await api.addProjectFolder(http, projectId, path)
+        if (r.error) setError(r.error)
       }
       await refresh()
+      flagRestart()
       onChange?.()
     } catch (err: any) {
       setError(err?.message ?? 'Failed to add folder')
     } finally {
       setBusy(null)
     }
-  }, [desktop, http, projectId, refresh, onChange])
+  }, [desktop, http, projectId, refresh, flagRestart, onChange])
 
-  const handleRemove = useCallback(
+  const handleRemoveFolder = useCallback(
     async (folderId: string) => {
-      setBusy(`remove-${folderId}`)
+      setBusy(`remove-folder-${folderId}`)
       try {
-        await http.delete(`/api/local/projects/${encodeURIComponent(projectId)}/folders/${encodeURIComponent(folderId)}`)
+        const r = await api.removeProjectFolder(http, projectId, folderId)
+        if (r.error) setError(r.error)
         await refresh()
+        flagRestart()
         onChange?.()
       } catch (err: any) {
         setError(err?.message ?? 'Failed to remove folder')
@@ -251,7 +283,7 @@ export function FoldersPanel({ projectId, visible, onChange }: FoldersPanelProps
         setBusy(null)
       }
     },
-    [http, projectId, refresh, onChange],
+    [http, projectId, refresh, flagRestart, onChange],
   )
 
   const handlePromote = useCallback(
@@ -270,14 +302,49 @@ export function FoldersPanel({ projectId, visible, onChange }: FoldersPanelProps
     [http, projectId, refresh, onChange],
   )
 
+  // ─── Attached projects ─────────────────────────────────────────────
+  const handleAttachProject = useCallback(
+    async (attachedProjectId: string, mode: 'readwrite' | 'readonly' = 'readwrite') => {
+      setBusy(`attach-${attachedProjectId}`)
+      try {
+        const r = await api.attachProjectToProject(http, projectId, attachedProjectId, mode)
+        if (r.error) {
+          setError(r.error)
+          return
+        }
+        setPickerOpen(false)
+        await refresh()
+        flagRestart()
+        onChange?.()
+      } finally {
+        setBusy(null)
+      }
+    },
+    [http, projectId, refresh, flagRestart, onChange],
+  )
+
+  const handleDetachProject = useCallback(
+    async (attachedProjectId: string) => {
+      setBusy(`detach-${attachedProjectId}`)
+      try {
+        const r = await api.detachProjectFromProject(http, projectId, attachedProjectId)
+        if (r.error) setError(r.error)
+        await refresh()
+        flagRestart()
+        onChange?.()
+      } finally {
+        setBusy(null)
+      }
+    },
+    [http, projectId, refresh, flagRestart, onChange],
+  )
+
   const handleToggleTrust = useCallback(async () => {
     if (!project) return
     const next = project.trustLevel === 'trusted' ? false : true
     setBusy('trust')
     try {
-      await http.post(`/api/local/projects/${encodeURIComponent(projectId)}/trust`, {
-        trusted: next,
-      })
+      await http.post(`/api/local/projects/${encodeURIComponent(projectId)}/trust`, { trusted: next })
       await refresh()
       onChange?.()
     } catch (err: any) {
@@ -290,272 +357,367 @@ export function FoldersPanel({ projectId, visible, onChange }: FoldersPanelProps
   if (!visible) return null
 
   return (
-    <View className="absolute inset-0 flex-col bg-background" style={{ display: visible ? 'flex' : 'none' }}>
+    <View
+      testID="folders-panel"
+      className="absolute inset-0 flex-col bg-background"
+      style={{ display: visible ? 'flex' : 'none' }}
+    >
       <View className="px-4 py-3 border-b border-border flex-row items-center justify-between">
         <View className="flex-row items-center gap-2">
           <FolderTree size={16} className="text-muted-foreground" />
-          <Text className="text-sm font-semibold text-foreground">Folders</Text>
-          {folders.length > 0 && (
-            <View className="bg-muted rounded-full px-1.5 py-0.5">
-              <Text className="text-[10px] font-medium text-muted-foreground">{folders.length}</Text>
-            </View>
-          )}
+          <Text className="text-sm font-semibold text-foreground">Folders & projects</Text>
         </View>
-        {isExternal && desktop?.pickFolders ? (
-          <Pressable
-            onPress={handleAdd}
-            disabled={busy !== null}
-            className={cn(
-              'flex-row items-center gap-1.5 rounded-lg px-3 py-1.5',
-              busy === 'add' ? 'bg-muted' : 'bg-primary active:opacity-80',
-            )}
-          >
-            <FolderPlus size={14} className={busy === 'add' ? 'text-muted-foreground' : 'text-primary-foreground'} />
-            <Text
-              className={cn(
-                'text-xs font-medium',
-                busy === 'add' ? 'text-muted-foreground' : 'text-primary-foreground',
-              )}
-            >
-              Add folder
-            </Text>
-          </Pressable>
+        {restarting ? (
+          <View testID="runtime-restarting" className="flex-row items-center gap-1.5">
+            <ActivityIndicator size="small" />
+            <Text className="text-[11px] text-muted-foreground">Restarting context…</Text>
+          </View>
         ) : null}
       </View>
 
-      {isLoading ? (
+      {isLoading && !project ? (
         <View className="flex-1 items-center justify-center">
           <ActivityIndicator size="small" />
         </View>
-      ) : !isExternal ? (
-        <View className="flex-1 items-center justify-center px-6">
-          <Folder size={28} className="text-muted-foreground mb-3" />
-          <Text className="text-base font-semibold text-foreground mb-1 text-center">
-            Managed project
-          </Text>
-          <Text className="text-sm text-muted-foreground text-center">
-            This project lives in Shogo's managed workspace, not a folder on your machine.
-            Folder linking and Workspace Trust apply to "Open Folder…" projects.
-          </Text>
-          {canOpenFolder ? (
-            <Pressable
-              onPress={() => void openFolder()}
-              disabled={isPicking}
-              className={cn(
-                'mt-4 flex-row items-center gap-1.5 rounded-lg px-3.5 py-2',
-                isPicking ? 'bg-muted' : 'bg-primary active:opacity-80',
-              )}
-            >
-              <FolderPlus
-                size={14}
-                className={isPicking ? 'text-muted-foreground' : 'text-primary-foreground'}
-              />
-              <Text
-                className={cn(
-                  'text-xs font-medium',
-                  isPicking ? 'text-muted-foreground' : 'text-primary-foreground',
-                )}
-              >
-                {isPicking ? 'Opening\u2026' : 'Open a folder'}
-              </Text>
-            </Pressable>
-          ) : null}
-        </View>
       ) : (
         <ScrollView className="flex-1" contentContainerClassName="pb-6">
-          {/* Trust banner — sticky reminder of restricted mode. */}
-          {project?.trustLevel === 'restricted' ? (
-            <View className="mx-4 mt-3 rounded-lg border border-amber-300/50 bg-amber-50 dark:bg-amber-900/20 px-3 py-2.5 flex-row items-start gap-2">
-              <ShieldAlert size={16} className="text-amber-600 mt-0.5" />
-              <View className="flex-1">
-                <Text className="text-xs font-medium text-amber-800 dark:text-amber-200">
-                  Workspace is restricted
-                </Text>
-                <Text className="text-[11px] text-amber-700 dark:text-amber-300 mt-0.5">
-                  Edits and shell commands are blocked until you trust this folder.
-                </Text>
-              </View>
-              <Pressable
-                onPress={handleToggleTrust}
-                disabled={busy === 'trust'}
-                className={cn(
-                  'rounded-md bg-amber-600 px-2.5 py-1',
-                  busy === 'trust' ? 'opacity-60' : 'active:opacity-80',
-                )}
-              >
-                <Text className="text-[11px] font-medium text-white">Trust folder</Text>
-              </Pressable>
-            </View>
-          ) : (
-            <View className="mx-4 mt-3 rounded-lg border border-emerald-200/60 bg-emerald-50/50 dark:bg-emerald-900/10 px-3 py-2 flex-row items-center gap-2">
-              <ShieldCheck size={14} className="text-emerald-600" />
-              <Text className="text-[11px] text-emerald-700 dark:text-emerald-300 flex-1">
-                Workspace trusted — edits and shell allowed.
-              </Text>
-              <Pressable
-                onPress={handleToggleTrust}
-                disabled={busy === 'trust'}
-                className="active:opacity-60"
-              >
-                <Text className="text-[11px] text-muted-foreground underline">Restrict</Text>
-              </Pressable>
-            </View>
-          )}
-
-          {/* External preview URL — for "I'm running my own dev server"
-              workflows. The "Preview" tab embeds whatever URL is saved
-              here (or the most recent auto-detected one). */}
-          <View className="mx-4 mt-3 rounded-lg border border-border bg-card px-3 py-3 gap-2">
-            <View className="flex-row items-start gap-2">
-              <Globe size={16} className="text-muted-foreground mt-0.5" />
-              <View className="flex-1">
-                <Text className="text-xs font-medium text-foreground">External preview URL</Text>
-                <Text className="text-[11px] text-muted-foreground mt-0.5">
-                  Tell Shogo where your dev server is running. Only local hosts (localhost, 127.0.0.1) are allowed.
-                </Text>
-              </View>
-            </View>
-            <View className="flex-row items-center gap-2">
-              <View className="flex-1 flex-row items-center rounded-md bg-muted px-2 py-1">
-                <TextInput
-                  value={previewDraft}
-                  onChangeText={setPreviewDraft}
-                  placeholder="http://localhost:3000"
-                  placeholderTextColor="rgba(115,115,115,0.7)"
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  keyboardType="url"
-                  spellCheck={false}
-                  className="flex-1 text-[11px] text-foreground"
-                  style={{ paddingVertical: 0 } as any}
-                  onSubmitEditing={() => handleSavePreviewUrl(previewDraft)}
-                />
-              </View>
-              <Pressable
-                onPress={() => handleSavePreviewUrl(previewDraft)}
-                disabled={busy === 'preview-url' || !previewDraft.trim()}
-                className={cn(
-                  'rounded-md bg-primary px-2.5 py-1',
-                  (busy === 'preview-url' || !previewDraft.trim()) ? 'opacity-60' : 'active:opacity-80',
-                )}
-              >
-                <Text className="text-[11px] font-medium text-primary-foreground">Save</Text>
-              </Pressable>
-              {previewSavedUrl ? (
-                <Pressable
-                  onPress={handleClearPreviewUrl}
-                  disabled={busy === 'preview-url'}
-                  className="rounded-md px-2 py-1 active:bg-muted"
-                >
-                  <Text className="text-[11px] text-muted-foreground underline">Clear</Text>
-                </Pressable>
-              ) : null}
-            </View>
-            {previewDetectedUrl && previewDetectedUrl !== previewSavedUrl ? (
-              <View className="flex-row items-center gap-2">
-                <Text className="text-[10px] text-muted-foreground flex-1" numberOfLines={1}>
-                  Detected from terminal: <Text className="font-mono text-foreground">{previewDetectedUrl}</Text>
-                </Text>
-                <Pressable
-                  onPress={() => handleSavePreviewUrl(previewDetectedUrl)}
-                  disabled={busy === 'preview-url'}
-                  className="rounded-md bg-emerald-500/10 px-2 py-0.5 active:opacity-80"
-                >
-                  <Text className="text-[10px] font-medium text-emerald-700 dark:text-emerald-300">
-                    Use this
+          {/* Trust banner (external only). */}
+          {isExternal ? (
+            project?.trustLevel === 'restricted' ? (
+              <View className="mx-4 mt-3 rounded-lg border border-amber-300/50 bg-amber-50 dark:bg-amber-900/20 px-3 py-2.5 flex-row items-start gap-2">
+                <ShieldAlert size={16} className="text-amber-600 mt-0.5" />
+                <View className="flex-1">
+                  <Text className="text-xs font-medium text-amber-800 dark:text-amber-200">
+                    Workspace is restricted
                   </Text>
+                  <Text className="text-[11px] text-amber-700 dark:text-amber-300 mt-0.5">
+                    Edits and shell commands are blocked until you trust this folder.
+                  </Text>
+                </View>
+                <Pressable
+                  testID="trust-folder-button"
+                  onPress={handleToggleTrust}
+                  disabled={busy === 'trust'}
+                  className={cn(
+                    'rounded-md bg-amber-600 px-2.5 py-1',
+                    busy === 'trust' ? 'opacity-60' : 'active:opacity-80',
+                  )}
+                >
+                  <Text className="text-[11px] font-medium text-white">Trust folder</Text>
                 </Pressable>
               </View>
-            ) : null}
-          </View>
+            ) : (
+              <View className="mx-4 mt-3 rounded-lg border border-emerald-200/60 bg-emerald-50/50 dark:bg-emerald-900/10 px-3 py-2 flex-row items-center gap-2">
+                <ShieldCheck size={14} className="text-emerald-600" />
+                <Text className="text-[11px] text-emerald-700 dark:text-emerald-300 flex-1">
+                  Workspace trusted — edits and shell allowed.
+                </Text>
+                <Pressable onPress={handleToggleTrust} disabled={busy === 'trust'} className="active:opacity-60">
+                  <Text className="text-[11px] text-muted-foreground underline">Restrict</Text>
+                </Pressable>
+              </View>
+            )
+          ) : null}
 
           {error ? (
-            <View className="mx-4 mt-3 rounded-lg bg-destructive/10 px-3 py-2">
+            <View testID="folders-error" className="mx-4 mt-3 rounded-lg bg-destructive/10 px-3 py-2">
               <Text className="text-xs text-destructive">{error}</Text>
             </View>
           ) : null}
 
-          <View className="px-4 mt-4 gap-2">
-            {folders.length === 0 ? (
-              <View className="rounded-lg border border-dashed border-border px-4 py-6 items-center">
-                <Folder size={24} className="text-muted-foreground mb-2" />
-                <Text className="text-sm text-muted-foreground">No folders linked yet.</Text>
-                {desktop?.pickFolders ? (
-                  <Pressable
-                    onPress={handleAdd}
-                    className="mt-3 flex-row items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 active:opacity-80"
+          {/* ─── Linked folders ─────────────────────────────────────── */}
+          <View className="px-4 mt-4">
+            <View className="flex-row items-center justify-between mb-2">
+              <View className="flex-row items-center gap-1.5">
+                <Folder size={13} className="text-muted-foreground" />
+                <Text className="text-xs font-semibold text-foreground">Linked folders</Text>
+                {folders.length > 0 ? (
+                  <View className="bg-muted rounded-full px-1.5 py-0.5">
+                    <Text className="text-[10px] font-medium text-muted-foreground">{folders.length}</Text>
+                  </View>
+                ) : null}
+              </View>
+              {desktop?.pickFolders ? (
+                <Pressable
+                  testID="folders-add-folder"
+                  onPress={handleAddFolder}
+                  disabled={busy !== null}
+                  className={cn(
+                    'flex-row items-center gap-1.5 rounded-lg px-2.5 py-1',
+                    busy === 'add-folder' ? 'bg-muted' : 'bg-primary active:opacity-80',
+                  )}
+                >
+                  <FolderPlus
+                    size={13}
+                    className={busy === 'add-folder' ? 'text-muted-foreground' : 'text-primary-foreground'}
+                  />
+                  <Text
+                    className={cn(
+                      'text-[11px] font-medium',
+                      busy === 'add-folder' ? 'text-muted-foreground' : 'text-primary-foreground',
+                    )}
                   >
-                    <FolderPlus size={14} className="text-primary-foreground" />
-                    <Text className="text-xs font-medium text-primary-foreground">Add folder</Text>
+                    Add folder
+                  </Text>
+                </Pressable>
+              ) : null}
+            </View>
+
+            {folders.length === 0 ? (
+              <View className="rounded-lg border border-dashed border-border px-4 py-5 items-center">
+                <Text className="text-[11px] text-muted-foreground text-center">
+                  {desktop?.pickFolders
+                    ? 'No folders linked. Add a folder on your machine to give the agent access.'
+                    : 'Folder linking is available in the Shogo desktop app.'}
+                </Text>
+              </View>
+            ) : (
+              <View className="gap-2">
+                {folders.map((folder) => (
+                  <View
+                    key={folder.id}
+                    testID={`linked-folder-${folder.id}`}
+                    className="rounded-lg border border-border bg-card px-3 py-2.5 flex-row items-start gap-2"
+                  >
+                    <View className="mt-0.5">
+                      {folder.isPrimary ? (
+                        <Star size={16} className="text-amber-500" />
+                      ) : (
+                        <Folder size={16} className="text-muted-foreground" />
+                      )}
+                    </View>
+                    <View className="flex-1">
+                      <View className="flex-row items-center gap-2">
+                        <Text className="text-xs font-medium text-foreground" numberOfLines={1}>
+                          {basename(folder.path)}
+                        </Text>
+                        {folder.isPrimary ? (
+                          <View className="rounded-full bg-amber-100 dark:bg-amber-900/30 px-1.5 py-0.5">
+                            <Text className="text-[9px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300">
+                              Primary
+                            </Text>
+                          </View>
+                        ) : null}
+                      </View>
+                      <Text className="text-[11px] text-muted-foreground font-mono mt-0.5" numberOfLines={1}>
+                        {folder.path}
+                      </Text>
+                    </View>
+                    <View className="flex-row items-center gap-1">
+                      {isExternal && !folder.isPrimary ? (
+                        <Pressable
+                          onPress={() => handlePromote(folder.id)}
+                          disabled={busy !== null}
+                          className="rounded-md px-2 py-1 active:bg-muted"
+                        >
+                          {busy === `primary-${folder.id}` ? (
+                            <ActivityIndicator size="small" />
+                          ) : (
+                            <Star size={13} className="text-muted-foreground" />
+                          )}
+                        </Pressable>
+                      ) : isExternal ? (
+                        <View className="rounded-md px-2 py-1 opacity-40">
+                          <StarOff size={13} className="text-muted-foreground" />
+                        </View>
+                      ) : null}
+                      {!folder.isPrimary ? (
+                        <Pressable
+                          testID={`remove-folder-${folder.id}`}
+                          onPress={() => handleRemoveFolder(folder.id)}
+                          disabled={busy !== null}
+                          className="rounded-md px-2 py-1 active:bg-destructive/10"
+                        >
+                          {busy === `remove-folder-${folder.id}` ? (
+                            <ActivityIndicator size="small" />
+                          ) : (
+                            <Trash2 size={13} className="text-destructive" />
+                          )}
+                        </Pressable>
+                      ) : null}
+                    </View>
+                  </View>
+                ))}
+              </View>
+            )}
+          </View>
+
+          {/* ─── Attached projects ──────────────────────────────────── */}
+          <View className="px-4 mt-5">
+            <View className="flex-row items-center justify-between mb-2">
+              <View className="flex-row items-center gap-1.5">
+                <Boxes size={13} className="text-muted-foreground" />
+                <Text className="text-xs font-semibold text-foreground">Attached projects</Text>
+                {attachments.length > 0 ? (
+                  <View className="bg-muted rounded-full px-1.5 py-0.5">
+                    <Text className="text-[10px] font-medium text-muted-foreground">{attachments.length}</Text>
+                  </View>
+                ) : null}
+              </View>
+              <Pressable
+                testID="attachments-add-project"
+                onPress={() => setPickerOpen((v) => !v)}
+                disabled={busy !== null}
+                className="flex-row items-center gap-1.5 rounded-lg bg-primary px-2.5 py-1 active:opacity-80"
+              >
+                <Plus size={13} className="text-primary-foreground" />
+                <Text className="text-[11px] font-medium text-primary-foreground">Add project</Text>
+              </Pressable>
+            </View>
+
+            {pickerOpen ? (
+              <View
+                testID="attach-picker"
+                className="mb-2 rounded-lg border border-border bg-card overflow-hidden"
+              >
+                {attachCandidates.length === 0 ? (
+                  <View className="px-3 py-4 items-center">
+                    <Text className="text-[11px] text-muted-foreground text-center">
+                      No other projects in this workspace to attach.
+                    </Text>
+                  </View>
+                ) : (
+                  attachCandidates.map((p) => (
+                    <Pressable
+                      key={p.id}
+                      testID={`attach-pick-${p.id}`}
+                      onPress={() => handleAttachProject(p.id)}
+                      disabled={busy !== null}
+                      className="flex-row items-center gap-2 px-3 py-2.5 border-b border-border active:bg-muted"
+                    >
+                      <Boxes size={14} className="text-muted-foreground" />
+                      <Text className="text-xs text-foreground flex-1" numberOfLines={1}>
+                        {p.name || p.id}
+                      </Text>
+                      {busy === `attach-${p.id}` ? <ActivityIndicator size="small" /> : null}
+                    </Pressable>
+                  ))
+                )}
+              </View>
+            ) : null}
+
+            {attachments.length === 0 ? (
+              <View className="rounded-lg border border-dashed border-border px-4 py-5 items-center">
+                <Text className="text-[11px] text-muted-foreground text-center">
+                  Attach another project to read and edit across both in the same chat.
+                </Text>
+              </View>
+            ) : (
+              <View className="gap-2">
+                {attachments.map((att) => (
+                  <View
+                    key={att.id}
+                    testID={`attached-project-${att.attachedProjectId}`}
+                    className="rounded-lg border border-border bg-card px-3 py-2.5 flex-row items-center gap-2"
+                  >
+                    <Boxes size={16} className="text-muted-foreground" />
+                    <View className="flex-1">
+                      <Text className="text-xs font-medium text-foreground" numberOfLines={1}>
+                        {att.attachedProjectName || att.attachedProjectId}
+                      </Text>
+                      <Text className="text-[10px] text-muted-foreground mt-0.5">
+                        {att.attachMode === 'readonly' ? 'Read-only' : 'Read / write'}
+                      </Text>
+                    </View>
+                    <Pressable
+                      testID={`toggle-mode-${att.attachedProjectId}`}
+                      onPress={() =>
+                        handleAttachProject(
+                          att.attachedProjectId,
+                          att.attachMode === 'readonly' ? 'readwrite' : 'readonly',
+                        )
+                      }
+                      disabled={busy !== null}
+                      className="rounded-md px-2 py-1 active:bg-muted"
+                    >
+                      <Text className="text-[10px] text-muted-foreground underline">
+                        {att.attachMode === 'readonly' ? 'Allow edits' : 'Make read-only'}
+                      </Text>
+                    </Pressable>
+                    <Pressable
+                      testID={`detach-project-${att.attachedProjectId}`}
+                      onPress={() => handleDetachProject(att.attachedProjectId)}
+                      disabled={busy !== null}
+                      className="rounded-md px-2 py-1 active:bg-destructive/10"
+                    >
+                      {busy === `detach-${att.attachedProjectId}` ? (
+                        <ActivityIndicator size="small" />
+                      ) : (
+                        <Trash2 size={13} className="text-destructive" />
+                      )}
+                    </Pressable>
+                  </View>
+                ))}
+              </View>
+            )}
+          </View>
+
+          {/* External preview URL (external only). */}
+          {isExternal ? (
+            <View className="mx-4 mt-5 rounded-lg border border-border bg-card px-3 py-3 gap-2">
+              <View className="flex-row items-start gap-2">
+                <Globe size={16} className="text-muted-foreground mt-0.5" />
+                <View className="flex-1">
+                  <Text className="text-xs font-medium text-foreground">External preview URL</Text>
+                  <Text className="text-[11px] text-muted-foreground mt-0.5">
+                    Tell Shogo where your dev server is running. Only local hosts (localhost, 127.0.0.1) are allowed.
+                  </Text>
+                </View>
+              </View>
+              <View className="flex-row items-center gap-2">
+                <View className="flex-1 flex-row items-center rounded-md bg-muted px-2 py-1">
+                  <TextInput
+                    value={previewDraft}
+                    onChangeText={setPreviewDraft}
+                    placeholder="http://localhost:3000"
+                    placeholderTextColor="rgba(115,115,115,0.7)"
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    keyboardType="url"
+                    spellCheck={false}
+                    className="flex-1 text-[11px] text-foreground"
+                    style={{ paddingVertical: 0 } as any}
+                    onSubmitEditing={() => handleSavePreviewUrl(previewDraft)}
+                  />
+                </View>
+                <Pressable
+                  onPress={() => handleSavePreviewUrl(previewDraft)}
+                  disabled={busy === 'preview-url' || !previewDraft.trim()}
+                  className={cn(
+                    'rounded-md bg-primary px-2.5 py-1',
+                    busy === 'preview-url' || !previewDraft.trim() ? 'opacity-60' : 'active:opacity-80',
+                  )}
+                >
+                  <Text className="text-[11px] font-medium text-primary-foreground">Save</Text>
+                </Pressable>
+                {previewSavedUrl ? (
+                  <Pressable
+                    onPress={handleClearPreviewUrl}
+                    disabled={busy === 'preview-url'}
+                    className="rounded-md px-2 py-1 active:bg-muted"
+                  >
+                    <Text className="text-[11px] text-muted-foreground underline">Clear</Text>
                   </Pressable>
                 ) : null}
               </View>
-            ) : (
-              folders.map((folder) => (
-                <View
-                  key={folder.id}
-                  className="rounded-lg border border-border bg-card px-3 py-2.5 flex-row items-start gap-2"
-                >
-                  <View className="mt-0.5">
-                    {folder.isPrimary ? (
-                      <Star size={16} className="text-amber-500" />
-                    ) : (
-                      <Folder size={16} className="text-muted-foreground" />
-                    )}
-                  </View>
-                  <View className="flex-1">
-                    <View className="flex-row items-center gap-2">
-                      <Text className="text-xs font-medium text-foreground" numberOfLines={1}>
-                        {basename(folder.path)}
-                      </Text>
-                      {folder.isPrimary ? (
-                        <View className="rounded-full bg-amber-100 dark:bg-amber-900/30 px-1.5 py-0.5">
-                          <Text className="text-[9px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300">
-                            Primary
-                          </Text>
-                        </View>
-                      ) : null}
-                    </View>
-                    <Text className="text-[11px] text-muted-foreground font-mono mt-0.5" numberOfLines={1}>
-                      {folder.path}
+              {previewDetectedUrl && previewDetectedUrl !== previewSavedUrl ? (
+                <View className="flex-row items-center gap-2">
+                  <Text className="text-[10px] text-muted-foreground flex-1" numberOfLines={1}>
+                    Detected from terminal: <Text className="font-mono text-foreground">{previewDetectedUrl}</Text>
+                  </Text>
+                  <Pressable
+                    onPress={() => handleSavePreviewUrl(previewDetectedUrl)}
+                    disabled={busy === 'preview-url'}
+                    className="rounded-md bg-emerald-500/10 px-2 py-0.5 active:opacity-80"
+                  >
+                    <Text className="text-[10px] font-medium text-emerald-700 dark:text-emerald-300">
+                      Use this
                     </Text>
-                  </View>
-                  <View className="flex-row items-center gap-1">
-                    {!folder.isPrimary ? (
-                      <Pressable
-                        onPress={() => handlePromote(folder.id)}
-                        disabled={busy !== null}
-                        className="rounded-md px-2 py-1 active:bg-muted"
-                      >
-                        {busy === `primary-${folder.id}` ? (
-                          <ActivityIndicator size="small" />
-                        ) : (
-                          <Star size={13} className="text-muted-foreground" />
-                        )}
-                      </Pressable>
-                    ) : (
-                      <View className="rounded-md px-2 py-1 opacity-40">
-                        <StarOff size={13} className="text-muted-foreground" />
-                      </View>
-                    )}
-                    {!folder.isPrimary ? (
-                      <Pressable
-                        onPress={() => handleRemove(folder.id)}
-                        disabled={busy !== null}
-                        className="rounded-md px-2 py-1 active:bg-destructive/10"
-                      >
-                        {busy === `remove-${folder.id}` ? (
-                          <ActivityIndicator size="small" />
-                        ) : (
-                          <Trash2 size={13} className="text-destructive" />
-                        )}
-                      </Pressable>
-                    ) : null}
-                  </View>
+                  </Pressable>
                 </View>
-              ))
-            )}
-          </View>
+              ) : null}
+            </View>
+          ) : null}
         </ScrollView>
       )}
     </View>

--- a/apps/mobile/components/project/panels/SettingsPanel.tsx
+++ b/apps/mobile/components/project/panels/SettingsPanel.tsx
@@ -191,6 +191,7 @@ function WideSidebar({
               return (
                 <Pressable
                   key={item.id}
+                  testID={`settings-nav-${item.id}`}
                   onPress={() => onSelect(item.id)}
                   className={cn(
                     'mx-1.5 my-0.5 px-2 py-1.5 rounded-md flex-row items-center gap-2',
@@ -253,6 +254,7 @@ function NarrowSidebar({
                 )}
                 <Pressable
                   onPress={() => onSelect(item.id)}
+                  testID={`settings-nav-${item.id}`}
                   className={cn(
                     'px-2.5 py-1 rounded-md flex-row items-center gap-1.5',
                     isActive ? 'bg-accent' : 'active:bg-muted',

--- a/apps/mobile/components/project/panels/ide/FileTree.tsx
+++ b/apps/mobile/components/project/panels/ide/FileTree.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ChevronRight,
+  Download,
   File,
   FilePlus,
   Folder,
@@ -25,6 +26,11 @@ export interface FileTreeHandlers {
   onRename: (node: TreeNode, newName: string) => Promise<void>;
   onDelete: (node: TreeNode) => Promise<void>;
   onMove: (from: TreeNode, toDir: TreeNode | null) => Promise<void>;
+  /**
+   * Download a file to the user's machine (web only). Wired to the workspace
+   * service's authed blob fetch in Workbench; only offered for files.
+   */
+  onDownload: (node: TreeNode) => void | Promise<void>;
   /**
    * Fetch the children of a directory whose `lazy` flag was set by the
    * server (e.g. `node_modules`, `dist`). The handler is expected to splice
@@ -585,6 +591,19 @@ export function FileTree({
               selectedNodes.map((n) => n.path).join("\n"),
             ),
         },
+        ...(fileCount > 0
+          ? [
+              {
+                label: `Download ${fileCount} file${fileCount === 1 ? "" : "s"}`,
+                icon: <Download size={14} />,
+                onClick: () => {
+                  for (const n of selectedNodes) {
+                    if (n.kind === "file") void handlers.onDownload(n);
+                  }
+                },
+              } as MenuEntry,
+            ]
+          : []),
         { separator: true },
         {
           label: `Delete ${count} items`,
@@ -623,6 +642,15 @@ export function FileTree({
         label: "Copy Path",
         onClick: () => void navigator.clipboard.writeText(node.path),
       },
+      ...(node.kind === "file"
+        ? [
+            {
+              label: "Download",
+              icon: <Download size={14} />,
+              onClick: () => void handlers.onDownload(node),
+            } as MenuEntry,
+          ]
+        : []),
       {
         label: "Delete",
         shortcut: "⌫",

--- a/apps/mobile/components/project/panels/ide/Workbench.tsx
+++ b/apps/mobile/components/project/panels/ide/Workbench.tsx
@@ -1003,6 +1003,47 @@ export function Workbench({
     [svcOf, loadRoot, showToast],
   );
 
+  // Download a file via the workspace service's authed blob fetch (same path
+  // as binary previews). We fetch to a blob: URL rather than linking the agent
+  // download endpoint directly so the `download` attribute is always honored
+  // (blob: is same-origin) and the IDE never navigates away — the runtime
+  // serves images/pdf with `Content-Disposition: inline`. Web only.
+  const handleDownload = useCallback(
+    async (node: TreeNode) => {
+      if (node.kind !== "file" || typeof document === "undefined") return;
+      const svc = svcOf(node.rootId);
+      if (!svc) {
+        showToast(`Unknown workspace: ${node.rootId}`, 2500);
+        return;
+      }
+      if (!svc.readFileUrl) {
+        showToast("Download not supported for this workspace", 2500);
+        return;
+      }
+      let url: string | null = null;
+      try {
+        url = await svc.readFileUrl(node.path);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = node.name;
+        a.rel = "noopener noreferrer";
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+      } catch (err) {
+        showToast(`Download failed: ${err instanceof Error ? err.message : String(err)}`, 3000);
+      } finally {
+        // Defer revocation so the browser has started the download before the
+        // blob: URL is released.
+        if (url) {
+          const toRevoke = url;
+          setTimeout(() => URL.revokeObjectURL(toRevoke), 1000);
+        }
+      }
+    },
+    [svcOf, showToast],
+  );
+
   const treeHandlers: FileTreeHandlers = useMemo(
     () => ({
       onOpen: handleOpenFile,
@@ -1010,9 +1051,10 @@ export function Workbench({
       onRename: handleRenameNode,
       onDelete: handleDeleteNode,
       onMove: handleMove,
+      onDownload: handleDownload,
       onLoadSubtree: loadSubtree,
     }),
-    [handleOpenFile, handleCreate, handleRenameNode, handleDeleteNode, handleMove, loadSubtree],
+    [handleOpenFile, handleCreate, handleRenameNode, handleDeleteNode, handleMove, handleDownload, loadSubtree],
   );
 
   // ─── Save ────────────────────────────────────────────────────────────

--- a/apps/mobile/components/project/panels/ide/__tests__/FileTree.compactFolders.rtl.test.tsx
+++ b/apps/mobile/components/project/panels/ide/__tests__/FileTree.compactFolders.rtl.test.tsx
@@ -22,6 +22,7 @@ function handlers(overrides: Partial<FileTreeHandlers> = {}): FileTreeHandlers {
     onRename: mock(async () => {}),
     onDelete: mock(async () => {}),
     onMove: mock(async () => {}),
+    onDownload: mock(() => {}),
     ...overrides,
   };
 }

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -739,6 +739,68 @@ export const api = {
     }
   },
 
+  // ─── Workspace-scoped chat sessions ─────────────────────────
+  // The workspace-aware sibling of per-project chat: a workspace session
+  // (contextType='workspace') with a set of attached projects, chatting
+  // against the merged-root runtime. See routes/workspace-chat.ts.
+
+  /**
+   * Create a workspace-scoped chat session, optionally pre-attaching
+   * projects. Returns the session id + the resolved attachments.
+   */
+  async createWorkspaceSession(
+    http: HttpClient,
+    workspaceId: string,
+    opts: {
+      name?: string
+      inferredName?: string
+      attachProjectIds?: string[]
+      attachMode?: 'readwrite' | 'readonly'
+    } = {},
+  ): Promise<{ id: string; workspaceId: string; attached: Array<{ id: string; projectId: string; attachMode: string }> }> {
+    const res = await http.post<{ session: { id: string; workspaceId: string; attached: Array<{ id: string; projectId: string; attachMode: string }> } }>(
+      `/api/workspaces/${encodeURIComponent(workspaceId)}/sessions`,
+      opts,
+    )
+    if (!res.data?.session) throw new Error('createWorkspaceSession: no session returned')
+    return res.data.session
+  },
+
+  /** Attach a project to an existing workspace session. */
+  async attachProject(
+    http: HttpClient,
+    workspaceId: string,
+    sessionId: string,
+    projectId: string,
+    attachMode: 'readwrite' | 'readonly' = 'readwrite',
+  ): Promise<{ id: string; projectId: string; attachMode: string }> {
+    const res = await http.post<{ attached: { id: string; projectId: string; attachMode: string } }>(
+      `/api/workspaces/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}/projects`,
+      { projectId, attachMode },
+    )
+    if (!res.data?.attached) throw new Error('attachProject: no attachment returned')
+    return res.data.attached
+  },
+
+  /**
+   * Best-effort: warm the merged-root workspace runtime. Mirrors
+   * prewarmProjectRuntime. Pass the workspace session id (and/or explicit
+   * attach project ids) so the runtime mounts the right subfolders.
+   */
+  async prewarmWorkspaceRuntime(
+    http: HttpClient,
+    workspaceId: string,
+    opts: { sessionId?: string; attachProjectIds?: string[] } = {},
+  ): Promise<void> {
+    try {
+      await http.post(`/api/workspaces/${encodeURIComponent(workspaceId)}/runtime/prewarm`, opts)
+    } catch (err) {
+      // Prewarm is an optimization only; the first chat turn still resolves
+      // (or cold-starts) the runtime.
+      console.warn('[api.prewarmWorkspaceRuntime] best-effort prewarm failed:', err)
+    }
+  },
+
   // ─── Local "external folder" projects (Shogo Desktop only) ─────────────
   /**
    * Create an external (VS Code-style) project from a set of host
@@ -824,6 +886,155 @@ export const api = {
       }
     } catch (err: any) {
       return { error: err?.message ?? 'Browse failed' }
+    }
+  },
+
+  /**
+   * Fetch a project with its persistent attachments (the anchor merged-root
+   * runtime mounts these). Returns `{ project, attachments }`.
+   */
+  async getLocalProjectWithAttachments(
+    http: HttpClient,
+    projectId: string,
+  ): Promise<{
+    project: any | null
+    attachments: Array<{
+      id: string
+      attachedProjectId: string
+      attachedProjectName: string | null
+      attachMode: 'readwrite' | 'readonly'
+    }>
+  }> {
+    try {
+      const res = await http.get<any>(`/api/local/projects/${encodeURIComponent(projectId)}`)
+      return {
+        project: res.data?.project ?? null,
+        attachments: Array.isArray(res.data?.attachments) ? res.data!.attachments : [],
+      }
+    } catch {
+      return { project: null, attachments: [] }
+    }
+  },
+
+  /**
+   * Attach another Shogo project (same workspace) to this anchor project so
+   * its files mount into the anchor merged-root runtime. `attachMode`
+   * defaults to `readwrite`; `readonly` mounts it write-protected.
+   */
+  async attachProjectToProject(
+    http: HttpClient,
+    projectId: string,
+    attachedProjectId: string,
+    attachMode: 'readwrite' | 'readonly' = 'readwrite',
+  ): Promise<{ attachment?: any; error?: string }> {
+    try {
+      const res = await http.post<any>(
+        `/api/local/projects/${encodeURIComponent(projectId)}/attachments`,
+        { attachedProjectId, attachMode },
+      )
+      if (res.data?.attachment) return { attachment: res.data.attachment }
+      const errBody = (res.error ?? res.data ?? {}) as { error?: string; message?: string }
+      return { error: errBody.message ?? errBody.error ?? 'Failed to attach project' }
+    } catch (err: any) {
+      return { error: err?.message ?? 'Failed to attach project' }
+    }
+  },
+
+  /** Detach a previously-attached project. No-op if it wasn't attached. */
+  async detachProjectFromProject(
+    http: HttpClient,
+    projectId: string,
+    attachedProjectId: string,
+  ): Promise<{ ok: boolean; error?: string }> {
+    try {
+      await http.delete(
+        `/api/local/projects/${encodeURIComponent(projectId)}/attachments/${encodeURIComponent(attachedProjectId)}`,
+      )
+      return { ok: true }
+    } catch (err: any) {
+      return { ok: false, error: err?.message ?? 'Failed to detach project' }
+    }
+  },
+
+  /** Add a linked local folder to a project (managed or external). */
+  async addProjectFolder(
+    http: HttpClient,
+    projectId: string,
+    path: string,
+  ): Promise<{ folder?: any; error?: string }> {
+    try {
+      const res = await http.post<any>(
+        `/api/local/projects/${encodeURIComponent(projectId)}/folders`,
+        { path },
+      )
+      if (res.data?.folder) return { folder: res.data.folder }
+      const errBody = (res.error ?? res.data ?? {}) as { error?: string }
+      return { error: errBody.error ?? 'Failed to add folder' }
+    } catch (err: any) {
+      return { error: err?.message ?? 'Failed to add folder' }
+    }
+  },
+
+  /** Remove a linked local folder. */
+  async removeProjectFolder(
+    http: HttpClient,
+    projectId: string,
+    folderId: string,
+  ): Promise<{ ok: boolean; error?: string }> {
+    try {
+      await http.delete(
+        `/api/local/projects/${encodeURIComponent(projectId)}/folders/${encodeURIComponent(folderId)}`,
+      )
+      return { ok: true }
+    } catch (err: any) {
+      return { ok: false, error: err?.message ?? 'Failed to remove folder' }
+    }
+  },
+
+  /**
+   * Get (or create) the project-pinned workspace chat session. Routing the
+   * project's chat through this session boots the anchor merged-root runtime.
+   */
+  async getProjectWorkspaceSession(
+    http: HttpClient,
+    projectId: string,
+  ): Promise<{ session?: { id: string; workspaceId: string }; attachments?: any[]; error?: string }> {
+    try {
+      const res = await http.post<any>(
+        `/api/local/projects/${encodeURIComponent(projectId)}/workspace-session`,
+        {},
+      )
+      if (res.data?.session) return { session: res.data.session, attachments: res.data.attachments ?? [] }
+      const errBody = (res.error ?? res.data ?? {}) as { error?: string; message?: string }
+      return { error: errBody.message ?? errBody.error ?? 'Failed to open workspace session' }
+    } catch (err: any) {
+      return { error: err?.message ?? 'Failed to open workspace session' }
+    }
+  },
+
+  /**
+   * Poll the readiness of a project's anchor merged-root runtime. `generation`
+   * bumps on every fresh boot (e.g. a read-only attach that needs a
+   * READONLY_ROOTS restart), and `ready` means the runtime answered a health
+   * probe. Used to clear the Folders panel's "Restarting context…" indicator
+   * on real readiness rather than a fixed timer.
+   */
+  async getWorkspaceRuntimeStatus(
+    http: HttpClient,
+    projectId: string,
+  ): Promise<{ running: boolean; ready: boolean; generation: number }> {
+    try {
+      const res = await http.get<{ running?: boolean; ready?: boolean; generation?: number }>(
+        `/api/local/projects/${encodeURIComponent(projectId)}/workspace-runtime-status`,
+      )
+      const d = res.data ?? {}
+      return {
+        running: !!d.running,
+        ready: !!d.ready,
+        generation: typeof d.generation === 'number' ? d.generation : 0,
+      }
+    } catch {
+      return { running: false, ready: false, generation: 0 }
     }
   },
 

--- a/apps/mobile/lib/chat-stop.ts
+++ b/apps/mobile/lib/chat-stop.ts
@@ -4,6 +4,12 @@
 export interface StopRequestConfig {
   localAgentUrl?: string | null
   projectId?: string | null
+  /**
+   * Workspace id for workspace-scoped chat. When set (and no localAgentUrl),
+   * the stop request targets `/api/workspaces/:workspaceId/chat/stop` instead
+   * of the per-project endpoint.
+   */
+  workspaceId?: string | null
   apiBaseUrl: string
   platform: string
   getCookie?: () => string | null
@@ -20,13 +26,15 @@ export interface StopRequestResult {
  * including the correct auth credentials for the target.
  */
 export function buildStopRequest(config: StopRequestConfig): StopRequestResult | null {
-  const { localAgentUrl, projectId, apiBaseUrl, platform, getCookie, chatSessionId } = config
+  const { localAgentUrl, projectId, workspaceId, apiBaseUrl, platform, getCookie, chatSessionId } = config
 
   const url = localAgentUrl
     ? `${localAgentUrl}/agent/stop`
-    : projectId
-      ? `${apiBaseUrl}/api/projects/${projectId}/chat/stop`
-      : null
+    : workspaceId
+      ? `${apiBaseUrl}/api/workspaces/${workspaceId}/chat/stop`
+      : projectId
+        ? `${apiBaseUrl}/api/projects/${projectId}/chat/stop`
+        : null
 
   if (!url) return null
 

--- a/apps/mobile/lib/platform-config.ts
+++ b/apps/mobile/lib/platform-config.ts
@@ -58,6 +58,20 @@ function isLocalMode(): boolean {
   return !!(window as any).shogoDesktop?.isDesktop
 }
 
+/**
+ * Whether the client should route new "home" chats through the
+ * workspace-aware (merged-root) runtime — a workspace-scoped chat session
+ * with the project attached — instead of the per-project runtime.
+ *
+ * Opt-in via `EXPO_PUBLIC_WORKSPACE_RUNTIME=true`. The API independently
+ * gates the actual runtime behind `SHOGO_WORKSPACE_RUNTIME` (workspace chat
+ * returns 501 when that's off), so BOTH must agree for workspace chat to
+ * function. Default off preserves the existing per-project create flow.
+ */
+export function isWorkspaceRuntimeEnabled(): boolean {
+  return process.env.EXPO_PUBLIC_WORKSPACE_RUNTIME === 'true'
+}
+
 let cachedConfig: PlatformConfig | null = null
 
 function getInitialConfig(): PlatformConfig {

--- a/e2e/staging/project-preview-boot.test.ts
+++ b/e2e/staging/project-preview-boot.test.ts
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import { test, expect, type FrameLocator, type Page } from "@playwright/test"
+import {
+  createProjectAndWait,
+  homeComposerInput,
+  makeTestUser,
+  signUpAndOnboard,
+  waitForAgentResponse,
+  type TestUser,
+} from "./helpers"
+
+/**
+ * Project Preview Boot & Cycle E2E (UI-driven)
+ *
+ * Guards the runtime → preview-iframe path that regressed into the stuck
+ * "Loading preview… (this usually takes 20-40 seconds)" spinner:
+ *
+ *   1. Single project: a freshly created project's runtime boots and the
+ *      preview iframe renders the default template — the literal
+ *      "Project Ready" / "Start building your app!" from
+ *      templates/runtime-template/src/App.tsx. We abort the initial agent
+ *      build immediately after creation so App.tsx stays on the template
+ *      (the cold-boot state), making the assertion deterministic instead
+ *      of racing the agent's first edit.
+ *
+ *   2. Multiple projects: two projects whose App.tsx renders "Project A
+ *      Ready" / "Project B Ready" respectively, then cycle between them via
+ *      the top-bar project switcher and assert each project's own preview
+ *      renders. This exercises that warm, distinct per-project runtimes are
+ *      addressed correctly (no cross-project bleed, no duplicate-runtime
+ *      regression) when navigating between projects in a workspace.
+ *
+ * The preview iframe is tagged `data-testid="canvas-preview-iframe"`
+ * (CanvasWebView). The switcher entry points are
+ * `project-switcher-trigger` → `project-switcher-open` →
+ * `project-switcher-item-<id>` (ProjectTopBar).
+ *
+ * This suite is independent of the workspace-runtime rollout flag: the
+ * per-project preview boot and the switcher both work in legacy
+ * single-project and merged-workspace modes.
+ *
+ * Run: STAGING_URL=... npx playwright test \
+ *   --config e2e/playwright.config.ts project-preview-boot
+ * or locally against the dev web server on :8081.
+ */
+
+const TEST_USER = makeTestUser("PreviewBoot")
+
+const PREVIEW_BOOT_TIMEOUT_MS = 120_000
+const PREVIEW_CONTENT_TIMEOUT_MS = 60_000
+
+// ── Auth ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Lands on an authenticated home screen in both shapes: hosted/staging
+ * (real /sign-in → signUpAndOnboard) and local desktop mode
+ * (SHOGO_LOCAL_MODE=true, which boots straight to the home screen with no
+ * auth). Mirrors the helper in workspace-attachments.test.ts.
+ */
+async function ensureAuthenticated(page: Page, user: TestUser): Promise<void> {
+  await page.goto("/")
+  const home = page.getByText("What's on your mind", { exact: false }).first()
+  const signUpTab = page.getByRole("tab", { name: "Sign Up" })
+  await Promise.race([
+    home.waitFor({ state: "visible", timeout: 60_000 }).catch(() => {}),
+    signUpTab.waitFor({ state: "visible", timeout: 60_000 }).catch(() => {}),
+  ])
+  if (await home.isVisible().catch(() => false)) return
+  await signUpAndOnboard(page, user)
+}
+
+// ── Preview helpers ────────────────────────────────────────────────────────
+
+/** The live preview iframe (CanvasWebView, web). */
+function previewFrame(page: Page): FrameLocator {
+  return page.frameLocator('[data-testid="canvas-preview-iframe"]')
+}
+
+/**
+ * Waits until the runtime is healthy enough that the CanvasPanel swaps the
+ * "Loading preview…" placeholder for the actual iframe. The iframe is only
+ * mounted once `agentUrl && readyCanvasBaseUrl` resolve, so its presence is
+ * the real boot gate.
+ */
+async function waitForPreviewIframe(page: Page): Promise<void> {
+  await page
+    .getByTestId("canvas-preview-iframe")
+    .waitFor({ state: "attached", timeout: PREVIEW_BOOT_TIMEOUT_MS })
+}
+
+/** The chat stop button (present only while the agent is streaming). */
+function stopButton(page: Page) {
+  return page.locator('[data-testid="stop-streaming"], [aria-label="Stop"]').first()
+}
+
+/**
+ * Aborts the agent's in-flight build stream if it is running. Used right
+ * after project creation so the runtime keeps serving the untouched
+ * template App.tsx (the agent edits files on disk; stopping it before its
+ * first edit lands keeps "Project Ready" on screen).
+ */
+async function stopAgentStreamIfRunning(page: Page): Promise<void> {
+  const appeared = await stopButton(page)
+    .waitFor({ state: "visible", timeout: 20_000 })
+    .then(() => true)
+    .catch(() => false)
+  if (appeared) {
+    await stopButton(page).click({ force: true }).catch(() => {})
+    await stopButton(page).waitFor({ state: "detached", timeout: 15_000 }).catch(() => {})
+  }
+}
+
+/**
+ * Creates a project from the home composer and aborts the initial build as
+ * fast as possible, returning its project id. Leaves the runtime booting
+ * with the template App.tsx intact.
+ */
+async function createProjectAndStop(page: Page, prompt: string): Promise<string> {
+  await page.goto("/")
+  await page.waitForSelector("text=What's on your mind", { timeout: 30_000 })
+  const input = homeComposerInput(page)
+  await input.click()
+  await input.fill(prompt)
+  await page.waitForTimeout(300)
+  await page.keyboard.press("Enter")
+  await page.waitForURL(/\/projects\//, { timeout: 60_000 })
+  // Kill the build before the agent rewrites the template.
+  await stopAgentStreamIfRunning(page)
+  const m = page.url().match(/\/projects\/([^/?#]+)/)
+  expect(m, `expected a /projects/<id> URL, got ${page.url()}`).toBeTruthy()
+  return m![1]
+}
+
+/**
+ * Creates a project, lets the initial build run, parses its id and returns
+ * it. Used for the multi-project case where we then drive the agent to set
+ * a distinct App.tsx.
+ */
+async function createProjectReturningId(page: Page, prompt: string): Promise<string> {
+  await createProjectAndWait(page, prompt)
+  const m = page.url().match(/\/projects\/([^/?#]+)/)
+  expect(m, `expected a /projects/<id> URL, got ${page.url()}`).toBeTruthy()
+  return m![1]
+}
+
+// ── Project chat helpers (project composer, not the home composer) ───────────
+
+/** The currently-visible project chat composer. */
+function visibleComposer(page: Page) {
+  return page
+    .getByRole("textbox", { name: "Chat message input" })
+    .filter({ visible: true })
+    .first()
+}
+
+/** Sends a message into the project chat composer and waits for it to land. */
+async function sendProjectChatMessage(page: Page, text: string): Promise<void> {
+  const snippet = text.slice(0, 24)
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const box = visibleComposer(page)
+    await box.waitFor({ state: "visible", timeout: 15_000 })
+    await box.fill(text)
+    await page
+      .getByRole("button", { name: "Send message" })
+      .filter({ visible: true })
+      .first()
+      .click({ force: true })
+    const landed = await page
+      .getByText(snippet, { exact: false })
+      .first()
+      .waitFor({ state: "visible", timeout: 8_000 })
+      .then(() => true)
+      .catch(() => false)
+    if (landed) return
+  }
+  throw new Error("sendProjectChatMessage: message never appeared in the transcript")
+}
+
+/**
+ * Drives the agent to replace src/App.tsx so the preview renders a single
+ * heading exactly equal to `heading`, then waits for the agent to finish
+ * and the preview iframe (HMR) to show it.
+ */
+async function setAppHeadingViaAgent(page: Page, heading: string): Promise<void> {
+  await waitForAgentResponse(page)
+  await sendProjectChatMessage(
+    page,
+    `Replace the ENTIRE contents of src/App.tsx with a minimal default-exported ` +
+      `React component whose only visible content is a single <h1> with the exact ` +
+      `text "${heading}". Do not add any other text, components, or files. After ` +
+      `writing the file, stop.`,
+  )
+  await waitForAgentResponse(page)
+  await waitForPreviewIframe(page)
+  await expect(previewFrame(page).getByText(heading, { exact: false })).toBeVisible({
+    timeout: PREVIEW_CONTENT_TIMEOUT_MS,
+  })
+}
+
+// ── Project switcher (the "cycle through projects" control) ──────────────────
+
+/**
+ * Switches the active project via the top-bar project switcher dropdown:
+ * trigger → "Switch project" → the target row. RN-web Popovers can swallow
+ * the first synthetic click, so the open step retries.
+ */
+async function switchToProject(page: Page, projectId: string): Promise<void> {
+  const trigger = page.getByTestId("project-switcher-trigger").first()
+  const openSwitcher = page.getByTestId("project-switcher-open").first()
+  const targetRow = page.getByTestId(`project-switcher-item-${projectId}`).first()
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await trigger.click({ force: true })
+    const menuOpen = await openSwitcher
+      .waitFor({ state: "visible", timeout: 3_000 })
+      .then(() => true)
+      .catch(() => false)
+    if (menuOpen) break
+    await page.waitForTimeout(300)
+  }
+  await openSwitcher.click({ force: true })
+  await targetRow.waitFor({ state: "visible", timeout: 10_000 })
+  await targetRow.click({ force: true })
+  await page.waitForURL(new RegExp(`/projects/${projectId}(?:[/?#]|$)`), { timeout: 30_000 })
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe("Project preview boot & cycle", () => {
+  test.describe.configure({ mode: "serial" })
+
+  let page: Page
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+    await ensureAuthenticated(page, TEST_USER)
+  })
+
+  test.afterAll(async () => {
+    await page.close()
+  })
+
+  test("single project boots and the preview iframe shows the template", async () => {
+    test.setTimeout(180_000)
+    await createProjectAndStop(page, "A simple starter project for preview-boot testing")
+
+    await waitForPreviewIframe(page)
+    const frame = previewFrame(page)
+    await expect(frame.getByText("Project Ready", { exact: false })).toBeVisible({
+      timeout: PREVIEW_CONTENT_TIMEOUT_MS,
+    })
+    await expect(frame.getByText("Start building your app!", { exact: false })).toBeVisible({
+      timeout: PREVIEW_CONTENT_TIMEOUT_MS,
+    })
+  })
+
+  test("two projects render distinct previews and cycle via the switcher", async () => {
+    test.setTimeout(480_000)
+
+    // Project A → "Project A Ready"
+    const projectA = await createProjectReturningId(page, "Project A for preview-cycle testing")
+    await page.goto(`/projects/${projectA}`)
+    await setAppHeadingViaAgent(page, "Project A Ready")
+
+    // Project B → "Project B Ready"
+    const projectB = await createProjectReturningId(page, "Project B for preview-cycle testing")
+    await page.goto(`/projects/${projectB}`)
+    await setAppHeadingViaAgent(page, "Project B Ready")
+
+    expect(projectA).not.toBe(projectB)
+
+    // We are on B. Cycle B → A and assert A's preview.
+    await switchToProject(page, projectA)
+    await waitForPreviewIframe(page)
+    await expect(previewFrame(page).getByText("Project A Ready", { exact: false })).toBeVisible({
+      timeout: PREVIEW_CONTENT_TIMEOUT_MS,
+    })
+    await expect(
+      previewFrame(page).getByText("Project B Ready", { exact: false }),
+    ).toHaveCount(0)
+
+    // Cycle A → B and assert B's preview.
+    await switchToProject(page, projectB)
+    await waitForPreviewIframe(page)
+    await expect(previewFrame(page).getByText("Project B Ready", { exact: false })).toBeVisible({
+      timeout: PREVIEW_CONTENT_TIMEOUT_MS,
+    })
+    await expect(
+      previewFrame(page).getByText("Project A Ready", { exact: false }),
+    ).toHaveCount(0)
+  })
+})

--- a/e2e/staging/workspace-attachments.test.ts
+++ b/e2e/staging/workspace-attachments.test.ts
@@ -1,0 +1,433 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import { test, expect, type Page } from "@playwright/test"
+import {
+  makeTestUser,
+  signUpAndOnboard,
+  createProjectAndWait,
+  waitForAgentResponse,
+  type TestUser,
+} from "./helpers"
+
+/**
+ * Workspace Attachments E2E Tests (UI-driven)
+ *
+ * Exercises the Folders panel → "Attached projects" flow that converges
+ * every project onto its anchor-keyed merged-root workspace runtime:
+ *
+ *   Basic path (project attachments only, web-reachable):
+ *     1. Create anchor project A and a second project B.
+ *     2. A → Settings → Folders → Add project → B; assert B attaches and
+ *        the "Restarting context…" state resolves.
+ *     3. In A's chat, ask the agent to list top-level folders; assert it
+ *        sees BOTH A and B (proves the anchor-scoped merged root) and not
+ *        the whole filesystem — the original `ls -la` symptom.
+ *     4. Cross-project read: ask the agent to read a file in B.
+ *
+ *   Complex path:
+ *     5. Cross-project write (readwrite attach): edit a file in B.
+ *     6. Readonly enforcement: attach C as read-only; an edit to C is
+ *        refused while a read succeeds.
+ *     7. Detach B; after the restart B is gone from the merged tree.
+ *
+ * This whole suite depends on the workspace-runtime rollout flag being on
+ * in the target environment (SHOGO_WORKSPACE_RUNTIME /
+ * EXPO_PUBLIC_WORKSPACE_RUNTIME). When the flag is off, project chat uses
+ * the legacy single-project runtime and there are no attachments, so the
+ * suite skips cleanly. Set E2E_WORKSPACE_RUNTIME=true when running against
+ * a flag-on env.
+ *
+ * Local-folder coverage (add a folder + agent reads a file in it) is
+ * Electron-only: `window.shogoDesktop.pickFolders` is not present in web
+ * Playwright. It is covered under the desktop harness
+ * (apps/desktop/e2e/playwright.config.ts) or by stubbing the bridge with
+ * page.addInitScript — see the stubbed case at the end of this file.
+ *
+ * Run: STAGING_URL=... E2E_WORKSPACE_RUNTIME=true \
+ *   npx playwright test --config e2e/playwright.config.ts workspace-attachments
+ */
+
+const WORKSPACE_RUNTIME_ENABLED =
+  process.env.EXPO_PUBLIC_WORKSPACE_RUNTIME === "true" ||
+  process.env.SHOGO_WORKSPACE_RUNTIME === "true" ||
+  process.env.E2E_WORKSPACE_RUNTIME === "true"
+
+const TEST_USER = makeTestUser("WorkspaceAttachments")
+
+// ── Local UI helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Ensures we land on an authenticated home screen, working in both target
+ * shapes:
+ *   - Hosted/staging: a real `/sign-in` flow → run `signUpAndOnboard`.
+ *   - Local desktop mode (SHOGO_LOCAL_MODE=true): there is no auth; the app
+ *     boots straight to the home screen as "Local User", so signing up would
+ *     hang waiting for a Sign Up tab that never renders. Detect the home
+ *     screen first and short-circuit.
+ */
+async function ensureAuthenticated(page: Page, user: TestUser): Promise<void> {
+  await page.goto("/")
+  // A cold Playwright context loads the dev bundle on first navigation, which
+  // can take far longer than a few seconds, so race the two possible shells
+  // with a generous budget: the authenticated home (local mode, or an
+  // already-signed-in staging session) vs. the sign-in screen's "Sign Up" tab
+  // (fresh staging account).
+  const home = page.getByText("What's on your mind", { exact: false }).first()
+  const signUpTab = page.getByRole("tab", { name: "Sign Up" })
+  await Promise.race([
+    home.waitFor({ state: "visible", timeout: 60_000 }).catch(() => {}),
+    signUpTab.waitFor({ state: "visible", timeout: 60_000 }).catch(() => {}),
+  ])
+  if (await home.isVisible().catch(() => false)) return
+  await signUpAndOnboard(page, user)
+}
+
+/**
+ * Creates a project from the home composer and returns its project id,
+ * parsed out of the `/projects/<id>` URL we land on. Reuses the shared
+ * `createProjectAndWait` so we wait through the initial build stream.
+ */
+async function createProjectReturningId(page: Page, prompt: string): Promise<string> {
+  await createProjectAndWait(page, prompt)
+  const m = page.url().match(/\/projects\/([^/?#]+)/)
+  expect(m, `expected a /projects/<id> URL, got ${page.url()}`).toBeTruthy()
+  return m![1]
+}
+
+/**
+ * Opens the project's Settings → Folders panel using the stable testIDs we
+ * added (`project-tab-settings`, `settings-nav-folders`). Leaves the
+ * FoldersPanel visible.
+ */
+async function openFoldersPanel(page: Page): Promise<void> {
+  const settingsTab = page
+    .getByTestId("project-tab-settings")
+    .or(page.getByLabel("Settings", { exact: true }))
+    .first()
+  await settingsTab.waitFor({ state: "visible", timeout: 15_000 })
+  await settingsTab.click()
+
+  const foldersNav = page.getByTestId("settings-nav-folders").first()
+  await foldersNav.waitFor({ state: "visible", timeout: 10_000 })
+  await foldersNav.click()
+
+  await page.getByTestId("folders-panel").waitFor({ state: "visible", timeout: 10_000 })
+}
+
+/**
+ * Attaches `attachedProjectId` to the currently-open project via the
+ * Folders panel picker, then waits for the optimistic "Restarting context…"
+ * state to resolve (best-effort — it may be too quick to observe).
+ */
+async function attachProject(page: Page, attachedProjectId: string): Promise<void> {
+  await page.getByTestId("attachments-add-project").click()
+  await page.getByTestId("attach-picker").waitFor({ state: "visible", timeout: 5_000 })
+  await page.getByTestId(`attach-pick-${attachedProjectId}`).click()
+  await page
+    .getByTestId(`attached-project-${attachedProjectId}`)
+    .waitFor({ state: "visible", timeout: 15_000 })
+  // The "Restarting context…" banner now polls the runtime-status endpoint and
+  // only clears once the anchor runtime reports healthy again — so waiting for
+  // it to detach is a real readiness gate (no sleeps): subsequent chat is
+  // guaranteed to hit the rebuilt/rebooted merged root.
+  await page
+    .getByTestId("runtime-restarting")
+    .waitFor({ state: "detached", timeout: 30_000 })
+    .catch(() => {})
+}
+
+/**
+ * Navigates fresh to a project and waits until its chat is genuinely ready to
+ * drive: the pinned workspace session has been promoted to the active tab and
+ * its conversation has finished loading. Navigating fresh (rather than
+ * clicking the Chat tab on carried-over state) avoids the transient
+ * dual-tab/"Loading conversation…" race where the pinned session is still
+ * mounting alongside the prior project session. Also picks up any merged-root
+ * changes from a just-completed attach/detach, since the runtime refreshes its
+ * symlinks on resolve.
+ */
+async function openProjectChat(page: Page, projectId: string): Promise<void> {
+  await page.goto(`/projects/${projectId}`)
+  // Flag-on, the chat area shows a "Starting workspace…" gate and mounts NO
+  // composer until the anchor-pinned session resolves and becomes the sole
+  // tab — so the composer only appears once routing has settled (no async
+  // tab-swap / fill-wipe race to wait out). Wait for the gate to clear, then
+  // the visible composer.
+  await page
+    .getByTestId("workspace-chat-loading")
+    .waitFor({ state: "detached", timeout: 30_000 })
+    .catch(() => {})
+  await visibleComposer(page).waitFor({ state: "visible", timeout: 30_000 })
+  await page
+    .getByText("Loading conversation...", { exact: false })
+    .first()
+    .waitFor({ state: "detached", timeout: 30_000 })
+    .catch(() => {})
+  await waitForAgentResponse(page)
+}
+
+/** The currently-visible project chat composer (there can be a hidden,
+ * still-loading sibling tab, so we must filter to the visible one). */
+function visibleComposer(page: Page) {
+  return page
+    .getByRole("textbox", { name: "Chat message input" })
+    .filter({ visible: true })
+    .first()
+}
+
+/**
+ * Sends a message into the *project* chat composer. The shared
+ * `sendChatMessage` helper targets the home screen's `home-composer-input`,
+ * which does not exist inside a project — the project ChatPanel renders
+ * `ChatInput` (testID `project-composer-input`, accessibilityLabel
+ * "Chat message input"). Mirrors `sendChatMessage`'s fill + Enter flow.
+ */
+async function sendProjectChatMessage(page: Page, text: string): Promise<void> {
+  // With the deterministic single-session routing (Phase 1) the composer no
+  // longer re-mounts out from under us, so this is a straightforward
+  // fill → click "Send message" → confirm-by-transcript. Enter submission is
+  // unreliable in RN-web, so we use the explicit Send button (it appears once
+  // the box is non-empty). A single retry covers the rare slow first paint.
+  const snippet = text.slice(0, 24)
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const box = visibleComposer(page)
+    await box.waitFor({ state: "visible", timeout: 15_000 })
+    await box.fill(text)
+    await page
+      .getByRole("button", { name: "Send message" })
+      .filter({ visible: true })
+      .first()
+      .click({ force: true })
+    const landed = await page
+      .getByText(snippet, { exact: false })
+      .first()
+      .waitFor({ state: "visible", timeout: 8_000 })
+      .then(() => true)
+      .catch(() => false)
+    if (landed) return
+  }
+  throw new Error("sendProjectChatMessage: message never appeared in the transcript")
+}
+
+/** Returns the concatenated visible text of the chat transcript. */
+async function chatTranscript(page: Page): Promise<string> {
+  return (await page.locator("body").innerText()).toLowerCase()
+}
+
+test.describe("Workspace Attachments (Folders panel → merged runtime)", () => {
+  test.describe.configure({ mode: "serial" })
+  test.skip(
+    !WORKSPACE_RUNTIME_ENABLED,
+    "Requires the workspace-runtime rollout flag (SHOGO_WORKSPACE_RUNTIME / " +
+      "EXPO_PUBLIC_WORKSPACE_RUNTIME). Set E2E_WORKSPACE_RUNTIME=true when the " +
+      "target env has it on.",
+  )
+
+  let page: Page
+  let projectA = ""
+  let projectB = ""
+  let projectC = ""
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+    await ensureAuthenticated(page, TEST_USER)
+  })
+
+  test.afterAll(async () => {
+    await page.close()
+  })
+
+  // ── Setup: three projects in the same workspace ────────────────────────────
+
+  test("create anchor A and attach targets B, C", async () => {
+    projectA = await createProjectReturningId(page, "Anchor project A for attachment tests")
+    projectB = await createProjectReturningId(page, "Target project B with a readme")
+    projectC = await createProjectReturningId(page, "Target project C read-only")
+    expect(projectA).not.toBe(projectB)
+    expect(projectB).not.toBe(projectC)
+  })
+
+  // ── Basic path ─────────────────────────────────────────────────────────────
+
+  test("attach B to A via the Folders panel", async () => {
+    await page.goto(`/projects/${projectA}`)
+    await openFoldersPanel(page)
+    await attachProject(page, projectB)
+    await expect(page.getByTestId(`attached-project-${projectB}`)).toBeVisible()
+  })
+
+  test("agent in A sees only the anchor-scoped merged root (A + B)", async () => {
+    await openProjectChat(page, projectA)
+    await sendProjectChatMessage(
+      page,
+      "List ONLY the top-level folder names you can see in your workspace root. " +
+        "Output them as a plain list.",
+    )
+    await waitForAgentResponse(page)
+
+    const text = await chatTranscript(page)
+    // Merged-root subfolders are named by project id. The agent must see
+    // both the anchor (A) and the attached project (B)…
+    expect(text).toContain(projectA)
+    expect(text).toContain(projectB)
+    // …and must NOT be staring at the whole local projects dir / templates,
+    // which was the original `ls -la` regression this feature fixes.
+    expect(text).not.toContain("template-yc-founder-operating-system")
+  })
+
+  test("cross-project READ: agent reads a file in B", async () => {
+    await sendProjectChatMessage(
+      page,
+      `Read the file at ${projectB}/AGENTS.md (or, if it does not exist, ` +
+        `any top-level file inside the ${projectB} folder) and quote its first line back to me.`,
+    )
+    await waitForAgentResponse(page)
+    const text = await chatTranscript(page)
+    // A successful read should not surface a permission/allowlist error.
+    expect(text).not.toContain("not allowed")
+    expect(text).not.toContain("outside the workspace")
+  })
+
+  // ── Complex path ───────────────────────────────────────────────────────────
+
+  test("cross-project WRITE: agent edits a file in B (readwrite attach)", async () => {
+    await sendProjectChatMessage(
+      page,
+      `Create a file ${projectB}/SHOGO_E2E_WRITE.md containing the single line ` +
+        `"attached-write-ok", then confirm it was written.`,
+    )
+    await waitForAgentResponse(page)
+    const text = await chatTranscript(page)
+    expect(text).not.toContain("readonly")
+    expect(text).not.toContain("read-only")
+    expect(text).toContain("attached-write-ok")
+  })
+
+  test("readonly enforcement: attach C read-only, edits are refused", async () => {
+    await page.goto(`/projects/${projectA}`)
+    await openFoldersPanel(page)
+    await attachProject(page, projectC)
+    // Flip C to read-only. Assert on the EXACT status label — a substring
+    // match on "Read-only" also hits the toggle button ("Make read-only") and
+    // can hit the project's display name (the agent may name a project
+    // something like "Read-Only Access"), tripping Playwright strict mode.
+    await page.getByTestId(`toggle-mode-${projectC}`).click()
+    await expect(
+      page.getByTestId(`attached-project-${projectC}`).getByText("Read-only", { exact: true }),
+    ).toBeVisible({ timeout: 10_000 })
+    // READONLY_ROOTS is seeded at boot, so flipping to read-only forces an
+    // env-coupled restart. The banner clears on real readiness (status poll),
+    // so this wait is the gate that the readonly runtime is up before we
+    // assert the write is refused — no sleep needed.
+    await page
+      .getByTestId("runtime-restarting")
+      .waitFor({ state: "detached", timeout: 30_000 })
+      .catch(() => {})
+
+    await openProjectChat(page, projectA)
+    // A read of C should still work…
+    await sendProjectChatMessage(
+      page,
+      `List the top-level files inside the ${projectC} folder.`,
+    )
+    await waitForAgentResponse(page)
+    let text = await chatTranscript(page)
+    expect(text).not.toContain("not allowed")
+
+    // …but a write must be blocked by the runtime (READONLY_ROOTS).
+    await sendProjectChatMessage(
+      page,
+      `Create a file ${projectC}/SHOGO_E2E_SHOULD_FAIL.md with the text "nope".`,
+    )
+    await waitForAgentResponse(page)
+    text = await chatTranscript(page)
+    expect(text).toMatch(/read-?only|not allowed|denied|cannot write|permission/)
+  })
+
+  test("detach B; after restart B is gone from the merged tree", async () => {
+    await page.goto(`/projects/${projectA}`)
+    await openFoldersPanel(page)
+    await page.getByTestId(`detach-project-${projectB}`).click()
+    await expect(page.getByTestId(`attached-project-${projectB}`)).toHaveCount(0, {
+      timeout: 15_000,
+    })
+    await page
+      .getByTestId("runtime-restarting")
+      .waitFor({ state: "detached", timeout: 30_000 })
+      .catch(() => {})
+
+    await openProjectChat(page, projectA)
+    await sendProjectChatMessage(
+      page,
+      "List ONLY the top-level folder names in your workspace root as a plain list.",
+    )
+    await waitForAgentResponse(page)
+    const text = await chatTranscript(page)
+    expect(text).toContain(projectA)
+    expect(text).not.toContain(projectB)
+  })
+})
+
+// ── Local-folder coverage (stubbed desktop bridge) ───────────────────────────
+
+/**
+ * The "add a local folder + agent reads a file in it" path uses the
+ * Electron-only `window.shogoDesktop.pickFolders` picker, which is absent in
+ * web Playwright. We cover the UI half here by injecting a fake bridge with
+ * page.addInitScript before the app loads, so the "Add folder" button is
+ * reachable and the panel records the linked folder.
+ *
+ * The agent-side read of a file inside that folder is only meaningful under
+ * the real desktop harness (apps/desktop/e2e/playwright.config.ts), where
+ * the runtime can actually symlink and serve the host path; this web case
+ * asserts the UI wiring only and is skipped unless a stub dir is provided
+ * via E2E_LOCAL_FOLDER_STUB.
+ */
+test.describe("Workspace Attachments — local folder (stubbed bridge)", () => {
+  test.describe.configure({ mode: "serial" })
+  const STUB_DIR = process.env.E2E_LOCAL_FOLDER_STUB
+  test.skip(
+    !WORKSPACE_RUNTIME_ENABLED || !STUB_DIR,
+    "Local-folder UI coverage needs the workspace-runtime flag and a host " +
+      "path in E2E_LOCAL_FOLDER_STUB to feed the stubbed pickFolders bridge.",
+  )
+
+  const LOCAL_USER = makeTestUser("WorkspaceLocalFolder")
+  let page: Page
+  let projectId = ""
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+    // Inject a fake desktop bridge BEFORE any app code runs so FoldersPanel
+    // detects pickFolders support and the "Add folder" CTA is enabled.
+    await page.addInitScript((dir) => {
+      // @ts-expect-error — test-only shim of the Electron preload bridge.
+      window.shogoDesktop = {
+        ...(window as any).shogoDesktop,
+        pickFolders: async () => [dir],
+      }
+    }, STUB_DIR)
+    await ensureAuthenticated(page, LOCAL_USER)
+  })
+
+  test.afterAll(async () => {
+    await page.close()
+  })
+
+  test("link a local folder via the stubbed picker", async () => {
+    projectId = await createProjectReturningId(page, "Project that links a local folder")
+    await page.goto(`/projects/${projectId}`)
+    await openFoldersPanel(page)
+
+    await page.getByTestId("folders-add-folder").click()
+    // The folder is keyed by id we don't know up front, so assert that a
+    // linked-folder row appeared and the restart state resolved.
+    await expect(page.locator('[data-testid^="linked-folder-"]')).toHaveCount(1, {
+      timeout: 15_000,
+    })
+    await page
+      .getByTestId("runtime-restarting")
+      .waitFor({ state: "detached", timeout: 30_000 })
+      .catch(() => {})
+  })
+})

--- a/packages/agent-runtime/src/__tests__/helpers/test-trust.ts
+++ b/packages/agent-runtime/src/__tests__/helpers/test-trust.ts
@@ -57,6 +57,11 @@ export interface TrustWorkspaceOpts {
    * test and a static path for another.
    */
   linkedFolders?: string[]
+  /**
+   * Subset of allowed roots mounted read-only (write/exec denied). Used by
+   * tests exercising `attachMode='readonly'` enforcement.
+   */
+  readonlyRoots?: string[]
 }
 
 /**
@@ -82,6 +87,7 @@ export function trustWorkspaceForTests(
     workspaceDir,
     linkedFolders: opts.linkedFolders ?? [],
     initialized: true,
+    readonlyRoots: opts.readonlyRoots ?? [],
   })
   ;(globalThis as any).__SHOGO_AGENT_RUNTIME_CONFIG__ = {
     workingMode: opts.workingMode ?? 'managed',

--- a/packages/agent-runtime/src/__tests__/runtime-trust.test.ts
+++ b/packages/agent-runtime/src/__tests__/runtime-trust.test.ts
@@ -39,6 +39,7 @@ function clearTrustState(): void {
   delete process.env.WORKING_MODE
   delete process.env.TRUST_LEVEL
   delete process.env.LINKED_FOLDERS
+  delete process.env.READONLY_ROOTS
 }
 
 describe('runtime-trust', () => {
@@ -67,12 +68,14 @@ describe('runtime-trust', () => {
     workingMode?: 'managed' | 'external'
     trustLevel?: 'trusted' | 'restricted'
     linkedFolders?: string[]
+    readonlyRoots?: string[]
   }): void {
     __setTrustForTests({
       workingMode: opts.workingMode ?? 'external',
       trustLevel: opts.trustLevel ?? 'restricted',
       workspaceDir,
       linkedFolders: opts.linkedFolders ?? [],
+      readonlyRoots: opts.readonlyRoots ?? [],
       initialized: true,
     })
   }
@@ -205,6 +208,49 @@ describe('runtime-trust', () => {
     setTrust({ trustLevel: 'trusted', linkedFolders: [linkedDir] })
     const r = assertAllowedPath(join(linkedDir, 'inside.txt'), 'read')
     expect(r.ok).toBe(true)
+  })
+
+  describe('read-only roots (attachMode=readonly)', () => {
+    test('read inside a read-only root: ALLOWED', () => {
+      setTrust({ trustLevel: 'trusted', linkedFolders: [linkedDir], readonlyRoots: [linkedDir] })
+      const r = assertAllowedPath(join(linkedDir, 'inside.txt'), 'read')
+      expect(r.ok).toBe(true)
+    })
+
+    test('write inside a read-only root: BLOCKED even when trusted', () => {
+      setTrust({ trustLevel: 'trusted', linkedFolders: [linkedDir], readonlyRoots: [linkedDir] })
+      const r = assertAllowedPath(join(linkedDir, 'inside.txt'), 'write')
+      expect(r.ok).toBe(false)
+      expect(r.reason).toBe('readonly_root_write')
+    })
+
+    test('exec inside a read-only root: BLOCKED even when trusted', () => {
+      setTrust({ trustLevel: 'trusted', linkedFolders: [linkedDir], readonlyRoots: [linkedDir] })
+      const r = assertAllowedPath(join(linkedDir, 'inside.txt'), 'exec')
+      expect(r.ok).toBe(false)
+      expect(r.reason).toBe('readonly_root_exec')
+    })
+
+    test('new file under a read-only root: write BLOCKED (ancestor resolves under root)', () => {
+      setTrust({ trustLevel: 'trusted', linkedFolders: [linkedDir], readonlyRoots: [linkedDir] })
+      const r = assertAllowedPath(join(linkedDir, 'newdir', 'newfile.txt'), 'write')
+      expect(r.ok).toBe(false)
+      expect(r.reason).toBe('readonly_root_write')
+    })
+
+    test('write in workspaceDir is unaffected when only a sibling root is read-only', () => {
+      setTrust({ trustLevel: 'trusted', linkedFolders: [linkedDir], readonlyRoots: [linkedDir] })
+      const r = assertAllowedPath(join(workspaceDir, 'inside.txt'), 'write')
+      expect(r.ok).toBe(true)
+    })
+
+    test('env fallback: READONLY_ROOTS JSON parsed', () => {
+      process.env.WORKSPACE_DIR = workspaceDir
+      process.env.WORKING_MODE = 'managed'
+      process.env.READONLY_ROOTS = JSON.stringify([linkedDir])
+      const t = getRuntimeTrust()
+      expect(t.readonlyRoots).toEqual([linkedDir])
+    })
   })
 
   test('symlink escape: symlink inside workspace pointing to outsideDir is REJECTED', () => {

--- a/packages/agent-runtime/src/runtime-trust.ts
+++ b/packages/agent-runtime/src/runtime-trust.ts
@@ -49,6 +49,11 @@ export interface RuntimeTrust {
   workspaceDir: string
   /** Additional host folders linked to the project (external mode). */
   linkedFolders: string[]
+  /**
+   * Subset of allowed roots mounted read-only (e.g. an attached project
+   * with `attachMode='readonly'`). Reads pass; writes/exec are denied.
+   */
+  readonlyRoots: string[]
 }
 
 /**
@@ -94,19 +99,21 @@ export function getRuntimeTrust(): RuntimeTrust {
         : workingMode === 'external'
           ? 'restricted'
           : 'trusted'
-  let linkedFolders: string[] = []
-  try {
-    const raw = process.env.LINKED_FOLDERS
-    if (raw) {
+  const parseFolderEnv = (raw: string | undefined): string[] => {
+    if (!raw) return []
+    try {
       const parsed = JSON.parse(raw)
       if (Array.isArray(parsed)) {
-        linkedFolders = parsed.filter((p): p is string => typeof p === 'string' && p.length > 0)
+        return parsed.filter((p): p is string => typeof p === 'string' && p.length > 0)
       }
+    } catch {
+      // ignore, default to empty
     }
-  } catch {
-    // ignore, default to empty
+    return []
   }
-  return { workingMode, trustLevel, workspaceDir, linkedFolders }
+  const linkedFolders = parseFolderEnv(process.env.LINKED_FOLDERS)
+  const readonlyRoots = parseFolderEnv(process.env.READONLY_ROOTS)
+  return { workingMode, trustLevel, workspaceDir, linkedFolders, readonlyRoots }
 }
 
 /** Allowed roots = [workspaceDir, ...linkedFolders], deduplicated. */
@@ -125,6 +132,8 @@ export interface PathCheckResult {
     | 'outside_allowed_roots'
     | 'restricted_mode_write'
     | 'restricted_mode_exec'
+    | 'readonly_root_write'
+    | 'readonly_root_exec'
     | 'invalid_path'
   /**
    * Human-readable error suitable for surfacing to the agent (so it
@@ -241,6 +250,37 @@ export function assertAllowedPath(targetPath: string, mode: PathMode): PathCheck
         message:
           `Workspace is in restricted mode — shell / exec tools are disabled. ` +
           `Click "Trust folder" in the project header to enable edits and shell commands.`,
+      }
+    }
+  }
+
+  // Read-only attachment enforcement. The root is allowed for reads (it
+  // passed the `inAllowedRoot` check above), but writes / exec under a
+  // read-only root are denied even when the runtime is otherwise trusted.
+  if ((mode === 'write' || mode === 'exec') && (trust.readonlyRoots?.length ?? 0) > 0) {
+    const readonlyRoots = trust.readonlyRoots
+      .filter((p) => typeof p === 'string' && p.length > 0)
+      .map((p) => {
+        const resolved = resolve(p)
+        try {
+          return realpathSync(resolved)
+        } catch {
+          return resolved
+        }
+      })
+    const underReadonly = readonlyRoots.some((root) => {
+      const normalized = root.endsWith(sep) ? root : root + sep
+      return real === root || real.startsWith(normalized)
+    })
+    if (underReadonly) {
+      return {
+        ok: false,
+        reason: mode === 'write' ? 'readonly_root_write' : 'readonly_root_exec',
+        resolved: real,
+        message:
+          `This folder is attached read-only — ${mode === 'write' ? 'edits' : 'shell / exec commands'} are disabled here.\n` +
+          `Path: ${real}\n` +
+          `Re-attach the project as read-write in the "Folders" panel to allow changes.`,
       }
     }
   }

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -136,18 +136,27 @@ const WORKSPACE_RUNTIME_PROJECT_IDS = workspaceAttachedProjectIds()
  * in addition to `WORKSPACE_DIR`. Parsed once at boot — folder set is
  * immutable for a runtime instance (changing it requires a restart).
  */
-const LINKED_FOLDERS: string[] = (() => {
-  const raw = process.env.LINKED_FOLDERS
+const parseFolderListEnv = (name: string): string[] => {
+  const raw = process.env[name]
   if (!raw) return []
   try {
     const parsed = JSON.parse(raw)
     if (!Array.isArray(parsed)) return []
     return parsed.filter((p): p is string => typeof p === 'string' && p.length > 0)
   } catch (err) {
-    console.warn(`[agent-runtime] Could not parse LINKED_FOLDERS env: ${err}`)
+    console.warn(`[agent-runtime] Could not parse ${name} env: ${err}`)
     return []
   }
-})()
+}
+const LINKED_FOLDERS: string[] = parseFolderListEnv('LINKED_FOLDERS')
+
+/**
+ * Subset of the allowed roots mounted READ-ONLY (attachments added with
+ * `attachMode='readonly'`). Reads pass; writes/exec are denied under these
+ * roots even when the runtime is trusted. Parsed once at boot — the set is
+ * immutable for a runtime instance (changing it requires a restart).
+ */
+const READONLY_ROOTS: string[] = parseFolderListEnv('READONLY_ROOTS')
 
 // Seed the live trust resolver with the immutable directory layout
 // (workspaceDir, workingMode, linkedFolders). The initial trustLevel
@@ -163,6 +172,7 @@ initTrustResolver({
   workspaceDir: WORKSPACE_DIR,
   workingMode: WORKING_MODE,
   linkedFolders: LINKED_FOLDERS,
+  readonlyRoots: READONLY_ROOTS,
   isWorkspaceRuntime: IS_WORKSPACE_RUNTIME,
 })
 refreshTrust().catch(() => {

--- a/packages/agent-runtime/src/trust-resolver.ts
+++ b/packages/agent-runtime/src/trust-resolver.ts
@@ -56,6 +56,13 @@ export interface ResolvedTrust {
   workingMode: WorkingMode
   workspaceDir: string
   linkedFolders: string[]
+  /**
+   * Subset of allowed roots that are mounted READ-ONLY (e.g. a project
+   * attached with `attachMode='readonly'`). Reads are permitted; writes
+   * and exec under these roots are denied even though the root is allowed
+   * for reads. Enforced in `assertAllowedPath` (runtime-trust.ts).
+   */
+  readonlyRoots: string[]
 }
 
 interface ResolverState extends ResolvedTrust {
@@ -92,6 +99,7 @@ const state: ResolverState = {
   workingMode: 'external',
   workspaceDir: '',
   linkedFolders: [],
+  readonlyRoots: [],
   initialized: false,
   projectId: null,
   isWorkspaceRuntime: false,
@@ -104,6 +112,8 @@ export interface InitArgs {
   workspaceDir: string
   workingMode: WorkingMode
   linkedFolders: string[]
+  /** Read-only subset of the allowed roots (write/exec denied). */
+  readonlyRoots?: string[]
   /** Workspace (merged-root) runtime — statically trusted, no API trust read. */
   isWorkspaceRuntime?: boolean
 }
@@ -121,6 +131,7 @@ export function initTrustResolver(args: InitArgs): void {
   state.workspaceDir = args.workspaceDir
   state.workingMode = args.workingMode
   state.linkedFolders = args.linkedFolders.slice()
+  state.readonlyRoots = (args.readonlyRoots ?? []).slice()
   state.isWorkspaceRuntime = args.isWorkspaceRuntime ?? false
   // Workspace runtimes are always trusted (sandboxed, multi-project);
   // there is no per-project trust to reconcile, so mark initialized.
@@ -137,6 +148,7 @@ export function getResolvedTrust(): ResolvedTrust {
     workingMode: state.workingMode,
     workspaceDir: state.workspaceDir,
     linkedFolders: state.linkedFolders.slice(),
+    readonlyRoots: state.readonlyRoots.slice(),
   }
 }
 
@@ -264,6 +276,7 @@ export function __setTrustForTests(partial: Partial<ResolvedTrust> & { initializ
   if (partial.workingMode) state.workingMode = partial.workingMode
   if (typeof partial.workspaceDir === 'string') state.workspaceDir = partial.workspaceDir
   if (Array.isArray(partial.linkedFolders)) state.linkedFolders = partial.linkedFolders.slice()
+  if (Array.isArray(partial.readonlyRoots)) state.readonlyRoots = partial.readonlyRoots.slice()
   if (typeof partial.initialized === 'boolean') state.initialized = partial.initialized
 }
 
@@ -273,6 +286,7 @@ export function __resetTrustForTests(): void {
   state.workingMode = 'external'
   state.workspaceDir = ''
   state.linkedFolders = []
+  state.readonlyRoots = []
   state.initialized = false
   state.projectId = null
   state.isWorkspaceRuntime = false

--- a/packages/agent-runtime/src/workspace-runtime-mode.ts
+++ b/packages/agent-runtime/src/workspace-runtime-mode.ts
@@ -4,9 +4,11 @@
  * Workspace-runtime boot mode helpers.
  *
  * A WORKSPACE runtime serves a merged tree of several attached projects:
- * `WORKSPACE_DIR` points at the parent `workspaces/` directory and each
- * attached project is a top-level subfolder. This differs from the
- * single-project `managed` boot in two ways the boot path must respect:
+ * `WORKSPACE_DIR` points at a per-workspace merged root that contains only
+ * this workspace's attached projects as top-level subfolders (on host they
+ * are symlinks into the shared `workspaces/` pool; in cloud they are real
+ * subfolders on the pod volume). This differs from the single-project
+ * `managed` boot in two ways the boot path must respect:
  *
  *   1. Template / tech-stack seeding must be skipped — the parent dir
  *      already contains real project subfolders; dumping a Vite + React

--- a/packages/domain-stores/src/domain-actions.ts
+++ b/packages/domain-stores/src/domain-actions.ts
@@ -324,7 +324,7 @@ export function createDomainActions(store: IDomainStore) {
      */
     createChatSession: async (data: {
       inferredName: string
-      contextType: "feature" | "project" | "general"
+      contextType: "feature" | "project" | "general" | "workspace"
       contextId?: string
       name?: string
       phase?: string

--- a/packages/domain-stores/src/project.collection.ts
+++ b/packages/domain-stores/src/project.collection.ts
@@ -392,7 +392,7 @@ export const ProjectCollection = types
 // ============================================================================
 
 // Relation fields that expect IDs (safeReference)
-const relationFields = ["workspace","folder","members","inviteLinks","featureSessions","chatSessions","usageEvents","checkpoints","githubConnection","starredBy","agentConfig","meetings","marketplaceListing","agentCostMetrics","modelExperiments","subagentModelOverrides","agentEvalSets","voiceConfig","agents","projectFolders","preferredInstance","authConfig","authSignIns","attachedSessions"]
+const relationFields = ["workspace","folder","members","inviteLinks","featureSessions","chatSessions","usageEvents","checkpoints","githubConnection","starredBy","agentConfig","meetings","marketplaceListing","agentCostMetrics","modelExperiments","subagentModelOverrides","agentEvalSets","voiceConfig","agents","projectFolders","preferredInstance","authConfig","authSignIns","attachedSessions","attachments","attachedTo"]
 
 /**
  * Transform API response for MST compatibility:

--- a/packages/shared-app/src/chat/useChatTransport.ts
+++ b/packages/shared-app/src/chat/useChatTransport.ts
@@ -15,6 +15,14 @@ export interface ChatTransportOptions {
   apiBaseUrl?: string
   /** Project ID for routing to the correct chat endpoint */
   projectId: string | undefined
+  /**
+   * Workspace ID for routing to the workspace-scoped chat endpoint
+   * (`/api/workspaces/:workspaceId/chat`). When set it takes precedence
+   * over `projectId` so a workspace session chats against the merged-root
+   * runtime instead of a single project pod. `localAgentUrl` still wins
+   * (direct-to-runtime local dev).
+   */
+  workspaceId?: string | undefined
   /** Direct agent URL for local development (bypasses API proxy) */
   localAgentUrl?: string | null
   /** Fetch credentials mode */
@@ -63,8 +71,10 @@ export function buildChatApiUrl(
   apiBaseUrl: string,
   projectId: string | undefined,
   localAgentUrl?: string | null,
+  workspaceId?: string | undefined,
 ): string {
   if (localAgentUrl) return `${localAgentUrl}/agent/chat`
+  if (workspaceId) return `${apiBaseUrl}/api/workspaces/${workspaceId}/chat`
   if (projectId) return `${apiBaseUrl}/api/projects/${projectId}/chat`
   return `${apiBaseUrl}/api/chat`
 }
@@ -88,8 +98,9 @@ export function buildChatTurnUrl(
   projectId: string | undefined,
   localAgentUrl: string | null | undefined,
   chatSessionId: string,
+  workspaceId?: string | undefined,
 ): string {
-  const base = buildChatApiUrl(apiBaseUrl, projectId, localAgentUrl).replace(/\/+$/, '')
+  const base = buildChatApiUrl(apiBaseUrl, projectId, localAgentUrl, workspaceId).replace(/\/+$/, '')
   return `${base}/${encodeURIComponent(chatSessionId)}/turn`
 }
 
@@ -99,6 +110,7 @@ export function buildChatTurnUrl(
 export function useChatTransportConfig({
   apiBaseUrl = '',
   projectId,
+  workspaceId,
   localAgentUrl,
   credentials,
   fetch: customFetch,
@@ -108,7 +120,7 @@ export function useChatTransportConfig({
   onChunk,
 }: ChatTransportOptions): ChatTransportConfig | undefined {
   return useMemo(() => {
-    if (!projectId && !localAgentUrl) return undefined
+    if (!projectId && !workspaceId && !localAgentUrl) return undefined
 
     const baseFetch = customFetch ?? globalThis.fetch
     const fetch = durableResume
@@ -127,10 +139,10 @@ export function useChatTransportConfig({
         : headers
 
     return {
-      api: buildChatApiUrl(apiBaseUrl, projectId, localAgentUrl),
+      api: buildChatApiUrl(apiBaseUrl, projectId, localAgentUrl, workspaceId),
       credentials,
       fetch,
       headers: composedHeaders,
     }
-  }, [apiBaseUrl, projectId, localAgentUrl, credentials, customFetch, headers, chatSessionId, durableResume, onChunk])
+  }, [apiBaseUrl, projectId, workspaceId, localAgentUrl, credentials, customFetch, headers, chatSessionId, durableResume, onChunk])
 }

--- a/packages/shogo-worker/src/lib/runtime-manager.ts
+++ b/packages/shogo-worker/src/lib/runtime-manager.ts
@@ -51,6 +51,16 @@ const API_PORT_OFFSET = 1; // API server port = agentPort + 1.
 /** Default idle eviction window — unused runtimes get killed after this. */
 const RUNTIME_IDLE_MS = 15 * 60 * 1000;
 
+/**
+ * A runtime touched within this window is treated as "actively in use"
+ * (likely mid-stream — the agent-proxy/ai-proxy refresh `lastUsedAt` on
+ * every forwarded chunk) and is never picked as an LRU eviction victim
+ * by {@link WorkerRuntimeManager.enforceMaxRuntimes}, even when the cap
+ * is exceeded. Better to briefly run one over the cap than to SIGKILL a
+ * live chat stream out from under the user.
+ */
+const STREAM_ACTIVE_WINDOW_MS = 30 * 1000;
+
 /** Restart backoff bounds. */
 const RESTART_BACKOFF_BASE_MS = 1_000;
 const RESTART_BACKOFF_MAX_MS = 60_000;
@@ -222,6 +232,16 @@ export interface WorkerRuntimeManagerOptions {
    * Cloud workers leave this unset so the default still fires.
    */
   idleMs?: number;
+  /**
+   * Hard ceiling on the number of concurrently-running runtimes. Once
+   * exceeded, `ensureRunning` LRU-evicts the least-recently-used slot
+   * that has not been touched within {@link STREAM_ACTIVE_WINDOW_MS}
+   * (i.e. is not mid-stream). Pass `0`, a negative number, or a
+   * non-finite value to disable the cap (the historical behaviour —
+   * runtimes were then bounded only by idle eviction). Defaults to
+   * disabled when unset.
+   */
+  maxRuntimes?: number;
   /** Optional logger. Defaults to console. */
   logger?: Pick<Console, 'log' | 'warn' | 'error'>;
   /** Working directory for spawned runtimes. Defaults to OS tmpdir/shogo-runtime. */
@@ -629,9 +649,68 @@ export class WorkerRuntimeManager implements RuntimeResolver {
     slot.startPromise = this.doStart(slot);
     try {
       const r = await slot.startPromise;
+      // We just brought a (possibly new) runtime up — enforce the hard
+      // ceiling now so a busy multi-project session can't accumulate
+      // runtimes without bound. Never evicts the one we just started.
+      this.enforceMaxRuntimes(projectId);
       return this.snapshot(r);
     } finally {
       slot.startPromise = null;
+    }
+  }
+
+  /**
+   * Enforce {@link WorkerRuntimeManagerOptions.maxRuntimes} by LRU-evicting
+   * the least-recently-used running slot until the count is at/under the
+   * cap. Skips:
+   *   - the slot we just started (`keepProjectId`),
+   *   - any slot touched within {@link STREAM_ACTIVE_WINDOW_MS} (treated as
+   *     mid-stream — we never cut a live chat),
+   *   - non-running slots (starting/restarting/stopping/failed don't count
+   *     against the cap and aren't safe to tear down here).
+   *
+   * If every over-cap slot is actively streaming we stop early and let the
+   * count ride briefly over the cap rather than killing a live stream — the
+   * next ensureRunning (or idle eviction) reclaims it once it goes quiet.
+   *
+   * Fire-and-forget: eviction `stop()` is async (process-group kill +
+   * grace window) but we don't await it — the caller shouldn't block its
+   * own spawn on tearing down someone else's idle runtime.
+   */
+  private enforceMaxRuntimes(keepProjectId: string): void {
+    const cap = this.opts.maxRuntimes;
+    if (cap == null || !Number.isFinite(cap) || cap <= 0) return;
+
+    const now = Date.now();
+    const running = Array.from(this.runtimes.values()).filter((r) => r.status === 'running');
+    if (running.length <= cap) return;
+
+    // LRU order: oldest lastUsedAt first.
+    const candidates = running
+      .filter((r) => r.projectId !== keepProjectId && now - r.lastUsedAt >= STREAM_ACTIVE_WINDOW_MS)
+      .sort((a, b) => a.lastUsedAt - b.lastUsedAt);
+
+    let overBy = running.length - cap;
+    for (const victim of candidates) {
+      if (overBy <= 0) break;
+      const idleMs = now - victim.lastUsedAt;
+      this.log.log(
+        `[WorkerRuntimeManager] maxRuntimes=${cap} exceeded (${running.length} running) — ` +
+          `LRU-evicting ${victim.projectId} (idle ${Math.round(idleMs / 1000)}s)`,
+      );
+      void this.stop(victim.projectId).catch((err: any) => {
+        this.log.warn(
+          `[WorkerRuntimeManager] maxRuntimes eviction of ${victim.projectId} failed: ${err?.message ?? err}`,
+        );
+      });
+      overBy--;
+    }
+
+    if (overBy > 0) {
+      this.log.log(
+        `[WorkerRuntimeManager] maxRuntimes=${cap} still exceeded by ${overBy} after eviction pass — ` +
+          `remaining over-cap slots are mid-stream; will retry on next spawn / idle reap`,
+      );
     }
   }
 

--- a/prisma/migrations/20260602225000_add_project_attachments/migration.sql
+++ b/prisma/migrations/20260602225000_add_project_attachments/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "project_attachments" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "attachedProjectId" TEXT NOT NULL,
+    "attachMode" TEXT NOT NULL DEFAULT 'readwrite',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "project_attachments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "project_attachments_projectId_idx" ON "project_attachments"("projectId");
+
+-- CreateIndex
+CREATE INDEX "project_attachments_attachedProjectId_idx" ON "project_attachments"("attachedProjectId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "project_attachments_projectId_attachedProjectId_key" ON "project_attachments"("projectId", "attachedProjectId");
+
+-- AddForeignKey
+ALTER TABLE "project_attachments" ADD CONSTRAINT "project_attachments_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "project_attachments" ADD CONSTRAINT "project_attachments_attachedProjectId_fkey" FOREIGN KEY ("attachedProjectId") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.local.prisma
+++ b/prisma/schema.local.prisma
@@ -216,11 +216,31 @@ model Project {
   authConfig             ProjectAuthConfig?
   authSignIns            ProjectAuthSignIn[]
   attachedSessions       ChatSessionProject[]
+  attachments            ProjectAttachment[]     @relation("ProjectAttachmentAnchor")
+  attachedTo             ProjectAttachment[]     @relation("ProjectAttachmentTarget")
 
   @@index([workspaceId])
   @@index([folderId])
   @@index([preferredInstanceId])
   @@map("projects")
+}
+
+/// Persistent project-to-project attachment. See prisma/schema.prisma for
+/// the canonical comment.
+model ProjectAttachment {
+  id                String   @id @default(uuid())
+  projectId         String
+  attachedProjectId String
+  attachMode        String   @default("readwrite")
+  createdAt         DateTime @default(now())
+
+  project  Project @relation("ProjectAttachmentAnchor", fields: [projectId], references: [id], onDelete: Cascade)
+  attached Project @relation("ProjectAttachmentTarget", fields: [attachedProjectId], references: [id], onDelete: Cascade)
+
+  @@unique([projectId, attachedProjectId])
+  @@index([projectId])
+  @@index([attachedProjectId])
+  @@map("project_attachments")
 }
 
 /// External host folder linked to a project (workingMode='external').

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -262,11 +262,35 @@ model Project {
   authConfig             ProjectAuthConfig?
   authSignIns            ProjectAuthSignIn[]
   attachedSessions       ChatSessionProject[]
+  attachments            ProjectAttachment[]     @relation("ProjectAttachmentAnchor")
+  attachedTo             ProjectAttachment[]     @relation("ProjectAttachmentTarget")
 
   @@index([workspaceId])
   @@index([folderId])
   @@index([preferredInstanceId])
   @@map("projects")
+}
+
+/// Persistent project-to-project attachment. The ANCHOR project (`projectId`)
+/// runs an anchor-keyed merged-root workspace runtime that mounts each
+/// attached project (`attachedProjectId`) as an additional member root, so
+/// the agent can read/edit across them. `attachMode` controls whether the
+/// attached project is read-only or read-write (enforced via READONLY_ROOTS
+/// in the runtime; see packages/agent-runtime/src/runtime-trust.ts).
+model ProjectAttachment {
+  id                String   @id @default(uuid())
+  projectId         String
+  attachedProjectId String
+  attachMode        String   @default("readwrite")
+  createdAt         DateTime @default(now())
+
+  project  Project @relation("ProjectAttachmentAnchor", fields: [projectId], references: [id], onDelete: Cascade)
+  attached Project @relation("ProjectAttachmentTarget", fields: [attachedProjectId], references: [id], onDelete: Cascade)
+
+  @@unique([projectId, attachedProjectId])
+  @@index([projectId])
+  @@index([attachedProjectId])
+  @@map("project_attachments")
 }
 
 /// External host folder linked to a project (workingMode='external').

--- a/scripts/check-multiregion-cron-locks.ts
+++ b/scripts/check-multiregion-cron-locks.ts
@@ -391,6 +391,12 @@ const ACCEPTED_UNIQUE_KEYS: UniqueKeyRule[] = [
       'Written when a user attaches a project to a workspace-scoped chat session (generated chat-session-project route). One user request per attach; the unique pair just dedupes a double-attach of the same project to the same session.',
   },
   {
+    key: 'ProjectAttachment.(attachedProjectId,projectId)',
+    category: 'single_tenant_upsert',
+    reason:
+      'project-attachment.service.ts:attachProjectToProject upserts on the (projectId,attachedProjectId) composite from a single Folders-panel attach request (one project owner per region); detach is deleteMany on the same pair.',
+  },
+  {
     key: 'VoiceCallMeter.conversationId',
     category: 'request_scoped',
     reason:


### PR DESCRIPTION
## Summary
- Adds a **Download** action to the cloud IDE file explorer's right-click menu so users can save a file from the runtime to their machine.
- Single-file entry on the per-item menu (files only; folders excluded) plus a **Download N files** entry on the multi-select menu.
- Downloads reuse the workspace service's existing authed blob fetch (`svc.readFileUrl` → `/agent/workspace/download/*`) into a `blob:` URL, then trigger an anchor `download` click and revoke the URL. Using a blob URL (rather than linking the agent endpoint directly) keeps the `download` attribute honored and prevents the IDE from navigating away for types the runtime serves with `Content-Disposition: inline` (images/PDF). Web-only, with graceful toasts when the workspace can't resolve a URL.

## Changes
- `apps/mobile/components/project/panels/ide/FileTree.tsx`: import `Download` icon, add required `onDownload` to `FileTreeHandlers`, add menu entries (single + multi-select).
- `apps/mobile/components/project/panels/ide/Workbench.tsx`: implement `handleDownload` (service lookup, blob fetch, anchor click, deferred revoke, error toasts) and wire it into `treeHandlers`.
- `.../__tests__/FileTree.compactFolders.rtl.test.tsx`: add `onDownload` to the test handlers factory (field is now required).

## Test plan
- [x] `bun test` for `FileTree.compactFolders.rtl.test.tsx` passes (6/6).
- [x] Language-server lint/types clean on edited files.
- [ ] Manual: right-click a text file and a binary file (e.g. an image) in the cloud IDE Explorer → each downloads with the correct filename; the IDE does not navigate away.
- [ ] Manual: multi-select several files → **Download N files** downloads each.
- [ ] Manual: confirm **Download** does not appear for folders.

Made with [Cursor](https://cursor.com)