### PR TITLE
fix(preview): don't re-run prisma generate on warm restart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,24 @@ AWS_SECRET_ACCESS_KEY=minioadmin
 SCHEMA_STORAGE=s3
 
 # -----------------------------------------------------------------------------
+# Git LFS (large-file versioning, git_only mode) — see apps/api/src/routes/git-lfs.ts
+# -----------------------------------------------------------------------------
+# Master switch. When true, git_only pods track large files with Git LFS
+# (pointers in git + bytes offloaded to OCI via the batch endpoint) instead of
+# the legacy size-based assets/ offload.
+LFS_ENABLED=false
+# Optional dedicated bucket for LFS objects. Defaults to S3_WORKSPACES_BUCKET,
+# where objects live under <projectId>/lfs/objects/<oid>.
+# S3_LFS_BUCKET=shogo-lfs
+# Key prefix within the project namespace (default: lfs/objects).
+# S3_LFS_PREFIX=lfs/objects
+# Endpoint pods use to PUT/GET LFS object bytes; must be pod-reachable AND match
+# the presign signature. Defaults to S3_ENDPOINT (NOT the browser endpoint).
+# S3_LFS_ENDPOINT=http://localhost:9000
+# Presigned-URL TTL for LFS transfers, in seconds (default: 3600).
+# LFS_PRESIGN_EXPIRY=3600
+
+# -----------------------------------------------------------------------------
 # AI providers
 # -----------------------------------------------------------------------------
 ANTHROPIC_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -70,10 +70,10 @@ SCHEMA_STORAGE=s3
 # -----------------------------------------------------------------------------
 # Git LFS (large-file versioning, git_only mode) — see apps/api/src/routes/git-lfs.ts
 # -----------------------------------------------------------------------------
-# Master switch. When true, git_only pods track large files with Git LFS
-# (pointers in git + bytes offloaded to OCI via the batch endpoint) instead of
-# the legacy size-based assets/ offload.
-LFS_ENABLED=false
+# Git LFS is always on for git_only pods (the default sync mode): large files
+# are tracked as pointers in git with the bytes offloaded to OCI via the batch
+# endpoint, replacing the legacy size-based assets/ offload. No enable flag —
+# the settings below are optional overrides (defaults shown).
 # Optional dedicated bucket for LFS objects. Defaults to S3_WORKSPACES_BUCKET,
 # where objects live under <projectId>/lfs/objects/<oid>.
 # S3_LFS_BUCKET=shogo-lfs

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -36,10 +36,14 @@ WORKDIR /app
 #   bash  -> shell scripts
 #   netcat-openbsd -> entrypoint.sh nc port-wait
 #   ca-certificates -> outbound HTTPS
+#   git   -> routes/git-http.ts spawns `git http-backend` for smart-HTTP
+#            clone/fetch/push and `git.service` runs git for status/graph.
+#            (NOT git-lfs: the LFS batch endpoint only mints presigned URLs,
+#            so the API never shells out to git-lfs — see routes/git-lfs.ts.)
 # Plus Bun (entry point uses `bun run`).
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        curl bash unzip ca-certificates netcat-openbsd && \
+        curl bash git unzip ca-certificates netcat-openbsd && \
     curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash -s "bun-v1.3.9" && \
     rm -rf /root/.bun /var/lib/apt/lists/*
 

--- a/apps/api/src/__tests__/build-project-env.test.ts
+++ b/apps/api/src/__tests__/build-project-env.test.ts
@@ -69,7 +69,6 @@ const ENV_KEYS = [
   'S3_REGION',
   'S3_ENDPOINT',
   'S3_FORCE_PATH_STYLE',
-  'LFS_ENABLED',
   'SHOGO_VOICE_MODE',
   'SHOGO_DEMO_VOICE',
   'SHOGO_MOCK_CAPTURE_DIR',
@@ -407,27 +406,6 @@ describe('buildProjectEnv — S3 config', () => {
     process.env.S3_FORCE_PATH_STYLE = '1' // non-"true" string → omitted
     env = await buildProjectEnv('proj-s3-fps-2')
     expect(env.S3_FORCE_PATH_STYLE).toBeUndefined()
-  })
-})
-
-// ─── Git LFS ───────────────────────────────────────────────────────────────
-
-describe('buildProjectEnv — Git LFS', () => {
-  test('omits LFS_ENABLED by default', async () => {
-    const env = await buildProjectEnv('proj-no-lfs')
-    expect(env.LFS_ENABLED).toBeUndefined()
-  })
-
-  test('forwards LFS_ENABLED to the pod when enabled on the API', async () => {
-    process.env.LFS_ENABLED = 'true'
-    const env = await buildProjectEnv('proj-lfs')
-    expect(env.LFS_ENABLED).toBe('true')
-  })
-
-  test('does not forward a non-truthy LFS_ENABLED', async () => {
-    process.env.LFS_ENABLED = 'false'
-    const env = await buildProjectEnv('proj-lfs-off')
-    expect(env.LFS_ENABLED).toBeUndefined()
   })
 })
 

--- a/apps/api/src/__tests__/build-project-env.test.ts
+++ b/apps/api/src/__tests__/build-project-env.test.ts
@@ -69,6 +69,7 @@ const ENV_KEYS = [
   'S3_REGION',
   'S3_ENDPOINT',
   'S3_FORCE_PATH_STYLE',
+  'LFS_ENABLED',
   'SHOGO_VOICE_MODE',
   'SHOGO_DEMO_VOICE',
   'SHOGO_MOCK_CAPTURE_DIR',
@@ -406,6 +407,27 @@ describe('buildProjectEnv — S3 config', () => {
     process.env.S3_FORCE_PATH_STYLE = '1' // non-"true" string → omitted
     env = await buildProjectEnv('proj-s3-fps-2')
     expect(env.S3_FORCE_PATH_STYLE).toBeUndefined()
+  })
+})
+
+// ─── Git LFS ───────────────────────────────────────────────────────────────
+
+describe('buildProjectEnv — Git LFS', () => {
+  test('omits LFS_ENABLED by default', async () => {
+    const env = await buildProjectEnv('proj-no-lfs')
+    expect(env.LFS_ENABLED).toBeUndefined()
+  })
+
+  test('forwards LFS_ENABLED to the pod when enabled on the API', async () => {
+    process.env.LFS_ENABLED = 'true'
+    const env = await buildProjectEnv('proj-lfs')
+    expect(env.LFS_ENABLED).toBe('true')
+  })
+
+  test('does not forward a non-truthy LFS_ENABLED', async () => {
+    process.env.LFS_ENABLED = 'false'
+    const env = await buildProjectEnv('proj-lfs-off')
+    expect(env.LFS_ENABLED).toBeUndefined()
   })
 })
 

--- a/apps/api/src/__tests__/chat-inference-retry-reset.test.ts
+++ b/apps/api/src/__tests__/chat-inference-retry-reset.test.ts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Accumulator-reset tests for `trackUsageFromStream` in `project-chat.ts`.
+ *
+ * When the runtime re-issues a model call that dropped mid-generation it emits
+ * a `data-inference-retry` frame. The API-side parser must discard the failed
+ * step's partial text/reasoning (and any partially-streamed tool input that
+ * never executed) so the persisted `ChatMessage` reflects ONLY the final,
+ * retried output — never a concatenation of the thrown-away partial with the
+ * regenerated text. Completed tool calls from earlier steps must be preserved.
+ *
+ * Run: bun test apps/api/src/__tests__/chat-inference-retry-reset.test.ts
+ */
+
+import { describe, test, expect, beforeEach, mock } from 'bun:test'
+
+// ─── Prisma mock ──────────────────────────────────────────────────────────
+type PersistedMessage = {
+  id: string
+  sessionId: string
+  role: string
+  content: string
+  parts?: string
+  agent?: string
+}
+
+let persistedMessages: PersistedMessage[] = []
+let persistedToolCalls: any[] = []
+let messageIdCounter = 0
+
+const mockPrisma = {
+  chatSession: {
+    findUnique: mock(async (args: any) => (args?.where?.id ? { id: args.where.id } : null)),
+  },
+  chatMessage: {
+    create: mock(async (args: any) => {
+      const msg: PersistedMessage = { id: `msg-${++messageIdCounter}`, ...args.data }
+      persistedMessages.push(msg)
+      return msg
+    }),
+  },
+  toolCallLog: {
+    createMany: mock(async (args: any) => {
+      persistedToolCalls.push(...args.data)
+      return { count: args.data.length }
+    }),
+  },
+  project: {
+    update: mock(async (args: any) => ({ id: args.where.id, ...args.data })),
+  },
+}
+mock.module('../lib/prisma', () => ({ prisma: mockPrisma }))
+
+mock.module('../services/billing.service', () => ({
+  consumeUsage: async () => ({ success: true, remainingIncludedUsd: 99 }),
+}))
+mock.module('../services/git.service', () => ({ isGitAvailable: () => false }))
+
+import { openSession, accumulateUsage } from '../lib/proxy-billing-session'
+import { trackUsageFromStream } from '../routes/project-chat'
+
+function makeSseStream(frames: string[]): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const f of frames) controller.enqueue(enc.encode(f))
+      controller.close()
+    },
+  })
+}
+
+function dataFrame(payload: Record<string, unknown>): string {
+  return `data: ${JSON.stringify(payload)}\n\n`
+}
+
+describe('trackUsageFromStream — inference-retry accumulator reset', () => {
+  beforeEach(() => {
+    persistedMessages = []
+    persistedToolCalls = []
+    messageIdCounter = 0
+  })
+
+  test('discards the failed step partial text on data-inference-retry', async () => {
+    const projectId = 'proj-retry-text'
+    const chatSessionId = 'sess-retry-text'
+    openSession(projectId, 'ws', 'user')
+    accumulateUsage(projectId, 'claude-sonnet-4-5', 100, 30)
+
+    const stream = makeSseStream([
+      // Failed step: partial text streamed, then the model call drops and is retried.
+      dataFrame({ type: 'text-delta', delta: 'partial that was ' }),
+      dataFrame({ type: 'text-delta', delta: 'thrown away' }),
+      dataFrame({ type: 'data-inference-retry', data: { attempt: 1, maxAttempts: 2, reason: 'network' } }),
+      // Retried step: the real, final answer.
+      dataFrame({ type: 'text-delta', delta: 'final ' }),
+      dataFrame({ type: 'text-delta', delta: 'answer' }),
+      dataFrame({ type: 'data-turn-complete', data: { status: 'completed', lastSeq: 9 } }),
+      dataFrame({ type: 'finish', usage: { inputTokens: 100, outputTokens: 30 } }),
+    ])
+
+    await trackUsageFromStream(
+      stream,
+      { chatSessionId, agentMode: 'sonnet' },
+      { id: projectId, workspaceId: 'ws' },
+      { resume: async () => null },
+    )
+
+    expect(persistedMessages).toHaveLength(1)
+    // Only the post-retry output — no concatenation of the discarded partial.
+    expect(persistedMessages[0].content).toBe('final answer')
+    expect(persistedMessages[0].content).not.toContain('thrown away')
+    const parts = JSON.parse(persistedMessages[0].parts || '[]')
+    const textParts = parts.filter((p: any) => p.type === 'text')
+    expect(textParts).toHaveLength(1)
+    expect(textParts[0].text).toBe('final answer')
+  })
+
+  test('preserves completed tool calls from earlier steps across a retry', async () => {
+    const projectId = 'proj-retry-tool'
+    const chatSessionId = 'sess-retry-tool'
+    openSession(projectId, 'ws', 'user')
+    accumulateUsage(projectId, 'claude-sonnet-4-5', 100, 30)
+
+    const stream = makeSseStream([
+      // Step 1 completes a tool call (executed -> has output).
+      dataFrame({ type: 'text-delta', delta: 'looking at the file. ' }),
+      dataFrame({
+        type: 'tool-input-available',
+        toolCallId: 'tc-1',
+        toolName: 'read_file',
+        input: { path: 'a.ts' },
+      }),
+      dataFrame({ type: 'tool-output-available', toolCallId: 'tc-1', output: { content: 'body' } }),
+      // Step 2 starts generating text + a partial tool input, then drops -> retry.
+      dataFrame({ type: 'text-delta', delta: 'half-written ' }),
+      dataFrame({ type: 'tool-input-start', toolCallId: 'tc-2-partial', toolName: 'edit_file' }),
+      dataFrame({ type: 'data-inference-retry', data: { attempt: 1, maxAttempts: 2, reason: 'server_5xx' } }),
+      // Retried step 2: the final answer text.
+      dataFrame({ type: 'text-delta', delta: 'Here is the summary.' }),
+      dataFrame({ type: 'data-turn-complete', data: { status: 'completed', lastSeq: 12 } }),
+      dataFrame({ type: 'finish', usage: { inputTokens: 100, outputTokens: 30 } }),
+    ])
+
+    await trackUsageFromStream(
+      stream,
+      { chatSessionId, agentMode: 'sonnet' },
+      { id: projectId, workspaceId: 'ws' },
+      { resume: async () => null },
+    )
+
+    expect(persistedMessages).toHaveLength(1)
+    // Completed tool call survives; the partial step-2 text is dropped.
+    expect(persistedMessages[0].content).toBe('looking at the file. Here is the summary.')
+    expect(persistedMessages[0].content).not.toContain('half-written')
+
+    // Only the executed tool is logged; the partial (never-executed) tool is dropped.
+    expect(persistedToolCalls).toHaveLength(1)
+    expect(persistedToolCalls[0].toolName).toBe('read_file')
+
+    const parts = JSON.parse(persistedMessages[0].parts || '[]')
+    const toolParts = parts.filter((p: any) => p.type === 'dynamic-tool')
+    expect(toolParts).toHaveLength(1)
+    expect(toolParts[0].toolName).toBe('read_file')
+  })
+})

--- a/apps/api/src/__tests__/git-lfs-route.test.ts
+++ b/apps/api/src/__tests__/git-lfs-route.test.ts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Tests for the Git LFS batch + verify API at `src/routes/git-lfs.ts`.
+ *
+ * We mock object storage (`../lib/s3`) and auth so the route logic is
+ * exercised deterministically without OCI or a real session. Coverage:
+ *
+ *   - 401 (+ WWW-Authenticate) when unauthenticated
+ *   - workingMode='external' → 404
+ *   - download: presigned GET for existing, per-object 404 for missing
+ *   - upload: presigned PUT + verify for new, no actions (dedup) for existing
+ *   - invalid oid / operation → 422
+ *   - verify: 200 / 404 / 422 (size mismatch)
+ */
+
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { Hono } from 'hono'
+
+// ─── @shogo/shared-runtime mock (avoid loading the whole runtime index) ──
+mock.module('@shogo/shared-runtime', () => ({
+  isValidLfsOid: (oid: string) => /^[0-9a-f]{64}$/.test(oid),
+  lfsObjectKey: (projectId: string, oid: string) =>
+    `${projectId}/lfs/objects/${oid.slice(0, 2)}/${oid.slice(2, 4)}/${oid}`,
+}))
+
+// ─── prisma mock ─────────────────────────────────────────────────────
+const projectFindUnique = mock(async (_: any): Promise<any> => ({
+  workingMode: 'cloud',
+  workspaceId: 'ws_test',
+}))
+mock.module('../lib/prisma', () => ({
+  prisma: { project: { findUnique: projectFindUnique } },
+}))
+
+// ─── auth mock ───────────────────────────────────────────────────────
+mock.module('../middleware/auth', () => ({
+  authorizeProject: async (c: any, projectId: string) => {
+    const auth = c.get('auth')
+    if (!auth?.isAuthenticated) return { ok: false, status: 401, code: 'unauthorized', message: 'no auth' }
+    return { ok: true, workspaceId: 'ws_test', projectId }
+  },
+}))
+
+// ─── s3 mock (stores oid→size; controllable per test) ────────────────
+const heads = new Map<string, number>()
+const headLfsObject = mock(async (key: string): Promise<{ size: number } | null> => {
+  const oid = key.split('/').pop()!
+  return heads.has(oid) ? { size: heads.get(oid)! } : null
+})
+mock.module('../lib/s3', () => ({
+  headLfsObject,
+  getLfsPresignedReadUrl: async (key: string) => `https://oci.example/get/${key}?sig=read`,
+  getLfsPresignedWriteUrl: async (key: string) => `https://oci.example/put/${key}?sig=write`,
+}))
+
+const { gitLfsRoutes } = await import('../routes/git-lfs')
+
+const OID_A = 'a'.repeat(64)
+const OID_B = 'b'.repeat(64)
+
+function makeApp(auth?: { userId: string; isAuthenticated: boolean }) {
+  const app = new Hono()
+  app.use('*', async (c, next) => {
+    c.set('auth', (auth ?? { isAuthenticated: false }) as any)
+    await next()
+  })
+  app.route('/api', gitLfsRoutes({ workspacesDir: '/tmp/lfs-ws' }))
+  return app
+}
+
+function batch(app: Hono, projectId: string, body: unknown) {
+  return app.request(`/api/projects/${projectId}/git/info/lfs/objects/batch`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/vnd.git-lfs+json' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  heads.clear()
+  projectFindUnique.mockClear()
+  projectFindUnique.mockImplementation(async () => ({ workingMode: 'cloud', workspaceId: 'ws_test' }))
+  headLfsObject.mockClear()
+})
+
+describe('git-lfs batch route — auth', () => {
+  it('401 + WWW-Authenticate when unauthenticated', async () => {
+    const res = await batch(makeApp(undefined), 'p_abc', { operation: 'download', objects: [{ oid: OID_A, size: 1 }] })
+    expect(res.status).toBe(401)
+    expect(res.headers.get('www-authenticate')).toBe('Basic realm="shogo"')
+  })
+
+  it('404 for workingMode=external projects', async () => {
+    projectFindUnique.mockImplementation(async () => ({ workingMode: 'external', workspaceId: 'ws_test' }))
+    const res = await batch(makeApp({ userId: 'u', isAuthenticated: true }), 'p_ext', {
+      operation: 'download', objects: [{ oid: OID_A, size: 1 }],
+    })
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('git-lfs batch route — download', () => {
+  it('returns a presigned download action for an existing object', async () => {
+    heads.set(OID_A, 123)
+    const res = await batch(makeApp({ userId: 'u', isAuthenticated: true }), 'p1', {
+      operation: 'download', objects: [{ oid: OID_A, size: 123 }],
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('application/vnd.git-lfs+json')
+    const body: any = await res.json()
+    expect(body.transfer).toBe('basic')
+    expect(body.objects[0].actions.download.href).toContain(`/get/p1/lfs/objects/`)
+    expect(body.objects[0].actions.download.expires_in).toBeGreaterThan(0)
+  })
+
+  it('returns a per-object 404 error for a missing object', async () => {
+    const res = await batch(makeApp({ userId: 'u', isAuthenticated: true }), 'p1', {
+      operation: 'download', objects: [{ oid: OID_A, size: 123 }],
+    })
+    expect(res.status).toBe(200)
+    const body: any = await res.json()
+    expect(body.objects[0].error.code).toBe(404)
+    expect(body.objects[0].actions).toBeUndefined()
+  })
+})
+
+describe('git-lfs batch route — upload', () => {
+  it('returns upload + verify actions for a new object', async () => {
+    const res = await batch(makeApp({ userId: 'u', isAuthenticated: true }), 'p1', {
+      operation: 'upload', objects: [{ oid: OID_A, size: 10 }],
+    })
+    expect(res.status).toBe(200)
+    const body: any = await res.json()
+    expect(body.objects[0].actions.upload.href).toContain('/put/p1/lfs/objects/')
+    expect(body.objects[0].actions.verify.href).toContain('/git/info/lfs/objects/verify')
+  })
+
+  it('omits actions (dedup) when the object already exists', async () => {
+    heads.set(OID_B, 10)
+    const res = await batch(makeApp({ userId: 'u', isAuthenticated: true }), 'p1', {
+      operation: 'upload', objects: [{ oid: OID_B, size: 10 }],
+    })
+    expect(res.status).toBe(200)
+    const body: any = await res.json()
+    expect(body.objects[0].actions).toBeUndefined()
+    expect(body.objects[0].authenticated).toBe(true)
+  })
+})
+
+describe('git-lfs batch route — validation', () => {
+  it('422 for an unknown operation', async () => {
+    const res = await batch(makeApp({ userId: 'u', isAuthenticated: true }), 'p1', {
+      operation: 'sideload', objects: [{ oid: OID_A, size: 1 }],
+    })
+    expect(res.status).toBe(422)
+  })
+
+  it('per-object 422 for a malformed oid', async () => {
+    const res = await batch(makeApp({ userId: 'u', isAuthenticated: true }), 'p1', {
+      operation: 'download', objects: [{ oid: 'not-a-real-oid', size: 1 }],
+    })
+    expect(res.status).toBe(200)
+    const body: any = await res.json()
+    expect(body.objects[0].error.code).toBe(422)
+  })
+})
+
+describe('git-lfs verify route', () => {
+  function verify(app: Hono, projectId: string, body: unknown) {
+    return app.request(`/api/projects/${projectId}/git/info/lfs/objects/verify`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/vnd.git-lfs+json' },
+      body: JSON.stringify(body),
+    })
+  }
+
+  it('200 when the object exists with the expected size', async () => {
+    heads.set(OID_A, 42)
+    const res = await verify(makeApp({ userId: 'u', isAuthenticated: true }), 'p1', { oid: OID_A, size: 42 })
+    expect(res.status).toBe(200)
+  })
+
+  it('404 when the object is missing', async () => {
+    const res = await verify(makeApp({ userId: 'u', isAuthenticated: true }), 'p1', { oid: OID_A, size: 42 })
+    expect(res.status).toBe(404)
+  })
+
+  it('422 on size mismatch', async () => {
+    heads.set(OID_A, 7)
+    const res = await verify(makeApp({ userId: 'u', isAuthenticated: true }), 'p1', { oid: OID_A, size: 42 })
+    expect(res.status).toBe(422)
+  })
+})

--- a/apps/api/src/lib/runtime/build-project-env.ts
+++ b/apps/api/src/lib/runtime/build-project-env.ts
@@ -145,6 +145,16 @@ export async function buildProjectEnv(
     if (process.env.S3_FORCE_PATH_STYLE === 'true') env.S3_FORCE_PATH_STYLE = 'true'
   }
 
+  // Git LFS: propagate the master switch so git_only pods activate the LFS
+  // clean filter + object push/pull (see shared-runtime `isLfsActive` /
+  // `lfs.ts`). Pods reach the LFS batch endpoint via SHOGO_API_URL +
+  // RUNTIME_AUTH_SECRET and transfer bytes with presigned URLs, so they need
+  // no S3 credentials or S3_LFS_* (those are API-side, used only to mint the
+  // presigned URLs). Inert unless the project is in git_only mode.
+  if (process.env.LFS_ENABLED === 'true' || process.env.LFS_ENABLED === '1') {
+    env.LFS_ENABLED = 'true'
+  }
+
   // Voice mock mode for demo recordings. When the API server has
   // SHOGO_VOICE_MODE=mock (or SHOGO_DEMO_VOICE=mock as a more obvious
   // alias), forward it into the pod env so `createClient().voice.telephony`

--- a/apps/api/src/lib/runtime/build-project-env.ts
+++ b/apps/api/src/lib/runtime/build-project-env.ts
@@ -145,16 +145,6 @@ export async function buildProjectEnv(
     if (process.env.S3_FORCE_PATH_STYLE === 'true') env.S3_FORCE_PATH_STYLE = 'true'
   }
 
-  // Git LFS: propagate the master switch so git_only pods activate the LFS
-  // clean filter + object push/pull (see shared-runtime `isLfsActive` /
-  // `lfs.ts`). Pods reach the LFS batch endpoint via SHOGO_API_URL +
-  // RUNTIME_AUTH_SECRET and transfer bytes with presigned URLs, so they need
-  // no S3 credentials or S3_LFS_* (those are API-side, used only to mint the
-  // presigned URLs). Inert unless the project is in git_only mode.
-  if (process.env.LFS_ENABLED === 'true' || process.env.LFS_ENABLED === '1') {
-    env.LFS_ENABLED = 'true'
-  }
-
   // Voice mock mode for demo recordings. When the API server has
   // SHOGO_VOICE_MODE=mock (or SHOGO_DEMO_VOICE=mock as a more obvious
   // alias), forward it into the pod env so `createClient().voice.telephony`

--- a/apps/api/src/lib/runtime/build-workspace-env.ts
+++ b/apps/api/src/lib/runtime/build-workspace-env.ts
@@ -236,6 +236,15 @@ export async function buildWorkspaceEnv(
     if (process.env.S3_FORCE_PATH_STYLE === 'true') env.S3_FORCE_PATH_STYLE = 'true'
   }
 
+  // Git LFS: propagate the master switch so git_only pods activate the LFS
+  // clean filter + object push/pull (see shared-runtime `isLfsActive`). Pods
+  // reach the LFS batch endpoint via SHOGO_API_URL + RUNTIME_AUTH_SECRET and
+  // transfer bytes with presigned URLs, so no S3 creds / S3_LFS_* are needed
+  // pod-side. Inert unless the project is in git_only mode.
+  if (process.env.LFS_ENABLED === 'true' || process.env.LFS_ENABLED === '1') {
+    env.LFS_ENABLED = 'true'
+  }
+
   console.log(`[${prefix}] total ${Date.now() - startTime}ms for workspace ${workspaceId} (${attachedProjectIds.length} projects)`)
   return env
 }

--- a/apps/api/src/lib/runtime/build-workspace-env.ts
+++ b/apps/api/src/lib/runtime/build-workspace-env.ts
@@ -236,15 +236,6 @@ export async function buildWorkspaceEnv(
     if (process.env.S3_FORCE_PATH_STYLE === 'true') env.S3_FORCE_PATH_STYLE = 'true'
   }
 
-  // Git LFS: propagate the master switch so git_only pods activate the LFS
-  // clean filter + object push/pull (see shared-runtime `isLfsActive`). Pods
-  // reach the LFS batch endpoint via SHOGO_API_URL + RUNTIME_AUTH_SECRET and
-  // transfer bytes with presigned URLs, so no S3 creds / S3_LFS_* are needed
-  // pod-side. Inert unless the project is in git_only mode.
-  if (process.env.LFS_ENABLED === 'true' || process.env.LFS_ENABLED === '1') {
-    env.LFS_ENABLED = 'true'
-  }
-
   console.log(`[${prefix}] total ${Date.now() - startTime}ms for workspace ${workspaceId} (${attachedProjectIds.length} projects)`)
   return env
 }

--- a/apps/api/src/lib/s3.ts
+++ b/apps/api/src/lib/s3.ts
@@ -29,6 +29,7 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 // Lazy-initialized S3 clients
 let s3Client: S3Client | null = null
 let s3PublicClient: S3Client | null = null
+let s3LfsClient: S3Client | null = null
 
 /**
  * Get or create the S3 client for internal operations.
@@ -97,11 +98,47 @@ export function getS3PublicClient(): S3Client {
 }
 
 /**
+ * Get or create the S3 client used to mint presigned URLs for Git LFS
+ * objects.
+ *
+ * Unlike {@link getS3PublicClient} (which targets the browser-facing
+ * `S3_PUBLIC_ENDPOINT`), LFS transfers run pod<->OCI, so the presigned host
+ * must be the endpoint pods can actually reach AND the one used to compute
+ * the SigV4 signature. We default to `S3_LFS_ENDPOINT` then `S3_ENDPOINT`
+ * (the internal/compat endpoint), never the public browser endpoint.
+ */
+export function getLfsS3Client(): S3Client {
+  if (!s3LfsClient) {
+    const region = process.env.S3_REGION || process.env.AWS_REGION || 'us-east-1'
+    const endpoint = process.env.S3_LFS_ENDPOINT || process.env.S3_ENDPOINT
+    const forcePathStyle = process.env.S3_FORCE_PATH_STYLE === 'true'
+
+    const config: ConstructorParameters<typeof S3Client>[0] = {
+      region,
+      ...(endpoint && {
+        endpoint,
+        forcePathStyle: forcePathStyle || !!endpoint,
+      }),
+      ...(process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY && {
+        credentials: {
+          accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+          secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+        },
+      }),
+    }
+
+    s3LfsClient = new S3Client(config)
+  }
+  return s3LfsClient
+}
+
+/**
  * Reset the S3 clients (useful for testing with different configs).
  */
 export function resetS3Client(): void {
   s3Client = null
   s3PublicClient = null
+  s3LfsClient = null
 }
 
 /**
@@ -312,6 +349,71 @@ export async function getPresignedWriteUrl(
   })
 
   return getSignedUrl(client, command, { expiresIn })
+}
+
+// ============================================================================
+// Git LFS object helpers
+// ============================================================================
+
+/**
+ * Bucket for Git LFS objects. Defaults to the workspaces bucket (LFS objects
+ * live under `<projectId>/lfs/objects/...` there) unless `S3_LFS_BUCKET`
+ * points at a dedicated bucket.
+ */
+export function getLfsBucket(): string {
+  const bucket = process.env.S3_LFS_BUCKET || process.env.S3_WORKSPACES_BUCKET
+  if (!bucket) {
+    throw new Error('S3_LFS_BUCKET or S3_WORKSPACES_BUCKET is required for Git LFS')
+  }
+  return bucket
+}
+
+/**
+ * Presigned GET for an LFS object download. Bound to the pod-reachable LFS
+ * client/bucket (see {@link getLfsS3Client}).
+ */
+export async function getLfsPresignedReadUrl(
+  key: string,
+  options: PresignOptions = {},
+): Promise<string> {
+  const client = getLfsS3Client()
+  const bucket = options.bucket || getLfsBucket()
+  const expiresIn = options.expiresIn || 3600
+  const command = new GetObjectCommand({ Bucket: bucket, Key: key })
+  return getSignedUrl(client, command, { expiresIn })
+}
+
+/**
+ * Presigned PUT for an LFS object upload. We deliberately do NOT sign a
+ * Content-Type so the git-lfs basic transfer agent can PUT the raw bytes
+ * with any (or no) content-type header without breaking the signature.
+ */
+export async function getLfsPresignedWriteUrl(
+  key: string,
+  options: PresignOptions = {},
+): Promise<string> {
+  const client = getLfsS3Client()
+  const bucket = options.bucket || getLfsBucket()
+  const expiresIn = options.expiresIn || 3600
+  const command = new PutObjectCommand({ Bucket: bucket, Key: key })
+  return getSignedUrl(client, command, { expiresIn })
+}
+
+/**
+ * HEAD an LFS object. Returns its size when present, or null when absent.
+ * Used by the batch endpoint for download existence + upload dedup.
+ */
+export async function headLfsObject(key: string, bucket?: string): Promise<{ size: number } | null> {
+  const client = getLfsS3Client()
+  try {
+    const res = await client.send(new HeadObjectCommand({
+      Bucket: bucket || getLfsBucket(),
+      Key: key,
+    }))
+    return { size: res.ContentLength ?? 0 }
+  } catch {
+    return null
+  }
 }
 
 /**

--- a/apps/api/src/routes/ai-proxy.ts
+++ b/apps/api/src/routes/ai-proxy.ts
@@ -636,13 +636,21 @@ export function wrapSseForErrorVisibility(
     code: StreamErrorCode,
     message: string,
   ): StreamErrorPayload {
+    const retryable = code !== 'upstream_error'
+    // Embed a stable, machine-readable marker so the retryable flag + code
+    // survive transport through the provider SDK into pi-ai's `errorMessage`,
+    // where the agent-runtime's retry classifier can read them deterministically
+    // instead of guessing from prose. Kept in sync with
+    // `packages/agent/src/retry-classifier.ts` (parseStreamErrorMarker) and
+    // stripped from user-facing text by `formatErrorMessage`.
+    const taggedMessage = `${message} [shogo:retryable=${retryable};code=${code}]`
     return {
       type: 'error',
       error: {
         type: 'stream_error',
         code,
-        retryable: code !== 'upstream_error',
-        message,
+        retryable,
+        message: taggedMessage,
         meta: {
           chunks: chunkCount,
           bytes: totalBytes,

--- a/apps/api/src/routes/git-lfs.ts
+++ b/apps/api/src/routes/git-lfs.ts
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Git LFS server (basic transfer adapter) backed by OCI Object Storage.
+ *
+ * Implements the Git LFS Batch API for each project's repo:
+ *   POST /projects/:projectId/git/info/lfs/objects/batch
+ *   POST /projects/:projectId/git/info/lfs/objects/verify
+ *
+ * The API never touches object bytes: the batch response hands back
+ * presigned OCI URLs and the git-lfs client PUTs/GETs the bytes directly to
+ * object storage. This means:
+ *   - no `git-lfs` binary is required on the API image;
+ *   - the global 200 MB body limit is irrelevant to object size (only the
+ *     small JSON envelope flows through the API);
+ *   - hydrate/`reset --hard` on the API leaves pointer files in place, so
+ *     the commit graph still lists the large files.
+ *
+ * Objects are content-addressed (sha256 oid) under
+ *   `<projectId>/lfs/objects/<oid[0:2]>/<oid[2:4]>/<oid>`
+ * in `S3_LFS_BUCKET` (defaults to `S3_WORKSPACES_BUCKET`), giving free
+ * dedup within a project.
+ *
+ * Auth mirrors the smart-HTTP backend (`git-http.ts`): the parent
+ * `authMiddleware` + an explicit `authorizeProject` check. Internal pods
+ * authenticate with the runtime bearer forwarded by git-lfs via
+ * `http.extraHeader`. External (laptop/CI) git-lfs clients are out of scope
+ * — they have no way to present a Shogo credential yet.
+ *
+ * Spec: https://github.com/git-lfs/git-lfs/blob/main/docs/api/batch.md
+ */
+
+import { Hono, type Context } from 'hono'
+import { lfsObjectKey, isValidLfsOid } from '@shogo/shared-runtime'
+import { prisma } from '../lib/prisma'
+import { authorizeProject } from '../middleware/auth'
+import {
+  getLfsPresignedReadUrl,
+  getLfsPresignedWriteUrl,
+  headLfsObject,
+} from '../lib/s3'
+
+const LFS_CONTENT_TYPE = 'application/vnd.git-lfs+json'
+
+/** Presigned-URL TTL for LFS transfers (seconds). */
+const LFS_PRESIGN_EXPIRY = parseInt(process.env.LFS_PRESIGN_EXPIRY || '3600', 10) || 3600
+
+export interface GitLfsRoutesConfig {
+  /** Directory containing per-project workspaces (unused today; kept for parity). */
+  workspacesDir: string
+}
+
+interface BatchObjectRequest {
+  oid: string
+  size: number
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** JSON response with the git-lfs media type. */
+function lfsJson(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': LFS_CONTENT_TYPE },
+  })
+}
+
+/** LFS error envelope (`{ message }`) with the git-lfs media type. */
+function lfsError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ message }), {
+    status,
+    headers: {
+      'Content-Type': LFS_CONTENT_TYPE,
+      ...(status === 401 ? { 'WWW-Authenticate': 'Basic realm="shogo"' } : {}),
+    },
+  })
+}
+
+/**
+ * Shared auth + project resolution, mirroring `git-http.ts`. Returns null on
+ * success or a ready-to-return Response on any failure path.
+ */
+async function authorizeLfs(c: Context, projectId: string): Promise<Response | null> {
+  const auth = c.get('auth')
+  if (!auth?.isAuthenticated || !auth.userId) {
+    return lfsError('Authentication required', 401)
+  }
+  const access = await authorizeProject(c, projectId)
+  if (!access.ok) {
+    return lfsError(access.message || 'Forbidden', access.status || 403)
+  }
+  // workingMode=external projects don't have a Shogo-managed repo.
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: { workingMode: true } as any,
+  }) as { workingMode?: string } | null
+  if (project?.workingMode === 'external') {
+    return lfsError('Not found', 404)
+  }
+  return null
+}
+
+function parseBatchObjects(input: unknown): BatchObjectRequest[] | null {
+  if (!Array.isArray(input)) return null
+  const out: BatchObjectRequest[] = []
+  for (const raw of input) {
+    if (!raw || typeof raw !== 'object') return null
+    const oid = (raw as any).oid
+    const size = (raw as any).size
+    if (typeof oid !== 'string' || typeof size !== 'number' || size < 0) return null
+    out.push({ oid, size })
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+export function gitLfsRoutes(_config: GitLfsRoutesConfig) {
+  const router = new Hono()
+
+  /**
+   * POST /projects/:projectId/git/info/lfs/objects/batch
+   *
+   * The git-lfs client asks, for a set of {oid,size}, where to upload or
+   * download each object. We answer with presigned OCI URLs (basic transfer).
+   */
+  router.post('/projects/:projectId/git/info/lfs/objects/batch', async (c) => {
+    const projectId = c.req.param('projectId')
+    if (!projectId) return lfsError('projectId is required', 400)
+
+    const denied = await authorizeLfs(c, projectId)
+    if (denied) return denied
+
+    let body: any
+    try {
+      body = await c.req.json()
+    } catch {
+      return lfsError('Invalid JSON body', 422)
+    }
+
+    const operation = body?.operation
+    if (operation !== 'upload' && operation !== 'download') {
+      return lfsError('operation must be "upload" or "download"', 422)
+    }
+
+    const objects = parseBatchObjects(body?.objects)
+    if (!objects) {
+      return lfsError('objects must be an array of {oid, size}', 422)
+    }
+
+    const verifyHref =
+      `${new URL(c.req.url).origin}/api/projects/${projectId}/git/info/lfs/objects/verify`
+
+    const responseObjects = await Promise.all(
+      objects.map(async (obj) => {
+        // Reject malformed oids — they'd otherwise escape the project's S3
+        // key namespace.
+        if (!isValidLfsOid(obj.oid)) {
+          return {
+            oid: obj.oid,
+            size: obj.size,
+            error: { code: 422, message: 'invalid oid (expected sha256 hex)' },
+          }
+        }
+        const key = lfsObjectKey(projectId, obj.oid)
+        const existing = await headLfsObject(key)
+
+        if (operation === 'download') {
+          if (!existing) {
+            return {
+              oid: obj.oid,
+              size: obj.size,
+              error: { code: 404, message: 'object does not exist' },
+            }
+          }
+          const href = await getLfsPresignedReadUrl(key, { expiresIn: LFS_PRESIGN_EXPIRY })
+          return {
+            oid: obj.oid,
+            size: obj.size,
+            authenticated: true,
+            actions: { download: { href, expires_in: LFS_PRESIGN_EXPIRY } },
+          }
+        }
+
+        // upload: omit actions when the object already exists (dedup → the
+        // client treats it as already uploaded and skips the transfer).
+        if (existing) {
+          return { oid: obj.oid, size: obj.size, authenticated: true }
+        }
+        const href = await getLfsPresignedWriteUrl(key, { expiresIn: LFS_PRESIGN_EXPIRY })
+        return {
+          oid: obj.oid,
+          size: obj.size,
+          authenticated: true,
+          actions: {
+            upload: { href, expires_in: LFS_PRESIGN_EXPIRY },
+            verify: { href: verifyHref, expires_in: LFS_PRESIGN_EXPIRY },
+          },
+        }
+      }),
+    )
+
+    return lfsJson({ transfer: 'basic', objects: responseObjects, hash_algo: 'sha256' })
+  })
+
+  /**
+   * POST /projects/:projectId/git/info/lfs/objects/verify
+   *
+   * Optional integrity check the client calls after an upload: confirm the
+   * object landed in OCI with the expected size.
+   */
+  router.post('/projects/:projectId/git/info/lfs/objects/verify', async (c) => {
+    const projectId = c.req.param('projectId')
+    if (!projectId) return lfsError('projectId is required', 400)
+
+    const denied = await authorizeLfs(c, projectId)
+    if (denied) return denied
+
+    let body: any
+    try {
+      body = await c.req.json()
+    } catch {
+      return lfsError('Invalid JSON body', 422)
+    }
+    const oid = body?.oid
+    const size = body?.size
+    if (typeof oid !== 'string' || !isValidLfsOid(oid)) {
+      return lfsError('invalid oid', 422)
+    }
+
+    const existing = await headLfsObject(lfsObjectKey(projectId, oid))
+    if (!existing) return lfsError('object does not exist', 404)
+    if (typeof size === 'number' && existing.size !== size) {
+      return lfsError(`size mismatch: stored ${existing.size}, expected ${size}`, 422)
+    }
+    return new Response(null, { status: 200 })
+  })
+
+  return router
+}
+
+export default gitLfsRoutes

--- a/apps/api/src/routes/project-chat.ts
+++ b/apps/api/src/routes/project-chat.ts
@@ -194,6 +194,43 @@ export async function trackUsageFromStream(
   }
 
   /**
+   * Partial reset on an inference retry. The runtime re-issued a model call
+   * that dropped mid-generation, so the failed step's partial text/reasoning
+   * (and any partially-streamed tool input that never executed) must be
+   * discarded — otherwise the regenerated output gets concatenated onto the
+   * thrown-away partial in the persisted ChatMessage. Earlier COMPLETED steps
+   * (assistant text + executed tool calls) are preserved: pi-agent-core runs
+   * tools only after a complete assistant message, so a failed step never
+   * produced a `tool-input-available` part.
+   */
+  function resetCurrentStepPartials() {
+    if (currentReasoningPart) {
+      const idx = orderedParts.lastIndexOf(currentReasoningPart)
+      if (idx >= 0) orderedParts.splice(idx, 1)
+      currentReasoningPart = null
+      reasoningStartedAt = null
+    }
+    if (currentTextPart) {
+      const idx = orderedParts.lastIndexOf(currentTextPart)
+      if (idx >= 0) orderedParts.splice(idx, 1)
+      currentTextPart = null
+    }
+    // Drop any partially-streamed tool calls from the failed step. A completed
+    // tool from an earlier step reached `tool-input-available` and so has an
+    // entry in `toolPartIndex`; a failed step's tool only ever got a
+    // `tool-input-start` (toolCallMap only) and never executed.
+    for (const id of [...toolCallMap.keys()]) {
+      if (!toolPartIndex.has(id)) toolCallMap.delete(id)
+    }
+    // Recompute the flattened text from the surviving ordered text parts so
+    // `content` reflects only completed output.
+    accumulatedText = orderedParts
+      .filter((p) => p.type === 'text')
+      .map((p) => p.text)
+      .join('')
+  }
+
+  /**
    * Process one SSE line (already \n-split). Updates the closure-scoped
    * accumulator state in place. Tolerant of legacy (`9:`, `e:`, `d:`)
    * data-stream prefixes alongside the modern `data: {json}` SSE format.
@@ -326,6 +363,14 @@ export async function trackUsageFromStream(
         part.output = data.output ?? { success: true }
         part.state = 'output-available'
       }
+    }
+
+    // The runtime emits `data-inference-retry` when it re-issues a model call
+    // that dropped mid-generation. Discard the failed step's partial output so
+    // the persisted message holds the final retried output, not a concatenation.
+    if (type === 'data-inference-retry') {
+      resetCurrentStepPartials()
+      return
     }
 
     // The runtime writes `data-turn-complete` exactly once at the tail

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -45,6 +45,7 @@ import { securityRoutes } from './routes/security'
 import { databaseRoutes, stopAllPrismaStudios } from './routes/database'
 import { checkpointRoutes } from './routes/checkpoints'
 import { gitHttpRoutes } from './routes/git-http'
+import { gitLfsRoutes } from './routes/git-lfs'
 import { thumbnailRoutes } from './routes/thumbnail'
 import { githubRoutes } from './routes/github'
 import { aiProxyRoutes } from './routes/ai-proxy'
@@ -4251,6 +4252,12 @@ app.route('/api', checkpointRouter)
 // See routes/git-http.ts for the wire-protocol bridge to `git http-backend`.
 const gitHttpRouter = gitHttpRoutes({ workspacesDir: workspacesDirResolved })
 app.route('/api', gitHttpRouter)
+
+// Mount the Git LFS batch API (presigned OCI URLs for large-file objects).
+// See routes/git-lfs.ts. Object bytes flow pod<->OCI directly; the API only
+// mints the batch response, so no git-lfs binary is needed here.
+const gitLfsRouter = gitLfsRoutes({ workspacesDir: workspacesDirResolved })
+app.route('/api', gitLfsRouter)
 
 // Mount GitHub routes
 const githubRouter = githubRoutes({ workspacesDir: workspacesDirResolved })

--- a/apps/docs/docs/architecture/cloud-pod-sync.md
+++ b/apps/docs/docs/architecture/cloud-pod-sync.md
@@ -275,9 +275,9 @@ from the pod's durable object store:
 ## Large / binary file offload (hybrid)
 
 Git stays small by keeping only text/source. There are two strategies; which
-one runs depends on `LFS_ENABLED`.
+one runs depends on the cloud sync mode.
 
-### Git LFS (`LFS_ENABLED=true`, `git_only` only) — versioned
+### Git LFS (`git_only` mode) — versioned
 
 Real Git LFS replaces the legacy offload
 ([packages/shared-runtime/src/lfs.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/lfs.ts)):
@@ -309,7 +309,7 @@ Real Git LFS replaces the legacy offload
   pointers and pushes the bytes. **GC:** LFS objects are immutable and never
   auto-pruned, so a reachability-based retention job is a required follow-up.
 
-### Legacy size-based offload (default / non-LFS) — latest-only
+### Legacy size-based offload (`dual_shadow` / `s3` modes) — latest-only
 
 Any file `> LARGE_FILE_BYTES` is classified as an offloaded asset
 ([packages/shared-runtime/src/large-file-sync.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/large-file-sync.ts)):

--- a/apps/docs/docs/architecture/cloud-pod-sync.md
+++ b/apps/docs/docs/architecture/cloud-pod-sync.md
@@ -274,8 +274,44 @@ from the pod's durable object store:
 
 ## Large / binary file offload (hybrid)
 
-Git stays small by keeping only text/source. Any file `> LARGE_FILE_BYTES`
-(default 5 MB, env-tunable) is classified as an offloaded asset
+Git stays small by keeping only text/source. There are two strategies; which
+one runs depends on `LFS_ENABLED`.
+
+### Git LFS (`LFS_ENABLED=true`, `git_only` only) — versioned
+
+Real Git LFS replaces the legacy offload
+([packages/shared-runtime/src/lfs.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/lfs.ts)):
+
+- On repo setup the pod writes a curated `.gitattributes` (`filter=lfs` for
+  images/video/archives/model weights/…) and `git lfs install --local
+  --skip-smudge`. Before each `git add -A`, any file `> LARGE_FILE_BYTES`
+  (default 5 MB) not already matched is `git lfs track`-ed, preserving the
+  old "anything large" behavior.
+- The LFS **clean filter** commits a tiny pointer blob into the tree (so the
+  file **is** versioned and shows in the git graph/diff) and stores the bytes
+  in a local cache. After the commit, `git lfs push` uploads the bytes to the
+  API **batch endpoint** ([apps/api/src/routes/git-lfs.ts](https://github.com/shogo-ai/shogo-ai/blob/main/apps/api/src/routes/git-lfs.ts)),
+  which mints **presigned OCI URLs** so bytes flow pod→OCI directly under
+  `<projectId>/lfs/objects/<oid>` (content-addressed sha256 → free dedup).
+- `persistRepoToStore` then excludes `.git/lfs/objects` from the `.git`
+  tarball (only when the push succeeded — otherwise the bytes stay in the
+  tarball as a fallback). On cold start, after `.git` is restored, `git lfs
+  pull` materializes the object bytes (smudge is skipped on checkout for
+  speed). The **API hydrate path has no git-lfs**, so its `reset --hard`
+  intentionally leaves pointer files — the graph still lists the files.
+- Auth: every `git lfs` call passes the runtime bearer via
+  `-c http.extraHeader` and the endpoint via `-c lfs.url`, so neither the
+  token nor an env-specific URL is ever persisted into `.git/config`.
+  External (laptop/CI) git-lfs clients are out of scope (no Basic→token).
+- Projects on the legacy offload migrate lazily on pod start
+  (`migrateOffloadedAssetsToLfs`): the managed `.git/info/exclude` block is
+  cleared and the restored assets are LFS-tracked; the next sync commits the
+  pointers and pushes the bytes. **GC:** LFS objects are immutable and never
+  auto-pruned, so a reachability-based retention job is a required follow-up.
+
+### Legacy size-based offload (default / non-LFS) — latest-only
+
+Any file `> LARGE_FILE_BYTES` is classified as an offloaded asset
 ([packages/shared-runtime/src/large-file-sync.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/large-file-sync.ts)):
 
 - git-excluded via `.git/info/exclude` (never touches the user's
@@ -288,7 +324,7 @@ Git stays small by keeping only text/source. Any file `> LARGE_FILE_BYTES`
 Semantics (intentional, matches the old S3 tar): offloaded files are
 **latest-only** and don't appear in the git graph/diff. Checkpoints and
 publish tags pin the *source* commit; the asset snapshot is whatever
-object storage holds. True large-file versioning (Git LFS) is deferred.
+object storage holds.
 
 ## Publish as a git tag
 
@@ -422,7 +458,9 @@ noticing.
 | Pod durable repo store (persist/restore/seed/tag) | [packages/shared-runtime/src/repo-store.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/repo-store.ts) |
 | Pod commit-metadata gathering | [packages/shared-runtime/src/checkpoint-record.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/checkpoint-record.ts) |
 | Cold-start bootstrap / seed (`dual_shadow`) | [packages/shared-runtime/src/git-bootstrap.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/git-bootstrap.ts) |
-| Large/binary file offload | [packages/shared-runtime/src/large-file-sync.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/large-file-sync.ts) |
+| Large/binary file offload (legacy, latest-only) | [packages/shared-runtime/src/large-file-sync.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/large-file-sync.ts) |
+| Git LFS pod ops (track/push/pull/migrate) | [packages/shared-runtime/src/lfs.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/lfs.ts) |
+| Git LFS batch + verify API (presigned OCI) | [apps/api/src/routes/git-lfs.ts](https://github.com/shogo-ai/shogo-ai/blob/main/apps/api/src/routes/git-lfs.ts) |
 | API repo store (hydrate-only, ETag-fresh) | [apps/api/src/services/git-repo-store.ts](https://github.com/shogo-ai/shogo-ai/blob/main/apps/api/src/services/git-repo-store.ts) |
 | Internal checkpoint-record endpoint | [apps/api/src/routes/internal.ts](https://github.com/shogo-ai/shogo-ai/blob/main/apps/api/src/routes/internal.ts) (`POST /internal/projects/:id/checkpoints/record`) |
 | Pod → API record POST | `postCheckpointRecord` in [packages/agent-runtime/src/internal-api.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/agent-runtime/src/internal-api.ts) |

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -3472,23 +3472,56 @@ function CanvasPanel({
   // Dev server reachable (non-404 root) AND the agent runtime is up.
   const baseReady = !!agentUrl && !!readyCanvasBaseUrl
 
-  const CONNECTION_TIMEOUT_MS = 60_000
-  const [timedOut, setTimedOut] = useState(false)
+  // Two independent fallbacks, deliberately kept separate:
+  //
+  //  - baseTimedOut: the agent runtime / dev server never became reachable
+  //    (a genuine failure) → surface the "Connection timed out" error + Retry.
+  //
+  //  - apiWaitElapsed: the dev server IS up but the API sidecar hasn't reported
+  //    healthy within a bounded window → show the app anyway rather than block.
+  //    This is intentionally NON-RESETTING. On a fresh project the sidecar only
+  //    goes healthy after a cold `bun install` + build + spawn, and during that
+  //    time the dev-server root can flip 404<->200 as `dist/` is rebuilt. The
+  //    previous single timer keyed on `baseReady`, so every flip restarted the
+  //    clock and the gate could hang on "Starting API server…" forever. We
+  //    start this timer once (on first base-ready) and never restart it.
+  const BASE_TIMEOUT_MS = 60_000
+  const API_WAIT_TIMEOUT_MS = 20_000
+  const [baseTimedOut, setBaseTimedOut] = useState(false)
   useEffect(() => {
-    if (baseReady && apiLatched) {
-      setTimedOut(false)
+    if (baseReady) {
+      setBaseTimedOut(false)
       return
     }
-    setTimedOut(false)
-    const timer = setTimeout(() => setTimedOut(true), CONNECTION_TIMEOUT_MS)
+    setBaseTimedOut(false)
+    const timer = setTimeout(() => setBaseTimedOut(true), BASE_TIMEOUT_MS)
     return () => clearTimeout(timer)
-  }, [baseReady, apiLatched])
+  }, [baseReady])
 
-  // Load the canvas once the dev server is reachable AND the sidecar is
-  // healthy. The 60s timeout is a safety net so a sidecar that never reports
-  // healthy (crash loop, template without `/health`) still eventually shows
-  // the app instead of hanging on a spinner forever.
-  const showCanvas = shouldShowCanvas({ baseReady, apiLatched, timedOut })
+  const [apiWaitElapsed, setApiWaitElapsed] = useState(false)
+  const apiWaitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    if (apiLatched) return
+    if (!baseReady) return
+    // Start exactly once; do NOT restart on baseReady / phase oscillation.
+    if (apiWaitTimerRef.current) return
+    apiWaitTimerRef.current = setTimeout(() => setApiWaitElapsed(true), API_WAIT_TIMEOUT_MS)
+  }, [baseReady, apiLatched])
+  useEffect(
+    () => () => {
+      if (apiWaitTimerRef.current) {
+        clearTimeout(apiWaitTimerRef.current)
+        apiWaitTimerRef.current = null
+      }
+    },
+    [],
+  )
+
+  // Load the canvas once the dev server is reachable AND the sidecar is healthy
+  // (latched). `apiWaitElapsed` is the bounded safety net so a slow cold start
+  // or a sidecar that never reports healthy (crash loop, template without
+  // `/health`) still shows the app within ~20s instead of hanging forever.
+  const showCanvas = shouldShowCanvas({ baseReady, apiLatched, timedOut: apiWaitElapsed })
 
   if (!showCanvas) {
     // `!baseReady` → runtime / dev server not up yet (show its phase, and the
@@ -3503,7 +3536,7 @@ function CanvasPanel({
       : PHASE_LABELS['starting-api']
     return (
       <View className="flex-1 items-center justify-center px-6">
-        {timedOut ? (
+        {baseTimedOut ? (
           <>
             <View className="w-3 h-3 rounded-full mb-3 bg-destructive" />
             <Text className="text-foreground font-semibold mb-1">

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -69,7 +69,8 @@ import {
 import { useSDKDomains, useDomainActions, useChatMessageCollectionForSession } from "@shogo/shared-app/domain"
 import { decideMessagesPropagation } from "./messages-propagation"
 import { useNotifyOnTurnComplete } from "./useNotifyOnTurnComplete"
-import { probeChatTurnStatus, shouldAttachLiveStream } from "./probe-turn-status"
+import { probeChatTurnStatus, shouldAttachLiveStream, type ChatTurnStatus } from "./probe-turn-status"
+import { decideRetryAction, lastAssistantHasResumableWork } from "./retry-triage"
 import { cn } from "@shogo/shared-ui/primitives"
 import { API_URL, api, createHttpClient } from "../../lib/api"
 import { hasAcceptedAiConsent, acceptAiConsent, revokeAiConsent, AI_PROVIDERS } from "../../lib/ai-consent"
@@ -1329,6 +1330,32 @@ export const ChatPanel = observer(function ChatPanel({
       // still trip on a long pre-Anthropic warm-up even after we see
       // bytes. Cheap, safe, and orthogonal to message rendering.
       bumpChatProgress()
+
+      // The runtime re-issued a model call that dropped mid-generation. Drop
+      // the failed step's partial text/reasoning from the in-progress assistant
+      // message so the regenerated output replaces it instead of rendering
+      // twice. Completed tool calls (and any text committed before them) are
+      // preserved — a failed inference step never executed tools.
+      if (dataPart.type === "data-inference-retry") {
+        setMessages((prev) => {
+          if (prev.length === 0) return prev
+          const lastIdx = prev.length - 1
+          const last = prev[lastIdx]
+          if (last.role !== "assistant" || !Array.isArray(last.parts)) return prev
+          const parts = [...last.parts]
+          while (parts.length > 0) {
+            const p = parts[parts.length - 1] as any
+            if (p?.type === "text" || p?.type === "reasoning") {
+              parts.pop()
+              continue
+            }
+            break
+          }
+          if (parts.length === last.parts.length) return prev
+          return prev.map((m, i) => (i === lastIdx ? { ...m, parts } : m))
+        })
+        return
+      }
 
       // Handle virtual tool events
       if (dataPart.type === "data-virtual-tool") {
@@ -3340,7 +3367,7 @@ export const ChatPanel = observer(function ChatPanel({
 
   // Internal function that actually sends a message (used by queue processor)
   const sendMessageInternal = useCallback(
-    async (content: string, files?: FileAttachment[], perMsgModel?: string) => {
+    async (content: string, files?: FileAttachment[], perMsgModel?: string, extraBody?: Record<string, unknown>) => {
       if (!currentSessionId) {
         console.warn("[ChatPanel] No session ID - message will be lost!")
         return
@@ -3479,6 +3506,9 @@ export const ChatPanel = observer(function ChatPanel({
           bodyExtra.confirmedPlan = normalizePlanData(planToSend)
           bodyExtra.interactionMode = "agent"
           confirmedPlanRef.current = null
+        }
+        if (extraBody) {
+          Object.assign(bodyExtra, extraBody)
         }
         console.log("[ChatPanel][send] bodyExtra — interactionMode:", bodyExtra.interactionMode, "agentMode:", bodyExtra.agentMode, "hasConfirmedPlan:", !!bodyExtra.confirmedPlan, "text:", trimmedContent.slice(0, 80))
         await sendMessage(messagePayload, { body: bodyExtra })
@@ -3911,41 +3941,107 @@ export const ChatPanel = observer(function ChatPanel({
     }
   }, [isCollapsed, setIsCollapsed, onCollapsedChange])
 
-  // Error retry handler
+  // Error retry handler.
+  //
+  // Non-destructive triage (see retry-triage.ts). The old behavior truncated
+  // the conversation (`setMessages(messages.slice(0, lastUserIdx))`) and
+  // re-sent the original user message, throwing away the interrupted turn's
+  // completed tool calls + partial answer. Instead we probe the runtime:
+  //
+  //   - turn still `active` (transport drop, agent still running) -> reconnect
+  //     to the live buffered stream. No re-send, nothing truncated.
+  //   - terminal but the last assistant turn has resumable work -> ask the
+  //     server to continue from the preserved session context (continue:true).
+  //   - nothing resumable -> re-send the original user message (last resort),
+  //     still WITHOUT truncating any rendered work.
   const handleRetry = useCallback(() => {
-    if (messages.length > 0) {
-      const lastUserMsg = [...messages].reverse().find((m) => m.role === "user")
-      if (lastUserMsg) {
-        const parts = ((lastUserMsg as any).parts ?? []) as any[]
-        const textPart = parts.find((p: any) => p.type === "text")
-        const content = textPart?.text || ""
+    if (messages.length === 0) return
 
-        // Preserve file attachments on retry — previously dropped, so images/
-        // PDFs/etc. were lost and the model got a text-only prompt.
-        const fileParts = parts.filter((p: any) => p?.type === "file" && p?.url)
-        const cachedFiles = lastUserInputRef.current?.files
-        const filesFromParts: FileAttachment[] = fileParts.map((p: any) => ({
-          dataUrl: p.url,
-          name: p.name ?? p.filename ?? "file",
-          type: p.mediaType ?? extractMediaType(p.url),
-        }))
-        const files: FileAttachment[] | undefined =
-          cachedFiles && cachedFiles.length > 0
-            ? cachedFiles
-            : filesFromParts.length > 0
-              ? filesFromParts
-              : undefined
+    const lastUserMsg = [...messages].reverse().find((m) => m.role === "user")
+    // Extract the original content/files up front for the resend fallback.
+    const parts = ((lastUserMsg as any)?.parts ?? []) as any[]
+    const textPart = parts.find((p: any) => p.type === "text")
+    const content = textPart?.text || ""
+    const fileParts = parts.filter((p: any) => p?.type === "file" && p?.url)
+    const cachedFiles = lastUserInputRef.current?.files
+    const filesFromParts: FileAttachment[] = fileParts.map((p: any) => ({
+      dataUrl: p.url,
+      name: p.name ?? p.filename ?? "file",
+      type: p.mediaType ?? extractMediaType(p.url),
+    }))
+    const files: FileAttachment[] | undefined =
+      cachedFiles && cachedFiles.length > 0
+        ? cachedFiles
+        : filesFromParts.length > 0
+          ? filesFromParts
+          : undefined
 
-        if (content || (files && files.length > 0)) {
-          const lastUserIdx = messages.lastIndexOf(lastUserMsg)
-          setMessages(messages.slice(0, lastUserIdx))
-          sendMessageInternal(content, files).catch((err) =>
-            console.error("[ChatPanel] Retry failed:", err)
+    void (async () => {
+      // Probe whether the turn is still running on the server. Any failure mode
+      // collapses to 'unknown' (never throws), so this is safe to await.
+      let turnStatus: ChatTurnStatus = "unknown"
+      if (currentSessionId && API_URL) {
+        try {
+          const turnUrl = buildChatTurnUrl(
+            API_URL,
+            projectId,
+            localAgentUrl,
+            currentSessionId,
+            chatWorkspaceId,
           )
+          turnStatus = await probeChatTurnStatus({
+            url: turnUrl,
+            fetch: expoFetch,
+            headers: nativeHeaders ? nativeHeaders() : undefined,
+            credentials: Platform.OS === "web" ? "include" : undefined,
+          })
+        } catch {
+          turnStatus = "unknown"
         }
       }
-    }
-  }, [messages, sendMessageInternal, setMessages])
+
+      const action = decideRetryAction({
+        turnStatus,
+        hasResumableTurn: lastAssistantHasResumableWork(messages as any),
+      })
+
+      if (action === "reconnect") {
+        // Agent is still running and buffering frames — reattach. The rendered
+        // messages (including completed tool calls) stay exactly as they are.
+        void resumeStream()
+        return
+      }
+
+      if (action === "continue") {
+        // Continue from preserved server-side context. The `continue` flag
+        // tells the runtime to craft a continuation instruction and reuse the
+        // interrupted turn's persisted tool calls instead of restarting.
+        sendMessageInternal("Continue", undefined, undefined, { continue: true }).catch(
+          (err) => console.error("[ChatPanel] Retry continue failed:", err),
+        )
+        return
+      }
+
+      // resend: nothing to resume/continue. Re-send the original message — but
+      // do NOT truncate any already-rendered work.
+      if (content || (files && files.length > 0)) {
+        sendMessageInternal(content, files).catch((err) =>
+          console.error("[ChatPanel] Retry resend failed:", err),
+        )
+      }
+    })()
+  }, [
+    messages,
+    sendMessageInternal,
+    resumeStream,
+    currentSessionId,
+    projectId,
+    localAgentUrl,
+    chatWorkspaceId,
+    expoFetch,
+    nativeHeaders,
+    extractMediaType,
+  ])
 
   const handleRetryRef = useRef<(() => void) | null>(null)
   handleRetryRef.current = handleRetry

--- a/apps/mobile/components/chat/__tests__/retry-triage.test.ts
+++ b/apps/mobile/components/chat/__tests__/retry-triage.test.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Tests for the pure retry-triage decision behind ChatPanel's "Retry" button.
+ *
+ * Headline regression locked down here (the reported bug — must not come back):
+ *
+ *   Tapping "Retry" used to run
+ *     setMessages(messages.slice(0, lastUserIdx))
+ *     sendMessageInternal(content)            // re-send original prompt
+ *   which DELETED the interrupted turn's completed tool calls + partial answer
+ *   (potentially minutes of work) and restarted from scratch.
+ *
+ *   The fix triages into reconnect / continue / resend and NEVER truncates
+ *   completed work. These tests pin the decision and the no-truncation
+ *   guarantee.
+ *
+ * Run: bun test apps/mobile/components/chat/__tests__/retry-triage.test.ts
+ */
+import { describe, expect, test } from "bun:test"
+import { decideRetryAction, lastAssistantHasResumableWork } from "../retry-triage"
+
+describe("decideRetryAction", () => {
+  test("active turn -> reconnect (agent still running, transport drop)", () => {
+    expect(decideRetryAction({ turnStatus: "active", hasResumableTurn: false })).toBe("reconnect")
+    // 'active' wins even if there is resumable work — reconnecting to the live
+    // stream is strictly better than restarting a continuation.
+    expect(decideRetryAction({ turnStatus: "active", hasResumableTurn: true })).toBe("reconnect")
+  })
+
+  test("terminal/unknown with resumable work -> continue (preserve work)", () => {
+    for (const turnStatus of ["completed", "failed", "aborted", "unknown"] as const) {
+      expect(decideRetryAction({ turnStatus, hasResumableTurn: true })).toBe("continue")
+    }
+  })
+
+  test("nothing resumable -> resend (last resort)", () => {
+    for (const turnStatus of ["completed", "failed", "aborted", "unknown"] as const) {
+      expect(decideRetryAction({ turnStatus, hasResumableTurn: false })).toBe("resend")
+    }
+  })
+})
+
+describe("lastAssistantHasResumableWork", () => {
+  test("true when the last assistant message has a completed tool call", () => {
+    const messages = [
+      { role: "user", parts: [{ type: "text", text: "do it" }] },
+      {
+        role: "assistant",
+        parts: [
+          { type: "text", text: "working" },
+          { type: "dynamic-tool", toolName: "read_file", state: "output-available" },
+        ],
+      },
+    ]
+    expect(lastAssistantHasResumableWork(messages)).toBe(true)
+  })
+
+  test("true when the last assistant message has non-empty text", () => {
+    const messages = [
+      { role: "user", parts: [{ type: "text", text: "hi" }] },
+      { role: "assistant", parts: [{ type: "text", text: "partial answer" }] },
+    ]
+    expect(lastAssistantHasResumableWork(messages)).toBe(true)
+  })
+
+  test("false when the model produced nothing yet (user is last)", () => {
+    const messages = [{ role: "user", parts: [{ type: "text", text: "hi" }] }]
+    expect(lastAssistantHasResumableWork(messages)).toBe(false)
+  })
+
+  test("false when the last assistant message is empty", () => {
+    const messages = [
+      { role: "user", parts: [{ type: "text", text: "hi" }] },
+      { role: "assistant", parts: [{ type: "text", text: "   " }] },
+    ]
+    expect(lastAssistantHasResumableWork(messages)).toBe(false)
+  })
+})
+
+describe("REGRESSION: retry must never truncate completed work", () => {
+  // The exact shape from the bug report: a user message followed by an
+  // assistant turn that completed tool calls before the connection dropped.
+  const messages = [
+    { role: "user", parts: [{ type: "text", text: "build the feature" }] },
+    {
+      role: "assistant",
+      parts: [
+        { type: "text", text: "On it." },
+        { type: "dynamic-tool", toolName: "edit_file", state: "output-available" },
+        { type: "dynamic-tool", toolName: "exec", state: "output-available" },
+      ],
+    },
+  ]
+
+  test("a terminal turn with completed tool calls chooses continue (not resend)", () => {
+    const action = decideRetryAction({
+      turnStatus: "failed",
+      hasResumableTurn: lastAssistantHasResumableWork(messages),
+    })
+    // Must NOT be 'resend' — resend was the destructive path that truncated.
+    expect(action).toBe("continue")
+  })
+
+  test("an active turn with completed tool calls chooses reconnect (not resend)", () => {
+    const action = decideRetryAction({
+      turnStatus: "active",
+      hasResumableTurn: lastAssistantHasResumableWork(messages),
+    })
+    expect(action).toBe("reconnect")
+  })
+
+  test("the decision input does not mutate or drop the message list", () => {
+    const snapshot = JSON.parse(JSON.stringify(messages))
+    decideRetryAction({
+      turnStatus: "failed",
+      hasResumableTurn: lastAssistantHasResumableWork(messages),
+    })
+    // Pure functions: the completed assistant + tool-call messages are intact.
+    expect(messages).toEqual(snapshot)
+    expect(messages).toHaveLength(2)
+    expect((messages[1].parts as any[]).filter((p) => p.type === "dynamic-tool")).toHaveLength(2)
+  })
+})

--- a/apps/mobile/components/chat/retry-triage.ts
+++ b/apps/mobile/components/chat/retry-triage.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Pure decision logic for the chat "Retry" button.
+ *
+ * The reported bug: when the model stopped/errored the UI showed
+ * "Connection interrupted. Please tap Retry to continue." and tapping Retry
+ * TRUNCATED the conversation (`setMessages(messages.slice(0, lastUserIdx))`)
+ * and re-sent the original user message — discarding the interrupted turn's
+ * completed tool calls and partial answer (potentially minutes of work).
+ *
+ * The fix triages the failure into one of three NON-destructive actions:
+ *
+ *   - `reconnect`: the runtime reports the turn is still `active` (a transport
+ *     drop, not a real inference failure). The agent is still running and
+ *     buffering frames server-side; reattach to the live stream. Nothing was
+ *     lost and nothing is re-sent.
+ *   - `continue`: the turn genuinely ended but the last assistant turn left
+ *     resumable work (completed tool calls / partial text preserved in the
+ *     session). Continue from that preserved context instead of restarting.
+ *   - `resend`: there is genuinely nothing to resume or continue (e.g. the very
+ *     first model call produced zero output and ran no tools). Only then do we
+ *     re-send the original user message.
+ *
+ * Critically, NONE of these actions truncate already-rendered completed work.
+ * Extracted as a pure function so the regression can be unit-tested without
+ * React or the runtime.
+ */
+
+import type { ChatTurnStatus } from "./probe-turn-status"
+
+export type RetryAction = "reconnect" | "continue" | "resend"
+
+export interface RetryTriageInput {
+  /** Status from the runtime's read-only `/turn` probe. */
+  turnStatus: ChatTurnStatus
+  /**
+   * True when the last assistant turn left behind resumable work — completed
+   * tool calls or partial text/reasoning that should be built upon rather than
+   * thrown away. Compute via {@link lastAssistantHasResumableWork}.
+   */
+  hasResumableTurn: boolean
+}
+
+/**
+ * Decide how the "Retry" button should behave. Pure + total.
+ *
+ *  - `active`                              -> reconnect (agent still running)
+ *  - terminal/unknown + resumable work     -> continue (preserve work)
+ *  - terminal/unknown + nothing to resume  -> resend (last resort)
+ */
+export function decideRetryAction({ turnStatus, hasResumableTurn }: RetryTriageInput): RetryAction {
+  if (turnStatus === "active") return "reconnect"
+  if (hasResumableTurn) return "continue"
+  return "resend"
+}
+
+interface MinimalPart {
+  type?: string
+  text?: string
+  state?: string
+}
+
+interface MinimalMessage {
+  role?: string
+  parts?: MinimalPart[]
+}
+
+/**
+ * Does the most recent assistant message carry resumable work?
+ *
+ * Resumable work = any tool call (regardless of state — a completed tool result
+ * is the canonical "minutes of work" we must not discard) or any non-empty
+ * text/reasoning content. If the most recent message is the user's (the model
+ * produced nothing at all yet), there is nothing to resume.
+ */
+export function lastAssistantHasResumableWork(messages: MinimalMessage[]): boolean {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]
+    if (m.role === "assistant") {
+      const parts = Array.isArray(m.parts) ? m.parts : []
+      return parts.some((p) => {
+        const t = typeof p.type === "string" ? p.type : ""
+        if (t === "dynamic-tool" || t === "tool-invocation" || t.startsWith("tool-")) return true
+        if ((t === "text" || t === "reasoning") && typeof p.text === "string" && p.text.trim().length > 0) {
+          return true
+        }
+        return false
+      })
+    }
+    if (m.role === "user") return false
+  }
+  return false
+}

--- a/packages/agent-runtime/Dockerfile.base
+++ b/packages/agent-runtime/Dockerfile.base
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Git LFS: configure the clean/smudge filters system-wide but SKIP smudge
     # so checkout/`reset --hard` leaves pointer files (fast, no network). The
     # runtime materializes object bytes explicitly via `git lfs pull`. LFS only
-    # activates for repos that opt in via .gitattributes (git_only + LFS_ENABLED).
+    # activates for repos that opt in via .gitattributes (git_only mode).
     git lfs install --system --skip-smudge && \
     # Cleanup
     apt-get purge -y gnupg unzip && \

--- a/packages/agent-runtime/Dockerfile.base
+++ b/packages/agent-runtime/Dockerfile.base
@@ -14,7 +14,7 @@ WORKDIR /app
 
 # System packages + Node 24 + Bun 1.3
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl bash git tar gzip zstd ca-certificates gnupg unzip \
+    curl bash git git-lfs tar gzip zstd ca-certificates gnupg unzip \
     chromium nss-plugin-pem fonts-freefont-ttf \
     ffmpeg imagemagick ripgrep \
     build-essential && \
@@ -38,6 +38,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     STRIPE_ARCH="$(uname -m | sed 's/aarch64/arm64/' | sed 's/x86_64/x86_64/')" && \
     curl -fsSL "https://github.com/stripe/stripe-cli/releases/download/v${STRIPE_VER}/stripe_${STRIPE_VER}_linux_${STRIPE_ARCH}.tar.gz" \
       | tar -xz -C /usr/local/bin stripe && \
+    # Git LFS: configure the clean/smudge filters system-wide but SKIP smudge
+    # so checkout/`reset --hard` leaves pointer files (fast, no network). The
+    # runtime materializes object bytes explicitly via `git lfs pull`. LFS only
+    # activates for repos that opt in via .gitattributes (git_only + LFS_ENABLED).
+    git lfs install --system --skip-smudge && \
     # Cleanup
     apt-get purge -y gnupg unzip && \
     apt-get autoremove -y && \

--- a/packages/agent-runtime/src/__tests__/error-recovery.test.ts
+++ b/packages/agent-runtime/src/__tests__/error-recovery.test.ts
@@ -216,6 +216,202 @@ describe('runAgentLoop error recovery', () => {
 })
 
 // ===========================================================================
+// agent-loop: inference reconnect/retry (Agent.continue)
+// ===========================================================================
+
+type ScriptStep = AssistantMessage | { throw: string }
+
+/**
+ * StreamFn driven by a script of steps. Each call consumes the next step
+ * (clamped to the last so a single error step is "persistent"): an
+ * `AssistantMessage` streams normally; a `{ throw }` step throws, which
+ * pi-agent-core catches and surfaces as a trailing assistant `errorMessage`.
+ */
+function createScriptedStreamFn(
+  steps: ScriptStep[],
+  onCall?: (index: number, messages: Message[]) => void,
+): { fn: StreamFn; getCalls: () => number } {
+  let calls = 0
+  const fn: StreamFn = (_model, context, _options) => {
+    const i = calls++
+    onCall?.(i, context.messages)
+    const step = steps[Math.min(i, steps.length - 1)]
+    if (step && (step as any).throw) {
+      throw new Error((step as any).throw)
+    }
+    const msg = step as AssistantMessage
+    const stream = createAssistantMessageEventStream()
+    queueMicrotask(() => {
+      stream.push({ type: 'start', partial: msg })
+      const reason = msg.content.some((c) => c.type === 'toolCall') ? 'toolUse' : 'stop'
+      stream.push({ type: 'done', reason, message: msg })
+      stream.end(msg)
+    })
+    return stream as any
+  }
+  return { fn, getCalls: () => calls }
+}
+
+const NO_BACKOFF = { computeDelayMs: () => 0, sleep: async () => {} }
+
+describe('runAgentLoop inference retry', () => {
+  test('retryable mid-stream drop completes after retry', async () => {
+    const { fn, getCalls } = createScriptedStreamFn([
+      { throw: 'socket hang up' },
+      buildTextResponse('Recovered answer'),
+    ])
+
+    const result = await runAgentLoop({
+      model: 'claude-sonnet-4-5',
+      system: 'Test',
+      history: [],
+      prompt: 'Hello',
+      tools: [],
+      streamFn: fn,
+      inferenceRetry: { maxAttempts: 2, ...NO_BACKOFF },
+    })
+
+    expect(result.error).toBeUndefined()
+    expect(result.text).toBe('Recovered answer')
+    expect(getCalls()).toBe(2) // initial failure + one re-issue
+  })
+
+  test('no tool re-execution on retry; earlier tool result preserved', async () => {
+    const tracker = new MockToolTracker()
+    const tool = tracker.createTool('read_file', 'Read a file', { content: 'file data' })
+
+    // step0: tool use (executes the tool once)
+    // step1: follow-up LLM call fails (retryable 5xx)
+    // step2: re-issued follow-up succeeds with final text
+    const { fn, getCalls } = createScriptedStreamFn([
+      buildToolUseResponse([{ name: 'read_file', arguments: { path: 'a.txt' }, id: 'toolu_1' }]),
+      { throw: '502 Bad Gateway' },
+      buildTextResponse('Here is the file summary'),
+    ])
+
+    const result = await runAgentLoop({
+      model: 'claude-sonnet-4-5',
+      system: 'Test',
+      history: [],
+      prompt: 'Read a.txt',
+      tools: [tool],
+      streamFn: fn,
+      inferenceRetry: { maxAttempts: 2, ...NO_BACKOFF },
+    })
+
+    expect(result.error).toBeUndefined()
+    expect(result.text).toBe('Here is the file summary')
+    expect(result.toolCalls).toHaveLength(1)
+    expect(result.toolCalls[0].name).toBe('read_file')
+    // Critical idempotency guarantee: the completed tool executed exactly once
+    // across the failed attempt + successful retry.
+    expect(tracker.getCallsFor('read_file')).toHaveLength(1)
+    expect(getCalls()).toBe(3) // tool call + failed follow-up + retried follow-up
+  })
+
+  test('non-retryable error does not retry', async () => {
+    const { fn, getCalls } = createScriptedStreamFn([{ throw: '401 Unauthorized: invalid api key' }])
+
+    const result = await runAgentLoop({
+      model: 'claude-sonnet-4-5',
+      system: 'Test',
+      history: [],
+      prompt: 'Hello',
+      tools: [],
+      streamFn: fn,
+      inferenceRetry: { maxAttempts: 3, ...NO_BACKOFF },
+    })
+
+    expect(result.error).toBeDefined()
+    expect(getCalls()).toBe(1) // no re-issue for a non-retryable failure
+  })
+
+  test('abort never retries', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const { fn, getCalls } = createScriptedStreamFn([{ throw: 'socket hang up' }])
+
+    const result = await runAgentLoop({
+      model: 'claude-sonnet-4-5',
+      system: 'Test',
+      history: [],
+      prompt: 'Hello',
+      tools: [],
+      streamFn: fn,
+      signal: controller.signal,
+      inferenceRetry: { maxAttempts: 3, ...NO_BACKOFF },
+    })
+
+    // Aborted before the prompt ran: the stream fn is never invoked and the
+    // retry loop is skipped (guarded by !abortTriggered).
+    expect(getCalls()).toBe(0)
+    expect(result.toolCalls).toHaveLength(0)
+  })
+
+  test('persistent retryable failure stops at the cap', async () => {
+    const { fn, getCalls } = createScriptedStreamFn([{ throw: 'ECONNRESET' }])
+
+    const result = await runAgentLoop({
+      model: 'claude-sonnet-4-5',
+      system: 'Test',
+      history: [],
+      prompt: 'Hello',
+      tools: [],
+      streamFn: fn,
+      inferenceRetry: { maxAttempts: 2, ...NO_BACKOFF },
+    })
+
+    // initial attempt + exactly maxAttempts re-issues, then give up
+    expect(getCalls()).toBe(3)
+    expect(result.error).toBeDefined()
+  })
+
+  test('backoff is invoked between attempts with increasing delay', async () => {
+    const sleeps: number[] = []
+    const { fn, getCalls } = createScriptedStreamFn([{ throw: 'fetch failed' }])
+
+    await runAgentLoop({
+      model: 'claude-sonnet-4-5',
+      system: 'Test',
+      history: [],
+      prompt: 'Hello',
+      tools: [],
+      streamFn: fn,
+      inferenceRetry: {
+        maxAttempts: 3,
+        computeDelayMs: (attempt) => attempt * 100,
+        sleep: async (ms) => {
+          sleeps.push(ms)
+        },
+      },
+    })
+
+    expect(sleeps).toEqual([100, 200, 300])
+    expect(getCalls()).toBe(4) // initial + 3 re-issues
+  })
+
+  test('retry can be disabled via inferenceRetry: false', async () => {
+    const { fn, getCalls } = createScriptedStreamFn([
+      { throw: 'socket hang up' },
+      buildTextResponse('would-be recovery'),
+    ])
+
+    const result = await runAgentLoop({
+      model: 'claude-sonnet-4-5',
+      system: 'Test',
+      history: [],
+      prompt: 'Hello',
+      tools: [],
+      streamFn: fn,
+      inferenceRetry: false,
+    })
+
+    expect(getCalls()).toBe(1) // no retry attempted
+    expect(result.error).toBeDefined()
+  })
+})
+
+// ===========================================================================
 // gateway: error recovery + session persistence
 // ===========================================================================
 

--- a/packages/agent-runtime/src/__tests__/preview-manager.spawn-paths.test.ts
+++ b/packages/agent-runtime/src/__tests__/preview-manager.spawn-paths.test.ts
@@ -549,3 +549,77 @@ describe('PreviewManager.resolveBundlerCwd', () => {
     expect(pm.bundlerCwd).toBe(join(root, 'project'))
   })
 })
+
+// ---------------------------------------------------------------------------
+// 8. runPrismaIfNeeded — generated-client detection (Prisma 7 custom output)
+//
+// Regression guard: Prisma 7's `prisma-client` provider (what the SDK
+// templates pin) writes the client to a project-relative `output`
+// (`../src/generated/prisma`), NOT the legacy `node_modules/.prisma/client`.
+// The skip check used to look only at the legacy path, so `prisma generate`
+// re-ran on every warm restart even with no schema changes.
+// ---------------------------------------------------------------------------
+
+const PRISMA7_SCHEMA = `datasource db { provider = "sqlite"; url = "file:./dev.db" }
+generator client {
+  provider = "prisma-client"
+  output   = "../src/generated/prisma"
+}
+model User { id String @id }
+`
+
+describe('PreviewManager.prismaClientDirCandidates', () => {
+  test('resolves the generator `output` relative to prisma/ (Prisma 7)', () => {
+    const root = makeWorkspace({ withPrismaSchema: PRISMA7_SCHEMA })
+    const pm = new PreviewManager({ workspaceDir: root, runtimePort: 0 })
+    const cwd = (pm as any).bundlerCwd as string
+    const cands = (pm as any).prismaClientDirCandidates(cwd) as string[]
+    // Declared output wins (resolved against prisma/), then the legacy path.
+    expect(cands[0]).toBe(join(cwd, 'src', 'generated', 'prisma'))
+    expect(cands).toContain(join(cwd, 'node_modules', '.prisma', 'client'))
+  })
+
+  test('falls back to SDK default + legacy path when no `output` is declared', () => {
+    const root = makeWorkspace({
+      withPrismaSchema: `generator client { provider = "prisma-client-js" }\nmodel User { id String @id }\n`,
+    })
+    const pm = new PreviewManager({ workspaceDir: root, runtimePort: 0 })
+    const cwd = (pm as any).bundlerCwd as string
+    const cands = (pm as any).prismaClientDirCandidates(cwd) as string[]
+    expect(cands).toEqual([
+      join(cwd, 'src', 'generated', 'prisma'),
+      join(cwd, 'node_modules', '.prisma', 'client'),
+    ])
+  })
+})
+
+describe('PreviewManager.runPrismaIfNeeded (skip detection)', () => {
+  test('skips generate when the declared output dir exists (no respawn on warm restart)', async () => {
+    const root = makeWorkspace({ withPrismaSchema: PRISMA7_SCHEMA })
+    const cwd = join(root, 'project')
+    // Simulate a warm project: client already generated + sqlite db present.
+    mkdirSync(join(cwd, 'src', 'generated', 'prisma'), { recursive: true })
+    writeFileSync(join(cwd, 'src', 'generated', 'prisma', 'index.js'), '// client')
+    writeFileSync(join(cwd, 'prisma', 'dev.db'), '')
+
+    const pm = new PreviewManager({ workspaceDir: root, runtimePort: 0 })
+    const timings: Record<string, number> = {}
+    await (pm as any).runPrismaIfNeeded(timings)
+
+    // Both steps short-circuit → no `prisma generate` / `db push` subprocess.
+    expect(timings.prisma).toBe(0)
+    expect(timings.dbPush).toBe(0)
+    expect(spawnCalls.length).toBe(0)
+  })
+
+  test('still honors the legacy node_modules/.prisma/client location', () => {
+    const root = makeWorkspace({
+      withPrismaSchema: `generator client { provider = "prisma-client-js" }\nmodel User { id String @id }\n`,
+    })
+    const cwd = join(root, 'project')
+    mkdirSync(join(cwd, 'node_modules', '.prisma', 'client'), { recursive: true })
+    const pm = new PreviewManager({ workspaceDir: root, runtimePort: 0 })
+    const cands = (pm as any).prismaClientDirCandidates(cwd) as string[]
+    expect(cands.some((p) => existsSync(p))).toBe(true)
+  })
+})

--- a/packages/agent-runtime/src/gateway.ts
+++ b/packages/agent-runtime/src/gateway.ts
@@ -2362,6 +2362,36 @@ export class AgentGateway {
             uiWriter.write({ type: 'text-delta', id: uiTextId, delta })
           }
         },
+        onInferenceRetry: (info) => {
+          // The dropped model call is being re-issued. Close any in-progress
+          // text/reasoning block so the client can drop the failed step's
+          // partial deltas, then emit an explicit marker the client + the
+          // API-side accumulator key on to reset (avoids concatenating the
+          // discarded partial with the regenerated output).
+          if (uiWriter && uiTextId) {
+            uiWriter.write({ type: 'text-end', id: uiTextId })
+            uiTextId = null
+          }
+          if (uiWriter && uiReasoningId) {
+            uiWriter.write({ type: 'reasoning-end', id: uiReasoningId })
+            uiReasoningId = null
+          }
+          if (uiWriter) {
+            uiWriter.write({
+              type: 'data-inference-retry',
+              data: {
+                attempt: info.attempt,
+                maxAttempts: info.maxAttempts,
+                reason: info.reason,
+                delayMs: info.delayMs,
+              },
+            } as any)
+          }
+          console.warn(
+            `${this.logPrefix} Inference retry ${info.attempt}/${info.maxAttempts} ` +
+              `(reason=${info.reason}, delay=${info.delayMs}ms) for session ${sessionId}`,
+          )
+        },
         onToolCallStart: (toolName, toolCallId) => {
           this._lastTool = toolName
           if (uiWriter && uiTextId) {

--- a/packages/agent-runtime/src/preview-manager.ts
+++ b/packages/agent-runtime/src/preview-manager.ts
@@ -1898,13 +1898,48 @@ export class PreviewManager {
     this.depsReadyResolve = null
   }
 
+  /**
+   * Candidate on-disk locations for the generated Prisma client, used to
+   * decide whether `prisma generate` can be skipped on (re)start.
+   *
+   * Prisma 7's `prisma-client` provider (what the SDK templates pin) writes
+   * the client to a project-relative `output` — the runtime template uses
+   * `../src/generated/prisma` — NOT the legacy `node_modules/.prisma/client`
+   * that `prisma-client-js` used. Checking only the legacy path meant the
+   * client was "never found", so `prisma generate` re-ran on every restart
+   * even with no schema changes (the user-visible "shogo generate runs before
+   * the server starts" on a warm project). We parse the declared `output`
+   * from `schema.prisma` and fall back to the SDK default + the legacy path
+   * so both new and old projects skip correctly.
+   */
+  private prismaClientDirCandidates(cwd: string): string[] {
+    const candidates: string[] = []
+    const schemaDir = join(cwd, 'prisma')
+    try {
+      const schema = readFileSync(join(schemaDir, 'schema.prisma'), 'utf-8')
+      // `output = "..."` inside the `generator <name> { ... }` block.
+      const generatorBlock = schema.match(/generator\s+\w+\s*\{[\s\S]*?\}/)?.[0]
+      const output = generatorBlock?.match(/\boutput\s*=\s*["']([^"']+)["']/)?.[1]
+      if (output) {
+        // `output` resolves relative to the schema file's directory.
+        candidates.push(output.startsWith('/') ? output : join(schemaDir, output))
+      }
+    } catch {
+      // Unreadable schema — fall through to the defaults below.
+    }
+    // SDK template default (Prisma 7) + legacy prisma-client-js location.
+    candidates.push(join(cwd, 'src', 'generated', 'prisma'))
+    candidates.push(join(cwd, 'node_modules', '.prisma', 'client'))
+    return [...new Set(candidates)]
+  }
+
   private async runPrismaIfNeeded(timings: Record<string, number>): Promise<void> {
     const cwd = this.bundlerCwd
     const prismaSchema = join(cwd, 'prisma', 'schema.prisma')
     if (!existsSync(prismaSchema)) return
 
-    const prismaClientPath = join(cwd, 'node_modules', '.prisma', 'client')
-    if (existsSync(prismaClientPath)) {
+    const prismaClientExists = this.prismaClientDirCandidates(cwd).some((p) => existsSync(p))
+    if (prismaClientExists) {
       console.log(`[${LOG_PREFIX}] Prisma client exists — skipping generate`)
       timings.prisma = 0
     } else {

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -1357,6 +1357,27 @@ app.post('/agent/chat', async (c) => {
     }
   }
 
+  // Non-destructive continuation. When a turn ended incomplete (e.g. a model
+  // call dropped and inference retries were exhausted), the client can ask the
+  // agent to pick up from where it stopped WITHOUT re-sending the original user
+  // message. The interrupted turn's completed tool calls were already persisted
+  // to the session (see gateway: persist result.newMessages before UI cleanup),
+  // so buildHistory replays them and the agent continues from that exact point.
+  // We supply a crafted continuation instruction server-side rather than
+  // re-running the original prompt (which would restart the work).
+  const isContinueTurn = body.continue === true || body.continueTurn === true
+  if (isContinueTurn && userFileParts.length === 0) {
+    // The model receives a crafted continuation instruction regardless of any
+    // short label the client rendered (e.g. a "Continue" bubble) so it resumes
+    // the preserved work instead of re-running the original prompt.
+    userText =
+      'Continue from where you stopped. The previous response was interrupted ' +
+      'mid-turn. Build on the tool results and progress already made in this ' +
+      'conversation — do not restart, repeat completed steps, or re-run tools ' +
+      'whose results are already present. Pick up exactly where you left off ' +
+      'and finish the task.'
+  }
+
   if (!userText && userFileParts.length === 0) {
     return c.json({ error: 'message is required — send { messages: [{ role: "user", parts: [{ type: "text", text: "..." }] }] }' }, 400)
   }

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -55,6 +55,13 @@ import {
   getHeadSha,
   repoStoreConfigFromEnv,
   gatherCommitMeta,
+  isLfsEnabled,
+  ensureLfsRepoSetup,
+  autoTrackLargeFiles,
+  lfsPushAll,
+  lfsPull,
+  lfsRemoteConfigFromEnv,
+  migrateOffloadedAssetsToLfs,
   type CloudSyncMode,
 } from '@shogo/shared-runtime'
 import { getModelTier, resolveModelId, calculateDollarCost } from '@shogo/model-catalog'
@@ -311,13 +318,46 @@ let gitSyncInstance: GitWorkspaceSync | null = null
 let workspaceMemberSyncs: Map<string, import('@shogo/shared-runtime').S3Sync> = new Map()
 
 /**
+ * Whether real Git LFS is active for this pod. Scoped to `git_only` (the
+ * pod-owned default): the LFS object-offload step is wired into that mode's
+ * `afterCommit` durability path, and LFS attributes are only written for
+ * these repos, so other modes (dual_shadow/s3) keep the legacy offload and
+ * never accidentally LFS-ify files.
+ */
+function isLfsActive(): boolean {
+  return resolveCloudSyncMode() === 'git_only' && isLfsEnabled()
+}
+
+/**
+ * Persist `.git` to object storage, first offloading LFS object bytes to OCI
+ * when LFS is active. The local `.git/lfs/objects` cache is excluded from the
+ * tarball ONLY when the push succeeded — otherwise the bytes would be durable
+ * nowhere, so we keep them in the tarball as a fallback. Shared by the
+ * afterCommit, publish-tag, and shutdown durability paths.
+ */
+async function persistDurableRepo(): Promise<{ ok: boolean; changed: boolean; reason?: string }> {
+  const repoCfg = repoStoreConfigFromEnv()
+  if (!repoCfg) return { ok: true, changed: false, reason: 'no-store-config' }
+  let excludeLfsObjects = false
+  if (isLfsActive()) {
+    const lfsCfg = lfsRemoteConfigFromEnv(WORKSPACE_DIR)
+    if (lfsCfg) excludeLfsObjects = await lfsPushAll(lfsCfg)
+  }
+  return persistRepoToStore(WORKSPACE_DIR, repoCfg, { excludeLfsObjects })
+}
+
+/**
  * Offload large/binary assets to S3 and refresh `.git/info/exclude` so the
  * subsequent git push stays source-only. Fire-and-forget — paired with the
  * git push at the turn-complete boundary in `git_only` / `dual_shadow`.
  * No-op unless object storage is configured and a git sync is active.
+ *
+ * In Git LFS mode this legacy size-based offload is replaced by the LFS
+ * clean filter (pointers) + `git lfs push` (bytes), so it no-ops.
  */
 function triggerLargeFileSync(): void {
   if (!gitSyncInstance) return
+  if (isLfsActive()) return
   const cfg = largeFileSyncConfigFromEnv(WORKSPACE_DIR)
   if (!cfg) return
   void syncLargeFiles(cfg).catch((err: any) =>
@@ -334,9 +374,9 @@ function triggerLargeFileSync(): void {
  * is already durable and the row can be reconciled on the next API hydrate).
  */
 async function persistAndRecordCheckpoint(sha: string): Promise<void> {
-  const repoCfg = repoStoreConfigFromEnv()
-  if (repoCfg) {
-    const res = await persistRepoToStore(WORKSPACE_DIR, repoCfg)
+  if (repoStoreConfigFromEnv()) {
+    // Offload LFS object bytes to OCI (when active) then persist `.git`.
+    const res = await persistDurableRepo()
     if (!res.ok) throw new Error(`durable repo persist failed: ${res.reason}`)
   }
   // Record the checkpoint row (best-effort; the commit is already durable in
@@ -4301,16 +4341,18 @@ app.post('/agent/git-flush', async (c) => {
     /* no body */
   }
   try {
+    // Legacy size-based offload (skipped under LFS — flush() handles LFS via
+    // beforeStage track + afterCommit push).
     const lfCfg = largeFileSyncConfigFromEnv(WORKSPACE_DIR)
-    if (lfCfg) await syncLargeFiles(lfCfg)
+    if (lfCfg && !isLfsActive()) await syncLargeFiles(lfCfg)
     await gitSyncInstance.flush()
 
     let taggedSha: string | null = null
     if (tag) {
       taggedSha = await createTagLocal(WORKSPACE_DIR, tag, { message: tagMessage, force: true })
-      // Re-persist so the durable repo carries the new tag.
-      const repoCfg = repoStoreConfigFromEnv()
-      if (repoCfg) await persistRepoToStore(WORKSPACE_DIR, repoCfg)
+      // Re-persist so the durable repo carries the new tag (LFS objects are
+      // already in OCI from the flush; re-push is a cheap no-op via dedup).
+      await persistDurableRepo()
     }
 
     const sha = taggedSha ?? (await getHeadSha(WORKSPACE_DIR))
@@ -4702,6 +4744,23 @@ async function initializeEssentials(): Promise<void> {
           console.error('[agent-runtime] restoreLargeFiles failed:', error.message)
         }
       }
+      // Git LFS (git_only + LFS_ENABLED): configure the repo's LFS filter +
+      // .gitattributes, run the one-time migration off the legacy assets/
+      // offload (no-op once done), then materialize object bytes for the
+      // current checkout (smudge is skipped on checkout, so we fetch
+      // explicitly). All best-effort — a failure leaves pointer files and is
+      // recovered on the next pull.
+      if (isLfsActive()) {
+        try {
+          await ensureLfsRepoSetup(WORKSPACE_DIR)
+          await migrateOffloadedAssetsToLfs(WORKSPACE_DIR)
+          const lfsCfg = lfsRemoteConfigFromEnv(WORKSPACE_DIR)
+          if (lfsCfg) await lfsPull(lfsCfg)
+          logTiming('Git LFS setup + pull')
+        } catch (error: any) {
+          console.error('[agent-runtime] Git LFS setup failed:', error?.message ?? error)
+        }
+      }
     } else {
       console.warn('[agent-runtime] git mode requested but SHOGO_API_URL/RUNTIME_AUTH_SECRET/PROJECT_ID incomplete; skipping repo bootstrap')
     }
@@ -4712,6 +4771,11 @@ async function initializeEssentials(): Promise<void> {
         // origin. dual_shadow keeps the push model.
         localOnly: cloudSyncMode === 'git_only',
         afterCommit: cloudSyncMode === 'git_only' ? persistAndRecordCheckpoint : undefined,
+        // Git LFS: before each `git add -A`, track newly-introduced large
+        // files so the clean filter writes pointers instead of raw bytes.
+        beforeStage: isLfsActive()
+          ? async () => { await autoTrackLargeFiles(WORKSPACE_DIR) }
+          : undefined,
         onDegrade: (reason) => {
           console.warn(
             `[agent-runtime] cloud-sync degraded (mode=${cloudSyncMode}): ${reason}`,
@@ -5001,9 +5065,10 @@ async function gracefulShutdown(signal: string): Promise<void> {
     const mode = resolveCloudSyncMode()
     if (gitSyncInstance) {
       // Final large-file offload before the last push so the durable repo
-      // stays source-only and the offloaded asset set is current.
+      // stays source-only and the offloaded asset set is current. Skipped
+      // under LFS — flushAndShutdown's afterCommit runs the LFS object push.
       const lfCfg = largeFileSyncConfigFromEnv(WORKSPACE_DIR)
-      if (lfCfg) {
+      if (lfCfg && !isLfsActive()) {
         try {
           await syncLargeFiles(lfCfg)
         } catch (err: any) {

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -55,7 +55,6 @@ import {
   getHeadSha,
   repoStoreConfigFromEnv,
   gatherCommitMeta,
-  isLfsEnabled,
   ensureLfsRepoSetup,
   autoTrackLargeFiles,
   lfsPushAll,
@@ -322,10 +321,11 @@ let workspaceMemberSyncs: Map<string, import('@shogo/shared-runtime').S3Sync> = 
  * pod-owned default): the LFS object-offload step is wired into that mode's
  * `afterCommit` durability path, and LFS attributes are only written for
  * these repos, so other modes (dual_shadow/s3) keep the legacy offload and
- * never accidentally LFS-ify files.
+ * never accidentally LFS-ify files. LFS is always on for git_only — there is
+ * no separate enable flag.
  */
 function isLfsActive(): boolean {
-  return resolveCloudSyncMode() === 'git_only' && isLfsEnabled()
+  return resolveCloudSyncMode() === 'git_only'
 }
 
 /**
@@ -4744,7 +4744,7 @@ async function initializeEssentials(): Promise<void> {
           console.error('[agent-runtime] restoreLargeFiles failed:', error.message)
         }
       }
-      // Git LFS (git_only + LFS_ENABLED): configure the repo's LFS filter +
+      // Git LFS (git_only): configure the repo's LFS filter +
       // .gitattributes, run the one-time migration off the legacy assets/
       // offload (no-op once done), then materialize object bytes for the
       // current checkout (smudge is skipped on checkout, so we fetch

--- a/packages/agent/src/__tests__/retry-classifier.test.ts
+++ b/packages/agent/src/__tests__/retry-classifier.test.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Tests for the inference retryability classifier.
+ *
+ * Run: bun test packages/agent/src/__tests__/retry-classifier.test.ts
+ */
+import { describe, test, expect } from 'bun:test'
+import {
+  classifyRetryability,
+  parseStreamErrorMarker,
+  stripStreamErrorMarker,
+} from '../retry-classifier'
+
+describe('classifyRetryability — retryable failures', () => {
+  const retryable: Array<[string, string]> = [
+    ['ECONNRESET', 'read ECONNRESET'],
+    ['fetch failed', 'TypeError: fetch failed'],
+    ['socket hang up', 'socket hang up'],
+    ['ETIMEDOUT', 'connect ETIMEDOUT 10.0.0.1:443'],
+    ['mid-stream 500', 'Upstream anthropic returned 500 internal server error'],
+    ['502', '502 Bad Gateway'],
+    ['503', '503 Service Unavailable'],
+    ['overloaded', '{"type":"overloaded_error","message":"Overloaded"}'],
+    ['429', '429 Too Many Requests'],
+    [
+      'idle_timeout (with proxy marker)',
+      'No data from anthropic for 120000ms; giving up. Please retry. [shogo:retryable=true;code=idle_timeout]',
+    ],
+    [
+      'EOF before message_stop',
+      'Upstream anthropic stream ended without message_stop after 5000ms (likely network drop). Please retry.',
+    ],
+    ['premature close', 'Error: Premature close'],
+  ]
+
+  for (const [label, message] of retryable) {
+    test(`retryable: ${label}`, () => {
+      expect(classifyRetryability({ message }).retryable).toBe(true)
+    })
+  }
+})
+
+describe('classifyRetryability — non-retryable failures', () => {
+  const nonRetryable: Array<[string, string]> = [
+    ['401 auth', '401 Unauthorized'],
+    ['403 auth', '403 {"error":{"message":"permission denied"}}'],
+    ['invalid api key', 'Authentication error: invalid api key'],
+    ['400 invalid_request', '400 {"type":"invalid_request_error","message":"bad params"}'],
+    ['content policy', 'Your request was flagged by our content policy'],
+    ['content_filter', 'stop_reason: content_filter'],
+    ['billing', '402 billing_error: insufficient credits'],
+  ]
+
+  for (const [label, message] of nonRetryable) {
+    test(`non-retryable: ${label}`, () => {
+      expect(classifyRetryability({ message }).retryable).toBe(false)
+    })
+  }
+
+  test('user abort is never retryable (even with a retryable-looking message)', () => {
+    expect(classifyRetryability({ message: 'socket hang up', aborted: true }).retryable).toBe(false)
+    expect(classifyRetryability({ message: 'ECONNRESET', stopReason: 'aborted' }).retryable).toBe(false)
+    expect(classifyRetryability({ aborted: true }).reason).toBe('aborted')
+  })
+
+  test('unknown errors are conservatively non-retryable', () => {
+    const c = classifyRetryability({ message: 'something totally unexpected happened' })
+    expect(c.retryable).toBe(false)
+    expect(c.reason).toBe('unknown')
+  })
+})
+
+describe('classifyRetryability — status codes', () => {
+  test('5xx retryable', () => {
+    expect(classifyRetryability({ status: 500 }).retryable).toBe(true)
+    expect(classifyRetryability({ status: 503 }).retryable).toBe(true)
+  })
+  test('429 retryable', () => {
+    expect(classifyRetryability({ status: 429 }).retryable).toBe(true)
+  })
+  test('401/403/400 non-retryable', () => {
+    expect(classifyRetryability({ status: 401 }).retryable).toBe(false)
+    expect(classifyRetryability({ status: 403 }).retryable).toBe(false)
+    expect(classifyRetryability({ status: 400 }).retryable).toBe(false)
+  })
+})
+
+describe('classifyRetryability — structured proxy marker propagation', () => {
+  test('marker retryable=true classifies retryable regardless of prose', () => {
+    const message =
+      'Upstream anthropic stream dropped. Please retry. [shogo:retryable=true;code=upstream_truncated]'
+    const c = classifyRetryability({ message })
+    expect(c.retryable).toBe(true)
+    expect(c.reason).toBe('truncated')
+  })
+
+  test('marker retryable=false classifies non-retryable even with retryable-looking text', () => {
+    // Prose says "stream" / "retry" (retryable-looking) but the structured
+    // flag is authoritative: upstream_error is a definitive failure.
+    const message =
+      'Upstream stream error. Please retry. [shogo:retryable=false;code=upstream_error]'
+    const c = classifyRetryability({ message })
+    expect(c.retryable).toBe(false)
+    expect(c.reason).toBe('upstream_error')
+  })
+
+  test('parseStreamErrorMarker extracts the flag + code', () => {
+    expect(parseStreamErrorMarker('x [shogo:retryable=true;code=idle_timeout]')).toEqual({
+      retryable: true,
+      code: 'idle_timeout',
+    })
+    expect(parseStreamErrorMarker('no marker here')).toBeNull()
+  })
+
+  test('stripStreamErrorMarker removes the internal marker', () => {
+    expect(
+      stripStreamErrorMarker('Connection lost. Please retry. [shogo:retryable=true;code=econnreset]'),
+    ).toBe('Connection lost. Please retry.')
+  })
+
+  test('explicit retryable override is honored when no marker present', () => {
+    expect(classifyRetryability({ message: 'weird', retryable: true }).retryable).toBe(true)
+    expect(classifyRetryability({ message: 'weird', retryable: false }).retryable).toBe(false)
+  })
+})

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -33,9 +33,18 @@ import {
 } from './pi-adapter'
 import { wrapToolsWithOrchestration, type OrchestrationOptions } from './tool-orchestration'
 import { makeStallFallbackStreamFn, resolveStallFallbackOptions, type StallFallbackOptions } from './stall-fallback'
+import { classifyRetryability } from './retry-classifier'
+import {
+  resolveInferenceRetryOptions,
+  detectInferenceFailure,
+  stripTrailingFailedAssistants,
+  type InferenceRetryOptions,
+  type InferenceRetryInfo,
+} from './inference-retry'
 
 export type { LoopDetectorConfig, LoopDetectorResult }
 export type { OrchestrationOptions }
+export type { InferenceRetryOptions, InferenceRetryInfo }
 
 export type ThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
 
@@ -103,6 +112,26 @@ export interface AgentLoopOptions {
    * `SHOGO_STALL_FALLBACK_WINDOW_MS`.
    */
   stallFallback?: StallFallbackOptions | false
+  /**
+   * Inference reconnect/retry. When a single model call drops mid-generation
+   * with a *retryable* failure (network reset, provider 5xx, idle timeout,
+   * stream truncation before `message_stop`), the failed assistant tail is
+   * stripped and the call is re-issued via `Agent.continue()` — without
+   * re-running any already-executed tools. Capped + backed off; user aborts
+   * and definitive errors (auth, content policy, billing, invalid request) are
+   * never retried. Defaults to enabled (2 retries). Pass `false` to disable,
+   * or a config object to tune. Can also be disabled via
+   * `SHOGO_INFERENCE_RETRY=0` and tuned via
+   * `SHOGO_INFERENCE_RETRY_MAX_ATTEMPTS` / `SHOGO_INFERENCE_RETRY_BASE_MS`.
+   */
+  inferenceRetry?: InferenceRetryOptions | false
+  /**
+   * Called just before each inference retry re-issues the dropped model call.
+   * The gateway uses this to emit a `data-inference-retry` frame and reset the
+   * in-progress UI step so the client discards the failed step's partial
+   * deltas instead of concatenating the regenerated output.
+   */
+  onInferenceRetry?: (info: InferenceRetryInfo) => void
   /** Tool orchestration config. Pass false to disable wrapping (tools run raw parallel). */
   orchestration?: OrchestrationOptions | false
   /** AbortSignal for external cancellation (e.g., user stop). */
@@ -441,6 +470,85 @@ export async function runAgentLoop(options: AgentLoopOptions): Promise<AgentLoop
     signal?.removeEventListener('abort', onAbort)
   }
 
+  // Layer 6: Inference reconnect/retry. When the model call dropped mid-stream
+  // with a *retryable* failure, re-issue the SAME call via Agent.continue()
+  // after stripping the failed assistant tail. Because pi-agent-core executes
+  // tools only after a complete assistant message, a call that died mid-stream
+  // never ran that step's tools — so re-issuing is idempotent w.r.t. side
+  // effects, and earlier completed tool results are preserved in the transcript.
+  const inferenceRetry = resolveInferenceRetryOptions(options.inferenceRetry)
+  // Billing policy for retries: the provider (and therefore Shogo's AI proxy
+  // billing session) charges for tokens actually consumed on each call — even
+  // a dropped/partial one. The proxy accumulates those into the per-session
+  // bucket that `closeSession` bills, so the user is charged for the failed
+  // partial attempt as the provider charged us. We strip the failed assistant
+  // message from the transcript (so it isn't replayed to the model), but we
+  // keep its usage here and fold it back into the loop's reported totals so the
+  // surfaced usage stays consistent with what was actually billed. Retries are
+  // capped (default 2) so cost amplification is bounded.
+  const discardedUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+  if (inferenceRetry && !abortTriggered) {
+    let retryAttempt = 0
+    while (retryAttempt < inferenceRetry.maxAttempts) {
+      if (abortTriggered || signal?.aborted) break
+
+      const failure = detectInferenceFailure(agent.state.messages, promptError)
+      if (!failure) break
+
+      const classification = classifyRetryability({
+        message: failure.errorText,
+        stopReason: failure.stopReason,
+        aborted: abortTriggered || signal?.aborted,
+      })
+      if (!classification.retryable) break
+
+      // Strip the failed assistant tail so continue() resumes from the last
+      // user/tool-result message. When the call rejected before pi appended any
+      // assistant message (e.g. a synchronous stream throw on the very first
+      // call), there's nothing to strip and the transcript already ends on a
+      // user/tool-result message — continue() can re-issue directly.
+      const trimmed = stripTrailingFailedAssistants(agent.state.messages) ?? agent.state.messages
+      const last = trimmed[trimmed.length - 1]
+      // Can't continue from a clean assistant tail (continue() rejects) — bail.
+      if (!last || last.role === 'assistant') break
+      if (trimmed !== agent.state.messages) {
+        // Preserve the usage of the stripped failed attempt for billing parity.
+        const removedUsage = sumUsage(agent.state.messages.slice(trimmed.length))
+        discardedUsage.input += removedUsage.input
+        discardedUsage.output += removedUsage.output
+        discardedUsage.cacheRead += removedUsage.cacheRead
+        discardedUsage.cacheWrite += removedUsage.cacheWrite
+        agent.state.messages = trimmed
+      }
+
+      retryAttempt++
+      const delayMs = inferenceRetry.computeDelayMs(retryAttempt)
+      try {
+        options.onInferenceRetry?.({
+          attempt: retryAttempt,
+          maxAttempts: inferenceRetry.maxAttempts,
+          reason: classification.reason,
+          delayMs,
+          error: failure.errorText,
+        })
+      } catch { /* listener must not break the loop */ }
+      console.warn(
+        `[AgentLoop] INFERENCE_RETRY attempt=${retryAttempt}/${inferenceRetry.maxAttempts} ` +
+          `reason=${classification.reason} delayMs=${delayMs} error=${failure.errorText.slice(0, 160)}`,
+      )
+
+      promptError = undefined
+      if (delayMs > 0) await inferenceRetry.sleep(delayMs)
+      if (abortTriggered || signal?.aborted) break
+
+      try {
+        await agent.continue()
+      } catch (err: any) {
+        promptError = err
+      }
+    }
+  }
+
   let allMessages = agent.state.messages
   let newMessages = allMessages.slice(history.length)
   let finalText = extractFinalText(newMessages)
@@ -605,10 +713,10 @@ export async function runAgentLoop(options: AgentLoopOptions): Promise<AgentLoop
       : finalText,
     toolCalls,
     iterations,
-    inputTokens: usage.input,
-    outputTokens: usage.output,
-    cacheReadTokens: usage.cacheRead,
-    cacheWriteTokens: usage.cacheWrite,
+    inputTokens: usage.input + discardedUsage.input,
+    outputTokens: usage.output + discardedUsage.output,
+    cacheReadTokens: usage.cacheRead + discardedUsage.cacheRead,
+    cacheWriteTokens: usage.cacheWrite + discardedUsage.cacheWrite,
     newMessages,
     loopBreak,
     error: promptError || implicitError,

--- a/packages/agent/src/inference-retry.ts
+++ b/packages/agent/src/inference-retry.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Inference reconnect/retry for the agent loop.
+ *
+ * When a single model call drops mid-generation with a *retryable* failure
+ * (network reset, provider 5xx, idle timeout, a stream that ended before
+ * `message_stop`), the safe recovery is to re-issue that same call rather than
+ * end the turn. pi-agent-core runs tools only AFTER a complete assistant
+ * message, so a call that died mid-generation never executed that step's tools
+ * — re-issuing it is idempotent w.r.t. side effects. The earlier completed
+ * steps stay in the transcript and are reused via `Agent.continue()`.
+ *
+ * This module owns:
+ *   - option resolution (caps, backoff, env overrides), mirroring
+ *     `resolveStallFallbackOptions` in `stall-fallback.ts`.
+ *   - detecting whether the last attempt failed and extracting its error text.
+ *   - stripping the failed assistant tail so `Agent.continue()` can re-drive
+ *     from the last user/tool-result message.
+ *
+ * The actual retry loop lives in `agent-loop.ts` (it needs the live `Agent`).
+ */
+
+import type { Message } from '@mariozechner/pi-ai'
+import type { RetryReason } from './retry-classifier'
+
+export interface InferenceRetryOptions {
+  /** Max number of re-issues (continues) after the initial attempt. Default 2. */
+  maxAttempts?: number
+  /** Base backoff delay in ms (doubled per attempt). Default 500. */
+  baseDelayMs?: number
+  /** Cap on a single backoff delay in ms. Default 8000. */
+  maxDelayMs?: number
+  /** Apply +/- jitter to the backoff. Default true. */
+  jitter?: boolean
+  /** Injectable delay computer (tests can assert/replace). */
+  computeDelayMs?: (attempt: number) => number
+  /** Injectable sleep (tests pass a no-op / fake-timer). */
+  sleep?: (ms: number) => Promise<void>
+}
+
+export interface ResolvedInferenceRetry {
+  maxAttempts: number
+  computeDelayMs: (attempt: number) => number
+  sleep: (ms: number) => Promise<void>
+}
+
+export interface InferenceRetryInfo {
+  /** 1-based attempt index (1 = first retry). */
+  attempt: number
+  maxAttempts: number
+  reason: RetryReason
+  delayMs: number
+  /** The (cleaned) error text that triggered the retry. */
+  error: string
+}
+
+const DEFAULT_MAX_ATTEMPTS = 2
+const DEFAULT_BASE_DELAY_MS = 500
+const DEFAULT_MAX_DELAY_MS = 8_000
+
+function envInt(name: string): number | undefined {
+  const raw = process.env[name]
+  if (raw == null || raw === '') return undefined
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : undefined
+}
+
+/**
+ * Resolve effective inference-retry options from explicit config + env.
+ * Returns `null` when retries are disabled.
+ *
+ * Env:
+ * - `SHOGO_INFERENCE_RETRY=0|false|off` disables it entirely.
+ * - `SHOGO_INFERENCE_RETRY_MAX_ATTEMPTS=<n>` overrides the retry cap.
+ * - `SHOGO_INFERENCE_RETRY_BASE_MS=<n>` overrides the base backoff.
+ */
+export function resolveInferenceRetryOptions(
+  explicit?: InferenceRetryOptions | false,
+): ResolvedInferenceRetry | null {
+  if (explicit === false) return null
+  const envFlag = (process.env.SHOGO_INFERENCE_RETRY ?? '').trim().toLowerCase()
+  if (envFlag === '0' || envFlag === 'false' || envFlag === 'off') return null
+
+  const o = explicit ?? {}
+  const rawMax = o.maxAttempts ?? envInt('SHOGO_INFERENCE_RETRY_MAX_ATTEMPTS') ?? DEFAULT_MAX_ATTEMPTS
+  const maxAttempts = Math.max(0, Math.min(10, Math.floor(rawMax)))
+  if (maxAttempts <= 0) return null
+
+  const base = o.baseDelayMs ?? envInt('SHOGO_INFERENCE_RETRY_BASE_MS') ?? DEFAULT_BASE_DELAY_MS
+  const max = o.maxDelayMs ?? DEFAULT_MAX_DELAY_MS
+  const jitter = o.jitter ?? true
+
+  const computeDelayMs =
+    o.computeDelayMs ??
+    ((attempt: number) => {
+      const raw = Math.min(max, base * Math.pow(2, Math.max(0, attempt - 1)))
+      // Half-jitter: keep at least 50% of the computed delay so backoff still grows.
+      return jitter ? Math.round(raw * (0.5 + Math.random() * 0.5)) : Math.round(raw)
+    })
+
+  const sleep = o.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)))
+
+  return { maxAttempts, computeDelayMs, sleep }
+}
+
+export interface InferenceFailure {
+  errorText: string
+  stopReason?: string
+}
+
+/**
+ * Inspect the transcript after an attempt and decide whether the last model
+ * call failed. Returns the failure details, or `null` if the last assistant
+ * turn completed cleanly.
+ *
+ * pi-agent-core catches stream errors internally and appends an assistant
+ * message carrying `errorMessage` / `stopReason: 'error'` rather than throwing,
+ * so we inspect the trailing assistant message. A directly-thrown error
+ * (`promptError`) takes precedence.
+ */
+export function detectInferenceFailure(
+  messages: Message[],
+  promptError?: Error,
+): InferenceFailure | null {
+  if (promptError) {
+    return { errorText: promptError.message || String(promptError) }
+  }
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i] as any
+    if (m.role !== 'assistant') continue
+    if (m.errorMessage || m.stopReason === 'error') {
+      return { errorText: m.errorMessage || 'Provider error', stopReason: m.stopReason }
+    }
+    // First (trailing) assistant message is clean -> the turn succeeded.
+    return null
+  }
+  return null
+}
+
+/**
+ * Return a copy of `messages` with the trailing failed assistant message(s)
+ * removed, or `null` if there was nothing to strip. A "failed" assistant
+ * message is one with an `errorMessage`, `stopReason: 'error'`, or no usable
+ * content. Stripping leaves the transcript ending on the last user/tool-result
+ * message so `Agent.continue()` can re-issue the dropped call.
+ */
+export function stripTrailingFailedAssistants(messages: Message[]): Message[] | null {
+  let end = messages.length
+  while (end > 0) {
+    const m = messages[end - 1] as any
+    if (m.role !== 'assistant') break
+    const hasError = !!m.errorMessage || m.stopReason === 'error'
+    const emptyContent =
+      !Array.isArray(m.content) ||
+      m.content.length === 0 ||
+      m.content.every(
+        (c: any) =>
+          (c.type === 'text' && !(c.text && c.text.trim())) ||
+          (c.type === 'thinking' && !(c.thinking && c.thinking.trim())),
+      )
+    if (hasError || emptyContent) {
+      end--
+      continue
+    }
+    break
+  }
+  if (end === messages.length) return null
+  return messages.slice(0, end)
+}

--- a/packages/agent/src/retry-classifier.ts
+++ b/packages/agent/src/retry-classifier.ts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Retryability classifier for inference (model-call) failures.
+ *
+ * A single LLM call can fail mid-generation for many reasons. Some are
+ * transient and safe to re-issue (network reset, provider 5xx, idle timeout,
+ * a stream that ended before `message_stop`); others are definitive and must
+ * NOT be retried (user abort, auth/permission, malformed request, content
+ * policy, billing). This module makes that decision in one place so the agent
+ * loop and any callers stay consistent.
+ *
+ * Two signal sources are supported, in priority order:
+ *   1. A structured marker embedded by Shogo's AI proxy in the error message
+ *      (`[shogo:retryable=<bool>;code=<code>]`). This is the authoritative
+ *      signal and survives whatever wrapping the provider SDK applies.
+ *   2. String/heuristic matching on the raw error text + HTTP status as a
+ *      fallback when no marker is present (direct provider calls, thrown
+ *      Errors, non-proxied paths).
+ *
+ * A user-initiated abort is ALWAYS non-retryable regardless of any other
+ * signal.
+ */
+
+export type RetryReason =
+  | 'network'
+  | 'timeout'
+  | 'idle_timeout'
+  | 'server_5xx'
+  | 'overloaded'
+  | 'truncated'
+  | 'aborted'
+  | 'auth'
+  | 'invalid_request'
+  | 'content_policy'
+  | 'billing'
+  | 'upstream_error'
+  | 'unknown'
+
+export interface RetryClassification {
+  retryable: boolean
+  reason: RetryReason
+}
+
+export interface RetryClassifyInput {
+  /** Raw error text (pi-ai `errorMessage` or a thrown Error's message). */
+  message?: string | null
+  /** stopReason from the failed assistant message, if known. */
+  stopReason?: string | null
+  /** HTTP-ish status code, if known. */
+  status?: number | null
+  /** True when the failure was a user-initiated abort (never retryable). */
+  aborted?: boolean
+  /** Structured retryable override (e.g. already-decided upstream). */
+  retryable?: boolean | null
+}
+
+/**
+ * Stable marker the AI proxy embeds in stream-error messages so the
+ * retryable flag + code survive transport into pi-ai's `errorMessage`.
+ * Keep this format in sync with `apps/api/src/routes/ai-proxy.ts`.
+ */
+const STREAM_ERROR_MARKER = /\[shogo:retryable=(true|false);code=([a-z0-9_]+)\]/i
+
+export interface StreamErrorMarker {
+  retryable: boolean
+  code: string
+}
+
+/** Parse the proxy's `[shogo:retryable=...;code=...]` marker, if present. */
+export function parseStreamErrorMarker(message?: string | null): StreamErrorMarker | null {
+  if (!message) return null
+  const m = STREAM_ERROR_MARKER.exec(message)
+  if (!m) return null
+  return { retryable: m[1].toLowerCase() === 'true', code: m[2].toLowerCase() }
+}
+
+/** Strip the proxy marker so user-facing error text stays clean. */
+export function stripStreamErrorMarker(message?: string | null): string {
+  if (!message) return ''
+  return message.replace(/\s*\[shogo:retryable=[^\]]*\]/gi, '').trim()
+}
+
+function codeToReason(code: string): RetryReason {
+  switch (code) {
+    case 'idle_timeout':
+      return 'idle_timeout'
+    case 'upstream_truncated':
+      return 'truncated'
+    case 'upstream_error':
+      return 'upstream_error'
+    case 'econnreset':
+    case 'econnrefused':
+    case 'epipe':
+    case 'network_error':
+      return 'network'
+    case 'etimedout':
+    case 'timeout':
+      return 'timeout'
+    default:
+      return 'unknown'
+  }
+}
+
+function classifyByStatus(status: number): RetryClassification | null {
+  if (status === 408 || status === 425) return { retryable: true, reason: 'timeout' }
+  if (status === 429) return { retryable: true, reason: 'overloaded' }
+  if (status >= 500 && status <= 599) return { retryable: true, reason: 'server_5xx' }
+  if (status === 401 || status === 403) return { retryable: false, reason: 'auth' }
+  if (status === 402) return { retryable: false, reason: 'billing' }
+  if (status === 400 || status === 404 || status === 422) return { retryable: false, reason: 'invalid_request' }
+  return null
+}
+
+// Non-retryable patterns take precedence over retryable ones so that, e.g.,
+// "401 connection" is treated as auth rather than network.
+const NON_RETRYABLE_PATTERNS: Array<[RegExp, RetryReason]> = [
+  [/\bunauthorized\b|invalid[_\s-]?api[_\s-]?key|authentication|permission denied|\b401\b|\b403\b/i, 'auth'],
+  [/content[_\s-]?(policy|filter)|moderation|safety (system|filter)|stop_reason["'\s:]+content_filter/i, 'content_policy'],
+  [/billing|insufficient[_\s]?(credits|funds|balance)|payment required|\b402\b|quota (exceeded|reached)|usage limit/i, 'billing'],
+  [/invalid[_\s-]?request|\b400\b|\bunprocessable\b|\b422\b|prompt is too long|maximum context length|context (length|window) (exceeded|too)/i, 'invalid_request'],
+]
+
+const RETRYABLE_PATTERNS: Array<[RegExp, RetryReason]> = [
+  [/idle[_\s-]?timeout/i, 'idle_timeout'],
+  [/(ended|stopped|closed|dropped) (without|before) (a )?message_stop|upstream_truncated|truncat(ed|ion)|premature (close|end)|unexpected end of/i, 'truncated'],
+  [/\b429\b|rate[_\s-]?limit|overloaded|too many requests|capacity/i, 'overloaded'],
+  [/\b50[0-9]\b|\b502\b|\b503\b|\b504\b|internal server error|bad gateway|service unavailable|gateway timeout|server error/i, 'server_5xx'],
+  [/econnreset|econnrefused|enotfound|ehostunreach|enetunreach|epipe|socket hang up|fetch failed|network (error|failure)|connection (reset|closed|refused|error|lost|aborted|terminated)|stream (error|dropped|interrupted|faulted)|terminated|read econnreset/i, 'network'],
+  [/etimedout|timed out|stream timed out|request timeout|deadline exceeded/i, 'timeout'],
+]
+
+/**
+ * Classify whether an inference failure is safe to retry.
+ *
+ * Decision order:
+ *   1. User abort -> never retryable.
+ *   2. Proxy marker (authoritative structured signal).
+ *   3. Explicit `retryable` override.
+ *   4. HTTP status.
+ *   5. Non-retryable text patterns, then retryable text patterns.
+ *   6. Default: non-retryable / unknown (conservative — don't burn tokens or
+ *      loop on errors we don't recognize).
+ */
+export function classifyRetryability(input: RetryClassifyInput): RetryClassification {
+  if (input.aborted || input.stopReason === 'aborted') {
+    return { retryable: false, reason: 'aborted' }
+  }
+
+  const marker = parseStreamErrorMarker(input.message)
+  if (marker) {
+    return { retryable: marker.retryable, reason: codeToReason(marker.code) }
+  }
+
+  if (typeof input.retryable === 'boolean') {
+    // Honor the structured flag; still derive a best-effort reason from text.
+    const derived = deriveReasonFromText(input.message)
+    return { retryable: input.retryable, reason: derived ?? (input.retryable ? 'network' : 'unknown') }
+  }
+
+  if (typeof input.status === 'number' && Number.isFinite(input.status)) {
+    const byStatus = classifyByStatus(input.status)
+    if (byStatus) return byStatus
+  }
+
+  const msg = input.message ?? ''
+  for (const [re, reason] of NON_RETRYABLE_PATTERNS) {
+    if (re.test(msg)) return { retryable: false, reason }
+  }
+  for (const [re, reason] of RETRYABLE_PATTERNS) {
+    if (re.test(msg)) return { retryable: true, reason }
+  }
+
+  return { retryable: false, reason: 'unknown' }
+}
+
+function deriveReasonFromText(message?: string | null): RetryReason | null {
+  if (!message) return null
+  for (const [re, reason] of NON_RETRYABLE_PATTERNS) {
+    if (re.test(message)) return reason
+  }
+  for (const [re, reason] of RETRYABLE_PATTERNS) {
+    if (re.test(message)) return reason
+  }
+  return null
+}

--- a/packages/shared-app/src/chat/message-helpers.ts
+++ b/packages/shared-app/src/chat/message-helpers.ts
@@ -70,25 +70,38 @@ export function isTunnelDisconnectError(message: string): boolean {
     CONNECTION_ERROR_PATTERNS.some((p) => p.test(raw))
 }
 
+/**
+ * Internal retryability marker the AI proxy embeds in stream-error messages
+ * (see `apps/api/src/routes/ai-proxy.ts` / `packages/agent/src/retry-classifier.ts`).
+ * It is meant for the server-side retry classifier, never for users, so we
+ * strip it before rendering any error text.
+ */
+const STREAM_ERROR_MARKER_PATTERN = /\s*\[shogo:retryable=[^\]]*\]/gi
+
+export function stripInternalErrorMarkers(message: string): string {
+  return message.replace(STREAM_ERROR_MARKER_PATTERN, '').trim()
+}
+
 export function formatErrorMessage(rawMessage: string): string {
+  const cleaned = stripInternalErrorMarkers(rawMessage)
   try {
-    const parsed = JSON.parse(rawMessage)
+    const parsed = JSON.parse(cleaned)
     if (parsed?.error?.code && ERROR_CODE_MESSAGES[parsed.error.code]) {
       return ERROR_CODE_MESSAGES[parsed.error.code]
     }
     if (parsed?.error?.message) {
-      return parsed.error.message
+      return stripInternalErrorMarkers(parsed.error.message)
     }
     if (parsed?.message) {
-      return parsed.message
+      return stripInternalErrorMarkers(parsed.message)
     }
   } catch {
     // Not JSON
   }
-  if (CONNECTION_ERROR_PATTERNS.some((p) => p.test(rawMessage))) {
+  if (CONNECTION_ERROR_PATTERNS.some((p) => p.test(cleaned))) {
     return 'Connection interrupted. Please tap Retry to continue.'
   }
-  return rawMessage
+  return cleaned
 }
 
 /**

--- a/packages/shared-runtime/src/__tests__/lfs.test.ts
+++ b/packages/shared-runtime/src/__tests__/lfs.test.ts
@@ -16,7 +16,6 @@ import {
   lfsObjectKey,
   lfsKeyPrefix,
   buildLfsEndpointUrl,
-  isLfsEnabled,
   buildManagedAttributesBlock,
   writeManagedGitAttributes,
 } from '../lfs'
@@ -56,15 +55,6 @@ describe('buildLfsEndpointUrl', () => {
     expect(buildLfsEndpointUrl('https://api.shogo.ai/', 'p1')).toBe(
       'https://api.shogo.ai/api/projects/p1/git/info/lfs',
     )
-  })
-})
-
-describe('isLfsEnabled', () => {
-  it('is true only for "true"/"1"', () => {
-    expect(isLfsEnabled({ LFS_ENABLED: 'true' } as any)).toBe(true)
-    expect(isLfsEnabled({ LFS_ENABLED: '1' } as any)).toBe(true)
-    expect(isLfsEnabled({ LFS_ENABLED: 'false' } as any)).toBe(false)
-    expect(isLfsEnabled({} as any)).toBe(false)
   })
 })
 

--- a/packages/shared-runtime/src/__tests__/lfs.test.ts
+++ b/packages/shared-runtime/src/__tests__/lfs.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Unit tests for the pure / fs-level helpers in `lfs.ts`. The git-spawning
+ * transfer helpers (push/pull/track) need a real git+git-lfs and are covered
+ * by integration, not here.
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  isValidLfsOid,
+  lfsObjectKey,
+  lfsKeyPrefix,
+  buildLfsEndpointUrl,
+  isLfsEnabled,
+  buildManagedAttributesBlock,
+  writeManagedGitAttributes,
+} from '../lfs'
+
+const OID = 'a'.repeat(64)
+
+describe('isValidLfsOid', () => {
+  it('accepts a 64-char lowercase hex digest', () => {
+    expect(isValidLfsOid(OID)).toBe(true)
+  })
+  it('rejects wrong length, uppercase, and non-hex', () => {
+    expect(isValidLfsOid('abc')).toBe(false)
+    expect(isValidLfsOid('A'.repeat(64))).toBe(false)
+    expect(isValidLfsOid('g'.repeat(64))).toBe(false)
+    expect(isValidLfsOid('../../etc/passwd')).toBe(false)
+  })
+})
+
+describe('lfsObjectKey', () => {
+  it('shards by the first two byte-pairs of the oid', () => {
+    expect(lfsObjectKey('p1', OID, 'lfs/objects')).toBe(`p1/lfs/objects/aa/aa/${OID}`)
+  })
+  it('throws on an invalid oid (no key-namespace escape)', () => {
+    expect(() => lfsObjectKey('p1', 'not-an-oid')).toThrow()
+  })
+})
+
+describe('lfsKeyPrefix', () => {
+  it('defaults to lfs/objects and honors S3_LFS_PREFIX', () => {
+    expect(lfsKeyPrefix({} as any)).toBe('lfs/objects')
+    expect(lfsKeyPrefix({ S3_LFS_PREFIX: '/custom/lfs/' } as any)).toBe('custom/lfs')
+  })
+})
+
+describe('buildLfsEndpointUrl', () => {
+  it('builds the LFS base the client appends /objects/batch to', () => {
+    expect(buildLfsEndpointUrl('https://api.shogo.ai/', 'p1')).toBe(
+      'https://api.shogo.ai/api/projects/p1/git/info/lfs',
+    )
+  })
+})
+
+describe('isLfsEnabled', () => {
+  it('is true only for "true"/"1"', () => {
+    expect(isLfsEnabled({ LFS_ENABLED: 'true' } as any)).toBe(true)
+    expect(isLfsEnabled({ LFS_ENABLED: '1' } as any)).toBe(true)
+    expect(isLfsEnabled({ LFS_ENABLED: 'false' } as any)).toBe(false)
+    expect(isLfsEnabled({} as any)).toBe(false)
+  })
+})
+
+describe('buildManagedAttributesBlock', () => {
+  it('wraps curated patterns in managed markers', () => {
+    const block = buildManagedAttributesBlock()
+    expect(block).toContain('# >>> shogo git-lfs (managed) >>>')
+    expect(block).toContain('# <<< shogo git-lfs (managed) <<<')
+    expect(block).toContain('*.png filter=lfs diff=lfs merge=lfs -text')
+    expect(block).toContain('*.safetensors filter=lfs diff=lfs merge=lfs -text')
+  })
+})
+
+describe('writeManagedGitAttributes', () => {
+  let dir: string
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('creates .gitattributes with the managed block', () => {
+    dir = mkdtempSync(join(tmpdir(), 'lfs-attr-'))
+    writeManagedGitAttributes(dir)
+    const content = readFileSync(join(dir, '.gitattributes'), 'utf-8')
+    expect(content).toContain('*.mp4 filter=lfs diff=lfs merge=lfs -text')
+  })
+
+  it('preserves user content and is idempotent', () => {
+    dir = mkdtempSync(join(tmpdir(), 'lfs-attr-'))
+    const attrPath = join(dir, '.gitattributes')
+    writeFileSync(attrPath, '*.custom text\n')
+    writeManagedGitAttributes(dir)
+    writeManagedGitAttributes(dir) // second call must not duplicate the block
+    const content = readFileSync(attrPath, 'utf-8')
+    expect(content).toContain('*.custom text')
+    const markerCount = content.split('# >>> shogo git-lfs (managed) >>>').length - 1
+    expect(markerCount).toBe(1)
+  })
+})

--- a/packages/shared-runtime/src/git-sync.ts
+++ b/packages/shared-runtime/src/git-sync.ts
@@ -125,6 +125,14 @@ export interface GitWorkspaceSyncConfig {
    * retry/degrade path as a failed push.
    */
   afterCommit?: (sha: string) => Promise<void> | void
+  /**
+   * Optional hook run at the start of every push cycle, BEFORE `git add -A`.
+   * In Git LFS mode the agent-runtime wires this to `autoTrackLargeFiles` so
+   * newly-introduced large files are `git lfs track`-ed before staging and
+   * the clean filter writes pointers instead of raw bytes. Best-effort: a
+   * throw is logged and ignored so it can never block the commit/push.
+   */
+  beforeStage?: () => Promise<void> | void
 }
 
 export interface SpawnGitFn {
@@ -194,7 +202,7 @@ function buildGitUrl(cloudApiUrl: string, projectId: string): string {
 
 export class GitWorkspaceSync {
   private readonly cfg: Required<Omit<GitWorkspaceSyncConfig,
-    'onDegrade' | 'onRecovered' | 'logger' | 'spawnGit' | 'authorEmail' | 'authorName' | 'afterCommit'>> & {
+    'onDegrade' | 'onRecovered' | 'logger' | 'spawnGit' | 'authorEmail' | 'authorName' | 'afterCommit' | 'beforeStage'>> & {
     onDegrade: (reason: string) => void
     onRecovered: () => void
     logger: Logger
@@ -202,6 +210,7 @@ export class GitWorkspaceSync {
     authorEmail: string
     authorName: string
     afterCommit: ((sha: string) => Promise<void> | void) | null
+    beforeStage: (() => Promise<void> | void) | null
   }
 
   private debounceTimer: ReturnType<typeof setTimeout> | null = null
@@ -232,6 +241,7 @@ export class GitWorkspaceSync {
       authorEmail: config.authorEmail ?? 'agent-runtime@shogo.ai',
       authorName: config.authorName ?? 'Shogo Agent',
       afterCommit: config.afterCommit ?? null,
+      beforeStage: config.beforeStage ?? null,
     }
   }
 
@@ -351,6 +361,17 @@ export class GitWorkspaceSync {
     }
 
     try {
+      // LFS hook: track newly-introduced large files before staging so the
+      // clean filter writes pointers, not raw bytes. Best-effort — never let
+      // it block the commit/push.
+      if (this.cfg.beforeStage) {
+        try {
+          await this.cfg.beforeStage()
+        } catch (hookErr: any) {
+          logger.warn(`[GitWorkspaceSync] beforeStage hook threw: ${hookErr?.message ?? hookErr}`)
+        }
+      }
+
       // Stage everything (respects `.gitignore`).
       await this.runGit(spawnGit, ['add', '-A'], workspaceDir, commitEnv)
 
@@ -503,7 +524,7 @@ export function resolveCloudSyncMode(env: NodeJS.ProcessEnv = process.env): Clou
  */
 export function createGitSyncFromEnv(
   workspaceDir: string,
-  opts: Pick<GitWorkspaceSyncConfig, 'onDegrade' | 'onRecovered' | 'debounceMs' | 'degradeAfterFailures' | 'logger' | 'localOnly' | 'afterCommit'> = {},
+  opts: Pick<GitWorkspaceSyncConfig, 'onDegrade' | 'onRecovered' | 'debounceMs' | 'degradeAfterFailures' | 'logger' | 'localOnly' | 'afterCommit' | 'beforeStage'> = {},
 ): GitWorkspaceSync | null {
   const cloudApiUrl = process.env.SHOGO_API_URL
   const runtimeAuthSecret = process.env.RUNTIME_AUTH_SECRET

--- a/packages/shared-runtime/src/index.ts
+++ b/packages/shared-runtime/src/index.ts
@@ -53,7 +53,6 @@ export {
 } from './large-file-sync'
 
 export {
-  isLfsEnabled,
   lfsKeyPrefix,
   isValidLfsOid,
   lfsObjectKey,

--- a/packages/shared-runtime/src/index.ts
+++ b/packages/shared-runtime/src/index.ts
@@ -46,9 +46,29 @@ export {
   restoreLargeFiles,
   largeFileThreshold,
   largeFileSyncConfigFromEnv,
+  hasManagedExclude,
+  clearManagedExclude,
   DEFAULT_LARGE_FILE_BYTES,
   type LargeFileSyncConfig,
 } from './large-file-sync'
+
+export {
+  isLfsEnabled,
+  lfsKeyPrefix,
+  isValidLfsOid,
+  lfsObjectKey,
+  buildLfsEndpointUrl,
+  buildManagedAttributesBlock,
+  writeManagedGitAttributes,
+  ensureLfsRepoSetup,
+  autoTrackLargeFiles,
+  lfsPushAll,
+  lfsPull,
+  lfsRemoteConfigFromEnv,
+  migrateOffloadedAssetsToLfs,
+  DEFAULT_LFS_EXTENSIONS,
+  type LfsRemoteConfig,
+} from './lfs'
 
 export {
   initializePostgresBackup,

--- a/packages/shared-runtime/src/large-file-sync.ts
+++ b/packages/shared-runtime/src/large-file-sync.ts
@@ -180,6 +180,28 @@ function updateGitExclude(workspaceDir: string, relPaths: string[]): void {
 }
 
 /**
+ * Whether `.git/info/exclude` still carries the managed large-file block.
+ * Used as the "not yet migrated to Git LFS" marker for a project.
+ */
+export function hasManagedExclude(workspaceDir: string): boolean {
+  const excludePath = join(workspaceDir, '.git', 'info', 'exclude')
+  try {
+    return readFileSync(excludePath, 'utf-8').includes(MANAGED_EXCLUDE_HEADER)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Remove the managed large-file block from `.git/info/exclude` so the
+ * previously-offloaded files can be staged (and re-tracked via Git LFS).
+ * Part of the one-time LFS migration in `lfs.ts`.
+ */
+export function clearManagedExclude(workspaceDir: string): void {
+  updateGitExclude(workspaceDir, [])
+}
+
+/**
  * Sync the current large-file set to object storage: upload new/changed
  * assets, prune assets no longer present, and refresh the git-exclude
  * block. Best-effort — logs and continues on per-file errors.

--- a/packages/shared-runtime/src/lfs.ts
+++ b/packages/shared-runtime/src/lfs.ts
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Git LFS support for the pod-owned `git_only` model.
+ *
+ * Replaces the size-based S3 offload in `large-file-sync.ts` with real
+ * Git LFS: large files are tracked via `.gitattributes`, stored as tiny
+ * pointer blobs in the commit DAG, and their bytes are offloaded to OCI
+ * Object Storage through the API's LFS batch endpoint
+ * (`apps/api/src/routes/git-lfs.ts`).
+ *
+ * Division of labour:
+ *   - The POD has the `git-lfs` binary (see `Dockerfile.base`). It runs the
+ *     clean filter on `git add` (writing pointers + local objects), pushes
+ *     objects to OCI via `git lfs push`, and pulls them back on cold start.
+ *   - The API has NO `git-lfs` binary. It only mints presigned OCI URLs in
+ *     the batch response, so bytes flow pod<->OCI directly and the API's
+ *     hydrate/`reset --hard` path leaves pointer files untouched (the commit
+ *     graph still shows the files).
+ *
+ * Auth: every `git lfs` invocation passes the runtime bearer via
+ * `-c http.extraHeader=...` and the LFS endpoint via `-c lfs.url=...`, so
+ * neither the token nor an environment-specific URL is ever persisted into
+ * `.git/config` (which rides along in the durable `.git` tarball).
+ *
+ * Smudge is skipped globally in the pod image (`git lfs install --system
+ * --skip-smudge`): checkout/`reset --hard` leaves pointers (fast, no
+ * network), and the runtime materializes content deterministically with an
+ * explicit {@link lfsPull}.
+ */
+
+import { spawn } from 'child_process'
+import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+import {
+  classifyLargeFiles,
+  largeFileThreshold,
+  hasManagedExclude,
+  clearManagedExclude,
+} from './large-file-sync'
+
+type Logger = Pick<Console, 'log' | 'warn' | 'error'>
+
+const GIT_TIMEOUT_MS = 5 * 60 * 1000
+
+// ---------------------------------------------------------------------------
+// Feature flag + storage layout (shared API <-> pod contract)
+// ---------------------------------------------------------------------------
+
+/** Whether real Git LFS is enabled for this pod. */
+export function isLfsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.LFS_ENABLED === 'true' || env.LFS_ENABLED === '1'
+}
+
+/** Object-storage key prefix for LFS objects within a project namespace. */
+export function lfsKeyPrefix(env: NodeJS.ProcessEnv = process.env): string {
+  return (env.S3_LFS_PREFIX || 'lfs/objects').replace(/^\/+|\/+$/g, '')
+}
+
+/** A Git LFS oid is a lowercase sha256 hex digest. */
+export function isValidLfsOid(oid: string): boolean {
+  return /^[0-9a-f]{64}$/.test(oid)
+}
+
+/**
+ * Build the object-storage key for an LFS object, sharded by the first two
+ * byte-pairs of the oid (the same layout git-lfs uses on disk):
+ *   `<projectId>/lfs/objects/<oid[0:2]>/<oid[2:4]>/<oid>`
+ *
+ * Throws on an invalid oid so a malformed batch request can't escape the
+ * project's key namespace.
+ */
+export function lfsObjectKey(
+  projectId: string,
+  oid: string,
+  prefix: string = lfsKeyPrefix(),
+): string {
+  if (!isValidLfsOid(oid)) throw new Error(`invalid lfs oid: ${oid}`)
+  return `${projectId}/${prefix}/${oid.slice(0, 2)}/${oid.slice(2, 4)}/${oid}`
+}
+
+/**
+ * Derive the LFS server base URL from the cloud API root + project id. The
+ * git-lfs client appends `/objects/batch` (and `/objects/verify`) to this.
+ *
+ * We set this explicitly via `-c lfs.url=` rather than letting git-lfs guess
+ * it from the remote URL: our smart-HTTP remote ends in `/git` (not `.git`),
+ * which git-lfs would mangle into `.../git.git/info/lfs`.
+ */
+export function buildLfsEndpointUrl(cloudApiUrl: string, projectId: string): string {
+  const base = cloudApiUrl.replace(/\/+$/, '')
+  return `${base}/api/projects/${projectId}/git/info/lfs`
+}
+
+/** Smart-HTTP git URL for the project (used as the `cloud` remote). */
+function buildGitUrl(cloudApiUrl: string, projectId: string): string {
+  const base = cloudApiUrl.replace(/\/+$/, '')
+  return `${base}/api/projects/${projectId}/git`
+}
+
+// ---------------------------------------------------------------------------
+// .gitattributes management
+// ---------------------------------------------------------------------------
+
+const ATTR_HEADER = '# >>> shogo git-lfs (managed) >>>'
+const ATTR_FOOTER = '# <<< shogo git-lfs (managed) <<<'
+
+/**
+ * Curated set of binary-ish extensions tracked by Git LFS. Files outside
+ * this list that still exceed the size threshold are caught at sync time by
+ * {@link autoTrackLargeFiles} (preserving the legacy "anything large" rule).
+ */
+export const DEFAULT_LFS_EXTENSIONS: readonly string[] = [
+  // images
+  'png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'tif', 'tiff', 'ico', 'heic', 'avif', 'psd', 'ai',
+  // video
+  'mp4', 'mov', 'avi', 'mkv', 'webm', 'm4v',
+  // audio
+  'mp3', 'wav', 'flac', 'ogg', 'm4a', 'aac',
+  // archives
+  'zip', 'gz', 'tgz', 'bz2', 'xz', 'zst', '7z', 'rar',
+  // documents
+  'pdf',
+  // fonts
+  'ttf', 'otf', 'woff', 'woff2', 'eot',
+  // 3d / graphics
+  'glb', 'gltf', 'fbx', 'obj', 'blend',
+  // native / wasm
+  'wasm', 'so', 'dylib', 'dll', 'node',
+  // ml / data
+  'bin', 'onnx', 'pt', 'pth', 'h5', 'npy', 'npz', 'safetensors', 'gguf', 'parquet',
+]
+
+function attributeLineFor(ext: string): string {
+  return `*.${ext} filter=lfs diff=lfs merge=lfs -text`
+}
+
+/** The managed `.gitattributes` block (header + curated patterns + footer). */
+export function buildManagedAttributesBlock(): string {
+  return [ATTR_HEADER, ...DEFAULT_LFS_EXTENSIONS.map(attributeLineFor), ATTR_FOOTER].join('\n')
+}
+
+/**
+ * Write/refresh the Shogo-managed block in `<workspaceDir>/.gitattributes`,
+ * preserving any user-authored entries outside the markers. Idempotent.
+ */
+export function writeManagedGitAttributes(workspaceDir: string): void {
+  const attrPath = join(workspaceDir, '.gitattributes')
+  let existing = ''
+  try {
+    existing = readFileSync(attrPath, 'utf-8')
+  } catch {
+    existing = ''
+  }
+  const start = existing.indexOf(ATTR_HEADER)
+  if (start !== -1) {
+    const end = existing.indexOf(ATTR_FOOTER)
+    if (end !== -1) {
+      existing = existing.slice(0, start) + existing.slice(end + ATTR_FOOTER.length)
+    }
+  }
+  existing = existing.replace(/\n{3,}/g, '\n\n').trim()
+  const next = [existing, buildManagedAttributesBlock()].filter(Boolean).join('\n\n') + '\n'
+  writeFileSync(attrPath, next)
+}
+
+// ---------------------------------------------------------------------------
+// git invocation
+// ---------------------------------------------------------------------------
+
+interface GitResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+function runGit(args: string[], cwd: string, env?: NodeJS.ProcessEnv): Promise<GitResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('git', args, {
+      cwd,
+      env: { ...process.env, ...(env ?? {}) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    const out: string[] = []
+    const err: string[] = []
+    child.stdout.setEncoding('utf-8')
+    child.stderr.setEncoding('utf-8')
+    child.stdout.on('data', (c: string) => out.push(c))
+    child.stderr.on('data', (c: string) => err.push(c))
+    const timer = setTimeout(() => {
+      try { child.kill('SIGKILL') } catch { /* ignore */ }
+      reject(new Error(`git ${args.join(' ')} timed out after ${GIT_TIMEOUT_MS}ms`))
+    }, GIT_TIMEOUT_MS)
+    child.on('error', (e) => { clearTimeout(timer); reject(e) })
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve({ exitCode: code ?? -1, stdout: out.join(''), stderr: err.join('') })
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Repo setup (pod side, git_only + LFS_ENABLED only)
+// ---------------------------------------------------------------------------
+
+/**
+ * Configure `<workspaceDir>` for Git LFS: enable the per-repo filter with
+ * smudge skipped (content is materialized explicitly via {@link lfsPull}),
+ * and write the managed `.gitattributes`. Idempotent and best-effort — a
+ * failure here must never crash the pod, just disable LFS for the session.
+ */
+export async function ensureLfsRepoSetup(
+  workspaceDir: string,
+  opts: { logger?: Logger } = {},
+): Promise<boolean> {
+  const logger = opts.logger ?? console
+  if (!existsSync(join(workspaceDir, '.git'))) return false
+  try {
+    // `--local --skip-smudge` is belt-and-suspenders on top of the image's
+    // `git lfs install --system --skip-smudge`; it makes local dev (no system
+    // install) behave identically to production.
+    await runGit(['lfs', 'install', '--local', '--skip-smudge'], workspaceDir)
+    writeManagedGitAttributes(workspaceDir)
+    return true
+  } catch (err: any) {
+    logger.warn(`[lfs] repo setup failed: ${err?.message ?? err}`)
+    return false
+  }
+}
+
+/**
+ * Track any file larger than `thresholdBytes` that isn't already matched by
+ * an LFS pattern, by appending a path-specific rule to `.gitattributes`.
+ * Preserves the legacy "offload anything over the threshold" behavior for
+ * extensions outside {@link DEFAULT_LFS_EXTENSIONS}. Best-effort.
+ *
+ * Returns the number of newly-tracked paths.
+ */
+export async function autoTrackLargeFiles(
+  workspaceDir: string,
+  thresholdBytes: number = largeFileThreshold(),
+  opts: { logger?: Logger } = {},
+): Promise<number> {
+  const logger = opts.logger ?? console
+  if (!existsSync(join(workspaceDir, '.git'))) return 0
+  let tracked = 0
+  const candidates = classifyLargeFiles(workspaceDir, thresholdBytes)
+  for (const rel of candidates) {
+    const relPosix = rel.split(/[\\/]/).join('/')
+    try {
+      const attr = await runGit(['check-attr', 'filter', '--', relPosix], workspaceDir)
+      if (attr.stdout.includes(': filter: lfs')) continue // already LFS-tracked
+      const res = await runGit(['lfs', 'track', '--', relPosix], workspaceDir)
+      if (res.exitCode === 0) tracked++
+    } catch (err: any) {
+      logger.warn(`[lfs] auto-track failed for ${relPosix}: ${err?.message ?? err}`)
+    }
+  }
+  if (tracked) logger.log(`[lfs] auto-tracked ${tracked} large file(s) over ${thresholdBytes}B`)
+  return tracked
+}
+
+// ---------------------------------------------------------------------------
+// Migration off the legacy size-based offload (`large-file-sync.ts`)
+// ---------------------------------------------------------------------------
+
+/**
+ * One-time, idempotent migration of a project from the legacy `assets/`
+ * offload to Git LFS. The managed block in `.git/info/exclude` marks a
+ * not-yet-migrated project; once cleared, this is a no-op.
+ *
+ * Assumes the legacy assets have already been restored to disk (the boot
+ * sequence calls `restoreLargeFiles` first). We simply un-exclude them and
+ * LFS-track them; the next sync commits the pointers and {@link lfsPushAll}
+ * uploads the bytes. The S3 `assets/` copies are left in place for safety —
+ * a later GC pass can reclaim them.
+ *
+ * Best-effort: never throws.
+ */
+export async function migrateOffloadedAssetsToLfs(
+  workspaceDir: string,
+  opts: { thresholdBytes?: number; logger?: Logger } = {},
+): Promise<{ migrated: boolean; tracked: number }> {
+  const logger = opts.logger ?? console
+  if (!existsSync(join(workspaceDir, '.git'))) return { migrated: false, tracked: 0 }
+  if (!hasManagedExclude(workspaceDir)) return { migrated: false, tracked: 0 }
+  try {
+    clearManagedExclude(workspaceDir)
+    const tracked = await autoTrackLargeFiles(
+      workspaceDir,
+      opts.thresholdBytes ?? largeFileThreshold(),
+      { logger },
+    )
+    logger.log(`[lfs] migrated project off legacy asset offload (tracked=${tracked})`)
+    return { migrated: true, tracked }
+  } catch (err: any) {
+    logger.warn(`[lfs] asset migration failed: ${err?.message ?? err}`)
+    return { migrated: false, tracked: 0 }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Object transfer (push / pull) via the API LFS batch endpoint
+// ---------------------------------------------------------------------------
+
+export interface LfsRemoteConfig {
+  workspaceDir: string
+  cloudApiUrl: string
+  runtimeAuthSecret: string
+  projectId: string
+  /** Remote name to (idempotently) point at the smart-HTTP URL. Default `cloud`. */
+  remoteName?: string
+  logger?: Logger
+}
+
+/** Build an {@link LfsRemoteConfig} from the runtime env, or null when unset. */
+export function lfsRemoteConfigFromEnv(
+  workspaceDir: string,
+  logger?: Logger,
+): LfsRemoteConfig | null {
+  const cloudApiUrl = process.env.SHOGO_API_URL
+  const runtimeAuthSecret = process.env.RUNTIME_AUTH_SECRET
+  const projectId = process.env.PROJECT_ID
+  if (!cloudApiUrl || !runtimeAuthSecret || !projectId) return null
+  return { workspaceDir, cloudApiUrl, runtimeAuthSecret, projectId, logger }
+}
+
+/** Ensure a remote named `remoteName` points at the project's smart-HTTP URL. */
+async function ensureCloudRemote(cfg: LfsRemoteConfig): Promise<string> {
+  const remote = cfg.remoteName ?? 'cloud'
+  const url = buildGitUrl(cfg.cloudApiUrl, cfg.projectId)
+  const probe = await runGit(['remote', 'get-url', remote], cfg.workspaceDir)
+  if (probe.exitCode === 0) {
+    if (probe.stdout.trim() !== url) {
+      await runGit(['remote', 'set-url', remote, url], cfg.workspaceDir)
+    }
+  } else {
+    await runGit(['remote', 'add', remote, url], cfg.workspaceDir)
+  }
+  return remote
+}
+
+/** Per-invocation `-c` overrides: explicit LFS url + bearer auth (never persisted). */
+function lfsConfigArgs(cfg: LfsRemoteConfig): string[] {
+  const lfsUrl = buildLfsEndpointUrl(cfg.cloudApiUrl, cfg.projectId)
+  const header = `http.extraHeader=Authorization: Bearer ${cfg.runtimeAuthSecret}`
+  return ['-c', `lfs.url=${lfsUrl}`, '-c', header]
+}
+
+/**
+ * Upload all local LFS objects to OCI via the batch endpoint. The server
+ * dedups (objects it already has return no upload action), so re-running is
+ * cheap. Returns true on success; never throws (durability falls back to the
+ * `.git` tarball when this fails — see {@link persistRepoToStore}).
+ */
+export async function lfsPushAll(cfg: LfsRemoteConfig): Promise<boolean> {
+  const logger = cfg.logger ?? console
+  if (!existsSync(join(cfg.workspaceDir, '.git'))) return false
+  try {
+    const remote = await ensureCloudRemote(cfg)
+    const res = await runGit(
+      [...lfsConfigArgs(cfg), 'lfs', 'push', '--all', remote],
+      cfg.workspaceDir,
+    )
+    if (res.exitCode !== 0) {
+      logger.warn(`[lfs] push failed (${res.exitCode}): ${(res.stderr || '').slice(0, 400)}`)
+      return false
+    }
+    return true
+  } catch (err: any) {
+    logger.warn(`[lfs] push threw: ${err?.message ?? err}`)
+    return false
+  }
+}
+
+/**
+ * Fetch the LFS objects referenced by the current checkout and materialize
+ * them into the working tree (`git lfs pull` = fetch + checkout). Used on
+ * cold start after the `.git` tarball is restored. Best-effort.
+ */
+export async function lfsPull(cfg: LfsRemoteConfig): Promise<boolean> {
+  const logger = cfg.logger ?? console
+  if (!existsSync(join(cfg.workspaceDir, '.git'))) return false
+  try {
+    const remote = await ensureCloudRemote(cfg)
+    const res = await runGit(
+      [...lfsConfigArgs(cfg), 'lfs', 'pull', remote],
+      cfg.workspaceDir,
+    )
+    if (res.exitCode !== 0) {
+      logger.warn(`[lfs] pull failed (${res.exitCode}): ${(res.stderr || '').slice(0, 400)}`)
+      return false
+    }
+    return true
+  } catch (err: any) {
+    logger.warn(`[lfs] pull threw: ${err?.message ?? err}`)
+    return false
+  }
+}

--- a/packages/shared-runtime/src/lfs.ts
+++ b/packages/shared-runtime/src/lfs.ts
@@ -45,13 +45,8 @@ type Logger = Pick<Console, 'log' | 'warn' | 'error'>
 const GIT_TIMEOUT_MS = 5 * 60 * 1000
 
 // ---------------------------------------------------------------------------
-// Feature flag + storage layout (shared API <-> pod contract)
+// Storage layout (shared API <-> pod contract)
 // ---------------------------------------------------------------------------
-
-/** Whether real Git LFS is enabled for this pod. */
-export function isLfsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
-  return env.LFS_ENABLED === 'true' || env.LFS_ENABLED === '1'
-}
 
 /** Object-storage key prefix for LFS objects within a project namespace. */
 export function lfsKeyPrefix(env: NodeJS.ProcessEnv = process.env): string {
@@ -201,7 +196,7 @@ function runGit(args: string[], cwd: string, env?: NodeJS.ProcessEnv): Promise<G
 }
 
 // ---------------------------------------------------------------------------
-// Repo setup (pod side, git_only + LFS_ENABLED only)
+// Repo setup (pod side, git_only only)
 // ---------------------------------------------------------------------------
 
 /**

--- a/packages/shared-runtime/src/repo-store.ts
+++ b/packages/shared-runtime/src/repo-store.ts
@@ -209,10 +209,18 @@ export async function repoExistsInStore(cfg: RepoStoreConfig): Promise<boolean> 
 /**
  * Persist `<workspaceDir>/.git` to object storage. Called after each
  * local commit and at shutdown. No-op when `.git` is absent.
+ *
+ * In Git LFS mode the large object bytes live in their own object-storage
+ * namespace (`<projectId>/lfs/objects/...`, uploaded via `git lfs push`), so
+ * pass `excludeLfsObjects: true` to keep the local `.git/lfs/objects` cache
+ * OUT of the tarball and stop it bloating every hydrate. Callers should only
+ * set this once the LFS push has succeeded — otherwise the bytes would exist
+ * nowhere durable, so the safe fallback is to leave them in the tarball.
  */
 export async function persistRepoToStore(
   workspaceDir: string,
   cfg: RepoStoreConfig,
+  opts: { excludeLfsObjects?: boolean } = {},
 ): Promise<{ ok: boolean; changed: boolean; reason?: string }> {
   const logger = cfg.logger ?? console
   if (!existsSync(join(workspaceDir, '.git'))) {
@@ -221,7 +229,12 @@ export async function persistRepoToStore(
   const client = makeClient(cfg)
   const tmpFile = join(tmpdir(), `repo-${cfg.projectId}-${randomUUID()}.tar.gz`)
   try {
-    await run('tar', ['-czf', tmpFile, '-C', workspaceDir, '.git'])
+    // `--exclude` must precede the `.git` operand. Paths are matched as they
+    // appear in the archive (`.git/lfs/objects/...`).
+    const tarArgs = ['-czf', tmpFile, '-C', workspaceDir]
+    if (opts.excludeLfsObjects) tarArgs.push('--exclude=.git/lfs/objects')
+    tarArgs.push('.git')
+    await run('tar', tarArgs)
     await client.send(
       new PutObjectCommand({
         Bucket: cfg.bucket,

--- a/terraform/modules/object-storage/main.tf
+++ b/terraform/modules/object-storage/main.tf
@@ -107,8 +107,8 @@ resource "oci_objectstorage_bucket" "schemas" {
 # -----------------------------------------------------------------------------
 # Workspaces Sync Bucket (project file persistence)
 # -----------------------------------------------------------------------------
-# NOTE (Git LFS): when LFS_ENABLED is set on the app, Git LFS objects are
-# stored in THIS bucket under `<projectId>/lfs/objects/<oid>` (content-addressed
+# NOTE (Git LFS): git_only-mode pods store Git LFS objects in THIS bucket
+# under `<projectId>/lfs/objects/<oid>` (content-addressed
 # sha256), alongside repo.git.tar.gz and the legacy assets/ namespace. LFS
 # objects are immutable and never overwritten, so usage grows monotonically:
 # a reachability-based GC job (enumerate live pointer oids per project, delete

--- a/terraform/modules/object-storage/main.tf
+++ b/terraform/modules/object-storage/main.tf
@@ -107,6 +107,13 @@ resource "oci_objectstorage_bucket" "schemas" {
 # -----------------------------------------------------------------------------
 # Workspaces Sync Bucket (project file persistence)
 # -----------------------------------------------------------------------------
+# NOTE (Git LFS): when LFS_ENABLED is set on the app, Git LFS objects are
+# stored in THIS bucket under `<projectId>/lfs/objects/<oid>` (content-addressed
+# sha256), alongside repo.git.tar.gz and the legacy assets/ namespace. LFS
+# objects are immutable and never overwritten, so usage grows monotonically:
+# a reachability-based GC job (enumerate live pointer oids per project, delete
+# unreferenced objects) is a required follow-up before this is load-bearing.
+# Set S3_LFS_BUCKET on the app to split LFS into a dedicated bucket instead.
 resource "oci_objectstorage_bucket" "workspaces" {
   compartment_id = coalesce(var.workspaces_compartment_id, var.compartment_id)
   namespace      = local.namespace


### PR DESCRIPTION
## Summary
- On a **warm restart** (navigating back to a project that ran before, with no code changes), `shogo generate` / `prisma generate` ran again before the server started — wasting ~650–700ms and delaying the API sidecar.
- Root cause: `PreviewManager.runPrismaIfNeeded()` decided whether to skip `prisma generate` by checking **only** `node_modules/.prisma/client`. But the SDK templates pin **Prisma 7's `prisma-client` provider** with a custom output (`output = "../src/generated/prisma"`), so the client is emitted to `src/generated/prisma`. The legacy path never exists for modern projects, so the client was always treated as "missing" and regeneration re-ran every restart. (`db push` was already gated correctly on `prisma/dev.db`.)
- Fix: resolve the **actual** client location — parse the `output` from the `generator client {}` block in `prisma/schema.prisma` (resolved relative to the schema dir) and fall back to the SDK default (`src/generated/prisma`) **and** the legacy `node_modules/.prisma/client` so both new and old projects skip correctly. This restores the intended fast restart ("no shogo generate, no prisma db push").

### Code
- `packages/agent-runtime/src/preview-manager.ts`: new `prismaClientDirCandidates()` helper; `runPrismaIfNeeded()` now skips when any candidate exists.

## Test plan
- [x] New unit tests in `preview-manager.spawn-paths.test.ts`:
  - resolves the generator `output` relative to `prisma/` (Prisma 7)
  - falls back to SDK default + legacy path when no `output` is declared
  - `runPrismaIfNeeded` skips (no subprocess spawned) when the declared output dir + `dev.db` exist
  - still honors the legacy `node_modules/.prisma/client` location
- [x] Full `preview-manager.spawn-paths.test.ts` suite passes (31/31, run with `--conditions=development`).
- [x] Typecheck: no new errors introduced (0 errors in `preview-manager.ts`).

Made with [Cursor](https://cursor.com)