### PR TITLE
fix(analytics): show model names instead of UUIDs across admin surfaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,24 @@ AWS_SECRET_ACCESS_KEY=minioadmin
 SCHEMA_STORAGE=s3
 
 # -----------------------------------------------------------------------------
+# Git LFS (large-file versioning, git_only mode) — see apps/api/src/routes/git-lfs.ts
+# -----------------------------------------------------------------------------
+# Master switch. When true, git_only pods track large files with Git LFS
+# (pointers in git + bytes offloaded to OCI via the batch endpoint) instead of
+# the legacy size-based assets/ offload.
+LFS_ENABLED=false
+# Optional dedicated bucket for LFS objects. Defaults to S3_WORKSPACES_BUCKET,
+# where objects live under <projectId>/lfs/objects/<oid>.
+# S3_LFS_BUCKET=shogo-lfs
+# Key prefix within the project namespace (default: lfs/objects).
+# S3_LFS_PREFIX=lfs/objects
+# Endpoint pods use to PUT/GET LFS object bytes; must be pod-reachable AND match
+# the presign signature. Defaults to S3_ENDPOINT (NOT the browser endpoint).
+# S3_LFS_ENDPOINT=http://localhost:9000
+# Presigned-URL TTL for LFS transfers, in seconds (default: 3600).
+# LFS_PRESIGN_EXPIRY=3600
+
+# -----------------------------------------------------------------------------
 # AI providers
 # -----------------------------------------------------------------------------
 ANTHROPIC_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -70,10 +70,10 @@ SCHEMA_STORAGE=s3
 # -----------------------------------------------------------------------------
 # Git LFS (large-file versioning, git_only mode) — see apps/api/src/routes/git-lfs.ts
 # -----------------------------------------------------------------------------
-# Master switch. When true, git_only pods track large files with Git LFS
-# (pointers in git + bytes offloaded to OCI via the batch endpoint) instead of
-# the legacy size-based assets/ offload.
-LFS_ENABLED=false
+# Git LFS is always on for git_only pods (the default sync mode): large files
+# are tracked as pointers in git with the bytes offloaded to OCI via the batch
+# endpoint, replacing the legacy size-based assets/ offload. No enable flag —
+# the settings below are optional overrides (defaults shown).
 # Optional dedicated bucket for LFS objects. Defaults to S3_WORKSPACES_BUCKET,
 # where objects live under <projectId>/lfs/objects/<oid>.
 # S3_LFS_BUCKET=shogo-lfs

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -36,10 +36,14 @@ WORKDIR /app
 #   bash  -> shell scripts
 #   netcat-openbsd -> entrypoint.sh nc port-wait
 #   ca-certificates -> outbound HTTPS
+#   git   -> routes/git-http.ts spawns `git http-backend` for smart-HTTP
+#            clone/fetch/push and `git.service` runs git for status/graph.
+#            (NOT git-lfs: the LFS batch endpoint only mints presigned URLs,
+#            so the API never shells out to git-lfs — see routes/git-lfs.ts.)
 # Plus Bun (entry point uses `bun run`).
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        curl bash unzip ca-certificates netcat-openbsd && \
+        curl bash git unzip ca-certificates netcat-openbsd && \
     curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash -s "bun-v1.3.9" && \
     rm -rf /root/.bun /var/lib/apt/lists/*
 

--- a/apps/api/src/__tests__/build-project-env.test.ts
+++ b/apps/api/src/__tests__/build-project-env.test.ts
@@ -69,7 +69,6 @@ const ENV_KEYS = [
   'S3_REGION',
   'S3_ENDPOINT',
   'S3_FORCE_PATH_STYLE',
-  'LFS_ENABLED',
   'SHOGO_VOICE_MODE',
   'SHOGO_DEMO_VOICE',
   'SHOGO_MOCK_CAPTURE_DIR',
@@ -407,27 +406,6 @@ describe('buildProjectEnv — S3 config', () => {
     process.env.S3_FORCE_PATH_STYLE = '1' // non-"true" string → omitted
     env = await buildProjectEnv('proj-s3-fps-2')
     expect(env.S3_FORCE_PATH_STYLE).toBeUndefined()
-  })
-})
-
-// ─── Git LFS ───────────────────────────────────────────────────────────────
-
-describe('buildProjectEnv — Git LFS', () => {
-  test('omits LFS_ENABLED by default', async () => {
-    const env = await buildProjectEnv('proj-no-lfs')
-    expect(env.LFS_ENABLED).toBeUndefined()
-  })
-
-  test('forwards LFS_ENABLED to the pod when enabled on the API', async () => {
-    process.env.LFS_ENABLED = 'true'
-    const env = await buildProjectEnv('proj-lfs')
-    expect(env.LFS_ENABLED).toBe('true')
-  })
-
-  test('does not forward a non-truthy LFS_ENABLED', async () => {
-    process.env.LFS_ENABLED = 'false'
-    const env = await buildProjectEnv('proj-lfs-off')
-    expect(env.LFS_ENABLED).toBeUndefined()
   })
 })
 

--- a/apps/api/src/__tests__/build-project-env.test.ts
+++ b/apps/api/src/__tests__/build-project-env.test.ts
@@ -69,6 +69,7 @@ const ENV_KEYS = [
   'S3_REGION',
   'S3_ENDPOINT',
   'S3_FORCE_PATH_STYLE',
+  'LFS_ENABLED',
   'SHOGO_VOICE_MODE',
   'SHOGO_DEMO_VOICE',
   'SHOGO_MOCK_CAPTURE_DIR',
@@ -406,6 +407,27 @@ describe('buildProjectEnv — S3 config', () => {
     process.env.S3_FORCE_PATH_STYLE = '1' // non-"true" string → omitted
     env = await buildProjectEnv('proj-s3-fps-2')
     expect(env.S3_FORCE_PATH_STYLE).toBeUndefined()
+  })
+})
+
+// ─── Git LFS ───────────────────────────────────────────────────────────────
+
+describe('buildProjectEnv — Git LFS', () => {
+  test('omits LFS_ENABLED by default', async () => {
+    const env = await buildProjectEnv('proj-no-lfs')
+    expect(env.LFS_ENABLED).toBeUndefined()
+  })
+
+  test('forwards LFS_ENABLED to the pod when enabled on the API', async () => {
+    process.env.LFS_ENABLED = 'true'
+    const env = await buildProjectEnv('proj-lfs')
+    expect(env.LFS_ENABLED).toBe('true')
+  })
+
+  test('does not forward a non-truthy LFS_ENABLED', async () => {
+    process.env.LFS_ENABLED = 'false'
+    const env = await buildProjectEnv('proj-lfs-off')
+    expect(env.LFS_ENABLED).toBeUndefined()
   })
 })
 

--- a/apps/api/src/__tests__/chat-inference-retry-reset.test.ts
+++ b/apps/api/src/__tests__/chat-inference-retry-reset.test.ts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Accumulator-reset tests for `trackUsageFromStream` in `project-chat.ts`.
+ *
+ * When the runtime re-issues a model call that dropped mid-generation it emits
+ * a `data-inference-retry` frame. The API-side parser must discard the failed
+ * step's partial text/reasoning (and any partially-streamed tool input that
+ * never executed) so the persisted `ChatMessage` reflects ONLY the final,
+ * retried output — never a concatenation of the thrown-away partial with the
+ * regenerated text. Completed tool calls from earlier steps must be preserved.
+ *
+ * Run: bun test apps/api/src/__tests__/chat-inference-retry-reset.test.ts
+ */
+
+import { describe, test, expect, beforeEach, mock } from 'bun:test'
+
+// ─── Prisma mock ──────────────────────────────────────────────────────────
+type PersistedMessage = {
+  id: string
+  sessionId: string
+  role: string
+  content: string
+  parts?: string
+  agent?: string
+}
+
+let persistedMessages: PersistedMessage[] = []
+let persistedToolCalls: any[] = []
+let messageIdCounter = 0
+
+const mockPrisma = {
+  chatSession: {
+    findUnique: mock(async (args: any) => (args?.where?.id ? { id: args.where.id } : null)),
+  },
+  chatMessage: {
+    create: mock(async (args: any) => {
+      const msg: PersistedMessage = { id: `msg-${++messageIdCounter}`, ...args.data }
+      persistedMessages.push(msg)
+      return msg
+    }),
+  },
+  toolCallLog: {
+    createMany: mock(async (args: any) => {
+      persistedToolCalls.push(...args.data)
+      return { count: args.data.length }
+    }),
+  },
+  project: {
+    update: mock(async (args: any) => ({ id: args.where.id, ...args.data })),
+  },
+}
+mock.module('../lib/prisma', () => ({ prisma: mockPrisma }))
+
+mock.module('../services/billing.service', () => ({
+  consumeUsage: async () => ({ success: true, remainingIncludedUsd: 99 }),
+}))
+mock.module('../services/git.service', () => ({ isGitAvailable: () => false }))
+
+import { openSession, accumulateUsage } from '../lib/proxy-billing-session'
+import { trackUsageFromStream } from '../routes/project-chat'
+
+function makeSseStream(frames: string[]): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const f of frames) controller.enqueue(enc.encode(f))
+      controller.close()
+    },
+  })
+}
+
+function dataFrame(payload: Record<string, unknown>): string {
+  return `data: ${JSON.stringify(payload)}\n\n`
+}
+
+describe('trackUsageFromStream — inference-retry accumulator reset', () => {
+  beforeEach(() => {
+    persistedMessages = []
+    persistedToolCalls = []
+    messageIdCounter = 0
+  })
+
+  test('discards the failed step partial text on data-inference-retry', async () => {
+    const projectId = 'proj-retry-text'
+    const chatSessionId = 'sess-retry-text'
+    openSession(projectId, 'ws', 'user')
+    accumulateUsage(projectId, 'claude-sonnet-4-5', 100, 30)
+
+    const stream = makeSseStream([
+      // Failed step: partial text streamed, then the model call drops and is retried.
+      dataFrame({ type: 'text-delta', delta: 'partial that was ' }),
+      dataFrame({ type: 'text-delta', delta: 'thrown away' }),
+      dataFrame({ type: 'data-inference-retry', data: { attempt: 1, maxAttempts: 2, reason: 'network' } }),
+      // Retried step: the real, final answer.
+      dataFrame({ type: 'text-delta', delta: 'final ' }),
+      dataFrame({ type: 'text-delta', delta: 'answer' }),
+      dataFrame({ type: 'data-turn-complete', data: { status: 'completed', lastSeq: 9 } }),
+      dataFrame({ type: 'finish', usage: { inputTokens: 100, outputTokens: 30 } }),
+    ])
+
+    await trackUsageFromStream(
+      stream,
+      { chatSessionId, agentMode: 'sonnet' },
+      { id: projectId, workspaceId: 'ws' },
+      { resume: async () => null },
+    )
+
+    expect(persistedMessages).toHaveLength(1)
+    // Only the post-retry output — no concatenation of the discarded partial.
+    expect(persistedMessages[0].content).toBe('final answer')
+    expect(persistedMessages[0].content).not.toContain('thrown away')
+    const parts = JSON.parse(persistedMessages[0].parts || '[]')
+    const textParts = parts.filter((p: any) => p.type === 'text')
+    expect(textParts).toHaveLength(1)
+    expect(textParts[0].text).toBe('final answer')
+  })
+
+  test('preserves completed tool calls from earlier steps across a retry', async () => {
+    const projectId = 'proj-retry-tool'
+    const chatSessionId = 'sess-retry-tool'
+    openSession(projectId, 'ws', 'user')
+    accumulateUsage(projectId, 'claude-sonnet-4-5', 100, 30)
+
+    const stream = makeSseStream([
+      // Step 1 completes a tool call (executed -> has output).
+      dataFrame({ type: 'text-delta', delta: 'looking at the file. ' }),
+      dataFrame({
+        type: 'tool-input-available',
+        toolCallId: 'tc-1',
+        toolName: 'read_file',
+        input: { path: 'a.ts' },
+      }),
+      dataFrame({ type: 'tool-output-available', toolCallId: 'tc-1', output: { content: 'body' } }),
+      // Step 2 starts generating text + a partial tool input, then drops -> retry.
+      dataFrame({ type: 'text-delta', delta: 'half-written ' }),
+      dataFrame({ type: 'tool-input-start', toolCallId: 'tc-2-partial', toolName: 'edit_file' }),
+      dataFrame({ type: 'data-inference-retry', data: { attempt: 1, maxAttempts: 2, reason: 'server_5xx' } }),
+      // Retried step 2: the final answer text.
+      dataFrame({ type: 'text-delta', delta: 'Here is the summary.' }),
+      dataFrame({ type: 'data-turn-complete', data: { status: 'completed', lastSeq: 12 } }),
+      dataFrame({ type: 'finish', usage: { inputTokens: 100, outputTokens: 30 } }),
+    ])
+
+    await trackUsageFromStream(
+      stream,
+      { chatSessionId, agentMode: 'sonnet' },
+      { id: projectId, workspaceId: 'ws' },
+      { resume: async () => null },
+    )
+
+    expect(persistedMessages).toHaveLength(1)
+    // Completed tool call survives; the partial step-2 text is dropped.
+    expect(persistedMessages[0].content).toBe('looking at the file. Here is the summary.')
+    expect(persistedMessages[0].content).not.toContain('half-written')
+
+    // Only the executed tool is logged; the partial (never-executed) tool is dropped.
+    expect(persistedToolCalls).toHaveLength(1)
+    expect(persistedToolCalls[0].toolName).toBe('read_file')
+
+    const parts = JSON.parse(persistedMessages[0].parts || '[]')
+    const toolParts = parts.filter((p: any) => p.type === 'dynamic-tool')
+    expect(toolParts).toHaveLength(1)
+    expect(toolParts[0].toolName).toBe('read_file')
+  })
+})

--- a/apps/api/src/__tests__/git-lfs-route.test.ts
+++ b/apps/api/src/__tests__/git-lfs-route.test.ts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Tests for the Git LFS batch + verify API at `src/routes/git-lfs.ts`.
+ *
+ * We mock object storage (`../lib/s3`) and auth so the route logic is
+ * exercised deterministically without OCI or a real session. Coverage:
+ *
+ *   - 401 (+ WWW-Authenticate) when unauthenticated
+ *   - workingMode='external' → 404
+ *   - download: presigned GET for existing, per-object 404 for missing
+ *   - upload: presigned PUT + verify for new, no actions (dedup) for existing
+ *   - invalid oid / operation → 422
+ *   - verify: 200 / 404 / 422 (size mismatch)
+ */
+
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { Hono } from 'hono'
+
+// ─── @shogo/shared-runtime mock (avoid loading the whole runtime index) ──
+mock.module('@shogo/shared-runtime', () => ({
+  isValidLfsOid: (oid: string) => /^[0-9a-f]{64}$/.test(oid),
+  lfsObjectKey: (projectId: string, oid: string) =>
+    `${projectId}/lfs/objects/${oid.slice(0, 2)}/${oid.slice(2, 4)}/${oid}`,
+}))
+
+// ─── prisma mock ─────────────────────────────────────────────────────
+const projectFindUnique = mock(async (_: any): Promise<any> => ({
+  workingMode: 'cloud',
+  workspaceId: 'ws_test',
+}))
+mock.module('../lib/prisma', () => ({
+  prisma: { project: { findUnique: projectFindUnique } },
+}))
+
+// ─── auth mock ───────────────────────────────────────────────────────
+mock.module('../middleware/auth', () => ({
+  authorizeProject: async (c: any, projectId: string) => {
+    const auth = c.get('auth')
+    if (!auth?.isAuthenticated) return { ok: false, status: 401, code: 'unauthorized', message: 'no auth' }
+    return { ok: true, workspaceId: 'ws_test', projectId }
+  },
+}))
+
+// ─── s3 mock (stores oid→size; controllable per test) ────────────────
+const heads = new Map<string, number>()
+const headLfsObject = mock(async (key: string): Promise<{ size: number } | null> => {
+  const oid = key.split('/').pop()!
+  return heads.has(oid) ? { size: heads.get(oid)! } : null
+})
+mock.module('../lib/s3', () => ({
+  headLfsObject,
+  getLfsPresignedReadUrl: async (key: string) => `https://oci.example/get/${key}?sig=read`,
+  getLfsPresignedWriteUrl: async (key: string) => `https://oci.example/put/${key}?sig=write`,
+}))
+
+const { gitLfsRoutes } = await import('../routes/git-lfs')
+
+const OID_A = 'a'.repeat(64)
+const OID_B = 'b'.repeat(64)
+
+function makeApp(auth?: { userId: string; isAuthenticated: boolean }) {
+  const app = new Hono()
+  app.use('*', async (c, next) => {
+    c.set('auth', (auth ?? { isAuthenticated: false }) as any)
+    await next()
+  })
+  app.route('/api', gitLfsRoutes({ workspacesDir: '/tmp/lfs-ws' }))
+  return app
+}
+
+function batch(app: Hono, projectId: string, body: unknown) {
+  return app.request(`/api/projects/${projectId}/git/info/lfs/objects/batch`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/vnd.git-lfs+json' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  heads.clear()
+  projectFindUnique.mockClear()
+  projectFindUnique.mockImplementation(async () => ({ workingMode: 'cloud', workspaceId: 'ws_test' }))
+  headLfsObject.mockClear()
+})
+
+describe('git-lfs batch route — auth', () => {
+  it('401 + WWW-Authenticate when unauthenticated', async () => {
+    const res = await batch(makeApp(undefined), 'p_abc', { operation: 'download', objects: [{ oid: OID_A, size: 1 }] })
+    expect(res.status).toBe(401)
+    expect(res.headers.get('www-authenticate')).toBe('Basic realm="shogo"')
+  })
+
+  it('404 for workingMode=external projects', async () => {
+    projectFindUnique.mockImplementation(async () => ({ workingMode: 'external', workspaceId: 'ws_test' }))
+    const res = await batch(makeApp({ userId: 'u', isAuthenticated: true }), 'p_ext', {
+      operation: 'download', objects: [{ oid: OID_A, size: 1 }],
+    })
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('git-lfs batch route — download', () => {
+  it('returns a presigned download action for an existing object', async () => {
+    heads.set(OID_A, 123)
+    const res = await batch(makeApp({ userId: 'u', isAuthenticated: true }), 'p1', {
+      operation: 'download', objects: [{ oid: OID_A, size: 123 }],
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('application/vnd.git-lfs+json')
+    const body: any = await res.json()
+    expect(body.transfer).toBe('basic')
+    expect(body.objects[0].actions.download.href).toContain(`/get/p1/lfs/objects/`)
+    expect(body.objects[0].actions.download.expires_in).toBeGreaterThan(0)
+  })
+
+  it('returns a per-object 404 error for a missing object', async () => {
+    const res = await batch(makeApp({ userId: 'u', isAuthenticated: true }), 'p1', {
+      operation: 'download', objects: [{ oid: OID_A, size: 123 }],
+    })
+    expect(res.status).toBe(200)
+    const body: any = await res.json()
+    expect(body.objects[0].error.code).toBe(404)
+    expect(body.objects[0].actions).toBeUndefined()
+  })
+})
+
+describe('git-lfs batch route — upload', () => {
+  it('returns upload + verify actions for a new object', async () => {
+    const res = await batch(makeApp({ userId: 'u', isAuthenticated: true }), 'p1', {
+      operation: 'upload', objects: [{ oid: OID_A, size: 10 }],
+    })
+    expect(res.status).toBe(200)
+    const body: any = await res.json()
+    expect(body.objects[0].actions.upload.href).toContain('/put/p1/lfs/objects/')
+    expect(body.objects[0].actions.verify.href).toContain('/git/info/lfs/objects/verify')
+  })
+
+  it('omits actions (dedup) when the object already exists', async () => {
+    heads.set(OID_B, 10)
+    const res = await batch(makeApp({ userId: 'u', isAuthenticated: true }), 'p1', {
+      operation: 'upload', objects: [{ oid: OID_B, size: 10 }],
+    })
+    expect(res.status).toBe(200)
+    const body: any = await res.json()
+    expect(body.objects[0].actions).toBeUndefined()
+    expect(body.objects[0].authenticated).toBe(true)
+  })
+})
+
+describe('git-lfs batch route — validation', () => {
+  it('422 for an unknown operation', async () => {
+    const res = await batch(makeApp({ userId: 'u', isAuthenticated: true }), 'p1', {
+      operation: 'sideload', objects: [{ oid: OID_A, size: 1 }],
+    })
+    expect(res.status).toBe(422)
+  })
+
+  it('per-object 422 for a malformed oid', async () => {
+    const res = await batch(makeApp({ userId: 'u', isAuthenticated: true }), 'p1', {
+      operation: 'download', objects: [{ oid: 'not-a-real-oid', size: 1 }],
+    })
+    expect(res.status).toBe(200)
+    const body: any = await res.json()
+    expect(body.objects[0].error.code).toBe(422)
+  })
+})
+
+describe('git-lfs verify route', () => {
+  function verify(app: Hono, projectId: string, body: unknown) {
+    return app.request(`/api/projects/${projectId}/git/info/lfs/objects/verify`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/vnd.git-lfs+json' },
+      body: JSON.stringify(body),
+    })
+  }
+
+  it('200 when the object exists with the expected size', async () => {
+    heads.set(OID_A, 42)
+    const res = await verify(makeApp({ userId: 'u', isAuthenticated: true }), 'p1', { oid: OID_A, size: 42 })
+    expect(res.status).toBe(200)
+  })
+
+  it('404 when the object is missing', async () => {
+    const res = await verify(makeApp({ userId: 'u', isAuthenticated: true }), 'p1', { oid: OID_A, size: 42 })
+    expect(res.status).toBe(404)
+  })
+
+  it('422 on size mismatch', async () => {
+    heads.set(OID_A, 7)
+    const res = await verify(makeApp({ userId: 'u', isAuthenticated: true }), 'p1', { oid: OID_A, size: 42 })
+    expect(res.status).toBe(422)
+  })
+})

--- a/apps/api/src/lib/chat-references.ts
+++ b/apps/api/src/lib/chat-references.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Server-side hardening for the chat composer's "@" workspace references.
+ *
+ * The web composer sends a client-built `summary` for each tagged org/team
+ * workspace. Before forwarding the chat body to the agent runtime we:
+ *   1. verify the acting user is actually a member of that workspace, and
+ *   2. replace the client summary with authoritative DB metadata plus the
+ *      live project list.
+ *
+ * References the user can't access are dropped so another tenant's data can
+ * never be injected into the prompt. File references are intentionally left
+ * untouched here — the runtime resolves those from the project's own
+ * workspace on disk (already gated by project membership).
+ */
+
+import { prisma } from './prisma'
+
+/** Max projects to enumerate in a workspace reference summary. */
+const MAX_WORKSPACE_PROJECTS = 50
+
+/**
+ * Enrich + access-check `parsedBody.references` in place. Returns true when
+ * the references array was modified (so the caller can re-serialize the body).
+ */
+export async function enrichWorkspaceReferences(
+  parsedBody: any,
+  actingUserId: string | undefined,
+): Promise<boolean> {
+  if (!actingUserId) return false
+  const refs = parsedBody?.references
+  if (!Array.isArray(refs) || refs.length === 0) return false
+
+  let changed = false
+  const next: any[] = []
+
+  for (const ref of refs) {
+    if (!ref || typeof ref !== 'object' || ref.type !== 'workspace' || !ref.id) {
+      next.push(ref)
+      continue
+    }
+
+    try {
+      const member = await prisma.member.findFirst({
+        where: { userId: actingUserId, workspaceId: ref.id },
+        select: { id: true },
+      })
+      if (!member) {
+        // Not a member — drop the reference entirely.
+        changed = true
+        continue
+      }
+
+      const ws = await prisma.workspace.findUnique({
+        where: { id: ref.id },
+        select: { name: true, slug: true, description: true },
+      })
+      if (!ws) {
+        next.push(ref)
+        continue
+      }
+
+      const projects = await prisma.project.findMany({
+        where: { workspaceId: ref.id },
+        select: { name: true },
+        orderBy: { name: 'asc' },
+        take: MAX_WORKSPACE_PROJECTS,
+      })
+
+      const lines = [`Workspace: ${ws.name} (slug: ${ws.slug}, id: ${ref.id})`]
+      if (ws.description && ws.description.trim()) {
+        lines.push(`Description: ${ws.description.trim()}`)
+      }
+      if (projects.length > 0) {
+        lines.push(
+          `Projects (${projects.length}): ${projects.map((p) => p.name).join(', ')}`,
+        )
+      }
+
+      next.push({
+        type: 'workspace',
+        id: ref.id,
+        name: ws.name,
+        slug: ws.slug,
+        summary: lines.join('\n'),
+      })
+      changed = true
+    } catch (err: any) {
+      console.error(
+        '[chat-references] Failed to enrich workspace reference:',
+        err?.message,
+      )
+      next.push(ref)
+    }
+  }
+
+  if (changed) parsedBody.references = next
+  return changed
+}

--- a/apps/api/src/lib/heartbeat-scheduler.ts
+++ b/apps/api/src/lib/heartbeat-scheduler.ts
@@ -93,14 +93,14 @@ export class HeartbeatScheduler extends BaseHeartbeatScheduler {
   protected async triggerAgent(projectId: string): Promise<void> {
     try {
       const { getProjectPodUrl } = await import('./knative-project-manager')
-      const { deriveRuntimeToken } = await import('./runtime-token')
+      const { deriveProjectRuntimeToken } = await import('./project-runtime-token')
       const podUrl = await getProjectPodUrl(projectId)
 
       const response = await fetch(`${podUrl}/agent/heartbeat/trigger`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-runtime-token': deriveRuntimeToken(projectId),
+          'x-runtime-token': await deriveProjectRuntimeToken(projectId),
         },
         signal: AbortSignal.timeout(TRIGGER_TIMEOUT_MS),
       })

--- a/apps/api/src/lib/local-heartbeat-scheduler.ts
+++ b/apps/api/src/lib/local-heartbeat-scheduler.ts
@@ -80,7 +80,7 @@ export class LocalHeartbeatScheduler extends BaseHeartbeatScheduler {
 
   protected async triggerAgent(projectId: string): Promise<void> {
     try {
-      const { deriveRuntimeToken } = await import('./runtime-token')
+      const { deriveProjectRuntimeToken } = await import('./project-runtime-token')
 
       let runtime = this.runtimeProvider?.status(projectId)
       if (!runtime?.agentPort) {
@@ -102,7 +102,8 @@ export class LocalHeartbeatScheduler extends BaseHeartbeatScheduler {
       }
 
       const podUrl = `http://localhost:${runtime.agentPort}`
-      const token = deriveRuntimeToken(projectId)
+      // Workspace token under SHOGO_WORKSPACE_RUNTIME, project token otherwise.
+      const token = await deriveProjectRuntimeToken(projectId)
 
       const response = await fetch(`${podUrl}/agent/heartbeat/trigger`, {
         method: 'POST',

--- a/apps/api/src/lib/project-runtime-token.ts
+++ b/apps/api/src/lib/project-runtime-token.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Resolve the `x-runtime-token` the API must present when calling a
+ * *project's* runtime.
+ *
+ * Two runtime topologies exist, and they authenticate with DIFFERENT
+ * token types:
+ *
+ *   - Legacy single-project runtime → PROJECT token
+ *     `rt_v1_<projectId>_…` (`deriveRuntimeToken`).
+ *   - Universal workspace runtime (`SHOGO_WORKSPACE_RUNTIME=true`) →
+ *     every project is served by a merged-root "unified" runtime whose
+ *     `RUNTIME_AUTH_SECRET` is the WORKSPACE token
+ *     `wrt_v1_<workspaceId>_…` (`deriveWorkspaceRuntimeToken`, keyed by
+ *     the project's `workspaceId`). Sending the project token to it
+ *     yields 401 — which is exactly what broke `/agent-proxy/*`
+ *     (config, quick-actions, workspace tree/search, chat) once the flag
+ *     was enabled locally.
+ *
+ * This helper centralizes the choice so every API→runtime caller
+ * (agent-proxy, project chat, local heartbeat, …) authenticates
+ * correctly under whichever topology is active. When the flag is OFF the
+ * result is byte-for-byte identical to calling `deriveRuntimeToken`
+ * directly, so cloud / non-flag behavior is unchanged.
+ *
+ * IMPORTANT — the workspace token applies to PROJECT callers in HOST mode
+ * only. `resolveProjectPodUrl` (the single source of truth for
+ * agent-proxy / project-chat / runtime routes) only reaches a workspace
+ * runtime on the host path, where it calls `RuntimeManager.start` — which,
+ * under the flag, anchors the project on its merged-root workspace runtime
+ * (workspace token). In Kubernetes and VM-isolation that same resolver
+ * returns a *project* pod / VM (`getProjectPodUrl` / `getVMProjectUrl`)
+ * whose `RUNTIME_AUTH_SECRET` is still the PROJECT token, so the workspace
+ * token would 401 there. (Workspace-scoped K8s traffic has its own path —
+ * `resolve-workspace-runtime-url` + `deriveWorkspaceRuntimeToken` — and
+ * never flows through this helper.) Hence the host-mode gate below.
+ */
+
+import { deriveRuntimeToken } from './runtime-token'
+import { deriveWorkspaceRuntimeToken } from './workspace-runtime-token'
+
+/**
+ * True only when a *project* caller should present the WORKSPACE token:
+ * the flag is on AND we're in host/desktop mode (not K8s, not VM). See the
+ * module doc for why K8s/VM keep the project token even with the flag on.
+ */
+function shouldUseWorkspaceToken(): boolean {
+  if (process.env.SHOGO_WORKSPACE_RUNTIME !== 'true') return false
+  if (process.env.KUBERNETES_SERVICE_HOST) return false
+  if (process.env.SHOGO_VM_ISOLATION === 'true') return false
+  return true
+}
+
+/** projectId → workspaceId is effectively immutable; cache briefly. */
+const WS_CACHE_TTL_MS = 60_000
+const wsCache = new Map<string, { workspaceId: string | null; expiresAt: number }>()
+
+/**
+ * Resolve (and briefly cache) a project's `workspaceId`.
+ *
+ * Cached because the runtime token is derived on every proxied request
+ * and the mapping never changes for the life of a project. Transient
+ * lookup failures are NOT cached so a DB hiccup self-heals on retry.
+ */
+export async function resolveProjectWorkspaceId(projectId: string): Promise<string | null> {
+  const cached = wsCache.get(projectId)
+  if (cached && cached.expiresAt > Date.now()) return cached.workspaceId
+
+  let workspaceId: string | null = null
+  try {
+    const { prisma } = await import('./prisma')
+    const row = await prisma.project.findUnique({
+      where: { id: projectId },
+      select: { workspaceId: true },
+    })
+    workspaceId = row?.workspaceId ?? null
+  } catch (err: any) {
+    console.warn(
+      `[ProjectRuntimeToken] workspaceId lookup failed for ${projectId}: ${err?.message ?? err}`,
+    )
+    return null // don't cache a transient failure
+  }
+
+  wsCache.set(projectId, { workspaceId, expiresAt: Date.now() + WS_CACHE_TTL_MS })
+  return workspaceId
+}
+
+/**
+ * The `x-runtime-token` to send when proxying to project `projectId`'s
+ * runtime. Pass `workspaceId` when the caller already has it (e.g. from
+ * `verifyProjectAccess`) to skip the lookup.
+ */
+export async function deriveProjectRuntimeToken(
+  projectId: string,
+  opts?: { workspaceId?: string | null },
+): Promise<string> {
+  if (shouldUseWorkspaceToken()) {
+    const workspaceId = opts?.workspaceId ?? (await resolveProjectWorkspaceId(projectId))
+    if (workspaceId) return deriveWorkspaceRuntimeToken(workspaceId)
+    // No workspace mapping (project deleted mid-flight, DB hiccup). The
+    // project token will 401 against a workspace runtime, but that's
+    // strictly better than throwing inside a proxy hot path.
+    console.warn(
+      `[ProjectRuntimeToken] SHOGO_WORKSPACE_RUNTIME on but no workspaceId for ${projectId}; ` +
+        `falling back to project token`,
+    )
+  }
+  return deriveRuntimeToken(projectId)
+}

--- a/apps/api/src/lib/pty-pod-rest-proxy.ts
+++ b/apps/api/src/lib/pty-pod-rest-proxy.ts
@@ -24,8 +24,12 @@ const HOP_BY_HOP = new Set(['transfer-encoding', 'connection'])
 export interface ProxyDeps {
   /** Resolves `getProjectPodUrl(projectId)` → http(s):// origin of the pod. */
   resolvePodUrl: (projectId: string) => Promise<string>
-  /** Derives the shared `x-runtime-token` for the pod's auth middleware. */
-  deriveRuntimeToken: (projectId: string) => string
+  /**
+   * Derives the `x-runtime-token` for the runtime's auth middleware. May be
+   * async — under `SHOGO_WORKSPACE_RUNTIME` the host path resolves the
+   * project's `workspaceId` to mint a workspace-scoped token.
+   */
+  deriveRuntimeToken: (projectId: string) => string | Promise<string>
   /** Guard against path-traversal / weird ids before we hit the resolver. */
   isSafeProjectId: (id: string) => boolean
   /** Injectable for tests. Defaults to global `fetch`. */
@@ -60,7 +64,7 @@ export async function proxyTerminalSessionsToPod(
   try {
     const podUrl = await resolvePodUrl(projectId)
     const targetUrl = `${trimTrailingSlash(podUrl)}/terminal/sessions${pathSuffix}`
-    const headers: Record<string, string> = { 'x-runtime-token': deriveRuntimeToken(projectId) }
+    const headers: Record<string, string> = { 'x-runtime-token': await deriveRuntimeToken(projectId) }
     if (body !== undefined) {
       headers['content-type'] = contentType ?? 'application/json'
     }

--- a/apps/api/src/lib/runtime/build-project-env.ts
+++ b/apps/api/src/lib/runtime/build-project-env.ts
@@ -145,6 +145,16 @@ export async function buildProjectEnv(
     if (process.env.S3_FORCE_PATH_STYLE === 'true') env.S3_FORCE_PATH_STYLE = 'true'
   }
 
+  // Git LFS: propagate the master switch so git_only pods activate the LFS
+  // clean filter + object push/pull (see shared-runtime `isLfsActive` /
+  // `lfs.ts`). Pods reach the LFS batch endpoint via SHOGO_API_URL +
+  // RUNTIME_AUTH_SECRET and transfer bytes with presigned URLs, so they need
+  // no S3 credentials or S3_LFS_* (those are API-side, used only to mint the
+  // presigned URLs). Inert unless the project is in git_only mode.
+  if (process.env.LFS_ENABLED === 'true' || process.env.LFS_ENABLED === '1') {
+    env.LFS_ENABLED = 'true'
+  }
+
   // Voice mock mode for demo recordings. When the API server has
   // SHOGO_VOICE_MODE=mock (or SHOGO_DEMO_VOICE=mock as a more obvious
   // alias), forward it into the pod env so `createClient().voice.telephony`

--- a/apps/api/src/lib/runtime/build-project-env.ts
+++ b/apps/api/src/lib/runtime/build-project-env.ts
@@ -145,16 +145,6 @@ export async function buildProjectEnv(
     if (process.env.S3_FORCE_PATH_STYLE === 'true') env.S3_FORCE_PATH_STYLE = 'true'
   }
 
-  // Git LFS: propagate the master switch so git_only pods activate the LFS
-  // clean filter + object push/pull (see shared-runtime `isLfsActive` /
-  // `lfs.ts`). Pods reach the LFS batch endpoint via SHOGO_API_URL +
-  // RUNTIME_AUTH_SECRET and transfer bytes with presigned URLs, so they need
-  // no S3 credentials or S3_LFS_* (those are API-side, used only to mint the
-  // presigned URLs). Inert unless the project is in git_only mode.
-  if (process.env.LFS_ENABLED === 'true' || process.env.LFS_ENABLED === '1') {
-    env.LFS_ENABLED = 'true'
-  }
-
   // Voice mock mode for demo recordings. When the API server has
   // SHOGO_VOICE_MODE=mock (or SHOGO_DEMO_VOICE=mock as a more obvious
   // alias), forward it into the pod env so `createClient().voice.telephony`

--- a/apps/api/src/lib/runtime/build-workspace-env.ts
+++ b/apps/api/src/lib/runtime/build-workspace-env.ts
@@ -236,6 +236,15 @@ export async function buildWorkspaceEnv(
     if (process.env.S3_FORCE_PATH_STYLE === 'true') env.S3_FORCE_PATH_STYLE = 'true'
   }
 
+  // Git LFS: propagate the master switch so git_only pods activate the LFS
+  // clean filter + object push/pull (see shared-runtime `isLfsActive`). Pods
+  // reach the LFS batch endpoint via SHOGO_API_URL + RUNTIME_AUTH_SECRET and
+  // transfer bytes with presigned URLs, so no S3 creds / S3_LFS_* are needed
+  // pod-side. Inert unless the project is in git_only mode.
+  if (process.env.LFS_ENABLED === 'true' || process.env.LFS_ENABLED === '1') {
+    env.LFS_ENABLED = 'true'
+  }
+
   console.log(`[${prefix}] total ${Date.now() - startTime}ms for workspace ${workspaceId} (${attachedProjectIds.length} projects)`)
   return env
 }

--- a/apps/api/src/lib/runtime/build-workspace-env.ts
+++ b/apps/api/src/lib/runtime/build-workspace-env.ts
@@ -236,15 +236,6 @@ export async function buildWorkspaceEnv(
     if (process.env.S3_FORCE_PATH_STYLE === 'true') env.S3_FORCE_PATH_STYLE = 'true'
   }
 
-  // Git LFS: propagate the master switch so git_only pods activate the LFS
-  // clean filter + object push/pull (see shared-runtime `isLfsActive`). Pods
-  // reach the LFS batch endpoint via SHOGO_API_URL + RUNTIME_AUTH_SECRET and
-  // transfer bytes with presigned URLs, so no S3 creds / S3_LFS_* are needed
-  // pod-side. Inert unless the project is in git_only mode.
-  if (process.env.LFS_ENABLED === 'true' || process.env.LFS_ENABLED === '1') {
-    env.LFS_ENABLED = 'true'
-  }
-
   console.log(`[${prefix}] total ${Date.now() - startTime}ms for workspace ${workspaceId} (${attachedProjectIds.length} projects)`)
   return env
 }

--- a/apps/api/src/lib/s3.ts
+++ b/apps/api/src/lib/s3.ts
@@ -29,6 +29,7 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 // Lazy-initialized S3 clients
 let s3Client: S3Client | null = null
 let s3PublicClient: S3Client | null = null
+let s3LfsClient: S3Client | null = null
 
 /**
  * Get or create the S3 client for internal operations.
@@ -97,11 +98,47 @@ export function getS3PublicClient(): S3Client {
 }
 
 /**
+ * Get or create the S3 client used to mint presigned URLs for Git LFS
+ * objects.
+ *
+ * Unlike {@link getS3PublicClient} (which targets the browser-facing
+ * `S3_PUBLIC_ENDPOINT`), LFS transfers run pod<->OCI, so the presigned host
+ * must be the endpoint pods can actually reach AND the one used to compute
+ * the SigV4 signature. We default to `S3_LFS_ENDPOINT` then `S3_ENDPOINT`
+ * (the internal/compat endpoint), never the public browser endpoint.
+ */
+export function getLfsS3Client(): S3Client {
+  if (!s3LfsClient) {
+    const region = process.env.S3_REGION || process.env.AWS_REGION || 'us-east-1'
+    const endpoint = process.env.S3_LFS_ENDPOINT || process.env.S3_ENDPOINT
+    const forcePathStyle = process.env.S3_FORCE_PATH_STYLE === 'true'
+
+    const config: ConstructorParameters<typeof S3Client>[0] = {
+      region,
+      ...(endpoint && {
+        endpoint,
+        forcePathStyle: forcePathStyle || !!endpoint,
+      }),
+      ...(process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY && {
+        credentials: {
+          accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+          secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+        },
+      }),
+    }
+
+    s3LfsClient = new S3Client(config)
+  }
+  return s3LfsClient
+}
+
+/**
  * Reset the S3 clients (useful for testing with different configs).
  */
 export function resetS3Client(): void {
   s3Client = null
   s3PublicClient = null
+  s3LfsClient = null
 }
 
 /**
@@ -312,6 +349,71 @@ export async function getPresignedWriteUrl(
   })
 
   return getSignedUrl(client, command, { expiresIn })
+}
+
+// ============================================================================
+// Git LFS object helpers
+// ============================================================================
+
+/**
+ * Bucket for Git LFS objects. Defaults to the workspaces bucket (LFS objects
+ * live under `<projectId>/lfs/objects/...` there) unless `S3_LFS_BUCKET`
+ * points at a dedicated bucket.
+ */
+export function getLfsBucket(): string {
+  const bucket = process.env.S3_LFS_BUCKET || process.env.S3_WORKSPACES_BUCKET
+  if (!bucket) {
+    throw new Error('S3_LFS_BUCKET or S3_WORKSPACES_BUCKET is required for Git LFS')
+  }
+  return bucket
+}
+
+/**
+ * Presigned GET for an LFS object download. Bound to the pod-reachable LFS
+ * client/bucket (see {@link getLfsS3Client}).
+ */
+export async function getLfsPresignedReadUrl(
+  key: string,
+  options: PresignOptions = {},
+): Promise<string> {
+  const client = getLfsS3Client()
+  const bucket = options.bucket || getLfsBucket()
+  const expiresIn = options.expiresIn || 3600
+  const command = new GetObjectCommand({ Bucket: bucket, Key: key })
+  return getSignedUrl(client, command, { expiresIn })
+}
+
+/**
+ * Presigned PUT for an LFS object upload. We deliberately do NOT sign a
+ * Content-Type so the git-lfs basic transfer agent can PUT the raw bytes
+ * with any (or no) content-type header without breaking the signature.
+ */
+export async function getLfsPresignedWriteUrl(
+  key: string,
+  options: PresignOptions = {},
+): Promise<string> {
+  const client = getLfsS3Client()
+  const bucket = options.bucket || getLfsBucket()
+  const expiresIn = options.expiresIn || 3600
+  const command = new PutObjectCommand({ Bucket: bucket, Key: key })
+  return getSignedUrl(client, command, { expiresIn })
+}
+
+/**
+ * HEAD an LFS object. Returns its size when present, or null when absent.
+ * Used by the batch endpoint for download existence + upload dedup.
+ */
+export async function headLfsObject(key: string, bucket?: string): Promise<{ size: number } | null> {
+  const client = getLfsS3Client()
+  try {
+    const res = await client.send(new HeadObjectCommand({
+      Bucket: bucket || getLfsBucket(),
+      Key: key,
+    }))
+    return { size: res.ContentLength ?? 0 }
+  } catch {
+    return null
+  }
 }
 
 /**

--- a/apps/api/src/lib/voice-context.ts
+++ b/apps/api/src/lib/voice-context.ts
@@ -28,7 +28,7 @@
 
 import { prisma } from './prisma'
 import { getProjectPodUrl } from './knative-project-manager'
-import { deriveRuntimeToken } from './runtime-token'
+import { deriveProjectRuntimeToken } from './project-runtime-token'
 
 /**
  * Per-file size caps on what we paste into Shogo's prompt. The
@@ -94,7 +94,7 @@ async function fetchPodFile(params: {
 
   try {
     const res = await fetch(url, {
-      headers: { 'x-runtime-token': deriveRuntimeToken(projectId) },
+      headers: { 'x-runtime-token': await deriveProjectRuntimeToken(projectId) },
       signal: controller.signal,
     })
     if (!res.ok) {

--- a/apps/api/src/lib/warm-pool-controller.ts
+++ b/apps/api/src/lib/warm-pool-controller.ts
@@ -1578,10 +1578,10 @@ export class WarmPoolController {
         }
 
         try {
-          const { deriveRuntimeToken } = await import('./runtime-token')
+          const { deriveProjectRuntimeToken } = await import('./project-runtime-token')
           const resp = await fetch(`${pod.url}/pool/activity`, {
             signal: AbortSignal.timeout(5000),
-            headers: { 'x-runtime-token': deriveRuntimeToken(pod.projectId) },
+            headers: { 'x-runtime-token': await deriveProjectRuntimeToken(pod.projectId) },
           })
           if (resp.ok) {
             const activity = await resp.json() as { idleSeconds: number; activeStreams?: number }

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -15,6 +15,7 @@ import { requireSuperAdmin } from '../middleware/super-admin'
 import { authMiddleware, requireAuth } from '../middleware/auth'
 import * as analytics from '../services/analytics.service'
 import type { AnalyticsPeriod } from '../services/analytics.service'
+import { resolveModelLabel, resolveModelLabels } from '../services/model-registry.service'
 import { prisma } from '../lib/prisma'
 
 // ============================================================================
@@ -555,10 +556,16 @@ export function adminRoutes(): Hono {
         }),
       ])
 
+      // agent_configs.modelName is an opaque UUID for DB models post catalog-uuid
+      // migration; resolve display labels (id kept intact for the model picker).
+      const modelLabels = await resolveModelLabels(
+        rows.map((r) => r.modelName).filter((m): m is string => !!m),
+      )
       const enriched = rows.map((row) => {
         const b = breakerById.get(row.projectId)
         return {
           ...row,
+          modelLabel: row.modelName ? (modelLabels.get(row.modelName) ?? row.modelName) : null,
           breaker: b ? { count: b.count, backoffUntil: b.backoffUntil } : null,
         }
       })
@@ -692,7 +699,13 @@ export function adminRoutes(): Hono {
         },
       })
 
-      return c.json({ ok: true, data: updated })
+      return c.json({
+        ok: true,
+        data: {
+          ...updated,
+          modelLabel: updated.modelName ? await resolveModelLabel(updated.modelName) : null,
+        },
+      })
     } catch (error: any) {
       console.error('[Admin] Heartbeats patch error:', error)
       return c.json({ error: { code: 'heartbeats_failed', message: error.message } }, 500)

--- a/apps/api/src/routes/ai-proxy.ts
+++ b/apps/api/src/routes/ai-proxy.ts
@@ -636,13 +636,21 @@ export function wrapSseForErrorVisibility(
     code: StreamErrorCode,
     message: string,
   ): StreamErrorPayload {
+    const retryable = code !== 'upstream_error'
+    // Embed a stable, machine-readable marker so the retryable flag + code
+    // survive transport through the provider SDK into pi-ai's `errorMessage`,
+    // where the agent-runtime's retry classifier can read them deterministically
+    // instead of guessing from prose. Kept in sync with
+    // `packages/agent/src/retry-classifier.ts` (parseStreamErrorMarker) and
+    // stripped from user-facing text by `formatErrorMessage`.
+    const taggedMessage = `${message} [shogo:retryable=${retryable};code=${code}]`
     return {
       type: 'error',
       error: {
         type: 'stream_error',
         code,
-        retryable: code !== 'upstream_error',
-        message,
+        retryable,
+        message: taggedMessage,
         meta: {
           chunks: chunkCount,
           bytes: totalBytes,

--- a/apps/api/src/routes/eval-admin.ts
+++ b/apps/api/src/routes/eval-admin.ts
@@ -19,6 +19,7 @@ import { spawn } from 'node:child_process'
 import { resolve } from 'node:path'
 import { MODEL_CATALOG, MODEL_ALIASES } from '@shogo/model-catalog'
 import { prisma } from '../lib/prisma'
+import { resolveModelLabelSync } from '../services/model-registry.service'
 import { requireSuperAdmin } from '../middleware/super-admin'
 import { authMiddleware, requireAuth } from '../middleware/auth'
 
@@ -134,7 +135,7 @@ function mapRunSummary(r: any) {
     id: r.id,
     name: `agent-runtime-${r.track}`,
     track: r.track,
-    model: r.model,
+    model: resolveModelLabelSync(r.model),
     workers: r.workers,
     status: r.status,
     label: r.label ?? null,
@@ -241,7 +242,7 @@ export function evalAdminRoutes(): Hono {
         id: activeRun.id,
         pid: activeRun.pid,
         track: activeRun.track,
-        model: activeRun.model,
+        model: resolveModelLabelSync(activeRun.model),
         workers: activeRun.workers,
         completed: progressResults.length,
         passed: progressResults.filter((r) => r.passed).length,
@@ -489,7 +490,7 @@ export function evalAdminRoutes(): Hono {
         history: completedResults.map((r) => ({
           runId: r.run.id,
           track: r.run.track,
-          model: r.run.model,
+          model: resolveModelLabelSync(r.run.model),
           timestamp: r.run.startedAt?.toISOString() ?? r.run.createdAt.toISOString(),
           passed: r.passed,
           score: r.score,
@@ -592,7 +593,7 @@ export function evalAdminRoutes(): Hono {
     }
 
     const models = Object.entries(byModel).map(([model, run]) => ({
-      model,
+      model: resolveModelLabelSync(model),
       runId: run.id,
       track: run.track,
       timestamp: run.startedAt?.toISOString() ?? run.createdAt.toISOString(),
@@ -673,7 +674,7 @@ export function evalAdminRoutes(): Hono {
         category: r.category,
         level: r.level,
         track: r.run.track,
-        model: r.run.model,
+        model: resolveModelLabelSync(r.run.model),
         passed: r.passed,
         score: r.score,
         maxScore: r.maxScore,

--- a/apps/api/src/routes/git-lfs.ts
+++ b/apps/api/src/routes/git-lfs.ts
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Git LFS server (basic transfer adapter) backed by OCI Object Storage.
+ *
+ * Implements the Git LFS Batch API for each project's repo:
+ *   POST /projects/:projectId/git/info/lfs/objects/batch
+ *   POST /projects/:projectId/git/info/lfs/objects/verify
+ *
+ * The API never touches object bytes: the batch response hands back
+ * presigned OCI URLs and the git-lfs client PUTs/GETs the bytes directly to
+ * object storage. This means:
+ *   - no `git-lfs` binary is required on the API image;
+ *   - the global 200 MB body limit is irrelevant to object size (only the
+ *     small JSON envelope flows through the API);
+ *   - hydrate/`reset --hard` on the API leaves pointer files in place, so
+ *     the commit graph still lists the large files.
+ *
+ * Objects are content-addressed (sha256 oid) under
+ *   `<projectId>/lfs/objects/<oid[0:2]>/<oid[2:4]>/<oid>`
+ * in `S3_LFS_BUCKET` (defaults to `S3_WORKSPACES_BUCKET`), giving free
+ * dedup within a project.
+ *
+ * Auth mirrors the smart-HTTP backend (`git-http.ts`): the parent
+ * `authMiddleware` + an explicit `authorizeProject` check. Internal pods
+ * authenticate with the runtime bearer forwarded by git-lfs via
+ * `http.extraHeader`. External (laptop/CI) git-lfs clients are out of scope
+ * — they have no way to present a Shogo credential yet.
+ *
+ * Spec: https://github.com/git-lfs/git-lfs/blob/main/docs/api/batch.md
+ */
+
+import { Hono, type Context } from 'hono'
+import { lfsObjectKey, isValidLfsOid } from '@shogo/shared-runtime'
+import { prisma } from '../lib/prisma'
+import { authorizeProject } from '../middleware/auth'
+import {
+  getLfsPresignedReadUrl,
+  getLfsPresignedWriteUrl,
+  headLfsObject,
+} from '../lib/s3'
+
+const LFS_CONTENT_TYPE = 'application/vnd.git-lfs+json'
+
+/** Presigned-URL TTL for LFS transfers (seconds). */
+const LFS_PRESIGN_EXPIRY = parseInt(process.env.LFS_PRESIGN_EXPIRY || '3600', 10) || 3600
+
+export interface GitLfsRoutesConfig {
+  /** Directory containing per-project workspaces (unused today; kept for parity). */
+  workspacesDir: string
+}
+
+interface BatchObjectRequest {
+  oid: string
+  size: number
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** JSON response with the git-lfs media type. */
+function lfsJson(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': LFS_CONTENT_TYPE },
+  })
+}
+
+/** LFS error envelope (`{ message }`) with the git-lfs media type. */
+function lfsError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ message }), {
+    status,
+    headers: {
+      'Content-Type': LFS_CONTENT_TYPE,
+      ...(status === 401 ? { 'WWW-Authenticate': 'Basic realm="shogo"' } : {}),
+    },
+  })
+}
+
+/**
+ * Shared auth + project resolution, mirroring `git-http.ts`. Returns null on
+ * success or a ready-to-return Response on any failure path.
+ */
+async function authorizeLfs(c: Context, projectId: string): Promise<Response | null> {
+  const auth = c.get('auth')
+  if (!auth?.isAuthenticated || !auth.userId) {
+    return lfsError('Authentication required', 401)
+  }
+  const access = await authorizeProject(c, projectId)
+  if (!access.ok) {
+    return lfsError(access.message || 'Forbidden', access.status || 403)
+  }
+  // workingMode=external projects don't have a Shogo-managed repo.
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: { workingMode: true } as any,
+  }) as { workingMode?: string } | null
+  if (project?.workingMode === 'external') {
+    return lfsError('Not found', 404)
+  }
+  return null
+}
+
+function parseBatchObjects(input: unknown): BatchObjectRequest[] | null {
+  if (!Array.isArray(input)) return null
+  const out: BatchObjectRequest[] = []
+  for (const raw of input) {
+    if (!raw || typeof raw !== 'object') return null
+    const oid = (raw as any).oid
+    const size = (raw as any).size
+    if (typeof oid !== 'string' || typeof size !== 'number' || size < 0) return null
+    out.push({ oid, size })
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+export function gitLfsRoutes(_config: GitLfsRoutesConfig) {
+  const router = new Hono()
+
+  /**
+   * POST /projects/:projectId/git/info/lfs/objects/batch
+   *
+   * The git-lfs client asks, for a set of {oid,size}, where to upload or
+   * download each object. We answer with presigned OCI URLs (basic transfer).
+   */
+  router.post('/projects/:projectId/git/info/lfs/objects/batch', async (c) => {
+    const projectId = c.req.param('projectId')
+    if (!projectId) return lfsError('projectId is required', 400)
+
+    const denied = await authorizeLfs(c, projectId)
+    if (denied) return denied
+
+    let body: any
+    try {
+      body = await c.req.json()
+    } catch {
+      return lfsError('Invalid JSON body', 422)
+    }
+
+    const operation = body?.operation
+    if (operation !== 'upload' && operation !== 'download') {
+      return lfsError('operation must be "upload" or "download"', 422)
+    }
+
+    const objects = parseBatchObjects(body?.objects)
+    if (!objects) {
+      return lfsError('objects must be an array of {oid, size}', 422)
+    }
+
+    const verifyHref =
+      `${new URL(c.req.url).origin}/api/projects/${projectId}/git/info/lfs/objects/verify`
+
+    const responseObjects = await Promise.all(
+      objects.map(async (obj) => {
+        // Reject malformed oids — they'd otherwise escape the project's S3
+        // key namespace.
+        if (!isValidLfsOid(obj.oid)) {
+          return {
+            oid: obj.oid,
+            size: obj.size,
+            error: { code: 422, message: 'invalid oid (expected sha256 hex)' },
+          }
+        }
+        const key = lfsObjectKey(projectId, obj.oid)
+        const existing = await headLfsObject(key)
+
+        if (operation === 'download') {
+          if (!existing) {
+            return {
+              oid: obj.oid,
+              size: obj.size,
+              error: { code: 404, message: 'object does not exist' },
+            }
+          }
+          const href = await getLfsPresignedReadUrl(key, { expiresIn: LFS_PRESIGN_EXPIRY })
+          return {
+            oid: obj.oid,
+            size: obj.size,
+            authenticated: true,
+            actions: { download: { href, expires_in: LFS_PRESIGN_EXPIRY } },
+          }
+        }
+
+        // upload: omit actions when the object already exists (dedup → the
+        // client treats it as already uploaded and skips the transfer).
+        if (existing) {
+          return { oid: obj.oid, size: obj.size, authenticated: true }
+        }
+        const href = await getLfsPresignedWriteUrl(key, { expiresIn: LFS_PRESIGN_EXPIRY })
+        return {
+          oid: obj.oid,
+          size: obj.size,
+          authenticated: true,
+          actions: {
+            upload: { href, expires_in: LFS_PRESIGN_EXPIRY },
+            verify: { href: verifyHref, expires_in: LFS_PRESIGN_EXPIRY },
+          },
+        }
+      }),
+    )
+
+    return lfsJson({ transfer: 'basic', objects: responseObjects, hash_algo: 'sha256' })
+  })
+
+  /**
+   * POST /projects/:projectId/git/info/lfs/objects/verify
+   *
+   * Optional integrity check the client calls after an upload: confirm the
+   * object landed in OCI with the expected size.
+   */
+  router.post('/projects/:projectId/git/info/lfs/objects/verify', async (c) => {
+    const projectId = c.req.param('projectId')
+    if (!projectId) return lfsError('projectId is required', 400)
+
+    const denied = await authorizeLfs(c, projectId)
+    if (denied) return denied
+
+    let body: any
+    try {
+      body = await c.req.json()
+    } catch {
+      return lfsError('Invalid JSON body', 422)
+    }
+    const oid = body?.oid
+    const size = body?.size
+    if (typeof oid !== 'string' || !isValidLfsOid(oid)) {
+      return lfsError('invalid oid', 422)
+    }
+
+    const existing = await headLfsObject(lfsObjectKey(projectId, oid))
+    if (!existing) return lfsError('object does not exist', 404)
+    if (typeof size === 'number' && existing.size !== size) {
+      return lfsError(`size mismatch: stored ${existing.size}, expected ${size}`, 422)
+    }
+    return new Response(null, { status: 200 })
+  })
+
+  return router
+}
+
+export default gitLfsRoutes

--- a/apps/api/src/routes/project-chat.ts
+++ b/apps/api/src/routes/project-chat.ts
@@ -194,6 +194,43 @@ export async function trackUsageFromStream(
   }
 
   /**
+   * Partial reset on an inference retry. The runtime re-issued a model call
+   * that dropped mid-generation, so the failed step's partial text/reasoning
+   * (and any partially-streamed tool input that never executed) must be
+   * discarded — otherwise the regenerated output gets concatenated onto the
+   * thrown-away partial in the persisted ChatMessage. Earlier COMPLETED steps
+   * (assistant text + executed tool calls) are preserved: pi-agent-core runs
+   * tools only after a complete assistant message, so a failed step never
+   * produced a `tool-input-available` part.
+   */
+  function resetCurrentStepPartials() {
+    if (currentReasoningPart) {
+      const idx = orderedParts.lastIndexOf(currentReasoningPart)
+      if (idx >= 0) orderedParts.splice(idx, 1)
+      currentReasoningPart = null
+      reasoningStartedAt = null
+    }
+    if (currentTextPart) {
+      const idx = orderedParts.lastIndexOf(currentTextPart)
+      if (idx >= 0) orderedParts.splice(idx, 1)
+      currentTextPart = null
+    }
+    // Drop any partially-streamed tool calls from the failed step. A completed
+    // tool from an earlier step reached `tool-input-available` and so has an
+    // entry in `toolPartIndex`; a failed step's tool only ever got a
+    // `tool-input-start` (toolCallMap only) and never executed.
+    for (const id of [...toolCallMap.keys()]) {
+      if (!toolPartIndex.has(id)) toolCallMap.delete(id)
+    }
+    // Recompute the flattened text from the surviving ordered text parts so
+    // `content` reflects only completed output.
+    accumulatedText = orderedParts
+      .filter((p) => p.type === 'text')
+      .map((p) => p.text)
+      .join('')
+  }
+
+  /**
    * Process one SSE line (already \n-split). Updates the closure-scoped
    * accumulator state in place. Tolerant of legacy (`9:`, `e:`, `d:`)
    * data-stream prefixes alongside the modern `data: {json}` SSE format.
@@ -326,6 +363,14 @@ export async function trackUsageFromStream(
         part.output = data.output ?? { success: true }
         part.state = 'output-available'
       }
+    }
+
+    // The runtime emits `data-inference-retry` when it re-issues a model call
+    // that dropped mid-generation. Discard the failed step's partial output so
+    // the persisted message holds the final retried output, not a concatenation.
+    if (type === 'data-inference-retry') {
+      resetCurrentStepPartials()
+      return
     }
 
     // The runtime writes `data-turn-complete` exactly once at the tail

--- a/apps/api/src/routes/project-chat.ts
+++ b/apps/api/src/routes/project-chat.ts
@@ -25,6 +25,7 @@ import * as checkpointService from "../services/checkpoint.service"
 import { isGitAvailable } from "../services/git.service"
 import { setProjectUser } from "../lib/project-user-context"
 import { openSession, closeSession, setQualitySignals } from "../lib/proxy-billing-session"
+import { enrichWorkspaceReferences } from "../lib/chat-references"
 
 const chatTracer = trace.getTracer("shogo-api-chat")
 
@@ -817,12 +818,12 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
     init?: RequestInit,
   ): Promise<Response> {
     const baseUrl = await getProjectUrl(projectId)
-    const { deriveRuntimeToken } = await import("../lib/runtime-token")
+    const { deriveProjectRuntimeToken } = await import("../lib/project-runtime-token")
     const headers = new Headers(init?.headers)
     if (!headers.has("Content-Type")) {
       headers.set("Content-Type", "application/json")
     }
-    headers.set("x-runtime-token", deriveRuntimeToken(projectId))
+    headers.set("x-runtime-token", await deriveProjectRuntimeToken(projectId))
     return fetch(`${baseUrl}${path}`, { ...init, headers })
   }
 
@@ -957,6 +958,17 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
         }
       }
 
+      // Harden "@" workspace references: verify the acting user's access and
+      // replace client summaries with authoritative DB metadata + project
+      // list (dropping any the user can't access) before forwarding. File
+      // references pass through untouched (resolved by the runtime on disk).
+      if (Array.isArray(parsedBody?.references) && parsedBody.references.length > 0) {
+        const refsChanged = await enrichWorkspaceReferences(parsedBody, verifiedUserId)
+        if (refsChanged) {
+          body = JSON.stringify(parsedBody)
+        }
+      }
+
       // Extract the chat-session id up-front so the billing session can be
       // keyed by `(projectId, chatSessionId)`. The id is on the request
       // body (`parsedBody.chatSessionId`) for follow-up turns and on the
@@ -1005,8 +1017,8 @@ export function projectChatRoutes(config: ProjectChatRoutesConfig) {
         "Content-Type": "application/json",
       }
 
-      const { deriveRuntimeToken } = await import('../lib/runtime-token')
-      headers["x-runtime-token"] = deriveRuntimeToken(projectId)
+      const { deriveProjectRuntimeToken } = await import('../lib/project-runtime-token')
+      headers["x-runtime-token"] = await deriveProjectRuntimeToken(projectId, { workspaceId: project.workspaceId })
 
       // Copy relevant headers from original request
       const authHeader = c.req.header("Authorization")

--- a/apps/api/src/routes/project-export-import.ts
+++ b/apps/api/src/routes/project-export-import.ts
@@ -25,7 +25,7 @@ import {
   decryptZip,
   ZipPasswordError,
 } from '../lib/zip-encryption'
-import { deriveRuntimeToken } from '../lib/runtime-token'
+import { deriveProjectRuntimeToken } from '../lib/project-runtime-token'
 
 const PROJECT_ROOT = resolve(import.meta.dir, '../../../..')
 const WORKSPACES_DIR = process.env.WORKSPACES_DIR || resolve(PROJECT_ROOT, 'workspaces')
@@ -992,7 +992,7 @@ export function projectExportImportRoutes() {
         // HEARTBEAT.md / MEMORY.md — the "Context Files").
         const agent = new AgentClient({
           baseUrl: podUrl,
-          headers: { 'x-runtime-token': deriveRuntimeToken(projectId) },
+          headers: { 'x-runtime-token': await deriveProjectRuntimeToken(projectId) },
         })
         const bundle: WorkspaceBundle = await agent.getWorkspaceBundle()
         const bundleFiles =

--- a/apps/api/src/routes/publish.ts
+++ b/apps/api/src/routes/publish.ts
@@ -18,7 +18,7 @@
 import { Hono } from "hono"
 import { S3Client, PutObjectCommand, DeleteObjectsCommand, ListObjectsV2Command } from "@aws-sdk/client-s3"
 import { prisma } from "../lib/prisma"
-import { deriveRuntimeToken } from "../lib/runtime-token"
+import { deriveProjectRuntimeToken } from "../lib/project-runtime-token"
 
 // S3 configuration. `PUBLISH_BUCKET` must be set explicitly in every K8s
 // overlay (k8s/overlays/{staging,production-*}/api-service.yaml) — the
@@ -252,7 +252,7 @@ async function downloadDistFiles(projectId: string): Promise<Map<string, Buffer>
   // publish before this fix either got a bare 404 (proxy's no-port branch)
   // or the user app's SPA fallback HTML (which then failed JSON parsing).
   const response = await fetch(`${podUrl}/agent/dist-files`, {
-    headers: { 'x-runtime-token': deriveRuntimeToken(projectId) },
+    headers: { 'x-runtime-token': await deriveProjectRuntimeToken(projectId) },
     signal: AbortSignal.timeout(PUBLISH_DOWNLOAD_TIMEOUT_MS),
   })
 
@@ -288,7 +288,7 @@ async function flushGitSync(
     const response = await fetch(`${podUrl}/agent/git-flush`, {
       method: 'POST',
       headers: {
-        'x-runtime-token': deriveRuntimeToken(projectId),
+        'x-runtime-token': await deriveProjectRuntimeToken(projectId),
         'content-type': 'application/json',
       },
       body: JSON.stringify({ tag: opts.tag, tagMessage: opts.tagMessage }),

--- a/apps/api/src/routes/workspace-chat.ts
+++ b/apps/api/src/routes/workspace-chat.ts
@@ -43,6 +43,7 @@ import {
 import { deriveWorkspaceRuntimeToken } from '../lib/workspace-runtime-token'
 import { setProjectUser } from '../lib/project-user-context'
 import { openSession, closeSession } from '../lib/proxy-billing-session'
+import { enrichWorkspaceReferences } from '../lib/chat-references'
 import { trackUsageFromStream } from './project-chat'
 
 // Same resolution as project-chat.ts / RuntimeManager: the `workspaces/`
@@ -552,6 +553,15 @@ export function workspaceChatRoutes(config: WorkspaceChatRoutesConfig): Hono {
           parsedBody.agentMode = 'claude-haiku-4-5-20251001'
           body = JSON.stringify(parsedBody)
         }
+      }
+    }
+
+    // Harden "@" workspace references: verify the acting user's access and
+    // replace client summaries with authoritative DB metadata + project list
+    // (dropping any the user can't access) before forwarding to the runtime.
+    if (Array.isArray(parsedBody?.references) && parsedBody.references.length > 0) {
+      if (await enrichWorkspaceReferences(parsedBody, auth.userId)) {
+        body = JSON.stringify(parsedBody)
       }
     }
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -45,6 +45,7 @@ import { securityRoutes } from './routes/security'
 import { databaseRoutes, stopAllPrismaStudios } from './routes/database'
 import { checkpointRoutes } from './routes/checkpoints'
 import { gitHttpRoutes } from './routes/git-http'
+import { gitLfsRoutes } from './routes/git-lfs'
 import { thumbnailRoutes } from './routes/thumbnail'
 import { githubRoutes } from './routes/github'
 import { aiProxyRoutes } from './routes/ai-proxy'
@@ -4251,6 +4252,12 @@ app.route('/api', checkpointRouter)
 // See routes/git-http.ts for the wire-protocol bridge to `git http-backend`.
 const gitHttpRouter = gitHttpRoutes({ workspacesDir: workspacesDirResolved })
 app.route('/api', gitHttpRouter)
+
+// Mount the Git LFS batch API (presigned OCI URLs for large-file objects).
+// See routes/git-lfs.ts. Object bytes flow pod<->OCI directly; the API only
+// mints the batch response, so no git-lfs binary is needed here.
+const gitLfsRouter = gitLfsRoutes({ workspacesDir: workspacesDirResolved })
+app.route('/api', gitLfsRouter)
 
 // Mount GitHub routes
 const githubRouter = githubRoutes({ workspacesDir: workspacesDirResolved })

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2345,8 +2345,14 @@ app.all('/api/projects/:projectId/agent-proxy/*', async (c) => {
   // transport.
   const contentType = c.req.header('content-type')
   const accept = c.req.header('accept')
-  const { deriveRuntimeToken } = await import('./lib/runtime-token')
-  const runtimeToken = deriveRuntimeToken(projectId)
+  // Under SHOGO_WORKSPACE_RUNTIME the project is served by a merged-root
+  // "unified" runtime that authenticates with the WORKSPACE token, not the
+  // project token — sending the project token here 401s every proxied call
+  // (config, quick-actions, workspace tree/search, chat). The resolver picks
+  // the right token type for the active topology. `authedWorkspaceId` is set
+  // for all non-webchat paths; webchat falls back to a (cached) lookup.
+  const { deriveProjectRuntimeToken } = await import('./lib/project-runtime-token')
+  const runtimeToken = await deriveProjectRuntimeToken(projectId, { workspaceId: authedWorkspaceId })
 
   // Read the chat-session id from the client. The billing-session map is
   // keyed by `(projectId, chatSessionId)` so concurrent chat sessions on
@@ -3013,14 +3019,14 @@ app.get('/api/projects/:projectId/terminal/commands', async (c) => {
     // In Kubernetes: Proxy to runtime pod
     try {
       const { getProjectPodUrl } = await import('./lib/knative-project-manager')
-      const { deriveRuntimeToken } = await import('./lib/runtime-token')
+      const { deriveProjectRuntimeToken } = await import('./lib/project-runtime-token')
       const podUrl = await getProjectPodUrl(projectId)
       const targetUrl = `${podUrl}/terminal/commands`
       
       console.log(`[TerminalProxy] Proxying commands list to ${targetUrl}`)
       
       const response = await fetch(targetUrl, {
-        headers: { 'x-runtime-token': deriveRuntimeToken(projectId) },
+        headers: { 'x-runtime-token': await deriveProjectRuntimeToken(projectId) },
       })
       
       // Handle non-OK responses with proper JSON errors
@@ -3140,13 +3146,13 @@ async function resolveRuntimeBaseUrl(projectId: string): Promise<string> {
  * stays a one-liner.
  */
 async function ptyPodRestDeps() {
-  const [{ deriveRuntimeToken }, { proxyTerminalSessionsToPod }] = await Promise.all([
-    import('./lib/runtime-token'),
+  const [{ deriveProjectRuntimeToken }, { proxyTerminalSessionsToPod }] = await Promise.all([
+    import('./lib/project-runtime-token'),
     import('./lib/pty-pod-rest-proxy'),
   ])
   return {
     proxyTerminalSessionsToPod,
-    deps: { resolvePodUrl: resolveRuntimeBaseUrl, deriveRuntimeToken, isSafeProjectId },
+    deps: { resolvePodUrl: resolveRuntimeBaseUrl, deriveRuntimeToken: deriveProjectRuntimeToken, isSafeProjectId },
   }
 }
 
@@ -3275,14 +3281,14 @@ app.get('/api/projects/:projectId/diagnostics', async (c) => {
   if (isKubernetes()) {
     try {
       const { getProjectPodUrl } = await import('./lib/knative-project-manager')
-      const { deriveRuntimeToken } = await import('./lib/runtime-token')
+      const { deriveProjectRuntimeToken } = await import('./lib/project-runtime-token')
       const podUrl = await raceAbort(getProjectPodUrl(projectId), c.req.raw.signal)
       // Forward the original query string verbatim (?source=, ?since=).
       const inUrl = new URL(c.req.url)
       const target = new URL(`${podUrl}/diagnostics`)
       inUrl.searchParams.forEach((v, k) => target.searchParams.set(k, v))
       const response = await fetch(target, {
-        headers: { 'x-runtime-token': deriveRuntimeToken(projectId) },
+        headers: { 'x-runtime-token': await deriveProjectRuntimeToken(projectId) },
         signal: c.req.raw.signal,
       })
       return forwardDiagnosticsResponse(c, response, 'GET /diagnostics')
@@ -3344,14 +3350,14 @@ app.post('/api/projects/:projectId/diagnostics/refresh', async (c) => {
   if (isKubernetes()) {
     try {
       const { getProjectPodUrl } = await import('./lib/knative-project-manager')
-      const { deriveRuntimeToken } = await import('./lib/runtime-token')
+      const { deriveProjectRuntimeToken } = await import('./lib/project-runtime-token')
       const podUrl = await raceAbort(getProjectPodUrl(projectId), c.req.raw.signal)
       const target = `${podUrl}/diagnostics/refresh`
       const body = await c.req.text()
       const response = await fetch(target, {
         method: 'POST',
         headers: {
-          'x-runtime-token': deriveRuntimeToken(projectId),
+          'x-runtime-token': await deriveProjectRuntimeToken(projectId),
           'content-type': c.req.header('content-type') ?? 'application/json',
         },
         body,
@@ -4529,12 +4535,12 @@ app.post('/api/projects/:projectId/agent/tool-mocks', async (c) => {
   }
 
   try {
-    const { deriveRuntimeToken } = await import('./lib/runtime-token')
+    const { deriveProjectRuntimeToken } = await import('./lib/project-runtime-token')
     const resp = await fetch(`${baseUrl}/agent/tool-mocks`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'x-runtime-token': deriveRuntimeToken(projectId),
+        'x-runtime-token': await deriveProjectRuntimeToken(projectId),
       },
       body,
     })
@@ -4560,10 +4566,10 @@ app.delete('/api/projects/:projectId/agent/tool-mocks', async (c) => {
   }
 
   try {
-    const { deriveRuntimeToken } = await import('./lib/runtime-token')
+    const { deriveProjectRuntimeToken } = await import('./lib/project-runtime-token')
     const resp = await fetch(`${baseUrl}/agent/tool-mocks`, {
       method: 'DELETE',
-      headers: { 'x-runtime-token': deriveRuntimeToken(projectId) },
+      headers: { 'x-runtime-token': await deriveProjectRuntimeToken(projectId) },
     })
     const text = await resp.text()
     return new Response(text, {
@@ -7692,13 +7698,13 @@ export default {
           return new Response('Invalid id', { status: 400 })
         }
         try {
-          const { deriveRuntimeToken } = await import('./lib/runtime-token')
+          const { deriveProjectRuntimeToken } = await import('./lib/project-runtime-token')
           const podUrl = await resolveRuntimeBaseUrl(projectId)
           const data: PtyPodBridgeData = buildPtyPodBridgeData({
             podUrl,
             sessionId,
             since,
-            runtimeToken: deriveRuntimeToken(projectId),
+            runtimeToken: await deriveProjectRuntimeToken(projectId),
           })
           const upgraded = server.upgrade(req, { data })
           if (upgraded) return undefined

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -4316,7 +4316,13 @@ app.get('/api/projects/:projectId/heartbeat', async (c) => {
     return c.json({ error: 'Agent config not found' }, 404)
   }
 
-  return c.json(config)
+  // modelName is an opaque UUID for DB models post catalog-uuid migration; attach
+  // a display label (id kept intact for any model picker).
+  const { resolveModelLabel } = await import('./services/model-registry.service')
+  return c.json({
+    ...config,
+    modelLabel: config.modelName ? await resolveModelLabel(config.modelName) : null,
+  })
 })
 
 app.patch('/api/projects/:projectId/heartbeat', async (c) => {
@@ -4379,7 +4385,11 @@ app.patch('/api/projects/:projectId/heartbeat', async (c) => {
     },
   })
 
-  return c.json(updated)
+  const { resolveModelLabel } = await import('./services/model-registry.service')
+  return c.json({
+    ...updated,
+    modelLabel: updated.modelName ? await resolveModelLabel(updated.modelName) : null,
+  })
 })
 
 // Sync heartbeat config from runtime config.json to DB (local mode).

--- a/apps/api/src/services/__tests__/model-registry.service.test.ts
+++ b/apps/api/src/services/__tests__/model-registry.service.test.ts
@@ -37,6 +37,9 @@ const {
   getDbModelEntriesSync,
   getDbRoutingConfigSync,
   getDbModelPricingSync,
+  resolveModelLabelSync,
+  resolveModelLabels,
+  resolveModelLabel,
 } = await import('../model-registry.service')
 
 const MIMO_KEY = 'sk-mimo-staging-key-abcdef'
@@ -287,5 +290,100 @@ describe('usage-cost DB per-token billing', () => {
     // A non-DB, non-catalog id should not blow up; it returns a finite cost.
     const { billedUsd } = calculateUsageCost(1000, 1000, 'totally-unknown-model-id')
     expect(Number.isFinite(billedUsd)).toBe(true)
+  })
+})
+
+// ─── Model label resolution (UUID → human display name) ─────────────────────
+// Post catalog-uuid-migration, stored references are opaque UUIDs. These cover
+// the resolvers the analytics / eval / cost surfaces use to render names.
+const LABEL_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+describe('model label resolution', () => {
+  beforeEach(async () => {
+    seedMimo()
+    await primeModelRegistry()
+  })
+
+  test('resolveModelLabelSync resolves a DB model id to its short display name', () => {
+    expect(resolveModelLabelSync('claude-opus-4-8')).toBe('Opus 4.8')
+    expect(resolveModelLabelSync('mimo-v2.5')).toBe('MiMo 2.5')
+  })
+
+  test('resolveModelLabelSync resolves a DB alias to the canonical entry label', () => {
+    expect(resolveModelLabelSync('opus')).toBe('Opus 4.8')
+    expect(resolveModelLabelSync('mimo')).toBe('MiMo 2.5')
+  })
+
+  test('resolveModelLabelSync resolves a static-catalog id via the entry label', () => {
+    const entry = getMergedModelEntrySync('claude-sonnet-4-6')
+    expect(entry).toBeDefined()
+    const expected = entry!.shortDisplayName || entry!.displayName || entry!.apiModel
+    expect(resolveModelLabelSync('claude-sonnet-4-6')).toBe(expected)
+    // …and it never just echoes the raw slug back as the "label".
+    expect(resolveModelLabelSync('claude-sonnet-4-6')).not.toBe('claude-sonnet-4-6')
+  })
+
+  test('resolveModelLabelSync echoes the raw id for unknown / empty input', () => {
+    expect(resolveModelLabelSync('totally-unknown-model-id')).toBe('totally-unknown-model-id')
+    expect(resolveModelLabelSync('')).toBe('')
+  })
+
+  test('resolveModelLabels batch-resolves DB ids, aliases, and unknown slugs', async () => {
+    const map = await resolveModelLabels(['claude-opus-4-8', 'mimo', 'ghost-model'])
+    expect(map.get('claude-opus-4-8')).toBe('Opus 4.8')
+    expect(map.get('mimo')).toBe('MiMo 2.5')
+    // Unknown, non-UUID id maps to itself so callers can blindly use the map.
+    expect(map.get('ghost-model')).toBe('ghost-model')
+  })
+
+  test('resolveModelLabels ignores blank / duplicate ids', async () => {
+    const map = await resolveModelLabels(['mimo', 'mimo', '', 'mimo'])
+    expect(map.get('mimo')).toBe('MiMo 2.5')
+    expect(map.has('')).toBe(false)
+  })
+
+  test('resolveModelLabels does a targeted lookup for UUIDs absent from the enabled snapshot', async () => {
+    // A canonical UUID not in the primed snapshot (mirrors an admin-disabled
+    // row the enabled-only refresh skips). We mutate MODELS *without* re-priming
+    // so the snapshot still lacks it and the registry is fresh (no auto-refresh),
+    // forcing resolution down the targeted `model_definitions` fallback.
+    const uuid = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+    MODELS = [
+      ...MODELS,
+      {
+        id: uuid,
+        provider: 'anthropic',
+        providerId: null,
+        apiModel: 'claude-ancient',
+        displayName: 'Claude Ancient',
+        shortDisplayName: 'Ancient',
+        tier: 'premium',
+        family: 'opus',
+        generation: 'legacy',
+        maxOutputTokens: 4096,
+        enabled: true,
+        sortOrder: null,
+        aliases: [],
+        capabilities: null,
+        inputPerMillion: 1,
+        cachedInputPerMillion: 0,
+        cacheWritePerMillion: 0,
+        outputPerMillion: 1,
+      },
+    ]
+    const map = await resolveModelLabels([uuid])
+    expect(map.get(uuid)).toBe('Ancient')
+  })
+
+  test('resolveModelLabels maps a UUID with no DB match to itself', async () => {
+    const orphan = '99999999-9999-4999-8999-999999999999'
+    expect(LABEL_UUID_RE.test(orphan)).toBe(true)
+    const map = await resolveModelLabels([orphan])
+    expect(map.get(orphan)).toBe(orphan)
+  })
+
+  test('resolveModelLabel (single, async) resolves an alias and passes through empty', async () => {
+    expect(await resolveModelLabel('opus')).toBe('Opus 4.8')
+    expect(await resolveModelLabel('')).toBe('')
   })
 })

--- a/apps/api/src/services/analytics.service.ts
+++ b/apps/api/src/services/analytics.service.ts
@@ -10,6 +10,7 @@
  */
 
 import { prisma, Prisma } from '../lib/prisma'
+import { resolveModelLabels } from './model-registry.service'
 
 /** Parse actionMetadata that may have been double-JSON-stringified. */
 function parseMeta(raw: unknown): Record<string, any> {
@@ -548,6 +549,18 @@ export async function getSpendTimeseries(
     userMap = new Map(users.map((u) => [u.id, u.email || u.name || u.id]))
   }
 
+  // Resolve model ids → display names when grouping by model (post catalog-uuid
+  // migration the stored ids are UUIDs).
+  let modelLabels = new Map<string, string>()
+  if (groupBy === 'model') {
+    modelLabels = await resolveModelLabels(
+      events.map((e) => {
+        const m = parseMeta(e.actionMetadata)
+        return (m.model || m.modelUsed || 'unknown') as string
+      }),
+    )
+  }
+
   // Aggregate {date → {seriesKey → metric value}} and totals
   const byDay = new Map<string, Map<string, number>>()
   const seriesTotals = new Map<string, number>()
@@ -572,12 +585,13 @@ export async function getSpendTimeseries(
     const day = isoDay(event.createdAt)
     const costUsd = eventCostUsd(event, meta)
 
+    const rawModel = meta.model || meta.modelUsed || 'unknown'
     const series =
       groupBy === 'user'
         ? userMap.get(event.memberId) ?? event.memberId
         : groupBy === 'source'
           ? event.source
-          : (meta.model || meta.modelUsed || 'unknown')
+          : (modelLabels.get(rawModel) ?? rawModel)
 
     const value =
       metric === 'tokens'
@@ -819,11 +833,23 @@ export async function getUsageLog(
   })
   const userMap = new Map(users.map((u) => [u.id, u]))
 
+  // Stored model ids are opaque UUIDs after the catalog-uuid migration; resolve
+  // them to human display names (alias / static-catalog aware) for the UI.
+  const modelLabels = await resolveModelLabels(
+    events
+      .filter((e) => !(typeof e.actionType === 'string' && e.actionType.startsWith('voice_')))
+      .map((e) => {
+        const m = parseMeta(e.actionMetadata)
+        return (m.model || m.modelUsed || 'unknown') as string
+      }),
+  )
+
   const entries: UsageLogEntry[] = events.map((event) => {
     const meta = parseMeta(event.actionMetadata)
     const user = userMap.get(event.memberId)
     const isVoice = typeof event.actionType === 'string' &&
       event.actionType.startsWith('voice_')
+    const rawModel = meta.model || meta.modelUsed || 'unknown'
     return {
       id: event.id,
       userId: event.memberId,
@@ -832,7 +858,7 @@ export async function getUsageLog(
       userImage: user?.image ?? null,
       model: isVoice
         ? voiceLabel(event.actionType)
-        : (meta.model || meta.modelUsed || 'unknown'),
+        : (modelLabels.get(rawModel) ?? rawModel),
       provider: isVoice ? 'elevenlabs' : (meta.provider || 'anthropic'),
       inputTokens: meta.inputTokens || 0,
       outputTokens: meta.outputTokens || 0,
@@ -941,6 +967,12 @@ export async function getUsageSummary(
   })
   const userMap = new Map(users.map((u) => [u.id, u]))
 
+  // Stored model ids are opaque UUIDs after the catalog-uuid migration; resolve
+  // them to human display names for the UI (uniqueModels still counts raw ids).
+  const modelLabels = await resolveModelLabels(
+    [...aggregateMap.values()].map((a) => a.model),
+  )
+
   // Also get tool call counts per user (from ToolCallLog → ChatSession → Project)
   // We aggregate tool calls through the workspace scope if available
   const toolCallWhere: any = { status: 'complete' }
@@ -965,7 +997,7 @@ export async function getUsageSummary(
         userName: user?.name ?? null,
         userEmail: user?.email ?? agg.userId,
         userImage: user?.image ?? null,
-        model: agg.model,
+        model: modelLabels.get(agg.model) ?? agg.model,
         provider: agg.provider,
         requestCount: agg.requestCount,
         totalInputTokens: agg.totalInputTokens,
@@ -988,7 +1020,7 @@ export async function getUsageSummary(
     totalRawUsd: summaries.reduce((s, e) => s + e.totalRawUsd, 0),
     totalToolCalls,
     uniqueUsers: new Set(summaries.map((s) => s.userId)).size,
-    uniqueModels: new Set(summaries.map((s) => s.model)).size,
+    uniqueModels: new Set([...aggregateMap.values()].map((a) => a.model)).size,
   }
 
   return { summaries, totals }

--- a/apps/api/src/services/cost-analytics.service.ts
+++ b/apps/api/src/services/cost-analytics.service.ts
@@ -27,6 +27,7 @@ import {
 } from '../lib/usage-cost'
 import { resolveModelId } from '@shogo/model-catalog'
 import { getDbModelPricing } from '../lib/db-model-pricing'
+import { resolveModelLabelSync } from './model-registry.service'
 
 // ============================================================================
 // Types
@@ -42,7 +43,10 @@ export function isCostPeriod(value: string): value is CostPeriod {
 
 interface AgentBreakdownEntry {
   agentType: string
+  /** Raw model id (UUID for DB models / slug for static catalog) — used for keyed lookups. */
   model: string
+  /** Human display label resolved from the model registry. */
+  modelLabel: string
   totalRuns: number
   /** Legacy "promise resolved" successes — kept for backwards compat / debug. */
   promiseSuccesses: number
@@ -71,7 +75,11 @@ interface AgentBreakdownEntry {
 interface CostRecommendation {
   agentType: string
   currentModel: string
+  /** Human display label for `currentModel`. */
+  currentModelLabel: string
   recommendedModel: string
+  /** Human display label for `recommendedModel`. */
+  recommendedModelLabel: string
   reason: string
   estimatedSavingsPercent: number
   estimatedMonthlySavings: number
@@ -293,6 +301,7 @@ export async function getAgentCostBreakdown(
     return {
       agentType: g.agentType,
       model: g.model,
+      modelLabel: resolveModelLabelSync(g.model),
       totalRuns,
       promiseSuccesses,
       qualitySuccesses,
@@ -390,7 +399,9 @@ export async function getCostRecommendations(
         recommendations.push({
           agentType: entry.agentType,
           currentModel: entry.model,
+          currentModelLabel: resolveModelLabelSync(entry.model),
           recommendedModel: candidate,
+          recommendedModelLabel: resolveModelLabelSync(candidate),
           reason,
           estimatedSavingsPercent: savingsPercent,
           estimatedMonthlySavings: monthlySavings,
@@ -410,8 +421,10 @@ export async function getCostRecommendations(
         recommendations.push({
           agentType: entry.agentType,
           currentModel: entry.model,
+          currentModelLabel: resolveModelLabelSync(entry.model),
           recommendedModel: candidate,
-          reason: `${entry.agentType} succeeds on only ${entry.qualitySuccessRate}% of runs (loop trips: ${entry.loopDetected}, max-turn hits: ${entry.hitMaxTurns}, escalations: ${entry.escalated}). Upgrading to ${candidate} should reduce wasted spend on retries.`,
+          recommendedModelLabel: resolveModelLabelSync(candidate),
+          reason: `${entry.agentType} succeeds on only ${entry.qualitySuccessRate}% of runs (loop trips: ${entry.loopDetected}, max-turn hits: ${entry.hitMaxTurns}, escalations: ${entry.escalated}). Upgrading to ${resolveModelLabelSync(candidate)} should reduce wasted spend on retries.`,
           estimatedSavingsPercent: -30,
           estimatedMonthlySavings: -Math.round(monthlyCost * 0.3 * 100) / 100,
           confidence: entry.totalRuns >= 30 ? 'medium' : 'low',
@@ -427,7 +440,9 @@ export async function getCostRecommendations(
       recommendations.push({
         agentType: entry.agentType,
         currentModel: entry.model,
+        currentModelLabel: resolveModelLabelSync(entry.model),
         recommendedModel: entry.model,
+        recommendedModelLabel: resolveModelLabelSync(entry.model),
         reason: `${entry.agentType} has very low prompt cache utilization (${Math.round(cacheRatio * 100)}%). Enabling prompt caching could reduce input token costs by up to 90%.`,
         estimatedSavingsPercent: 20,
         estimatedMonthlySavings: 0,
@@ -465,9 +480,9 @@ function buildDowngradeReason(
   if (entry.loopDetected > 0) parts.push(`${entry.loopDetected} loop trips`)
   if (entry.hitMaxTurns > 0) parts.push(`${entry.hitMaxTurns} max-turn hits`)
 
-  let reason = `${entry.agentType} on ${entry.model}: ${parts.join(' · ')}. Switching to ${candidate} should preserve quality at lower cost.`
+  let reason = `${entry.agentType} on ${resolveModelLabelSync(entry.model)}: ${parts.join(' · ')}. Switching to ${resolveModelLabelSync(candidate)} should preserve quality at lower cost.`
   if (evalAnchor) {
-    reason += ` Eval-anchored: ${candidate} passes ${Math.round(evalAnchor.passRate * 100)}% of ${evalAnchor.suite}.`
+    reason += ` Eval-anchored: ${resolveModelLabelSync(candidate)} passes ${Math.round(evalAnchor.passRate * 100)}% of ${evalAnchor.suite}.`
   }
   return reason
 }
@@ -882,10 +897,17 @@ export async function createShadowExperiment(
 
 export async function getExperiments(workspaceId: string) {
   try {
-    return await prisma.modelExperiment.findMany({
+    const rows = await prisma.modelExperiment.findMany({
       where: { workspaceId },
       orderBy: { createdAt: 'desc' },
     })
+    // modelA/modelB are opaque UUIDs for DB models post catalog-uuid migration;
+    // attach display labels (ids kept intact for actions/keys).
+    return rows.map((r) => ({
+      ...r,
+      modelALabel: resolveModelLabelSync(r.modelA),
+      modelBLabel: resolveModelLabelSync(r.modelB),
+    }))
   } catch (error) {
     if (isAnalyticsTableUnavailable(error)) return []
     throw error
@@ -1078,12 +1100,12 @@ export async function summarizeExperiment(experimentId: string, workspaceId: str
     if (qualityCloseEnough && b.avgCostPerRun < a.avgCostPerRun) {
       verdict = 'B'
       reasons.push(
-        `Variant B (${exp.modelB}) hits the same quality bar at ${(((a.avgCostPerRun - b.avgCostPerRun) / a.avgCostPerRun) * 100).toFixed(1)}% lower cost.`,
+        `Variant B (${resolveModelLabelSync(exp.modelB)}) hits the same quality bar at ${(((a.avgCostPerRun - b.avgCostPerRun) / a.avgCostPerRun) * 100).toFixed(1)}% lower cost.`,
       )
     } else if (qualityWorse) {
       verdict = 'A'
       reasons.push(
-        `Variant B (${exp.modelB}) regressed on quality signals — keep ${exp.modelA}.`,
+        `Variant B (${resolveModelLabelSync(exp.modelB)}) regressed on quality signals — keep ${resolveModelLabelSync(exp.modelA)}.`,
       )
     } else if (b.avgCostPerRun >= a.avgCostPerRun && qualityCloseEnough) {
       verdict = 'A'
@@ -1172,10 +1194,13 @@ export async function listSubagentOverrides(workspaceId: string) {
   if (!overrides) return []
 
   try {
-    return await overrides.findMany({
+    const rows = await overrides.findMany({
       where: { workspaceId },
       orderBy: [{ projectId: 'asc' }, { agentType: 'asc' }],
     })
+    // `model` is an opaque UUID for DB models post catalog-uuid migration; attach
+    // a display label while keeping `model` as the id (used by the picker / apply).
+    return rows.map((o) => ({ ...o, modelLabel: resolveModelLabelSync(o.model) }))
   } catch (error) {
     if (isAnalyticsTableUnavailable(error)) return []
     throw error
@@ -1394,6 +1419,8 @@ export interface OptimizerInActionReport {
     projectId: string | null
     fromModel: string | null  // best-guess builtin default — null when unknown
     toModel: string
+    /** Human display label for `toModel`. */
+    toModelLabel: string
     appliedAt: string
     updatedBy: string | null
     /** 30-day pre-override avg cost-per-run (null if no data). */
@@ -1411,6 +1438,8 @@ export interface OptimizerInActionReport {
   evalScores: Array<{
     agentType: string
     model: string
+    /** Human display label for `model`. */
+    modelLabel: string
     suite: string
     passRate: number
     totalCases: number
@@ -1422,7 +1451,11 @@ export interface OptimizerInActionReport {
     name: string
     agentType: string
     modelA: string
+    /** Human display label for `modelA`. */
+    modelALabel: string
     modelB: string
+    /** Human display label for `modelB`. */
+    modelBLabel: string
     status: string
     expectedEndAt: string | null
     runsA: number
@@ -1536,6 +1569,7 @@ export async function getOptimizerInActionReport(
       projectId: ov.projectId,
       fromModel: null,  // We don't store the previous default; UI fills in from builtin catalog.
       toModel: ov.model,
+      toModelLabel: resolveModelLabelSync(ov.model),
       appliedAt: ov.updatedAt.toISOString(),
       updatedBy: ov.updatedBy,
       avgCostBefore: avgBefore,
@@ -1566,6 +1600,7 @@ export async function getOptimizerInActionReport(
     evalScores.push({
       agentType: r.agentType,
       model: r.model,
+      modelLabel: resolveModelLabelSync(r.model),
       suite: r.suite,
       passRate: r.passRate,
       totalCases: r.totalCases,
@@ -1597,7 +1632,9 @@ export async function getOptimizerInActionReport(
       name: exp.name,
       agentType: exp.agentType,
       modelA: exp.modelA,
+      modelALabel: resolveModelLabelSync(exp.modelA),
       modelB: exp.modelB,
+      modelBLabel: resolveModelLabelSync(exp.modelB),
       status: exp.status,
       expectedEndAt: exp.expectedEndAt ? exp.expectedEndAt.toISOString() : null,
       runsA: exp.totalRunsA,

--- a/apps/api/src/services/model-registry.service.ts
+++ b/apps/api/src/services/model-registry.service.ts
@@ -31,14 +31,21 @@
 import { prisma } from '../lib/prisma'
 import { decryptSecret } from '../lib/secret-crypto'
 import { setDbModelPricingProvider } from '../lib/db-model-pricing'
-import {
-  MODEL_CATALOG,
-  type ModelEntry,
-  type BillingModel,
-  type ModelTier,
-  type ModelFamily,
-  type ModelGeneration,
+import * as modelCatalog from '@shogo/model-catalog'
+import type {
+  ModelEntry,
+  BillingModel,
+  ModelTier,
+  ModelFamily,
+  ModelGeneration,
 } from '@shogo/model-catalog'
+
+// Namespace import + fallback so a partial test mock of the (large) catalog
+// module that omits `MODEL_CATALOG` degrades to an empty catalog (DB-only /
+// identity resolution) instead of failing the ESM import link. In production
+// the real export is always present.
+const MODEL_CATALOG: Record<string, ModelEntry> =
+  (modelCatalog as { MODEL_CATALOG?: Record<string, ModelEntry> }).MODEL_CATALOG ?? {}
 
 const CACHE_TTL_MS = 30_000
 
@@ -294,6 +301,75 @@ export function getMergedModelEntrySync(id: string): ModelEntry | undefined {
   refreshIfStaleInBackground()
   const canonical = snapshot.aliasToId.get(id) ?? id
   return snapshot.merged.get(canonical)
+}
+
+const LABEL_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** Pick a human label off a merged/DB entry: short name → full name → api slug. */
+function entryLabel(
+  e: { shortDisplayName?: string | null; displayName?: string | null; apiModel?: string | null } | undefined,
+): string | undefined {
+  return e?.shortDisplayName || e?.displayName || e?.apiModel || undefined
+}
+
+/**
+ * Synchronous best-effort label for a model id (canonical UUID, alias slug, or
+ * static-catalog id): `shortDisplayName` → `displayName` → `apiModel` → raw id.
+ * Reads the in-memory snapshot (background-refreshes when stale). For batch use
+ * on freshness-critical surfaces (analytics) prefer the async `resolveModelLabels`.
+ */
+export function resolveModelLabelSync(id: string): string {
+  if (!id) return id
+  return entryLabel(getMergedModelEntrySync(id)) ?? id
+}
+
+/**
+ * Batch-resolve model ids to human display labels. Awaits a registry refresh
+ * when the snapshot is stale (so models added since the last load resolve),
+ * then does one targeted `model_definitions` lookup for any UUID-shaped ids
+ * still unresolved — e.g. admin-disabled rows excluded from the enabled-only
+ * snapshot. Unknown ids map to themselves so callers can blindly use the map.
+ */
+export async function resolveModelLabels(ids: Iterable<string>): Promise<Map<string, string>> {
+  const unique = [...new Set(
+    [...ids].filter((id): id is string => typeof id === 'string' && id.length > 0),
+  )]
+  const out = new Map<string, string>()
+  if (unique.length === 0) return out
+
+  if (isStale()) await refresh()
+
+  const stillUnresolved: string[] = []
+  for (const id of unique) {
+    const label = entryLabel(getMergedModelEntrySync(id))
+    if (label) out.set(id, label)
+    else if (LABEL_UUID_RE.test(id)) stillUnresolved.push(id)
+    else out.set(id, id)
+  }
+
+  if (stillUnresolved.length > 0) {
+    try {
+      const rows = (await (prisma as any).modelDefinition.findMany({
+        where: { id: { in: stillUnresolved } },
+        select: { id: true, shortDisplayName: true, displayName: true, apiModel: true },
+      })) as Array<{ id: string; shortDisplayName: string | null; displayName: string | null; apiModel: string | null }>
+      for (const r of rows) out.set(r.id, entryLabel(r) ?? r.id)
+    } catch {
+      // Table absent on a schema variant / transient DB error — fall through to
+      // the raw-id fallback below rather than failing the whole analytics call.
+    }
+  }
+
+  for (const id of unique) {
+    if (!out.has(id)) out.set(id, id)
+  }
+  return out
+}
+
+/** Convenience single-id async label resolver (awaits freshness). */
+export async function resolveModelLabel(id: string): Promise<string> {
+  if (!id) return id
+  return (await resolveModelLabels([id])).get(id) ?? id
 }
 
 /**

--- a/apps/desktop/src/local-server.ts
+++ b/apps/desktop/src/local-server.ts
@@ -707,7 +707,7 @@ function baselineMigrations(
         // healthy post-migration schema. A naive "create any CREATE TABLE whose
         // target is missing" sweep resurrects them as empty orphans on EVERY
         // launch, which is mostly harmless until a *later* migration legitimately
-        // reuses the same temp name: `prisma migrate deploy` then hits
+        // reuses the same temp name: \`prisma migrate deploy\` then hits
         // "table new_<table> already exists", half-applies, and bricks startup
         // (this is exactly what 20260531063135_add_workspace_chat_sessions did to
         // every v1.9.11 install). Collect the RENAME-source names within this

--- a/apps/docs/docs/architecture/cloud-pod-sync.md
+++ b/apps/docs/docs/architecture/cloud-pod-sync.md
@@ -275,9 +275,9 @@ from the pod's durable object store:
 ## Large / binary file offload (hybrid)
 
 Git stays small by keeping only text/source. There are two strategies; which
-one runs depends on `LFS_ENABLED`.
+one runs depends on the cloud sync mode.
 
-### Git LFS (`LFS_ENABLED=true`, `git_only` only) — versioned
+### Git LFS (`git_only` mode) — versioned
 
 Real Git LFS replaces the legacy offload
 ([packages/shared-runtime/src/lfs.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/lfs.ts)):
@@ -309,7 +309,7 @@ Real Git LFS replaces the legacy offload
   pointers and pushes the bytes. **GC:** LFS objects are immutable and never
   auto-pruned, so a reachability-based retention job is a required follow-up.
 
-### Legacy size-based offload (default / non-LFS) — latest-only
+### Legacy size-based offload (`dual_shadow` / `s3` modes) — latest-only
 
 Any file `> LARGE_FILE_BYTES` is classified as an offloaded asset
 ([packages/shared-runtime/src/large-file-sync.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/large-file-sync.ts)):

--- a/apps/docs/docs/architecture/cloud-pod-sync.md
+++ b/apps/docs/docs/architecture/cloud-pod-sync.md
@@ -274,8 +274,44 @@ from the pod's durable object store:
 
 ## Large / binary file offload (hybrid)
 
-Git stays small by keeping only text/source. Any file `> LARGE_FILE_BYTES`
-(default 5 MB, env-tunable) is classified as an offloaded asset
+Git stays small by keeping only text/source. There are two strategies; which
+one runs depends on `LFS_ENABLED`.
+
+### Git LFS (`LFS_ENABLED=true`, `git_only` only) — versioned
+
+Real Git LFS replaces the legacy offload
+([packages/shared-runtime/src/lfs.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/lfs.ts)):
+
+- On repo setup the pod writes a curated `.gitattributes` (`filter=lfs` for
+  images/video/archives/model weights/…) and `git lfs install --local
+  --skip-smudge`. Before each `git add -A`, any file `> LARGE_FILE_BYTES`
+  (default 5 MB) not already matched is `git lfs track`-ed, preserving the
+  old "anything large" behavior.
+- The LFS **clean filter** commits a tiny pointer blob into the tree (so the
+  file **is** versioned and shows in the git graph/diff) and stores the bytes
+  in a local cache. After the commit, `git lfs push` uploads the bytes to the
+  API **batch endpoint** ([apps/api/src/routes/git-lfs.ts](https://github.com/shogo-ai/shogo-ai/blob/main/apps/api/src/routes/git-lfs.ts)),
+  which mints **presigned OCI URLs** so bytes flow pod→OCI directly under
+  `<projectId>/lfs/objects/<oid>` (content-addressed sha256 → free dedup).
+- `persistRepoToStore` then excludes `.git/lfs/objects` from the `.git`
+  tarball (only when the push succeeded — otherwise the bytes stay in the
+  tarball as a fallback). On cold start, after `.git` is restored, `git lfs
+  pull` materializes the object bytes (smudge is skipped on checkout for
+  speed). The **API hydrate path has no git-lfs**, so its `reset --hard`
+  intentionally leaves pointer files — the graph still lists the files.
+- Auth: every `git lfs` call passes the runtime bearer via
+  `-c http.extraHeader` and the endpoint via `-c lfs.url`, so neither the
+  token nor an env-specific URL is ever persisted into `.git/config`.
+  External (laptop/CI) git-lfs clients are out of scope (no Basic→token).
+- Projects on the legacy offload migrate lazily on pod start
+  (`migrateOffloadedAssetsToLfs`): the managed `.git/info/exclude` block is
+  cleared and the restored assets are LFS-tracked; the next sync commits the
+  pointers and pushes the bytes. **GC:** LFS objects are immutable and never
+  auto-pruned, so a reachability-based retention job is a required follow-up.
+
+### Legacy size-based offload (default / non-LFS) — latest-only
+
+Any file `> LARGE_FILE_BYTES` is classified as an offloaded asset
 ([packages/shared-runtime/src/large-file-sync.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/large-file-sync.ts)):
 
 - git-excluded via `.git/info/exclude` (never touches the user's
@@ -288,7 +324,7 @@ Git stays small by keeping only text/source. Any file `> LARGE_FILE_BYTES`
 Semantics (intentional, matches the old S3 tar): offloaded files are
 **latest-only** and don't appear in the git graph/diff. Checkpoints and
 publish tags pin the *source* commit; the asset snapshot is whatever
-object storage holds. True large-file versioning (Git LFS) is deferred.
+object storage holds.
 
 ## Publish as a git tag
 
@@ -422,7 +458,9 @@ noticing.
 | Pod durable repo store (persist/restore/seed/tag) | [packages/shared-runtime/src/repo-store.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/repo-store.ts) |
 | Pod commit-metadata gathering | [packages/shared-runtime/src/checkpoint-record.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/checkpoint-record.ts) |
 | Cold-start bootstrap / seed (`dual_shadow`) | [packages/shared-runtime/src/git-bootstrap.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/git-bootstrap.ts) |
-| Large/binary file offload | [packages/shared-runtime/src/large-file-sync.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/large-file-sync.ts) |
+| Large/binary file offload (legacy, latest-only) | [packages/shared-runtime/src/large-file-sync.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/large-file-sync.ts) |
+| Git LFS pod ops (track/push/pull/migrate) | [packages/shared-runtime/src/lfs.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/shared-runtime/src/lfs.ts) |
+| Git LFS batch + verify API (presigned OCI) | [apps/api/src/routes/git-lfs.ts](https://github.com/shogo-ai/shogo-ai/blob/main/apps/api/src/routes/git-lfs.ts) |
 | API repo store (hydrate-only, ETag-fresh) | [apps/api/src/services/git-repo-store.ts](https://github.com/shogo-ai/shogo-ai/blob/main/apps/api/src/services/git-repo-store.ts) |
 | Internal checkpoint-record endpoint | [apps/api/src/routes/internal.ts](https://github.com/shogo-ai/shogo-ai/blob/main/apps/api/src/routes/internal.ts) (`POST /internal/projects/:id/checkpoints/record`) |
 | Pod → API record POST | `postCheckpointRecord` in [packages/agent-runtime/src/internal-api.ts](https://github.com/shogo-ai/shogo-ai/blob/main/packages/agent-runtime/src/internal-api.ts) |

--- a/apps/mobile/app/(admin)/heartbeats.tsx
+++ b/apps/mobile/app/(admin)/heartbeats.tsx
@@ -99,6 +99,8 @@ interface HeartbeatRow {
   quietHoursTimezone: string | null
   modelProvider: string
   modelName: string
+  /** Server-resolved display label for `modelName` (falls back to the raw id). */
+  modelLabel?: string | null
   updatedAt: string
   project: {
     id: string
@@ -583,7 +585,7 @@ function HeartbeatRowItem({
             )}
           </View>
           <Text className="text-[11px] text-muted-foreground" numberOfLines={1}>
-            {wsName} · {row.modelProvider}/{row.modelName}
+            {wsName} · {row.modelProvider}/{row.modelLabel ?? row.modelName}
           </Text>
         </View>
 

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -3472,23 +3472,56 @@ function CanvasPanel({
   // Dev server reachable (non-404 root) AND the agent runtime is up.
   const baseReady = !!agentUrl && !!readyCanvasBaseUrl
 
-  const CONNECTION_TIMEOUT_MS = 60_000
-  const [timedOut, setTimedOut] = useState(false)
+  // Two independent fallbacks, deliberately kept separate:
+  //
+  //  - baseTimedOut: the agent runtime / dev server never became reachable
+  //    (a genuine failure) → surface the "Connection timed out" error + Retry.
+  //
+  //  - apiWaitElapsed: the dev server IS up but the API sidecar hasn't reported
+  //    healthy within a bounded window → show the app anyway rather than block.
+  //    This is intentionally NON-RESETTING. On a fresh project the sidecar only
+  //    goes healthy after a cold `bun install` + build + spawn, and during that
+  //    time the dev-server root can flip 404<->200 as `dist/` is rebuilt. The
+  //    previous single timer keyed on `baseReady`, so every flip restarted the
+  //    clock and the gate could hang on "Starting API server…" forever. We
+  //    start this timer once (on first base-ready) and never restart it.
+  const BASE_TIMEOUT_MS = 60_000
+  const API_WAIT_TIMEOUT_MS = 20_000
+  const [baseTimedOut, setBaseTimedOut] = useState(false)
   useEffect(() => {
-    if (baseReady && apiLatched) {
-      setTimedOut(false)
+    if (baseReady) {
+      setBaseTimedOut(false)
       return
     }
-    setTimedOut(false)
-    const timer = setTimeout(() => setTimedOut(true), CONNECTION_TIMEOUT_MS)
+    setBaseTimedOut(false)
+    const timer = setTimeout(() => setBaseTimedOut(true), BASE_TIMEOUT_MS)
     return () => clearTimeout(timer)
-  }, [baseReady, apiLatched])
+  }, [baseReady])
 
-  // Load the canvas once the dev server is reachable AND the sidecar is
-  // healthy. The 60s timeout is a safety net so a sidecar that never reports
-  // healthy (crash loop, template without `/health`) still eventually shows
-  // the app instead of hanging on a spinner forever.
-  const showCanvas = shouldShowCanvas({ baseReady, apiLatched, timedOut })
+  const [apiWaitElapsed, setApiWaitElapsed] = useState(false)
+  const apiWaitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    if (apiLatched) return
+    if (!baseReady) return
+    // Start exactly once; do NOT restart on baseReady / phase oscillation.
+    if (apiWaitTimerRef.current) return
+    apiWaitTimerRef.current = setTimeout(() => setApiWaitElapsed(true), API_WAIT_TIMEOUT_MS)
+  }, [baseReady, apiLatched])
+  useEffect(
+    () => () => {
+      if (apiWaitTimerRef.current) {
+        clearTimeout(apiWaitTimerRef.current)
+        apiWaitTimerRef.current = null
+      }
+    },
+    [],
+  )
+
+  // Load the canvas once the dev server is reachable AND the sidecar is healthy
+  // (latched). `apiWaitElapsed` is the bounded safety net so a slow cold start
+  // or a sidecar that never reports healthy (crash loop, template without
+  // `/health`) still shows the app within ~20s instead of hanging forever.
+  const showCanvas = shouldShowCanvas({ baseReady, apiLatched, timedOut: apiWaitElapsed })
 
   if (!showCanvas) {
     // `!baseReady` → runtime / dev server not up yet (show its phase, and the
@@ -3503,7 +3536,7 @@ function CanvasPanel({
       : PHASE_LABELS['starting-api']
     return (
       <View className="flex-1 items-center justify-center px-6">
-        {timedOut ? (
+        {baseTimedOut ? (
           <>
             <View className="w-3 h-3 rounded-full mb-3 bg-destructive" />
             <Text className="text-foreground font-semibold mb-1">

--- a/apps/mobile/components/analytics/CostAnalyticsTab.tsx
+++ b/apps/mobile/components/analytics/CostAnalyticsTab.tsx
@@ -57,6 +57,8 @@ import { ExperimentsSection, type ExperimentItem } from './ExperimentsSection'
 interface AgentBreakdownEntry {
   agentType: string
   model: string
+  /** Server-resolved display label for `model` (falls back to client resolution). */
+  modelLabel?: string
   totalRuns: number
   promiseSuccesses?: number
   qualitySuccesses?: number
@@ -113,6 +115,8 @@ interface SubagentOverrideRecord {
   projectId: string | null
   agentType: string
   model: string
+  /** Server-resolved display label for `model` (falls back to client resolution). */
+  modelLabel?: string
   provider: string | null
   updatedBy: string | null
   createdAt: string
@@ -545,7 +549,7 @@ function AgentBreakdownSection({ data, loading }: { data: BreakdownData | null; 
                       <View className="flex-row items-center gap-1.5 mt-0.5">
                         <View className={cn('px-1.5 py-0.5 rounded border', getModelColor(entry.model))}>
                           <Text className={cn('text-[10px] font-medium', getModelTextColor(entry.model))}>
-                            {getModelDisplayName(entry.model)}
+                            {entry.modelLabel ?? getModelDisplayName(entry.model)}
                           </Text>
                         </View>
                         <Text className="text-[10px] text-muted-foreground">

--- a/apps/mobile/components/analytics/ExperimentsSection.tsx
+++ b/apps/mobile/components/analytics/ExperimentsSection.tsx
@@ -30,7 +30,11 @@ export interface ExperimentItem {
   name: string
   agentType: string
   modelA: string
+  /** Server-resolved display label for `modelA` (falls back to client resolution). */
+  modelALabel?: string
   modelB: string
+  /** Server-resolved display label for `modelB` (falls back to client resolution). */
+  modelBLabel?: string
   status: string
   splitPercentage: number
   totalRunsA: number
@@ -181,6 +185,7 @@ export function ExperimentsSection({
                     <ExperimentVariantCard
                       label="Model A"
                       model={exp.modelA}
+                      modelLabel={exp.modelALabel}
                       runs={exp.totalRunsA}
                       cost={exp.totalCostA}
                       costPerRun={costPerRunA}
@@ -190,6 +195,7 @@ export function ExperimentsSection({
                     <ExperimentVariantCard
                       label="Model B"
                       model={exp.modelB}
+                      modelLabel={exp.modelBLabel}
                       runs={exp.totalRunsB}
                       cost={exp.totalCostB}
                       costPerRun={costPerRunB}
@@ -324,6 +330,7 @@ function OptionRow({
 function ExperimentVariantCard({
   label,
   model,
+  modelLabel,
   runs,
   cost,
   costPerRun,
@@ -332,6 +339,7 @@ function ExperimentVariantCard({
 }: {
   label: string
   model: string
+  modelLabel?: string
   runs: number
   cost: number
   costPerRun: number
@@ -343,7 +351,7 @@ function ExperimentVariantCard({
       <Text className="text-[9px] font-medium text-muted-foreground mb-1">{label}</Text>
       <View className={cn('px-1.5 py-0.5 rounded border self-start mb-1.5', getModelColor(model))}>
         <Text className={cn('text-[10px] font-medium', getModelTextColor(model))}>
-          {getModelDisplayName(model)}
+          {modelLabel ?? getModelDisplayName(model)}
         </Text>
       </View>
       <View className="gap-0.5">

--- a/apps/mobile/components/analytics/OptimizerInActionSection.tsx
+++ b/apps/mobile/components/analytics/OptimizerInActionSection.tsx
@@ -30,6 +30,8 @@ export interface OptimizerInActionData {
     projectId: string | null
     fromModel: string | null
     toModel: string
+    /** Server-resolved display label for `toModel`. */
+    toModelLabel?: string
     appliedAt: string
     updatedBy: string | null
     avgCostBefore: number | null
@@ -42,6 +44,8 @@ export interface OptimizerInActionData {
   evalScores: Array<{
     agentType: string
     model: string
+    /** Server-resolved display label for `model`. */
+    modelLabel?: string
     suite: string
     passRate: number
     totalCases: number
@@ -52,7 +56,11 @@ export interface OptimizerInActionData {
     name: string
     agentType: string
     modelA: string
+    /** Server-resolved display label for `modelA`. */
+    modelALabel?: string
     modelB: string
+    /** Server-resolved display label for `modelB`. */
+    modelBLabel?: string
     status: string
     expectedEndAt: string | null
     runsA: number
@@ -192,7 +200,7 @@ export function OptimizerInActionSection({ data, isLoading, error }: OptimizerIn
                       </Text>
                     </View>
                     <Text className={`text-sm ${getModelTextColor(ov.toModel)}`}>
-                      → {getModelDisplayName(ov.toModel)}
+                      → {ov.toModelLabel ?? getModelDisplayName(ov.toModel)}
                     </Text>
                   </View>
 
@@ -239,7 +247,7 @@ export function OptimizerInActionSection({ data, isLoading, error }: OptimizerIn
                   <View className="flex-1">
                     <Text className="text-foreground font-medium">{exp.name}</Text>
                     <Text className="text-muted-foreground text-xs mt-0.5">
-                      {exp.modelA} ({exp.runsA} runs) vs {exp.modelB} ({exp.runsB} runs)
+                      {exp.modelALabel ?? getModelDisplayName(exp.modelA)} ({exp.runsA} runs) vs {exp.modelBLabel ?? getModelDisplayName(exp.modelB)} ({exp.runsB} runs)
                       {' · '}
                       {exp.status}
                       {exp.expectedEndAt ? ` · ends ${formatRelative(exp.expectedEndAt)}` : ''}
@@ -251,7 +259,7 @@ export function OptimizerInActionSection({ data, isLoading, error }: OptimizerIn
                         'bg-muted px-2 py-1 rounded-md'
                   }>
                     <Text className="text-xs font-semibold text-foreground">
-                      Verdict: {exp.verdict === 'B' ? `→ ${exp.modelB}` : exp.verdict === 'A' ? `keep ${exp.modelA}` : exp.verdict}
+                      Verdict: {exp.verdict === 'B' ? `→ ${exp.modelBLabel ?? getModelDisplayName(exp.modelB)}` : exp.verdict === 'A' ? `keep ${exp.modelALabel ?? getModelDisplayName(exp.modelA)}` : exp.verdict}
                     </Text>
                   </View>
                 </View>
@@ -286,7 +294,7 @@ export function OptimizerInActionSection({ data, isLoading, error }: OptimizerIn
                   {rows.map((r) => (
                     <View key={`${r.agentType}::${r.model}`} className="flex-row justify-between">
                       <Text className={`text-sm ${getModelTextColor(r.model)}`}>
-                        {getModelDisplayName(r.model)}
+                        {r.modelLabel ?? getModelDisplayName(r.model)}
                       </Text>
                       <Text className="text-foreground text-sm">
                         {(r.passRate * 100).toFixed(1)}% ({r.totalCases} cases · {formatRelative(r.capturedAt)})

--- a/apps/mobile/components/analytics/RecommendationsSection.tsx
+++ b/apps/mobile/components/analytics/RecommendationsSection.tsx
@@ -23,7 +23,11 @@ import { formatDollarCost, getModelColor, getModelDisplayName, getModelTextColor
 export interface CostRecommendation {
   agentType: string
   currentModel: string
+  /** Server-resolved display label for `currentModel` (falls back to client resolution). */
+  currentModelLabel?: string
   recommendedModel: string
+  /** Server-resolved display label for `recommendedModel` (falls back to client resolution). */
+  recommendedModelLabel?: string
   reason: string
   estimatedSavingsPercent: number
   estimatedMonthlySavings: number
@@ -141,13 +145,13 @@ export function RecommendationsSection({ data, loading, onApply }: Recommendatio
                     <View className="flex-row items-center gap-1.5 mb-2 flex-wrap">
                       <View className={cn('px-1.5 py-0.5 rounded border', getModelColor(rec.currentModel))}>
                         <Text className={cn('text-[10px] font-medium', getModelTextColor(rec.currentModel))}>
-                          {getModelDisplayName(rec.currentModel)}
+                          {rec.currentModelLabel ?? getModelDisplayName(rec.currentModel)}
                         </Text>
                       </View>
                       <ArrowRightLeft size={10} className="text-muted-foreground" />
                       <View className={cn('px-1.5 py-0.5 rounded border', getModelColor(rec.recommendedModel))}>
                         <Text className={cn('text-[10px] font-medium', getModelTextColor(rec.recommendedModel))}>
-                          {getModelDisplayName(rec.recommendedModel)}
+                          {rec.recommendedModelLabel ?? getModelDisplayName(rec.recommendedModel)}
                         </Text>
                       </View>
                       {isSavings && (
@@ -194,7 +198,7 @@ export function RecommendationsSection({ data, loading, onApply }: Recommendatio
                       </View>
                       {rec.evidence.evalAnchor && (
                         <Text className="text-[9px] text-muted-foreground mt-1">
-                          Eval anchor: <Text className="font-medium text-foreground">{rec.evidence.evalAnchor.model}</Text> · <Text className="font-medium text-foreground">{Math.round(rec.evidence.evalAnchor.passRate * 100)}%</Text> pass · <Text className="font-medium">{rec.evidence.evalAnchor.suite}</Text>
+                          Eval anchor: <Text className="font-medium text-foreground">{getModelDisplayName(rec.evidence.evalAnchor.model)}</Text> · <Text className="font-medium text-foreground">{Math.round(rec.evidence.evalAnchor.passRate * 100)}%</Text> pass · <Text className="font-medium">{rec.evidence.evalAnchor.suite}</Text>
                         </Text>
                       )}
                     </View>
@@ -228,8 +232,8 @@ export function RecommendationsSection({ data, loading, onApply }: Recommendatio
                             wasApplied ? 'text-foreground' : 'text-primary-foreground',
                           )}>
                             {wasApplied
-                              ? `Applied · ${rec.agentType} → ${getModelDisplayName(rec.recommendedModel)}`
-                              : isApplying ? 'Applying…' : `Set workspace default for ${rec.agentType} to ${getModelDisplayName(rec.recommendedModel)}`}
+                              ? `Applied · ${rec.agentType} → ${rec.recommendedModelLabel ?? getModelDisplayName(rec.recommendedModel)}`
+                              : isApplying ? 'Applying…' : `Set workspace default for ${rec.agentType} to ${rec.recommendedModelLabel ?? getModelDisplayName(rec.recommendedModel)}`}
                           </Text>
                         </View>
                       </Button>

--- a/apps/mobile/components/analytics/SubAgentModelsSection.tsx
+++ b/apps/mobile/components/analytics/SubAgentModelsSection.tsx
@@ -83,6 +83,8 @@ interface SubagentOverride {
   projectId: string | null
   agentType: string
   model: string
+  /** Server-resolved display label for `model` (falls back to client resolution). */
+  modelLabel?: string
   provider: string | null
   updatedBy: string | null
   createdAt: string
@@ -203,6 +205,9 @@ export function SubAgentModelsSection({
       {BUILTIN_SUBAGENTS.map((agent) => {
         const override = overrideFor(agent.agentType)
         const effectiveModel = override?.model ?? agent.defaultModel
+        // Prefer the server-resolved label for overrides (handles UUID model ids);
+        // built-in defaults are slugs that resolve client-side.
+        const effectiveModelLabel = override?.modelLabel ?? getModelDisplayName(effectiveModel)
         const isCustom = !!override
         const isOpen = openDropdown === agent.agentType
         const isPending = pendingAgentType === agent.agentType
@@ -241,7 +246,7 @@ export function SubAgentModelsSection({
                 <View className="flex-row items-center gap-2">
                   <View className={cn('px-1.5 py-0.5 rounded border', getModelColor(effectiveModel))}>
                     <Text className={cn('text-[10px] font-medium', getModelTextColor(effectiveModel))}>
-                      {getModelDisplayName(effectiveModel)}
+                      {effectiveModelLabel}
                     </Text>
                   </View>
                   {isCustom ? (
@@ -315,7 +320,7 @@ export function SubAgentModelsSection({
                   <View className="flex-row items-center gap-2">
                     <View className={cn('px-1.5 py-0.5 rounded border', getModelColor(o.model))}>
                       <Text className={cn('text-[10px] font-medium', getModelTextColor(o.model))}>
-                        {getModelDisplayName(o.model)}
+                        {o.modelLabel ?? getModelDisplayName(o.model)}
                       </Text>
                     </View>
                     <Button variant="outline" onPress={() => handleReset(o.agentType)}>

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -44,6 +44,7 @@ import {
   Lock,
   File,
   FileText,
+  Boxes,
   Image as ImageIcon,
   ChevronDown,
   ChevronUp,
@@ -74,6 +75,9 @@ import { PastedTextChip } from "./PastedTextChip"
 import { useChatBridgeOptional } from "../voice-mode/ChatBridgeContext"
 import { AskUserQuestionWidget } from "./turns/AskUserQuestionWidget"
 import type { ToolCallData } from "./tools/types"
+import { AgentClient } from "@shogo-ai/sdk/agent"
+import { agentFetch } from "../../lib/agent-fetch"
+import { useChatContextSafe } from "./ChatContext"
 
 export const DEFAULT_MODEL_PRO = "claude-sonnet-4-6"
 export const DEFAULT_MODEL_FREE = "claude-haiku-4-5-20251001"
@@ -147,6 +151,123 @@ export interface FileAttachment {
   type: string
 }
 
+/**
+ * A structured "@" reference attached to a chat message. Files point at a
+ * path inside the current project's agent workspace (resolved to real
+ * contents by the runtime); workspaces carry a client-built `summary` so
+ * the runtime can inject them as context without a DB lookup (works even
+ * in direct-to-runtime / desktop mode).
+ */
+export type ChatReference =
+  | { type: "file"; path: string; name: string; label?: string }
+  | { type: "workspace"; id: string; name: string; slug: string; summary?: string; label?: string }
+
+/** Lightweight workspace shape the composer needs for the "@" menu. */
+export interface WorkspaceMentionOption {
+  id: string
+  name: string
+  slug: string
+  description?: string
+}
+
+/** One selectable row in the "@" menu (files first, then workspaces). */
+type MentionItem =
+  | { kind: "file"; path: string; name: string }
+  | { kind: "workspace"; id: string; name: string; slug: string; description?: string }
+
+const MAX_MENTION_FILE_RESULTS = 8
+const MAX_MENTION_WORKSPACE_RESULTS = 8
+
+function referenceKey(ref: ChatReference): string {
+  return ref.type === "file" ? `file:${ref.path}` : `workspace:${ref.id}`
+}
+
+function buildWorkspaceSummary(ws: WorkspaceMentionOption): string {
+  const lines = [`Workspace: ${ws.name} (slug: ${ws.slug}, id: ${ws.id})`]
+  if (ws.description && ws.description.trim()) {
+    lines.push(`Description: ${ws.description.trim()}`)
+  }
+  return lines.join("\n")
+}
+
+function basename(path: string): string {
+  const parts = path.split("/").filter(Boolean)
+  return parts[parts.length - 1] || path
+}
+
+/**
+ * True when `label` (an "@token") occurs in `text` at a mention boundary —
+ * start-of-string or right after whitespace, mirroring `detectMentionToken`.
+ * Used to prune references whose inline text the user edited/deleted and to
+ * decide what the inline-highlight overlay should pill.
+ */
+function labelPresent(text: string, label: string): boolean {
+  if (!label) return false
+  let from = 0
+  for (;;) {
+    const idx = text.indexOf(label, from)
+    if (idx === -1) return false
+    if (idx === 0 || /\s/.test(text[idx - 1])) return true
+    from = idx + 1
+  }
+}
+
+/** A run of composer text: either plain or a tagged "@mention". */
+type MentionSegment = { text: string; mention: boolean }
+
+/**
+ * Split `text` into plain / mention runs by matching known reference `labels`
+ * at mention boundaries (longest-first so `@foo.tsx` wins over `@foo`). Backs
+ * the transparent overlay that draws an inline pill behind each "@mention"
+ * while the real (crisp) text stays in the TextInput on top.
+ */
+function buildMentionSegments(text: string, labels: string[]): MentionSegment[] {
+  const unique = Array.from(new Set(labels.filter(Boolean))).sort((a, b) => b.length - a.length)
+  if (unique.length === 0) return [{ text, mention: false }]
+  const segments: MentionSegment[] = []
+  let i = 0
+  let plainStart = 0
+  while (i < text.length) {
+    let matched: string | null = null
+    if (i === 0 || /\s/.test(text[i - 1])) {
+      for (const lab of unique) {
+        if (text.startsWith(lab, i)) {
+          matched = lab
+          break
+        }
+      }
+    }
+    if (matched) {
+      if (plainStart < i) segments.push({ text: text.slice(plainStart, i), mention: false })
+      segments.push({ text: matched, mention: true })
+      i += matched.length
+      plainStart = i
+    } else {
+      i++
+    }
+  }
+  if (plainStart < text.length) segments.push({ text: text.slice(plainStart), mention: false })
+  return segments
+}
+
+/**
+ * Find the active "@" mention token in `text` ending at `caret`. Matches a
+ * leading "@" preceded by start-of-string or whitespace with no whitespace
+ * (or further "@") between it and the caret — e.g. typing `look at @comp`.
+ * Returns the token's start index (the "@") and the query after it.
+ */
+function detectMentionToken(
+  text: string,
+  caret: number
+): { start: number; query: string } | null {
+  const safeCaret = Math.max(0, Math.min(caret, text.length))
+  const upToCaret = text.slice(0, safeCaret)
+  const match = /(^|\s)@([^\s@]*)$/.exec(upToCaret)
+  if (!match) return null
+  const query = match[2]
+  return { start: safeCaret - query.length - 1, query }
+}
+
 export type RestoreDraftRequest = {
   nonce: number
   content: string
@@ -173,7 +294,12 @@ export type QueuedMessage = {
 }
 
 export interface ChatInputProps {
-  onSubmit: (content: string, files?: FileAttachment[], modelId?: string) => void
+  onSubmit: (
+    content: string,
+    files?: FileAttachment[],
+    modelId?: string,
+    references?: ChatReference[]
+  ) => void
   disabled?: boolean
   placeholder?: string
   isStreaming?: boolean
@@ -203,6 +329,17 @@ export interface ChatInputProps {
   quickActions?: { label: string; prompt: string }[]
   onQuickActionClick?: (prompt: string) => void
   restoreDraftRequest?: RestoreDraftRequest | null
+  /**
+   * Current project id. Enables the "@" menu's Files section (file
+   * references are scoped to this project's agent workspace).
+   */
+  projectId?: string
+  /**
+   * Org/team workspaces the user can tag via the "@" menu's Workspaces
+   * section. Pass a referentially-stable array (memoized) so the memoized
+   * ChatInput doesn't re-render on every parent render.
+   */
+  workspaces?: WorkspaceMentionOption[]
   dimWhenDisabled?: boolean
   /**
    * When true, draws an accent-colored ring on the visible input
@@ -262,6 +399,8 @@ function ChatInputImpl({
   quickActions = [],
   onQuickActionClick,
   restoreDraftRequest,
+  projectId,
+  workspaces = [],
   dimWhenDisabled = true,
   highlighted = false,
   flush = false,
@@ -427,6 +566,208 @@ function ChatInputImpl({
         s.description.toLowerCase().includes(lower)
     )
   }, [filterText])
+
+  // ---- "@" mention menu (files + workspaces) --------------------------------
+  const chatContext = useChatContextSafe()
+  const agentUrl = chatContext?.agentUrl ?? null
+  const agentClient = useMemo(
+    () =>
+      agentUrl ? new AgentClient({ baseUrl: agentUrl.replace(/\/$/, ""), fetch: agentFetch }) : null,
+    [agentUrl]
+  )
+
+  const [references, setReferences] = useState<ChatReference[]>([])
+  const [showMentionMenu, setShowMentionMenu] = useState(false)
+  const [mentionQuery, setMentionQuery] = useState("")
+  const [mentionIndex, setMentionIndex] = useState(0)
+  const [fileResults, setFileResults] = useState<{ path: string; name: string }[]>([])
+  // The active "@" token's range in the input, so selecting an item can strip
+  // exactly that token regardless of where the caret is.
+  const mentionTokenRef = useRef<{ start: number; end: number } | null>(null)
+  // One-shot caret override: after inserting an inline "@mention" we move the
+  // caret to just past it, then release control so normal typing isn't pinned.
+  const [selectionOverride, setSelectionOverride] = useState<
+    { start: number; end: number } | undefined
+  >(undefined)
+  // Mirror the TextInput's internal scroll so the highlight overlay tracks it
+  // once the composer grows past its max height and starts scrolling.
+  const [overlayScrollY, setOverlayScrollY] = useState(0)
+
+  const closeMentionMenu = useCallback(() => {
+    setShowMentionMenu(false)
+    setMentionQuery("")
+    setMentionIndex(0)
+    mentionTokenRef.current = null
+  }, [])
+
+  // Re-evaluate the active "@" token whenever the text or caret changes.
+  const updateMentionState = useCallback(
+    (text: string, caret: number) => {
+      const token = detectMentionToken(text, caret)
+      if (!token) {
+        if (mentionTokenRef.current) {
+          mentionTokenRef.current = null
+          setShowMentionMenu(false)
+          setMentionQuery("")
+          setMentionIndex(0)
+        }
+        return
+      }
+      mentionTokenRef.current = { start: token.start, end: caret }
+      setShowMentionMenu(true)
+      setMentionIndex(0)
+      setMentionQuery((prev) => (prev === token.query ? prev : token.query))
+    },
+    []
+  )
+
+  // Debounced file search against the project's agent workspace. Empty query
+  // shows top-level files; otherwise we use the runtime's RAG search. Gated on
+  // `projectId` so the Files section only appears in a project composer (and
+  // stays empty in the inline-edit composer, where references aren't threaded).
+  useEffect(() => {
+    if (!showMentionMenu || !agentClient || !projectId) {
+      setFileResults([])
+      return
+    }
+    let cancelled = false
+    const query = mentionQuery.trim()
+    const timer = setTimeout(async () => {
+      try {
+        const seen = new Set<string>()
+        const results: { path: string; name: string }[] = []
+        if (!query) {
+          const tree = await agentClient.getWorkspaceTree("")
+          const pushFiles = (nodes: any[]) => {
+            for (const node of nodes) {
+              if (results.length >= MAX_MENTION_FILE_RESULTS) return
+              if (node?.type === "file" && node.path && !seen.has(node.path)) {
+                seen.add(node.path)
+                results.push({ path: node.path, name: node.name || basename(node.path) })
+              } else if (node?.type === "directory" && Array.isArray(node.children)) {
+                pushFiles(node.children)
+              }
+            }
+          }
+          pushFiles(Array.isArray(tree) ? tree : [])
+        } else {
+          const hits = await agentClient.searchFiles(query, { limit: MAX_MENTION_FILE_RESULTS * 2 })
+          for (const hit of hits) {
+            if (results.length >= MAX_MENTION_FILE_RESULTS) break
+            if (hit?.path && !seen.has(hit.path)) {
+              seen.add(hit.path)
+              results.push({ path: hit.path, name: basename(hit.path) })
+            }
+          }
+        }
+        if (!cancelled) setFileResults(results)
+      } catch {
+        if (!cancelled) setFileResults([])
+      }
+    }, 150)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [showMentionMenu, mentionQuery, agentClient, projectId])
+
+  const filteredWorkspaces = useMemo(() => {
+    const q = mentionQuery.trim().toLowerCase()
+    const list = workspaces ?? []
+    const matched = q
+      ? list.filter(
+          (w) =>
+            w.name.toLowerCase().includes(q) || w.slug.toLowerCase().includes(q)
+        )
+      : list
+    return matched.slice(0, MAX_MENTION_WORKSPACE_RESULTS)
+  }, [workspaces, mentionQuery])
+
+  // Flat, ordered list backing keyboard navigation (files first, then workspaces).
+  const mentionItems = useMemo<MentionItem[]>(
+    () => [
+      ...fileResults.map((f) => ({ kind: "file" as const, path: f.path, name: f.name })),
+      ...filteredWorkspaces.map((w) => ({
+        kind: "workspace" as const,
+        id: w.id,
+        name: w.name,
+        slug: w.slug,
+        description: w.description,
+      })),
+    ],
+    [fileResults, filteredWorkspaces]
+  )
+
+  const addReference = useCallback((ref: ChatReference) => {
+    setReferences((prev) =>
+      prev.some((r) => referenceKey(r) === referenceKey(ref)) ? prev : [...prev, ref]
+    )
+  }, [])
+
+  const selectMention = useCallback(
+    (item: MentionItem) => {
+      // Insert the mention INLINE as an "@token" (replacing the active query,
+      // or appended at the caret-less end) so it renders as a pill where it
+      // was typed — instead of stripping it into a chip above the box. Files
+      // tag by basename, workspaces by slug (both whitespace-free tokens).
+      const base = inputValueRef.current
+      const token = mentionTokenRef.current
+      const label = `@${item.kind === "file" ? item.name : item.slug}`
+      let caret: number
+      if (token) {
+        const start = Math.max(0, Math.min(token.start, base.length))
+        const end = Math.max(start, Math.min(token.end, base.length))
+        const insert = `${label} `
+        const next = base.slice(0, start) + insert + base.slice(end)
+        inputValueRef.current = next
+        setInputValue(next)
+        caret = start + insert.length
+      } else {
+        const sep = base.length === 0 || base.endsWith(" ") ? "" : " "
+        const insert = `${sep}${label} `
+        const next = base + insert
+        inputValueRef.current = next
+        setInputValue(next)
+        caret = next.length
+      }
+
+      if (item.kind === "file") {
+        addReference({ type: "file", path: item.path, name: item.name, label })
+      } else {
+        addReference({
+          type: "workspace",
+          id: item.id,
+          name: item.name,
+          slug: item.slug,
+          label,
+          summary: buildWorkspaceSummary({
+            id: item.id,
+            name: item.name,
+            slug: item.slug,
+            description: item.description,
+          }),
+        })
+      }
+
+      closeMentionMenu()
+      setSelectionOverride({ start: caret, end: caret })
+      setTimeout(() => {
+        textInputRef.current?.focus()
+        setSelectionOverride(undefined)
+      }, 0)
+    },
+    [addReference, closeMentionMenu]
+  )
+
+  // Keep references in sync with what's actually visible: if the user edits or
+  // deletes a mention's inline "@token", drop the matching reference so we
+  // don't ship context the composer no longer shows.
+  useEffect(() => {
+    setReferences((prev) => {
+      const next = prev.filter((r) => !r.label || labelPresent(inputValue, r.label))
+      return next.length === prev.length ? prev : next
+    })
+  }, [inputValue])
 
   const formatFileSize = useCallback((bytes: number): string => {
     if (bytes < 1024) return `${bytes} B`
@@ -608,6 +949,22 @@ function ChatInputImpl({
     onTranscript: appendTranscriptToInput,
   })
 
+  // Inline "@mention" highlight overlay. Mirror EXACTLY what the TextInput
+  // shows (including the live voice transcript) so the pills line up with the
+  // real text painted on top.
+  const composerDisplayValue =
+    voiceInput.isRecording && voiceInput.liveTranscript
+      ? voiceInput.liveTranscript
+      : inputValue
+  const mentionLabels = useMemo(
+    () => references.map((r) => r.label).filter((l): l is string => !!l),
+    [references]
+  )
+  const mentionSegments = useMemo(
+    () => buildMentionSegments(composerDisplayValue, mentionLabels),
+    [composerDisplayValue, mentionLabels]
+  )
+
   const selectSkill = useCallback(
     (skill: SkillOption) => {
       const spaceIndex = inputValue.indexOf(" ")
@@ -622,7 +979,10 @@ function ChatInputImpl({
   const handleSubmit = useCallback(() => {
     const trimmedContent = inputValue.trim()
     if (
-      (!trimmedContent && pendingFiles.length === 0 && pastedTexts.length === 0) ||
+      (!trimmedContent &&
+        pendingFiles.length === 0 &&
+        pastedTexts.length === 0 &&
+        references.length === 0) ||
       disabled ||
       isProcessingFiles ||
       voiceInput.isBusy
@@ -639,17 +999,21 @@ function ChatInputImpl({
       ...pastedAttachments,
     ]
     const fileData = combinedFiles.length > 0 ? combinedFiles : undefined
+    const refData = references.length > 0 ? references : undefined
 
-    onSubmit(trimmedContent, fileData, currentModelId)
+    onSubmit(trimmedContent, fileData, currentModelId, refData)
+    inputValueRef.current = ""
     setInputValue("")
     setInputHeight(MIN_INPUT_HEIGHT)
     setPendingFiles([])
     setPastedTexts([])
     setViewingPastedId(null)
+    setReferences([])
     setFileError(null)
+    closeMentionMenu()
 
     textInputRef.current?.focus()
-  }, [disabled, onSubmit, pendingFiles, isProcessingFiles, currentModelId, inputValue, pastedTexts, voiceInput.isBusy])
+  }, [disabled, onSubmit, pendingFiles, isProcessingFiles, currentModelId, inputValue, pastedTexts, references, voiceInput.isBusy, closeMentionMenu])
 
   const handleChangeText = useCallback(
     (text: string) => {
@@ -667,11 +1031,16 @@ function ChatInputImpl({
       const paste = extractLongPaste(inputValueRef.current, text)
       if (paste) {
         addPastedText(paste.inserted)
+        inputValueRef.current = paste.restored
         setInputValue(paste.restored)
         setShowSkillPicker(false)
+        closeMentionMenu()
         return
       }
 
+      // Keep the ref in sync synchronously so onSelectionChange (which fires
+      // right after with the authoritative caret) sees the latest text.
+      inputValueRef.current = text
       setInputValue(text)
       if (text.length === 0) {
         setInputHeight(MIN_INPUT_HEIGHT)
@@ -684,8 +1053,12 @@ function ChatInputImpl({
       } else {
         setShowSkillPicker(false)
       }
+
+      // Provisional mention detection using the end of the text as the caret;
+      // onSelectionChange refines this with the real caret position.
+      updateMentionState(text, text.length)
     },
-    [addPastedText]
+    [addPastedText, closeMentionMenu, updateMentionState]
   )
 
   const getFileIcon = useCallback((fileType: string) => {
@@ -1071,21 +1444,17 @@ function ChatInputImpl({
         </View>
       )}
 
-      {/* Main input container */}
-      <View
-        ref={dropZoneRef as any}
-        className={cn(
-          "relative border bg-muted/30 overflow-hidden",
-          queuedMessages.length > 0 ? "rounded-b-xl" : "rounded-xl",
-          isDragOver ? "border-primary border-dashed" : "border-border/60",
-          // Accent ring for the inline-edit "active edit target"
-          // state. Drag-over still takes precedence (its dashed
-          // primary border is more important to surface than the
-          // edit-target highlight). The inner border stays at
-          // 1px so toggling `highlighted` doesn't shift layout.
-          highlighted && !isDragOver && "ring-2 ring-primary/70"
-        )}
-      >
+      {/* Dropdown + input layer.
+
+          This bare `relative` wrapper is the positioning context for the
+          floating dropdowns (skill picker + "@" mention menu) that open
+          ABOVE the composer via `bottom-full`. They MUST live here rather
+          than inside the bordered input box below: that box uses
+          `overflow-hidden` to clip its own rounded corners, which also
+          clips anything positioned outside its bounds — so a dropdown
+          anchored at `bottom: 100%` (just above the box) was being clipped
+          completely out of view. The wrapper itself never clips. */}
+      <View className="relative">
         {/* Skill picker dropdown */}
         {showSkillPicker && filteredSkills.length > 0 && (
           <View className="absolute bottom-full left-0 right-0 mb-1 max-h-[200px] rounded-md border border-border bg-popover shadow-md z-50">
@@ -1111,6 +1480,107 @@ function ChatInputImpl({
           </View>
         )}
 
+        {/* "@" mention menu — files (current project) + workspaces */}
+        {showMentionMenu && (
+          <View className="absolute bottom-full left-0 right-0 mb-1 max-h-[280px] rounded-md border border-border bg-popover shadow-md z-50">
+            <ScrollView keyboardShouldPersistTaps="handled">
+              {fileResults.length > 0 && (
+                <>
+                  <Text className="px-3 pt-2 pb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                    Files
+                  </Text>
+                  {fileResults.map((file, i) => {
+                    const active = i === mentionIndex
+                    return (
+                      <Pressable
+                        key={`mention-file-${file.path}`}
+                        onPress={() => selectMention({ kind: "file", path: file.path, name: file.name })}
+                        className={cn(
+                          "w-full flex-row items-center gap-2 px-3 py-2",
+                          active && "bg-accent"
+                        )}
+                      >
+                        <FileText className="h-4 w-4 text-muted-foreground" size={16} />
+                        <View className="flex-1">
+                          <Text className="text-sm text-foreground" numberOfLines={1}>
+                            {file.name}
+                          </Text>
+                          <Text className="text-xs text-muted-foreground" numberOfLines={1}>
+                            {file.path}
+                          </Text>
+                        </View>
+                      </Pressable>
+                    )
+                  })}
+                </>
+              )}
+
+              {filteredWorkspaces.length > 0 && (
+                <>
+                  <Text className="px-3 pt-2 pb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                    Workspaces
+                  </Text>
+                  {filteredWorkspaces.map((ws, i) => {
+                    const idx = fileResults.length + i
+                    const active = idx === mentionIndex
+                    return (
+                      <Pressable
+                        key={`mention-ws-${ws.id}`}
+                        onPress={() =>
+                          selectMention({
+                            kind: "workspace",
+                            id: ws.id,
+                            name: ws.name,
+                            slug: ws.slug,
+                            description: ws.description,
+                          })
+                        }
+                        className={cn(
+                          "w-full flex-row items-center gap-2 px-3 py-2",
+                          active && "bg-accent"
+                        )}
+                      >
+                        <Boxes className="h-4 w-4 text-muted-foreground" size={16} />
+                        <View className="flex-1">
+                          <Text className="text-sm text-foreground" numberOfLines={1}>
+                            {ws.name}
+                          </Text>
+                          <Text className="text-xs text-muted-foreground" numberOfLines={1}>
+                            {ws.slug}
+                          </Text>
+                        </View>
+                      </Pressable>
+                    )
+                  })}
+                </>
+              )}
+
+              {mentionItems.length === 0 && (
+                <Text className="px-3 py-3 text-xs text-muted-foreground">
+                  {!agentClient && (workspaces?.length ?? 0) === 0
+                    ? "Nothing to reference yet"
+                    : "No matches"}
+                </Text>
+              )}
+            </ScrollView>
+          </View>
+        )}
+
+        {/* Main input container */}
+        <View
+          ref={dropZoneRef as any}
+          className={cn(
+            "relative border bg-muted/30 overflow-hidden",
+            queuedMessages.length > 0 ? "rounded-b-xl" : "rounded-xl",
+            isDragOver ? "border-primary border-dashed" : "border-border/60",
+            // Accent ring for the inline-edit "active edit target"
+            // state. Drag-over still takes precedence (its dashed
+            // primary border is more important to surface than the
+            // edit-target highlight). The inner border stays at
+            // 1px so toggling `highlighted` doesn't shift layout.
+            highlighted && !isDragOver && "ring-2 ring-primary/70"
+          )}
+        >
         {/* Hidden file input for web (including mobile-web on Android/iOS browsers) */}
         {Platform.OS === "web" && (
           <input
@@ -1139,12 +1609,96 @@ function ChatInputImpl({
           </View>
         )}
 
+        {/* Tagged files / workspaces now render INLINE as "@mention" pills via
+            the highlight overlay below, so the old chip row above the box is
+            gone. References themselves are still tracked + sent on submit. */}
+
+        <View className="relative">
+          {/* Highlight backdrop: a transparent mirror of the composer text that
+              paints a pill behind each "@mention". The real TextInput sits on
+              top (zIndex) so typed text stays crisp and the caret is native;
+              only the pill backgrounds show through its transparent fill. The
+              mirror MUST match the TextInput's font/line-height/padding (shared
+              `text-xs` + `px-4 pt-4`) or the pills drift off the words. */}
+          <View
+            pointerEvents="none"
+            className="absolute top-0 bottom-0 left-0 right-0 overflow-hidden px-4 pt-4"
+            style={{ zIndex: 0 }}
+          >
+            <Text
+              className="text-xs"
+              style={[
+                { color: "transparent", transform: [{ translateY: -overlayScrollY }] },
+                Platform.OS === "web"
+                  ? ({ whiteSpace: "pre-wrap", wordBreak: "break-word" } as any)
+                  : null,
+              ]}
+            >
+              {mentionSegments.map((seg, idx) =>
+                seg.mention ? (
+                  <Text
+                    key={idx}
+                    className="text-xs rounded bg-primary/20"
+                    style={{ color: "transparent" }}
+                  >
+                    {seg.text}
+                  </Text>
+                ) : (
+                  <Text key={idx} className="text-xs" style={{ color: "transparent" }}>
+                    {seg.text}
+                  </Text>
+                )
+              )}
+            </Text>
+          </View>
+
         <TextInput
           ref={textInputRef}
           value={voiceInput.isRecording && voiceInput.liveTranscript ? voiceInput.liveTranscript : inputValue}
+          selection={selectionOverride}
           onChangeText={handleChangeText}
+          onSelectionChange={(e) => {
+            // Re-detect against the freshest text (kept in inputValueRef by
+            // handleChangeText) using the authoritative caret position.
+            updateMentionState(inputValueRef.current, e.nativeEvent.selection.start)
+          }}
+          onScroll={(e) => {
+            // Keep the inline-mention overlay aligned once the box scrolls.
+            setOverlayScrollY((e.nativeEvent as any)?.contentOffset?.y ?? 0)
+          }}
+          scrollEventThrottle={16}
           onSubmitEditing={handleSubmit}
           onKeyPress={(e: any) => {
+            // While the "@" menu is open, intercept navigation keys so they
+            // drive the menu instead of the textarea / message submit.
+            if (
+              Platform.OS === "web" &&
+              showMentionMenu &&
+              mentionItems.length > 0
+            ) {
+              const key = e.nativeEvent.key
+              if (key === "ArrowDown") {
+                e.preventDefault()
+                setMentionIndex((i) => (i + 1) % mentionItems.length)
+                return
+              }
+              if (key === "ArrowUp") {
+                e.preventDefault()
+                setMentionIndex((i) => (i - 1 + mentionItems.length) % mentionItems.length)
+                return
+              }
+              if (key === "Enter" || key === "Tab") {
+                e.preventDefault()
+                const item = mentionItems[Math.min(mentionIndex, mentionItems.length - 1)]
+                if (item) selectMention(item)
+                return
+              }
+              if (key === "Escape") {
+                e.preventDefault()
+                closeMentionMenu()
+                return
+              }
+            }
             if (Platform.OS === "web" && e.nativeEvent.key === "Tab" && e.nativeEvent.shiftKey) {
               e.preventDefault()
               cycleInteractionMode()
@@ -1169,7 +1723,7 @@ function ChatInputImpl({
               setInputHeight(clamped)
             }
           }}
-          style={{ height: inputHeight }}
+          style={{ height: inputHeight, zIndex: 1 }}
           className={cn(
             "min-h-[60px] max-h-[200px] w-full",
             "bg-transparent",
@@ -1179,6 +1733,7 @@ function ChatInputImpl({
           )}
           textAlignVertical="top"
         />
+        </View>
 
         {/* Bottom toolbar */}
         <View className="flex-row items-center justify-between p-1.5">
@@ -1557,6 +2112,7 @@ function ChatInputImpl({
             ) : null}
           </View>
           )}
+        </View>
         </View>
       </View>
 

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -66,7 +66,7 @@ import {
   rollbackProjectToCheckpoint,
   type PrecedingCheckpointResult,
 } from "@shogo/shared-app/chat"
-import { useSDKDomains, useDomainActions, useChatMessageCollectionForSession } from "@shogo/shared-app/domain"
+import { useSDKDomains, useDomainActions, useChatMessageCollectionForSession, useWorkspaceCollection } from "@shogo/shared-app/domain"
 import { decideMessagesPropagation } from "./messages-propagation"
 import { useNotifyOnTurnComplete } from "./useNotifyOnTurnComplete"
 import { probeChatTurnStatus, shouldAttachLiveStream, type ChatTurnStatus } from "./probe-turn-status"
@@ -86,6 +86,8 @@ import {
   DEFAULT_MODEL_FREE,
   type InteractionMode,
   type FileAttachment,
+  type ChatReference,
+  type WorkspaceMentionOption,
   type RestoreDraftRequest,
 } from "./ChatInput"
 import {
@@ -183,6 +185,7 @@ export type QueuedMessage = {
   content: string
   files?: FileAttachment[]
   selectedModel?: string
+  references?: ChatReference[]
 }
 
 function buildOptimisticUserMessage(input: OptimisticUserInput, id = "optimistic-user-pending"): UIMessage {
@@ -727,6 +730,31 @@ export const ChatPanel = observer(function ChatPanel({
 
   const { studioChat } = useSDKDomains()
   const actions = useDomainActions()
+
+  // Org/team workspaces for the composer's "@" mention menu. AppSidebar
+  // already loads these app-wide; we call loadAll() defensively in case the
+  // panel mounts first. ChatPanel is an observer, so the memo below re-runs
+  // when the collection populates.
+  const workspaceCollection = useWorkspaceCollection()
+  useEffect(() => {
+    workspaceCollection.loadAll().catch(() => {})
+  }, [workspaceCollection])
+  const workspaceMentionSignature = workspaceCollection.all
+    .map((w: any) => `${w.id}:${w.name}:${w.slug}`)
+    .join("|")
+  const workspaceMentionOptions = useMemo<WorkspaceMentionOption[]>(
+    () =>
+      workspaceCollection.all.map((w: any) => ({
+        id: w.id,
+        name: w.name,
+        slug: w.slug,
+        description: w.description ?? "",
+      })),
+    // Signature keeps the array referentially stable across token-by-token
+    // streaming re-renders (matters because ChatInput is memoized).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [workspaceMentionSignature]
+  )
 
   const platformFeatures = legacyDomains?.platformFeatures
   const componentBuilder = legacyDomains?.componentBuilder
@@ -3367,7 +3395,13 @@ export const ChatPanel = observer(function ChatPanel({
 
   // Internal function that actually sends a message (used by queue processor)
   const sendMessageInternal = useCallback(
-    async (content: string, files?: FileAttachment[], perMsgModel?: string, extraBody?: Record<string, unknown>) => {
+    async (
+      content: string,
+      files?: FileAttachment[],
+      perMsgModel?: string,
+      extraBody?: Record<string, unknown>,
+      references?: ChatReference[]
+    ) => {
       if (!currentSessionId) {
         console.warn("[ChatPanel] No session ID - message will be lost!")
         return
@@ -3507,6 +3541,12 @@ export const ChatPanel = observer(function ChatPanel({
           bodyExtra.interactionMode = "agent"
           confirmedPlanRef.current = null
         }
+        if (references && references.length > 0) {
+          // The runtime resolves these into real context (file contents +
+          // workspace summaries) before the model runs. Passed through the
+          // API proxy untouched, so it also works in direct-to-runtime mode.
+          bodyExtra.references = references
+        }
         if (extraBody) {
           Object.assign(bodyExtra, extraBody)
         }
@@ -3588,7 +3628,9 @@ export const ChatPanel = observer(function ChatPanel({
       await sendMessageInternal(
         nextMessage.content,
         nextMessage.files,
-        nextMessage.selectedModel
+        nextMessage.selectedModel,
+        undefined,
+        nextMessage.references
       )
     } catch (err) {
       console.error("[ChatPanel] Error processing queued message:", err)
@@ -3794,13 +3836,22 @@ export const ChatPanel = observer(function ChatPanel({
 
   // Handle message submission
   const handleSendMessage = useCallback(
-    async (content: string, files?: FileAttachment[], perMsgModel?: string) => {
+    async (
+      content: string,
+      files?: FileAttachment[],
+      perMsgModel?: string,
+      references?: ChatReference[]
+    ) => {
       if (!currentSessionId) {
         console.warn("[ChatPanel] No session ID - message will be lost!")
         return
       }
 
-      if (!content.trim() && (!files || files.length === 0)) {
+      if (
+        !content.trim() &&
+        (!files || files.length === 0) &&
+        (!references || references.length === 0)
+      ) {
         return
       }
 
@@ -3814,20 +3865,26 @@ export const ChatPanel = observer(function ChatPanel({
             content: trimmedContent,
             files,
             selectedModel: perMsgModel,
+            references,
           },
         ])
         return
       }
 
-      await sendMessageInternal(trimmedContent, files, perMsgModel)
+      await sendMessageInternal(trimmedContent, files, perMsgModel, undefined, references)
     },
     [isStreaming, sendMessageInternal, currentSessionId]
   )
 
   // Handle form submit from ChatInput
   const handleInputSubmit = useCallback(
-    (content: string, files?: FileAttachment[], perMsgModel?: string) => {
-      handleSendMessage(content, files, perMsgModel)
+    (
+      content: string,
+      files?: FileAttachment[],
+      perMsgModel?: string,
+      references?: ChatReference[]
+    ) => {
+      handleSendMessage(content, files, perMsgModel, references)
     },
     [handleSendMessage]
   )
@@ -4936,6 +4993,8 @@ export const ChatPanel = observer(function ChatPanel({
               quickActions={quickActions}
               onQuickActionClick={handleQuickActionClick}
               restoreDraftRequest={restoreDraftRequest}
+              projectId={projectId}
+              workspaces={workspaceMentionOptions}
             />
           </View>
         </KeyboardAvoidingView>

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -69,7 +69,8 @@ import {
 import { useSDKDomains, useDomainActions, useChatMessageCollectionForSession } from "@shogo/shared-app/domain"
 import { decideMessagesPropagation } from "./messages-propagation"
 import { useNotifyOnTurnComplete } from "./useNotifyOnTurnComplete"
-import { probeChatTurnStatus, shouldAttachLiveStream } from "./probe-turn-status"
+import { probeChatTurnStatus, shouldAttachLiveStream, type ChatTurnStatus } from "./probe-turn-status"
+import { decideRetryAction, lastAssistantHasResumableWork } from "./retry-triage"
 import { cn } from "@shogo/shared-ui/primitives"
 import { API_URL, api, createHttpClient } from "../../lib/api"
 import { hasAcceptedAiConsent, acceptAiConsent, revokeAiConsent, AI_PROVIDERS } from "../../lib/ai-consent"
@@ -1329,6 +1330,32 @@ export const ChatPanel = observer(function ChatPanel({
       // still trip on a long pre-Anthropic warm-up even after we see
       // bytes. Cheap, safe, and orthogonal to message rendering.
       bumpChatProgress()
+
+      // The runtime re-issued a model call that dropped mid-generation. Drop
+      // the failed step's partial text/reasoning from the in-progress assistant
+      // message so the regenerated output replaces it instead of rendering
+      // twice. Completed tool calls (and any text committed before them) are
+      // preserved — a failed inference step never executed tools.
+      if (dataPart.type === "data-inference-retry") {
+        setMessages((prev) => {
+          if (prev.length === 0) return prev
+          const lastIdx = prev.length - 1
+          const last = prev[lastIdx]
+          if (last.role !== "assistant" || !Array.isArray(last.parts)) return prev
+          const parts = [...last.parts]
+          while (parts.length > 0) {
+            const p = parts[parts.length - 1] as any
+            if (p?.type === "text" || p?.type === "reasoning") {
+              parts.pop()
+              continue
+            }
+            break
+          }
+          if (parts.length === last.parts.length) return prev
+          return prev.map((m, i) => (i === lastIdx ? { ...m, parts } : m))
+        })
+        return
+      }
 
       // Handle virtual tool events
       if (dataPart.type === "data-virtual-tool") {
@@ -3340,7 +3367,7 @@ export const ChatPanel = observer(function ChatPanel({
 
   // Internal function that actually sends a message (used by queue processor)
   const sendMessageInternal = useCallback(
-    async (content: string, files?: FileAttachment[], perMsgModel?: string) => {
+    async (content: string, files?: FileAttachment[], perMsgModel?: string, extraBody?: Record<string, unknown>) => {
       if (!currentSessionId) {
         console.warn("[ChatPanel] No session ID - message will be lost!")
         return
@@ -3479,6 +3506,9 @@ export const ChatPanel = observer(function ChatPanel({
           bodyExtra.confirmedPlan = normalizePlanData(planToSend)
           bodyExtra.interactionMode = "agent"
           confirmedPlanRef.current = null
+        }
+        if (extraBody) {
+          Object.assign(bodyExtra, extraBody)
         }
         console.log("[ChatPanel][send] bodyExtra — interactionMode:", bodyExtra.interactionMode, "agentMode:", bodyExtra.agentMode, "hasConfirmedPlan:", !!bodyExtra.confirmedPlan, "text:", trimmedContent.slice(0, 80))
         await sendMessage(messagePayload, { body: bodyExtra })
@@ -3911,41 +3941,107 @@ export const ChatPanel = observer(function ChatPanel({
     }
   }, [isCollapsed, setIsCollapsed, onCollapsedChange])
 
-  // Error retry handler
+  // Error retry handler.
+  //
+  // Non-destructive triage (see retry-triage.ts). The old behavior truncated
+  // the conversation (`setMessages(messages.slice(0, lastUserIdx))`) and
+  // re-sent the original user message, throwing away the interrupted turn's
+  // completed tool calls + partial answer. Instead we probe the runtime:
+  //
+  //   - turn still `active` (transport drop, agent still running) -> reconnect
+  //     to the live buffered stream. No re-send, nothing truncated.
+  //   - terminal but the last assistant turn has resumable work -> ask the
+  //     server to continue from the preserved session context (continue:true).
+  //   - nothing resumable -> re-send the original user message (last resort),
+  //     still WITHOUT truncating any rendered work.
   const handleRetry = useCallback(() => {
-    if (messages.length > 0) {
-      const lastUserMsg = [...messages].reverse().find((m) => m.role === "user")
-      if (lastUserMsg) {
-        const parts = ((lastUserMsg as any).parts ?? []) as any[]
-        const textPart = parts.find((p: any) => p.type === "text")
-        const content = textPart?.text || ""
+    if (messages.length === 0) return
 
-        // Preserve file attachments on retry — previously dropped, so images/
-        // PDFs/etc. were lost and the model got a text-only prompt.
-        const fileParts = parts.filter((p: any) => p?.type === "file" && p?.url)
-        const cachedFiles = lastUserInputRef.current?.files
-        const filesFromParts: FileAttachment[] = fileParts.map((p: any) => ({
-          dataUrl: p.url,
-          name: p.name ?? p.filename ?? "file",
-          type: p.mediaType ?? extractMediaType(p.url),
-        }))
-        const files: FileAttachment[] | undefined =
-          cachedFiles && cachedFiles.length > 0
-            ? cachedFiles
-            : filesFromParts.length > 0
-              ? filesFromParts
-              : undefined
+    const lastUserMsg = [...messages].reverse().find((m) => m.role === "user")
+    // Extract the original content/files up front for the resend fallback.
+    const parts = ((lastUserMsg as any)?.parts ?? []) as any[]
+    const textPart = parts.find((p: any) => p.type === "text")
+    const content = textPart?.text || ""
+    const fileParts = parts.filter((p: any) => p?.type === "file" && p?.url)
+    const cachedFiles = lastUserInputRef.current?.files
+    const filesFromParts: FileAttachment[] = fileParts.map((p: any) => ({
+      dataUrl: p.url,
+      name: p.name ?? p.filename ?? "file",
+      type: p.mediaType ?? extractMediaType(p.url),
+    }))
+    const files: FileAttachment[] | undefined =
+      cachedFiles && cachedFiles.length > 0
+        ? cachedFiles
+        : filesFromParts.length > 0
+          ? filesFromParts
+          : undefined
 
-        if (content || (files && files.length > 0)) {
-          const lastUserIdx = messages.lastIndexOf(lastUserMsg)
-          setMessages(messages.slice(0, lastUserIdx))
-          sendMessageInternal(content, files).catch((err) =>
-            console.error("[ChatPanel] Retry failed:", err)
+    void (async () => {
+      // Probe whether the turn is still running on the server. Any failure mode
+      // collapses to 'unknown' (never throws), so this is safe to await.
+      let turnStatus: ChatTurnStatus = "unknown"
+      if (currentSessionId && API_URL) {
+        try {
+          const turnUrl = buildChatTurnUrl(
+            API_URL,
+            projectId,
+            localAgentUrl,
+            currentSessionId,
+            chatWorkspaceId,
           )
+          turnStatus = await probeChatTurnStatus({
+            url: turnUrl,
+            fetch: expoFetch,
+            headers: nativeHeaders ? nativeHeaders() : undefined,
+            credentials: Platform.OS === "web" ? "include" : undefined,
+          })
+        } catch {
+          turnStatus = "unknown"
         }
       }
-    }
-  }, [messages, sendMessageInternal, setMessages])
+
+      const action = decideRetryAction({
+        turnStatus,
+        hasResumableTurn: lastAssistantHasResumableWork(messages as any),
+      })
+
+      if (action === "reconnect") {
+        // Agent is still running and buffering frames — reattach. The rendered
+        // messages (including completed tool calls) stay exactly as they are.
+        void resumeStream()
+        return
+      }
+
+      if (action === "continue") {
+        // Continue from preserved server-side context. The `continue` flag
+        // tells the runtime to craft a continuation instruction and reuse the
+        // interrupted turn's persisted tool calls instead of restarting.
+        sendMessageInternal("Continue", undefined, undefined, { continue: true }).catch(
+          (err) => console.error("[ChatPanel] Retry continue failed:", err),
+        )
+        return
+      }
+
+      // resend: nothing to resume/continue. Re-send the original message — but
+      // do NOT truncate any already-rendered work.
+      if (content || (files && files.length > 0)) {
+        sendMessageInternal(content, files).catch((err) =>
+          console.error("[ChatPanel] Retry resend failed:", err),
+        )
+      }
+    })()
+  }, [
+    messages,
+    sendMessageInternal,
+    resumeStream,
+    currentSessionId,
+    projectId,
+    localAgentUrl,
+    chatWorkspaceId,
+    expoFetch,
+    nativeHeaders,
+    extractMediaType,
+  ])
 
   const handleRetryRef = useRef<(() => void) | null>(null)
   handleRetryRef.current = handleRetry

--- a/apps/mobile/components/chat/__tests__/retry-triage.test.ts
+++ b/apps/mobile/components/chat/__tests__/retry-triage.test.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Tests for the pure retry-triage decision behind ChatPanel's "Retry" button.
+ *
+ * Headline regression locked down here (the reported bug — must not come back):
+ *
+ *   Tapping "Retry" used to run
+ *     setMessages(messages.slice(0, lastUserIdx))
+ *     sendMessageInternal(content)            // re-send original prompt
+ *   which DELETED the interrupted turn's completed tool calls + partial answer
+ *   (potentially minutes of work) and restarted from scratch.
+ *
+ *   The fix triages into reconnect / continue / resend and NEVER truncates
+ *   completed work. These tests pin the decision and the no-truncation
+ *   guarantee.
+ *
+ * Run: bun test apps/mobile/components/chat/__tests__/retry-triage.test.ts
+ */
+import { describe, expect, test } from "bun:test"
+import { decideRetryAction, lastAssistantHasResumableWork } from "../retry-triage"
+
+describe("decideRetryAction", () => {
+  test("active turn -> reconnect (agent still running, transport drop)", () => {
+    expect(decideRetryAction({ turnStatus: "active", hasResumableTurn: false })).toBe("reconnect")
+    // 'active' wins even if there is resumable work — reconnecting to the live
+    // stream is strictly better than restarting a continuation.
+    expect(decideRetryAction({ turnStatus: "active", hasResumableTurn: true })).toBe("reconnect")
+  })
+
+  test("terminal/unknown with resumable work -> continue (preserve work)", () => {
+    for (const turnStatus of ["completed", "failed", "aborted", "unknown"] as const) {
+      expect(decideRetryAction({ turnStatus, hasResumableTurn: true })).toBe("continue")
+    }
+  })
+
+  test("nothing resumable -> resend (last resort)", () => {
+    for (const turnStatus of ["completed", "failed", "aborted", "unknown"] as const) {
+      expect(decideRetryAction({ turnStatus, hasResumableTurn: false })).toBe("resend")
+    }
+  })
+})
+
+describe("lastAssistantHasResumableWork", () => {
+  test("true when the last assistant message has a completed tool call", () => {
+    const messages = [
+      { role: "user", parts: [{ type: "text", text: "do it" }] },
+      {
+        role: "assistant",
+        parts: [
+          { type: "text", text: "working" },
+          { type: "dynamic-tool", toolName: "read_file", state: "output-available" },
+        ],
+      },
+    ]
+    expect(lastAssistantHasResumableWork(messages)).toBe(true)
+  })
+
+  test("true when the last assistant message has non-empty text", () => {
+    const messages = [
+      { role: "user", parts: [{ type: "text", text: "hi" }] },
+      { role: "assistant", parts: [{ type: "text", text: "partial answer" }] },
+    ]
+    expect(lastAssistantHasResumableWork(messages)).toBe(true)
+  })
+
+  test("false when the model produced nothing yet (user is last)", () => {
+    const messages = [{ role: "user", parts: [{ type: "text", text: "hi" }] }]
+    expect(lastAssistantHasResumableWork(messages)).toBe(false)
+  })
+
+  test("false when the last assistant message is empty", () => {
+    const messages = [
+      { role: "user", parts: [{ type: "text", text: "hi" }] },
+      { role: "assistant", parts: [{ type: "text", text: "   " }] },
+    ]
+    expect(lastAssistantHasResumableWork(messages)).toBe(false)
+  })
+})
+
+describe("REGRESSION: retry must never truncate completed work", () => {
+  // The exact shape from the bug report: a user message followed by an
+  // assistant turn that completed tool calls before the connection dropped.
+  const messages = [
+    { role: "user", parts: [{ type: "text", text: "build the feature" }] },
+    {
+      role: "assistant",
+      parts: [
+        { type: "text", text: "On it." },
+        { type: "dynamic-tool", toolName: "edit_file", state: "output-available" },
+        { type: "dynamic-tool", toolName: "exec", state: "output-available" },
+      ],
+    },
+  ]
+
+  test("a terminal turn with completed tool calls chooses continue (not resend)", () => {
+    const action = decideRetryAction({
+      turnStatus: "failed",
+      hasResumableTurn: lastAssistantHasResumableWork(messages),
+    })
+    // Must NOT be 'resend' — resend was the destructive path that truncated.
+    expect(action).toBe("continue")
+  })
+
+  test("an active turn with completed tool calls chooses reconnect (not resend)", () => {
+    const action = decideRetryAction({
+      turnStatus: "active",
+      hasResumableTurn: lastAssistantHasResumableWork(messages),
+    })
+    expect(action).toBe("reconnect")
+  })
+
+  test("the decision input does not mutate or drop the message list", () => {
+    const snapshot = JSON.parse(JSON.stringify(messages))
+    decideRetryAction({
+      turnStatus: "failed",
+      hasResumableTurn: lastAssistantHasResumableWork(messages),
+    })
+    // Pure functions: the completed assistant + tool-call messages are intact.
+    expect(messages).toEqual(snapshot)
+    expect(messages).toHaveLength(2)
+    expect((messages[1].parts as any[]).filter((p) => p.type === "dynamic-tool")).toHaveLength(2)
+  })
+})

--- a/apps/mobile/components/chat/retry-triage.ts
+++ b/apps/mobile/components/chat/retry-triage.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Pure decision logic for the chat "Retry" button.
+ *
+ * The reported bug: when the model stopped/errored the UI showed
+ * "Connection interrupted. Please tap Retry to continue." and tapping Retry
+ * TRUNCATED the conversation (`setMessages(messages.slice(0, lastUserIdx))`)
+ * and re-sent the original user message — discarding the interrupted turn's
+ * completed tool calls and partial answer (potentially minutes of work).
+ *
+ * The fix triages the failure into one of three NON-destructive actions:
+ *
+ *   - `reconnect`: the runtime reports the turn is still `active` (a transport
+ *     drop, not a real inference failure). The agent is still running and
+ *     buffering frames server-side; reattach to the live stream. Nothing was
+ *     lost and nothing is re-sent.
+ *   - `continue`: the turn genuinely ended but the last assistant turn left
+ *     resumable work (completed tool calls / partial text preserved in the
+ *     session). Continue from that preserved context instead of restarting.
+ *   - `resend`: there is genuinely nothing to resume or continue (e.g. the very
+ *     first model call produced zero output and ran no tools). Only then do we
+ *     re-send the original user message.
+ *
+ * Critically, NONE of these actions truncate already-rendered completed work.
+ * Extracted as a pure function so the regression can be unit-tested without
+ * React or the runtime.
+ */
+
+import type { ChatTurnStatus } from "./probe-turn-status"
+
+export type RetryAction = "reconnect" | "continue" | "resend"
+
+export interface RetryTriageInput {
+  /** Status from the runtime's read-only `/turn` probe. */
+  turnStatus: ChatTurnStatus
+  /**
+   * True when the last assistant turn left behind resumable work — completed
+   * tool calls or partial text/reasoning that should be built upon rather than
+   * thrown away. Compute via {@link lastAssistantHasResumableWork}.
+   */
+  hasResumableTurn: boolean
+}
+
+/**
+ * Decide how the "Retry" button should behave. Pure + total.
+ *
+ *  - `active`                              -> reconnect (agent still running)
+ *  - terminal/unknown + resumable work     -> continue (preserve work)
+ *  - terminal/unknown + nothing to resume  -> resend (last resort)
+ */
+export function decideRetryAction({ turnStatus, hasResumableTurn }: RetryTriageInput): RetryAction {
+  if (turnStatus === "active") return "reconnect"
+  if (hasResumableTurn) return "continue"
+  return "resend"
+}
+
+interface MinimalPart {
+  type?: string
+  text?: string
+  state?: string
+}
+
+interface MinimalMessage {
+  role?: string
+  parts?: MinimalPart[]
+}
+
+/**
+ * Does the most recent assistant message carry resumable work?
+ *
+ * Resumable work = any tool call (regardless of state — a completed tool result
+ * is the canonical "minutes of work" we must not discard) or any non-empty
+ * text/reasoning content. If the most recent message is the user's (the model
+ * produced nothing at all yet), there is nothing to resume.
+ */
+export function lastAssistantHasResumableWork(messages: MinimalMessage[]): boolean {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]
+    if (m.role === "assistant") {
+      const parts = Array.isArray(m.parts) ? m.parts : []
+      return parts.some((p) => {
+        const t = typeof p.type === "string" ? p.type : ""
+        if (t === "dynamic-tool" || t === "tool-invocation" || t.startsWith("tool-")) return true
+        if ((t === "text" || t === "reasoning") && typeof p.text === "string" && p.text.trim().length > 0) {
+          return true
+        }
+        return false
+      })
+    }
+    if (m.role === "user") return false
+  }
+  return false
+}

--- a/apps/mobile/components/chat/turns/SubagentCard.tsx
+++ b/apps/mobile/components/chat/turns/SubagentCard.tsx
@@ -17,6 +17,7 @@ import { Motion } from "@legendapp/motion"
 import { type ToolCallData, getToolKeyArg, formatToolName } from "../tools/types"
 import { subagentStreamStore } from "../../../lib/subagent-stream-store"
 import { stopSubagent } from "../../../lib/subagent-stop"
+import { resolveShortName } from "../../../lib/visible-models"
 import { LiveBrowserView } from "../LiveBrowserView"
 import { useChatContextSafe } from "../ChatContext"
 import { useChatBridgeOptional } from "../../voice-mode/ChatBridgeContext"
@@ -227,7 +228,7 @@ export function SubagentCard({ tool, className, agentUrl: agentUrlProp }: Subage
           </Text>
           {model && (
             <Text className="text-[10px] text-muted-foreground font-mono px-1.5 py-0.5 rounded bg-muted/60" numberOfLines={1}>
-              {model}
+              {resolveShortName(model)}
             </Text>
           )}
           <Text className="text-[10px] text-muted-foreground font-mono px-1.5 py-0.5 rounded bg-muted/60">

--- a/apps/mobile/components/project/panels/AgentsPanel.tsx
+++ b/apps/mobile/components/project/panels/AgentsPanel.tsx
@@ -25,6 +25,7 @@ import { Motion } from "@legendapp/motion"
 import { cn } from "@shogo/shared-ui/primitives"
 import { subagentStreamStore, type SubagentStreamData } from "../../../lib/subagent-stream-store"
 import { stopSubagent } from "../../../lib/subagent-stop"
+import { resolveShortName } from "../../../lib/visible-models"
 import { teamStore, type TeamData, type MemberData, type TaskData, type MessageData, type ActivityEvent, type AgentTypeInfo } from "../../../lib/team-store"
 import { MarkdownText } from "../../chat/MarkdownText"
 import { ThinkingWidget } from "../../chat/turns/ThinkingWidget"
@@ -162,7 +163,7 @@ function AgentEntry({
         </Text>
         {data.model && (
           <Text className="text-[10px] text-muted-foreground font-mono px-1.5 py-0.5 rounded bg-muted/60" numberOfLines={1}>
-            {data.model}
+            {resolveShortName(data.model)}
           </Text>
         )}
         <Text className="text-[10px] text-muted-foreground font-mono px-1.5 py-0.5 rounded bg-muted/60">

--- a/apps/mobile/components/project/panels/StatusPanel.tsx
+++ b/apps/mobile/components/project/panels/StatusPanel.tsx
@@ -26,6 +26,7 @@ import { Switch } from '@/components/ui/switch'
 import { useRouter } from 'expo-router'
 import { agentFetch } from '../../../lib/agent-fetch'
 import { API_URL } from '../../../lib/api'
+import { resolveShortName } from '../../../lib/visible-models'
 import { usePlatformConfig } from '../../../lib/platform-config'
 import { MarkdownText } from '../../chat/MarkdownText'
 
@@ -90,6 +91,8 @@ interface HeartbeatConfig {
   quietHoursEnd: string | null
   quietHoursTimezone: string | null
   modelName: string
+  /** Server-resolved display label for `modelName` (falls back to client resolution). */
+  modelLabel?: string | null
 }
 
 interface ChannelInfo {
@@ -819,7 +822,14 @@ export function StatusPanel({ projectId, agentUrl, visible, isPaidPlan }: Status
 
                     {/* Cost estimate */}
                     {!localMode && (() => {
-                      const modelName = hbConfig?.modelName ?? status.model?.name ?? 'claude-sonnet-4-5'
+                      // Prefer the server-resolved label; otherwise resolve the
+                      // raw id (a UUID for DB models) client-side. Either form
+                      // still carries the family substring the tier estimate needs.
+                      const modelName =
+                        hbConfig?.modelLabel
+                        ?? (hbConfig?.modelName ? resolveShortName(hbConfig.modelName) : undefined)
+                        ?? (status.model?.name ? resolveShortName(status.model.name) : undefined)
+                        ?? 'claude-sonnet-4-5'
                       const interval = hbConfig?.heartbeatInterval ?? status.heartbeat.intervalSeconds
                       const cost = estimateDailyCost(
                         interval,
@@ -853,7 +863,7 @@ export function StatusPanel({ projectId, agentUrl, visible, isPaidPlan }: Status
               <View className="flex-row items-center gap-2 px-3 py-2 rounded-lg border border-border/40 bg-muted/20">
                 <Zap size={14} className="text-muted-foreground" />
                 <Text className="text-xs text-muted-foreground">Model:</Text>
-                <Text className="text-xs font-medium text-foreground">{status.model.name}</Text>
+                <Text className="text-xs font-medium text-foreground">{resolveShortName(status.model.name)}</Text>
                 <Text className="text-xs text-muted-foreground">({status.model.provider})</Text>
               </View>
             )}

--- a/packages/agent-runtime/Dockerfile.base
+++ b/packages/agent-runtime/Dockerfile.base
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Git LFS: configure the clean/smudge filters system-wide but SKIP smudge
     # so checkout/`reset --hard` leaves pointer files (fast, no network). The
     # runtime materializes object bytes explicitly via `git lfs pull`. LFS only
-    # activates for repos that opt in via .gitattributes (git_only + LFS_ENABLED).
+    # activates for repos that opt in via .gitattributes (git_only mode).
     git lfs install --system --skip-smudge && \
     # Cleanup
     apt-get purge -y gnupg unzip && \

--- a/packages/agent-runtime/Dockerfile.base
+++ b/packages/agent-runtime/Dockerfile.base
@@ -14,7 +14,7 @@ WORKDIR /app
 
 # System packages + Node 24 + Bun 1.3
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl bash git tar gzip zstd ca-certificates gnupg unzip \
+    curl bash git git-lfs tar gzip zstd ca-certificates gnupg unzip \
     chromium nss-plugin-pem fonts-freefont-ttf \
     ffmpeg imagemagick ripgrep \
     build-essential && \
@@ -38,6 +38,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     STRIPE_ARCH="$(uname -m | sed 's/aarch64/arm64/' | sed 's/x86_64/x86_64/')" && \
     curl -fsSL "https://github.com/stripe/stripe-cli/releases/download/v${STRIPE_VER}/stripe_${STRIPE_VER}_linux_${STRIPE_ARCH}.tar.gz" \
       | tar -xz -C /usr/local/bin stripe && \
+    # Git LFS: configure the clean/smudge filters system-wide but SKIP smudge
+    # so checkout/`reset --hard` leaves pointer files (fast, no network). The
+    # runtime materializes object bytes explicitly via `git lfs pull`. LFS only
+    # activates for repos that opt in via .gitattributes (git_only + LFS_ENABLED).
+    git lfs install --system --skip-smudge && \
     # Cleanup
     apt-get purge -y gnupg unzip && \
     apt-get autoremove -y && \

--- a/packages/agent-runtime/src/__tests__/error-recovery.test.ts
+++ b/packages/agent-runtime/src/__tests__/error-recovery.test.ts
@@ -216,6 +216,202 @@ describe('runAgentLoop error recovery', () => {
 })
 
 // ===========================================================================
+// agent-loop: inference reconnect/retry (Agent.continue)
+// ===========================================================================
+
+type ScriptStep = AssistantMessage | { throw: string }
+
+/**
+ * StreamFn driven by a script of steps. Each call consumes the next step
+ * (clamped to the last so a single error step is "persistent"): an
+ * `AssistantMessage` streams normally; a `{ throw }` step throws, which
+ * pi-agent-core catches and surfaces as a trailing assistant `errorMessage`.
+ */
+function createScriptedStreamFn(
+  steps: ScriptStep[],
+  onCall?: (index: number, messages: Message[]) => void,
+): { fn: StreamFn; getCalls: () => number } {
+  let calls = 0
+  const fn: StreamFn = (_model, context, _options) => {
+    const i = calls++
+    onCall?.(i, context.messages)
+    const step = steps[Math.min(i, steps.length - 1)]
+    if (step && (step as any).throw) {
+      throw new Error((step as any).throw)
+    }
+    const msg = step as AssistantMessage
+    const stream = createAssistantMessageEventStream()
+    queueMicrotask(() => {
+      stream.push({ type: 'start', partial: msg })
+      const reason = msg.content.some((c) => c.type === 'toolCall') ? 'toolUse' : 'stop'
+      stream.push({ type: 'done', reason, message: msg })
+      stream.end(msg)
+    })
+    return stream as any
+  }
+  return { fn, getCalls: () => calls }
+}
+
+const NO_BACKOFF = { computeDelayMs: () => 0, sleep: async () => {} }
+
+describe('runAgentLoop inference retry', () => {
+  test('retryable mid-stream drop completes after retry', async () => {
+    const { fn, getCalls } = createScriptedStreamFn([
+      { throw: 'socket hang up' },
+      buildTextResponse('Recovered answer'),
+    ])
+
+    const result = await runAgentLoop({
+      model: 'claude-sonnet-4-5',
+      system: 'Test',
+      history: [],
+      prompt: 'Hello',
+      tools: [],
+      streamFn: fn,
+      inferenceRetry: { maxAttempts: 2, ...NO_BACKOFF },
+    })
+
+    expect(result.error).toBeUndefined()
+    expect(result.text).toBe('Recovered answer')
+    expect(getCalls()).toBe(2) // initial failure + one re-issue
+  })
+
+  test('no tool re-execution on retry; earlier tool result preserved', async () => {
+    const tracker = new MockToolTracker()
+    const tool = tracker.createTool('read_file', 'Read a file', { content: 'file data' })
+
+    // step0: tool use (executes the tool once)
+    // step1: follow-up LLM call fails (retryable 5xx)
+    // step2: re-issued follow-up succeeds with final text
+    const { fn, getCalls } = createScriptedStreamFn([
+      buildToolUseResponse([{ name: 'read_file', arguments: { path: 'a.txt' }, id: 'toolu_1' }]),
+      { throw: '502 Bad Gateway' },
+      buildTextResponse('Here is the file summary'),
+    ])
+
+    const result = await runAgentLoop({
+      model: 'claude-sonnet-4-5',
+      system: 'Test',
+      history: [],
+      prompt: 'Read a.txt',
+      tools: [tool],
+      streamFn: fn,
+      inferenceRetry: { maxAttempts: 2, ...NO_BACKOFF },
+    })
+
+    expect(result.error).toBeUndefined()
+    expect(result.text).toBe('Here is the file summary')
+    expect(result.toolCalls).toHaveLength(1)
+    expect(result.toolCalls[0].name).toBe('read_file')
+    // Critical idempotency guarantee: the completed tool executed exactly once
+    // across the failed attempt + successful retry.
+    expect(tracker.getCallsFor('read_file')).toHaveLength(1)
+    expect(getCalls()).toBe(3) // tool call + failed follow-up + retried follow-up
+  })
+
+  test('non-retryable error does not retry', async () => {
+    const { fn, getCalls } = createScriptedStreamFn([{ throw: '401 Unauthorized: invalid api key' }])
+
+    const result = await runAgentLoop({
+      model: 'claude-sonnet-4-5',
+      system: 'Test',
+      history: [],
+      prompt: 'Hello',
+      tools: [],
+      streamFn: fn,
+      inferenceRetry: { maxAttempts: 3, ...NO_BACKOFF },
+    })
+
+    expect(result.error).toBeDefined()
+    expect(getCalls()).toBe(1) // no re-issue for a non-retryable failure
+  })
+
+  test('abort never retries', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const { fn, getCalls } = createScriptedStreamFn([{ throw: 'socket hang up' }])
+
+    const result = await runAgentLoop({
+      model: 'claude-sonnet-4-5',
+      system: 'Test',
+      history: [],
+      prompt: 'Hello',
+      tools: [],
+      streamFn: fn,
+      signal: controller.signal,
+      inferenceRetry: { maxAttempts: 3, ...NO_BACKOFF },
+    })
+
+    // Aborted before the prompt ran: the stream fn is never invoked and the
+    // retry loop is skipped (guarded by !abortTriggered).
+    expect(getCalls()).toBe(0)
+    expect(result.toolCalls).toHaveLength(0)
+  })
+
+  test('persistent retryable failure stops at the cap', async () => {
+    const { fn, getCalls } = createScriptedStreamFn([{ throw: 'ECONNRESET' }])
+
+    const result = await runAgentLoop({
+      model: 'claude-sonnet-4-5',
+      system: 'Test',
+      history: [],
+      prompt: 'Hello',
+      tools: [],
+      streamFn: fn,
+      inferenceRetry: { maxAttempts: 2, ...NO_BACKOFF },
+    })
+
+    // initial attempt + exactly maxAttempts re-issues, then give up
+    expect(getCalls()).toBe(3)
+    expect(result.error).toBeDefined()
+  })
+
+  test('backoff is invoked between attempts with increasing delay', async () => {
+    const sleeps: number[] = []
+    const { fn, getCalls } = createScriptedStreamFn([{ throw: 'fetch failed' }])
+
+    await runAgentLoop({
+      model: 'claude-sonnet-4-5',
+      system: 'Test',
+      history: [],
+      prompt: 'Hello',
+      tools: [],
+      streamFn: fn,
+      inferenceRetry: {
+        maxAttempts: 3,
+        computeDelayMs: (attempt) => attempt * 100,
+        sleep: async (ms) => {
+          sleeps.push(ms)
+        },
+      },
+    })
+
+    expect(sleeps).toEqual([100, 200, 300])
+    expect(getCalls()).toBe(4) // initial + 3 re-issues
+  })
+
+  test('retry can be disabled via inferenceRetry: false', async () => {
+    const { fn, getCalls } = createScriptedStreamFn([
+      { throw: 'socket hang up' },
+      buildTextResponse('would-be recovery'),
+    ])
+
+    const result = await runAgentLoop({
+      model: 'claude-sonnet-4-5',
+      system: 'Test',
+      history: [],
+      prompt: 'Hello',
+      tools: [],
+      streamFn: fn,
+      inferenceRetry: false,
+    })
+
+    expect(getCalls()).toBe(1) // no retry attempted
+    expect(result.error).toBeDefined()
+  })
+})
+
+// ===========================================================================
 // gateway: error recovery + session persistence
 // ===========================================================================
 

--- a/packages/agent-runtime/src/gateway.ts
+++ b/packages/agent-runtime/src/gateway.ts
@@ -2362,6 +2362,36 @@ export class AgentGateway {
             uiWriter.write({ type: 'text-delta', id: uiTextId, delta })
           }
         },
+        onInferenceRetry: (info) => {
+          // The dropped model call is being re-issued. Close any in-progress
+          // text/reasoning block so the client can drop the failed step's
+          // partial deltas, then emit an explicit marker the client + the
+          // API-side accumulator key on to reset (avoids concatenating the
+          // discarded partial with the regenerated output).
+          if (uiWriter && uiTextId) {
+            uiWriter.write({ type: 'text-end', id: uiTextId })
+            uiTextId = null
+          }
+          if (uiWriter && uiReasoningId) {
+            uiWriter.write({ type: 'reasoning-end', id: uiReasoningId })
+            uiReasoningId = null
+          }
+          if (uiWriter) {
+            uiWriter.write({
+              type: 'data-inference-retry',
+              data: {
+                attempt: info.attempt,
+                maxAttempts: info.maxAttempts,
+                reason: info.reason,
+                delayMs: info.delayMs,
+              },
+            } as any)
+          }
+          console.warn(
+            `${this.logPrefix} Inference retry ${info.attempt}/${info.maxAttempts} ` +
+              `(reason=${info.reason}, delay=${info.delayMs}ms) for session ${sessionId}`,
+          )
+        },
         onToolCallStart: (toolName, toolCallId) => {
           this._lastTool = toolName
           if (uiWriter && uiTextId) {

--- a/packages/agent-runtime/src/reference-context.ts
+++ b/packages/agent-runtime/src/reference-context.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Reference resolution for the /agent/chat endpoint.
+ *
+ * The web composer's "@" menu lets a user tag:
+ *   - files: a path inside the current project's agent workspace, and
+ *   - workspaces: an org/team workspace (carried as a client-built summary).
+ *
+ * These arrive on the chat body as `references` (see ChatInput's
+ * `ChatReference`). `buildReferencedContext` turns them into a single text
+ * block that gets appended to the user's message so the model sees the real
+ * file contents / workspace metadata.
+ *
+ * File contents are read from disk here (the runtime owns the workspace), so
+ * this works both behind the API proxy and in direct-to-runtime / desktop
+ * mode. Workspace metadata is NOT looked up here (the runtime has no platform
+ * DB) — we trust the summary the client computed from data it already loaded.
+ */
+
+import { existsSync, readFileSync, statSync } from 'fs'
+import { resolve, sep } from 'path'
+import { isBinaryFilePath } from '@shogo/shared-runtime'
+
+/** Structured reference shape mirrored from the web composer. */
+export type ChatReference =
+  | { type: 'file'; path?: string; name?: string }
+  | { type: 'workspace'; id?: string; name?: string; slug?: string; summary?: string }
+
+/** Per-file inlined-content cap. Larger files are truncated. */
+const MAX_FILE_BYTES = 64 * 1024
+/** Aggregate cap across all referenced files in one message. */
+const MAX_TOTAL_BYTES = 256 * 1024
+
+/**
+ * Resolve `subPath` strictly inside `rootDir`, rejecting path traversal.
+ * Mirrors `resolveWorkspacePath` in server.ts but is self-contained so the
+ * helper has no dependency on the server module.
+ */
+function resolveInsideRoot(rootDir: string, subPath: string): string | null {
+  const root = resolve(rootDir)
+  const resolved = resolve(rootDir, subPath)
+  if (resolved !== root && !resolved.startsWith(root + sep)) return null
+  return resolved
+}
+
+function workspaceLabel(ref: Extract<ChatReference, { type: 'workspace' }>): string {
+  return ref.name || ref.slug || ref.id || 'workspace'
+}
+
+/**
+ * Build the "[Referenced context]" block for a message's `references`.
+ * Returns an empty string when there's nothing to inject.
+ */
+export function buildReferencedContext(
+  references: unknown,
+  workspaceDir: string,
+): string {
+  if (!Array.isArray(references) || references.length === 0) return ''
+
+  const sections: string[] = []
+  let totalBytes = 0
+
+  for (const raw of references) {
+    if (!raw || typeof raw !== 'object') continue
+    const ref = raw as ChatReference
+
+    if (ref.type === 'file') {
+      const relPath = typeof ref.path === 'string' ? ref.path : ''
+      if (!relPath) continue
+
+      const resolved = resolveInsideRoot(workspaceDir, relPath)
+      if (!resolved) {
+        sections.push(`[Referenced File: ${relPath}] (path outside workspace — skipped)`)
+        continue
+      }
+      if (!existsSync(resolved)) {
+        sections.push(`[Referenced File: ${relPath}] (not found in workspace)`)
+        continue
+      }
+      try {
+        const st = statSync(resolved)
+        if (!st.isFile()) continue
+        if (isBinaryFilePath(resolved)) {
+          sections.push(
+            `[Referenced File: ${relPath}] Binary file (not inlined). Use your file tools to read it if needed.`,
+          )
+          continue
+        }
+        if (totalBytes >= MAX_TOTAL_BYTES) {
+          sections.push(
+            `[Referenced File: ${relPath}] Skipped — reference context size limit reached. Read it with your file tools if needed.`,
+          )
+          continue
+        }
+        let content = readFileSync(resolved, 'utf-8')
+        let truncated = false
+        if (content.length > MAX_FILE_BYTES) {
+          content = content.slice(0, MAX_FILE_BYTES)
+          truncated = true
+        }
+        totalBytes += content.length
+        sections.push(
+          `[Referenced File: ${relPath}]\n${content}${truncated ? '\n…(truncated — read the full file with your file tools if needed)' : ''}\n[End of Referenced File]`,
+        )
+      } catch {
+        sections.push(`[Referenced File: ${relPath}] (could not read)`)
+      }
+    } else if (ref.type === 'workspace') {
+      const label = workspaceLabel(ref)
+      const summary = typeof ref.summary === 'string' ? ref.summary.trim() : ''
+      sections.push(
+        summary
+          ? `[Referenced Workspace: ${label}]\n${summary}`
+          : `[Referenced Workspace: ${label}]`,
+      )
+    }
+  }
+
+  if (sections.length === 0) return ''
+
+  return (
+    '[SYSTEM NOTE — the user attached the following references with their message ' +
+    'via the "@" menu. Treat them as relevant context for this turn.]\n\n' +
+    sections.join('\n\n')
+  )
+}

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -114,6 +114,7 @@ import { subscribe as subscribeScreencast, getLastFrame as getLastScreencastFram
 import { WhatsAppAdapter } from './channels/whatsapp'
 import { TeamsAdapter } from './channels/teams'
 import { saveUploadedFileParts, buildUploadedFilesNote } from './upload-attachments'
+import { buildReferencedContext } from './reference-context'
 import { maybeRunInteractive } from './interactive/entry'
 
 // Interactive CLI mode. When this binary is invoked as `agent-runtime
@@ -1376,6 +1377,18 @@ app.post('/agent/chat', async (c) => {
       'conversation — do not restart, repeat completed steps, or re-run tools ' +
       'whose results are already present. Pick up exactly where you left off ' +
       'and finish the task.'
+  }
+
+  // Resolve "@" references (tagged files + workspaces) into inline context and
+  // append it to the user's message. Done before the empty-message guard so a
+  // references-only message is still valid. Skipped on continuation turns (the
+  // client doesn't send references there). File contents are read from the
+  // workspace on disk; workspace metadata comes from the client-built summary.
+  if (!isContinueTurn) {
+    const referencedContext = buildReferencedContext(body.references, WORKSPACE_DIR)
+    if (referencedContext) {
+      userText = userText ? `${userText}\n\n${referencedContext}` : referencedContext
+    }
   }
 
   if (!userText && userFileParts.length === 0) {

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -1357,6 +1357,27 @@ app.post('/agent/chat', async (c) => {
     }
   }
 
+  // Non-destructive continuation. When a turn ended incomplete (e.g. a model
+  // call dropped and inference retries were exhausted), the client can ask the
+  // agent to pick up from where it stopped WITHOUT re-sending the original user
+  // message. The interrupted turn's completed tool calls were already persisted
+  // to the session (see gateway: persist result.newMessages before UI cleanup),
+  // so buildHistory replays them and the agent continues from that exact point.
+  // We supply a crafted continuation instruction server-side rather than
+  // re-running the original prompt (which would restart the work).
+  const isContinueTurn = body.continue === true || body.continueTurn === true
+  if (isContinueTurn && userFileParts.length === 0) {
+    // The model receives a crafted continuation instruction regardless of any
+    // short label the client rendered (e.g. a "Continue" bubble) so it resumes
+    // the preserved work instead of re-running the original prompt.
+    userText =
+      'Continue from where you stopped. The previous response was interrupted ' +
+      'mid-turn. Build on the tool results and progress already made in this ' +
+      'conversation — do not restart, repeat completed steps, or re-run tools ' +
+      'whose results are already present. Pick up exactly where you left off ' +
+      'and finish the task.'
+  }
+
   if (!userText && userFileParts.length === 0) {
     return c.json({ error: 'message is required — send { messages: [{ role: "user", parts: [{ type: "text", text: "..." }] }] }' }, 400)
   }

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -55,6 +55,13 @@ import {
   getHeadSha,
   repoStoreConfigFromEnv,
   gatherCommitMeta,
+  isLfsEnabled,
+  ensureLfsRepoSetup,
+  autoTrackLargeFiles,
+  lfsPushAll,
+  lfsPull,
+  lfsRemoteConfigFromEnv,
+  migrateOffloadedAssetsToLfs,
   type CloudSyncMode,
 } from '@shogo/shared-runtime'
 import { getModelTier, resolveModelId, calculateDollarCost } from '@shogo/model-catalog'
@@ -311,13 +318,46 @@ let gitSyncInstance: GitWorkspaceSync | null = null
 let workspaceMemberSyncs: Map<string, import('@shogo/shared-runtime').S3Sync> = new Map()
 
 /**
+ * Whether real Git LFS is active for this pod. Scoped to `git_only` (the
+ * pod-owned default): the LFS object-offload step is wired into that mode's
+ * `afterCommit` durability path, and LFS attributes are only written for
+ * these repos, so other modes (dual_shadow/s3) keep the legacy offload and
+ * never accidentally LFS-ify files.
+ */
+function isLfsActive(): boolean {
+  return resolveCloudSyncMode() === 'git_only' && isLfsEnabled()
+}
+
+/**
+ * Persist `.git` to object storage, first offloading LFS object bytes to OCI
+ * when LFS is active. The local `.git/lfs/objects` cache is excluded from the
+ * tarball ONLY when the push succeeded — otherwise the bytes would be durable
+ * nowhere, so we keep them in the tarball as a fallback. Shared by the
+ * afterCommit, publish-tag, and shutdown durability paths.
+ */
+async function persistDurableRepo(): Promise<{ ok: boolean; changed: boolean; reason?: string }> {
+  const repoCfg = repoStoreConfigFromEnv()
+  if (!repoCfg) return { ok: true, changed: false, reason: 'no-store-config' }
+  let excludeLfsObjects = false
+  if (isLfsActive()) {
+    const lfsCfg = lfsRemoteConfigFromEnv(WORKSPACE_DIR)
+    if (lfsCfg) excludeLfsObjects = await lfsPushAll(lfsCfg)
+  }
+  return persistRepoToStore(WORKSPACE_DIR, repoCfg, { excludeLfsObjects })
+}
+
+/**
  * Offload large/binary assets to S3 and refresh `.git/info/exclude` so the
  * subsequent git push stays source-only. Fire-and-forget — paired with the
  * git push at the turn-complete boundary in `git_only` / `dual_shadow`.
  * No-op unless object storage is configured and a git sync is active.
+ *
+ * In Git LFS mode this legacy size-based offload is replaced by the LFS
+ * clean filter (pointers) + `git lfs push` (bytes), so it no-ops.
  */
 function triggerLargeFileSync(): void {
   if (!gitSyncInstance) return
+  if (isLfsActive()) return
   const cfg = largeFileSyncConfigFromEnv(WORKSPACE_DIR)
   if (!cfg) return
   void syncLargeFiles(cfg).catch((err: any) =>
@@ -334,9 +374,9 @@ function triggerLargeFileSync(): void {
  * is already durable and the row can be reconciled on the next API hydrate).
  */
 async function persistAndRecordCheckpoint(sha: string): Promise<void> {
-  const repoCfg = repoStoreConfigFromEnv()
-  if (repoCfg) {
-    const res = await persistRepoToStore(WORKSPACE_DIR, repoCfg)
+  if (repoStoreConfigFromEnv()) {
+    // Offload LFS object bytes to OCI (when active) then persist `.git`.
+    const res = await persistDurableRepo()
     if (!res.ok) throw new Error(`durable repo persist failed: ${res.reason}`)
   }
   // Record the checkpoint row (best-effort; the commit is already durable in
@@ -4301,16 +4341,18 @@ app.post('/agent/git-flush', async (c) => {
     /* no body */
   }
   try {
+    // Legacy size-based offload (skipped under LFS — flush() handles LFS via
+    // beforeStage track + afterCommit push).
     const lfCfg = largeFileSyncConfigFromEnv(WORKSPACE_DIR)
-    if (lfCfg) await syncLargeFiles(lfCfg)
+    if (lfCfg && !isLfsActive()) await syncLargeFiles(lfCfg)
     await gitSyncInstance.flush()
 
     let taggedSha: string | null = null
     if (tag) {
       taggedSha = await createTagLocal(WORKSPACE_DIR, tag, { message: tagMessage, force: true })
-      // Re-persist so the durable repo carries the new tag.
-      const repoCfg = repoStoreConfigFromEnv()
-      if (repoCfg) await persistRepoToStore(WORKSPACE_DIR, repoCfg)
+      // Re-persist so the durable repo carries the new tag (LFS objects are
+      // already in OCI from the flush; re-push is a cheap no-op via dedup).
+      await persistDurableRepo()
     }
 
     const sha = taggedSha ?? (await getHeadSha(WORKSPACE_DIR))
@@ -4702,6 +4744,23 @@ async function initializeEssentials(): Promise<void> {
           console.error('[agent-runtime] restoreLargeFiles failed:', error.message)
         }
       }
+      // Git LFS (git_only + LFS_ENABLED): configure the repo's LFS filter +
+      // .gitattributes, run the one-time migration off the legacy assets/
+      // offload (no-op once done), then materialize object bytes for the
+      // current checkout (smudge is skipped on checkout, so we fetch
+      // explicitly). All best-effort — a failure leaves pointer files and is
+      // recovered on the next pull.
+      if (isLfsActive()) {
+        try {
+          await ensureLfsRepoSetup(WORKSPACE_DIR)
+          await migrateOffloadedAssetsToLfs(WORKSPACE_DIR)
+          const lfsCfg = lfsRemoteConfigFromEnv(WORKSPACE_DIR)
+          if (lfsCfg) await lfsPull(lfsCfg)
+          logTiming('Git LFS setup + pull')
+        } catch (error: any) {
+          console.error('[agent-runtime] Git LFS setup failed:', error?.message ?? error)
+        }
+      }
     } else {
       console.warn('[agent-runtime] git mode requested but SHOGO_API_URL/RUNTIME_AUTH_SECRET/PROJECT_ID incomplete; skipping repo bootstrap')
     }
@@ -4712,6 +4771,11 @@ async function initializeEssentials(): Promise<void> {
         // origin. dual_shadow keeps the push model.
         localOnly: cloudSyncMode === 'git_only',
         afterCommit: cloudSyncMode === 'git_only' ? persistAndRecordCheckpoint : undefined,
+        // Git LFS: before each `git add -A`, track newly-introduced large
+        // files so the clean filter writes pointers instead of raw bytes.
+        beforeStage: isLfsActive()
+          ? async () => { await autoTrackLargeFiles(WORKSPACE_DIR) }
+          : undefined,
         onDegrade: (reason) => {
           console.warn(
             `[agent-runtime] cloud-sync degraded (mode=${cloudSyncMode}): ${reason}`,
@@ -5001,9 +5065,10 @@ async function gracefulShutdown(signal: string): Promise<void> {
     const mode = resolveCloudSyncMode()
     if (gitSyncInstance) {
       // Final large-file offload before the last push so the durable repo
-      // stays source-only and the offloaded asset set is current.
+      // stays source-only and the offloaded asset set is current. Skipped
+      // under LFS — flushAndShutdown's afterCommit runs the LFS object push.
       const lfCfg = largeFileSyncConfigFromEnv(WORKSPACE_DIR)
-      if (lfCfg) {
+      if (lfCfg && !isLfsActive()) {
         try {
           await syncLargeFiles(lfCfg)
         } catch (err: any) {

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -55,7 +55,6 @@ import {
   getHeadSha,
   repoStoreConfigFromEnv,
   gatherCommitMeta,
-  isLfsEnabled,
   ensureLfsRepoSetup,
   autoTrackLargeFiles,
   lfsPushAll,
@@ -322,10 +321,11 @@ let workspaceMemberSyncs: Map<string, import('@shogo/shared-runtime').S3Sync> = 
  * pod-owned default): the LFS object-offload step is wired into that mode's
  * `afterCommit` durability path, and LFS attributes are only written for
  * these repos, so other modes (dual_shadow/s3) keep the legacy offload and
- * never accidentally LFS-ify files.
+ * never accidentally LFS-ify files. LFS is always on for git_only — there is
+ * no separate enable flag.
  */
 function isLfsActive(): boolean {
-  return resolveCloudSyncMode() === 'git_only' && isLfsEnabled()
+  return resolveCloudSyncMode() === 'git_only'
 }
 
 /**
@@ -4744,7 +4744,7 @@ async function initializeEssentials(): Promise<void> {
           console.error('[agent-runtime] restoreLargeFiles failed:', error.message)
         }
       }
-      // Git LFS (git_only + LFS_ENABLED): configure the repo's LFS filter +
+      // Git LFS (git_only): configure the repo's LFS filter +
       // .gitattributes, run the one-time migration off the legacy assets/
       // offload (no-op once done), then materialize object bytes for the
       // current checkout (smudge is skipped on checkout, so we fetch

--- a/packages/agent/src/__tests__/retry-classifier.test.ts
+++ b/packages/agent/src/__tests__/retry-classifier.test.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Tests for the inference retryability classifier.
+ *
+ * Run: bun test packages/agent/src/__tests__/retry-classifier.test.ts
+ */
+import { describe, test, expect } from 'bun:test'
+import {
+  classifyRetryability,
+  parseStreamErrorMarker,
+  stripStreamErrorMarker,
+} from '../retry-classifier'
+
+describe('classifyRetryability — retryable failures', () => {
+  const retryable: Array<[string, string]> = [
+    ['ECONNRESET', 'read ECONNRESET'],
+    ['fetch failed', 'TypeError: fetch failed'],
+    ['socket hang up', 'socket hang up'],
+    ['ETIMEDOUT', 'connect ETIMEDOUT 10.0.0.1:443'],
+    ['mid-stream 500', 'Upstream anthropic returned 500 internal server error'],
+    ['502', '502 Bad Gateway'],
+    ['503', '503 Service Unavailable'],
+    ['overloaded', '{"type":"overloaded_error","message":"Overloaded"}'],
+    ['429', '429 Too Many Requests'],
+    [
+      'idle_timeout (with proxy marker)',
+      'No data from anthropic for 120000ms; giving up. Please retry. [shogo:retryable=true;code=idle_timeout]',
+    ],
+    [
+      'EOF before message_stop',
+      'Upstream anthropic stream ended without message_stop after 5000ms (likely network drop). Please retry.',
+    ],
+    ['premature close', 'Error: Premature close'],
+  ]
+
+  for (const [label, message] of retryable) {
+    test(`retryable: ${label}`, () => {
+      expect(classifyRetryability({ message }).retryable).toBe(true)
+    })
+  }
+})
+
+describe('classifyRetryability — non-retryable failures', () => {
+  const nonRetryable: Array<[string, string]> = [
+    ['401 auth', '401 Unauthorized'],
+    ['403 auth', '403 {"error":{"message":"permission denied"}}'],
+    ['invalid api key', 'Authentication error: invalid api key'],
+    ['400 invalid_request', '400 {"type":"invalid_request_error","message":"bad params"}'],
+    ['content policy', 'Your request was flagged by our content policy'],
+    ['content_filter', 'stop_reason: content_filter'],
+    ['billing', '402 billing_error: insufficient credits'],
+  ]
+
+  for (const [label, message] of nonRetryable) {
+    test(`non-retryable: ${label}`, () => {
+      expect(classifyRetryability({ message }).retryable).toBe(false)
+    })
+  }
+
+  test('user abort is never retryable (even with a retryable-looking message)', () => {
+    expect(classifyRetryability({ message: 'socket hang up', aborted: true }).retryable).toBe(false)
+    expect(classifyRetryability({ message: 'ECONNRESET', stopReason: 'aborted' }).retryable).toBe(false)
+    expect(classifyRetryability({ aborted: true }).reason).toBe('aborted')
+  })
+
+  test('unknown errors are conservatively non-retryable', () => {
+    const c = classifyRetryability({ message: 'something totally unexpected happened' })
+    expect(c.retryable).toBe(false)
+    expect(c.reason).toBe('unknown')
+  })
+})
+
+describe('classifyRetryability — status codes', () => {
+  test('5xx retryable', () => {
+    expect(classifyRetryability({ status: 500 }).retryable).toBe(true)
+    expect(classifyRetryability({ status: 503 }).retryable).toBe(true)
+  })
+  test('429 retryable', () => {
+    expect(classifyRetryability({ status: 429 }).retryable).toBe(true)
+  })
+  test('401/403/400 non-retryable', () => {
+    expect(classifyRetryability({ status: 401 }).retryable).toBe(false)
+    expect(classifyRetryability({ status: 403 }).retryable).toBe(false)
+    expect(classifyRetryability({ status: 400 }).retryable).toBe(false)
+  })
+})
+
+describe('classifyRetryability — structured proxy marker propagation', () => {
+  test('marker retryable=true classifies retryable regardless of prose', () => {
+    const message =
+      'Upstream anthropic stream dropped. Please retry. [shogo:retryable=true;code=upstream_truncated]'
+    const c = classifyRetryability({ message })
+    expect(c.retryable).toBe(true)
+    expect(c.reason).toBe('truncated')
+  })
+
+  test('marker retryable=false classifies non-retryable even with retryable-looking text', () => {
+    // Prose says "stream" / "retry" (retryable-looking) but the structured
+    // flag is authoritative: upstream_error is a definitive failure.
+    const message =
+      'Upstream stream error. Please retry. [shogo:retryable=false;code=upstream_error]'
+    const c = classifyRetryability({ message })
+    expect(c.retryable).toBe(false)
+    expect(c.reason).toBe('upstream_error')
+  })
+
+  test('parseStreamErrorMarker extracts the flag + code', () => {
+    expect(parseStreamErrorMarker('x [shogo:retryable=true;code=idle_timeout]')).toEqual({
+      retryable: true,
+      code: 'idle_timeout',
+    })
+    expect(parseStreamErrorMarker('no marker here')).toBeNull()
+  })
+
+  test('stripStreamErrorMarker removes the internal marker', () => {
+    expect(
+      stripStreamErrorMarker('Connection lost. Please retry. [shogo:retryable=true;code=econnreset]'),
+    ).toBe('Connection lost. Please retry.')
+  })
+
+  test('explicit retryable override is honored when no marker present', () => {
+    expect(classifyRetryability({ message: 'weird', retryable: true }).retryable).toBe(true)
+    expect(classifyRetryability({ message: 'weird', retryable: false }).retryable).toBe(false)
+  })
+})

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -33,9 +33,18 @@ import {
 } from './pi-adapter'
 import { wrapToolsWithOrchestration, type OrchestrationOptions } from './tool-orchestration'
 import { makeStallFallbackStreamFn, resolveStallFallbackOptions, type StallFallbackOptions } from './stall-fallback'
+import { classifyRetryability } from './retry-classifier'
+import {
+  resolveInferenceRetryOptions,
+  detectInferenceFailure,
+  stripTrailingFailedAssistants,
+  type InferenceRetryOptions,
+  type InferenceRetryInfo,
+} from './inference-retry'
 
 export type { LoopDetectorConfig, LoopDetectorResult }
 export type { OrchestrationOptions }
+export type { InferenceRetryOptions, InferenceRetryInfo }
 
 export type ThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
 
@@ -103,6 +112,26 @@ export interface AgentLoopOptions {
    * `SHOGO_STALL_FALLBACK_WINDOW_MS`.
    */
   stallFallback?: StallFallbackOptions | false
+  /**
+   * Inference reconnect/retry. When a single model call drops mid-generation
+   * with a *retryable* failure (network reset, provider 5xx, idle timeout,
+   * stream truncation before `message_stop`), the failed assistant tail is
+   * stripped and the call is re-issued via `Agent.continue()` — without
+   * re-running any already-executed tools. Capped + backed off; user aborts
+   * and definitive errors (auth, content policy, billing, invalid request) are
+   * never retried. Defaults to enabled (2 retries). Pass `false` to disable,
+   * or a config object to tune. Can also be disabled via
+   * `SHOGO_INFERENCE_RETRY=0` and tuned via
+   * `SHOGO_INFERENCE_RETRY_MAX_ATTEMPTS` / `SHOGO_INFERENCE_RETRY_BASE_MS`.
+   */
+  inferenceRetry?: InferenceRetryOptions | false
+  /**
+   * Called just before each inference retry re-issues the dropped model call.
+   * The gateway uses this to emit a `data-inference-retry` frame and reset the
+   * in-progress UI step so the client discards the failed step's partial
+   * deltas instead of concatenating the regenerated output.
+   */
+  onInferenceRetry?: (info: InferenceRetryInfo) => void
   /** Tool orchestration config. Pass false to disable wrapping (tools run raw parallel). */
   orchestration?: OrchestrationOptions | false
   /** AbortSignal for external cancellation (e.g., user stop). */
@@ -441,6 +470,85 @@ export async function runAgentLoop(options: AgentLoopOptions): Promise<AgentLoop
     signal?.removeEventListener('abort', onAbort)
   }
 
+  // Layer 6: Inference reconnect/retry. When the model call dropped mid-stream
+  // with a *retryable* failure, re-issue the SAME call via Agent.continue()
+  // after stripping the failed assistant tail. Because pi-agent-core executes
+  // tools only after a complete assistant message, a call that died mid-stream
+  // never ran that step's tools — so re-issuing is idempotent w.r.t. side
+  // effects, and earlier completed tool results are preserved in the transcript.
+  const inferenceRetry = resolveInferenceRetryOptions(options.inferenceRetry)
+  // Billing policy for retries: the provider (and therefore Shogo's AI proxy
+  // billing session) charges for tokens actually consumed on each call — even
+  // a dropped/partial one. The proxy accumulates those into the per-session
+  // bucket that `closeSession` bills, so the user is charged for the failed
+  // partial attempt as the provider charged us. We strip the failed assistant
+  // message from the transcript (so it isn't replayed to the model), but we
+  // keep its usage here and fold it back into the loop's reported totals so the
+  // surfaced usage stays consistent with what was actually billed. Retries are
+  // capped (default 2) so cost amplification is bounded.
+  const discardedUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+  if (inferenceRetry && !abortTriggered) {
+    let retryAttempt = 0
+    while (retryAttempt < inferenceRetry.maxAttempts) {
+      if (abortTriggered || signal?.aborted) break
+
+      const failure = detectInferenceFailure(agent.state.messages, promptError)
+      if (!failure) break
+
+      const classification = classifyRetryability({
+        message: failure.errorText,
+        stopReason: failure.stopReason,
+        aborted: abortTriggered || signal?.aborted,
+      })
+      if (!classification.retryable) break
+
+      // Strip the failed assistant tail so continue() resumes from the last
+      // user/tool-result message. When the call rejected before pi appended any
+      // assistant message (e.g. a synchronous stream throw on the very first
+      // call), there's nothing to strip and the transcript already ends on a
+      // user/tool-result message — continue() can re-issue directly.
+      const trimmed = stripTrailingFailedAssistants(agent.state.messages) ?? agent.state.messages
+      const last = trimmed[trimmed.length - 1]
+      // Can't continue from a clean assistant tail (continue() rejects) — bail.
+      if (!last || last.role === 'assistant') break
+      if (trimmed !== agent.state.messages) {
+        // Preserve the usage of the stripped failed attempt for billing parity.
+        const removedUsage = sumUsage(agent.state.messages.slice(trimmed.length))
+        discardedUsage.input += removedUsage.input
+        discardedUsage.output += removedUsage.output
+        discardedUsage.cacheRead += removedUsage.cacheRead
+        discardedUsage.cacheWrite += removedUsage.cacheWrite
+        agent.state.messages = trimmed
+      }
+
+      retryAttempt++
+      const delayMs = inferenceRetry.computeDelayMs(retryAttempt)
+      try {
+        options.onInferenceRetry?.({
+          attempt: retryAttempt,
+          maxAttempts: inferenceRetry.maxAttempts,
+          reason: classification.reason,
+          delayMs,
+          error: failure.errorText,
+        })
+      } catch { /* listener must not break the loop */ }
+      console.warn(
+        `[AgentLoop] INFERENCE_RETRY attempt=${retryAttempt}/${inferenceRetry.maxAttempts} ` +
+          `reason=${classification.reason} delayMs=${delayMs} error=${failure.errorText.slice(0, 160)}`,
+      )
+
+      promptError = undefined
+      if (delayMs > 0) await inferenceRetry.sleep(delayMs)
+      if (abortTriggered || signal?.aborted) break
+
+      try {
+        await agent.continue()
+      } catch (err: any) {
+        promptError = err
+      }
+    }
+  }
+
   let allMessages = agent.state.messages
   let newMessages = allMessages.slice(history.length)
   let finalText = extractFinalText(newMessages)
@@ -605,10 +713,10 @@ export async function runAgentLoop(options: AgentLoopOptions): Promise<AgentLoop
       : finalText,
     toolCalls,
     iterations,
-    inputTokens: usage.input,
-    outputTokens: usage.output,
-    cacheReadTokens: usage.cacheRead,
-    cacheWriteTokens: usage.cacheWrite,
+    inputTokens: usage.input + discardedUsage.input,
+    outputTokens: usage.output + discardedUsage.output,
+    cacheReadTokens: usage.cacheRead + discardedUsage.cacheRead,
+    cacheWriteTokens: usage.cacheWrite + discardedUsage.cacheWrite,
     newMessages,
     loopBreak,
     error: promptError || implicitError,

--- a/packages/agent/src/inference-retry.ts
+++ b/packages/agent/src/inference-retry.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Inference reconnect/retry for the agent loop.
+ *
+ * When a single model call drops mid-generation with a *retryable* failure
+ * (network reset, provider 5xx, idle timeout, a stream that ended before
+ * `message_stop`), the safe recovery is to re-issue that same call rather than
+ * end the turn. pi-agent-core runs tools only AFTER a complete assistant
+ * message, so a call that died mid-generation never executed that step's tools
+ * — re-issuing it is idempotent w.r.t. side effects. The earlier completed
+ * steps stay in the transcript and are reused via `Agent.continue()`.
+ *
+ * This module owns:
+ *   - option resolution (caps, backoff, env overrides), mirroring
+ *     `resolveStallFallbackOptions` in `stall-fallback.ts`.
+ *   - detecting whether the last attempt failed and extracting its error text.
+ *   - stripping the failed assistant tail so `Agent.continue()` can re-drive
+ *     from the last user/tool-result message.
+ *
+ * The actual retry loop lives in `agent-loop.ts` (it needs the live `Agent`).
+ */
+
+import type { Message } from '@mariozechner/pi-ai'
+import type { RetryReason } from './retry-classifier'
+
+export interface InferenceRetryOptions {
+  /** Max number of re-issues (continues) after the initial attempt. Default 2. */
+  maxAttempts?: number
+  /** Base backoff delay in ms (doubled per attempt). Default 500. */
+  baseDelayMs?: number
+  /** Cap on a single backoff delay in ms. Default 8000. */
+  maxDelayMs?: number
+  /** Apply +/- jitter to the backoff. Default true. */
+  jitter?: boolean
+  /** Injectable delay computer (tests can assert/replace). */
+  computeDelayMs?: (attempt: number) => number
+  /** Injectable sleep (tests pass a no-op / fake-timer). */
+  sleep?: (ms: number) => Promise<void>
+}
+
+export interface ResolvedInferenceRetry {
+  maxAttempts: number
+  computeDelayMs: (attempt: number) => number
+  sleep: (ms: number) => Promise<void>
+}
+
+export interface InferenceRetryInfo {
+  /** 1-based attempt index (1 = first retry). */
+  attempt: number
+  maxAttempts: number
+  reason: RetryReason
+  delayMs: number
+  /** The (cleaned) error text that triggered the retry. */
+  error: string
+}
+
+const DEFAULT_MAX_ATTEMPTS = 2
+const DEFAULT_BASE_DELAY_MS = 500
+const DEFAULT_MAX_DELAY_MS = 8_000
+
+function envInt(name: string): number | undefined {
+  const raw = process.env[name]
+  if (raw == null || raw === '') return undefined
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : undefined
+}
+
+/**
+ * Resolve effective inference-retry options from explicit config + env.
+ * Returns `null` when retries are disabled.
+ *
+ * Env:
+ * - `SHOGO_INFERENCE_RETRY=0|false|off` disables it entirely.
+ * - `SHOGO_INFERENCE_RETRY_MAX_ATTEMPTS=<n>` overrides the retry cap.
+ * - `SHOGO_INFERENCE_RETRY_BASE_MS=<n>` overrides the base backoff.
+ */
+export function resolveInferenceRetryOptions(
+  explicit?: InferenceRetryOptions | false,
+): ResolvedInferenceRetry | null {
+  if (explicit === false) return null
+  const envFlag = (process.env.SHOGO_INFERENCE_RETRY ?? '').trim().toLowerCase()
+  if (envFlag === '0' || envFlag === 'false' || envFlag === 'off') return null
+
+  const o = explicit ?? {}
+  const rawMax = o.maxAttempts ?? envInt('SHOGO_INFERENCE_RETRY_MAX_ATTEMPTS') ?? DEFAULT_MAX_ATTEMPTS
+  const maxAttempts = Math.max(0, Math.min(10, Math.floor(rawMax)))
+  if (maxAttempts <= 0) return null
+
+  const base = o.baseDelayMs ?? envInt('SHOGO_INFERENCE_RETRY_BASE_MS') ?? DEFAULT_BASE_DELAY_MS
+  const max = o.maxDelayMs ?? DEFAULT_MAX_DELAY_MS
+  const jitter = o.jitter ?? true
+
+  const computeDelayMs =
+    o.computeDelayMs ??
+    ((attempt: number) => {
+      const raw = Math.min(max, base * Math.pow(2, Math.max(0, attempt - 1)))
+      // Half-jitter: keep at least 50% of the computed delay so backoff still grows.
+      return jitter ? Math.round(raw * (0.5 + Math.random() * 0.5)) : Math.round(raw)
+    })
+
+  const sleep = o.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)))
+
+  return { maxAttempts, computeDelayMs, sleep }
+}
+
+export interface InferenceFailure {
+  errorText: string
+  stopReason?: string
+}
+
+/**
+ * Inspect the transcript after an attempt and decide whether the last model
+ * call failed. Returns the failure details, or `null` if the last assistant
+ * turn completed cleanly.
+ *
+ * pi-agent-core catches stream errors internally and appends an assistant
+ * message carrying `errorMessage` / `stopReason: 'error'` rather than throwing,
+ * so we inspect the trailing assistant message. A directly-thrown error
+ * (`promptError`) takes precedence.
+ */
+export function detectInferenceFailure(
+  messages: Message[],
+  promptError?: Error,
+): InferenceFailure | null {
+  if (promptError) {
+    return { errorText: promptError.message || String(promptError) }
+  }
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i] as any
+    if (m.role !== 'assistant') continue
+    if (m.errorMessage || m.stopReason === 'error') {
+      return { errorText: m.errorMessage || 'Provider error', stopReason: m.stopReason }
+    }
+    // First (trailing) assistant message is clean -> the turn succeeded.
+    return null
+  }
+  return null
+}
+
+/**
+ * Return a copy of `messages` with the trailing failed assistant message(s)
+ * removed, or `null` if there was nothing to strip. A "failed" assistant
+ * message is one with an `errorMessage`, `stopReason: 'error'`, or no usable
+ * content. Stripping leaves the transcript ending on the last user/tool-result
+ * message so `Agent.continue()` can re-issue the dropped call.
+ */
+export function stripTrailingFailedAssistants(messages: Message[]): Message[] | null {
+  let end = messages.length
+  while (end > 0) {
+    const m = messages[end - 1] as any
+    if (m.role !== 'assistant') break
+    const hasError = !!m.errorMessage || m.stopReason === 'error'
+    const emptyContent =
+      !Array.isArray(m.content) ||
+      m.content.length === 0 ||
+      m.content.every(
+        (c: any) =>
+          (c.type === 'text' && !(c.text && c.text.trim())) ||
+          (c.type === 'thinking' && !(c.thinking && c.thinking.trim())),
+      )
+    if (hasError || emptyContent) {
+      end--
+      continue
+    }
+    break
+  }
+  if (end === messages.length) return null
+  return messages.slice(0, end)
+}

--- a/packages/agent/src/retry-classifier.ts
+++ b/packages/agent/src/retry-classifier.ts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Retryability classifier for inference (model-call) failures.
+ *
+ * A single LLM call can fail mid-generation for many reasons. Some are
+ * transient and safe to re-issue (network reset, provider 5xx, idle timeout,
+ * a stream that ended before `message_stop`); others are definitive and must
+ * NOT be retried (user abort, auth/permission, malformed request, content
+ * policy, billing). This module makes that decision in one place so the agent
+ * loop and any callers stay consistent.
+ *
+ * Two signal sources are supported, in priority order:
+ *   1. A structured marker embedded by Shogo's AI proxy in the error message
+ *      (`[shogo:retryable=<bool>;code=<code>]`). This is the authoritative
+ *      signal and survives whatever wrapping the provider SDK applies.
+ *   2. String/heuristic matching on the raw error text + HTTP status as a
+ *      fallback when no marker is present (direct provider calls, thrown
+ *      Errors, non-proxied paths).
+ *
+ * A user-initiated abort is ALWAYS non-retryable regardless of any other
+ * signal.
+ */
+
+export type RetryReason =
+  | 'network'
+  | 'timeout'
+  | 'idle_timeout'
+  | 'server_5xx'
+  | 'overloaded'
+  | 'truncated'
+  | 'aborted'
+  | 'auth'
+  | 'invalid_request'
+  | 'content_policy'
+  | 'billing'
+  | 'upstream_error'
+  | 'unknown'
+
+export interface RetryClassification {
+  retryable: boolean
+  reason: RetryReason
+}
+
+export interface RetryClassifyInput {
+  /** Raw error text (pi-ai `errorMessage` or a thrown Error's message). */
+  message?: string | null
+  /** stopReason from the failed assistant message, if known. */
+  stopReason?: string | null
+  /** HTTP-ish status code, if known. */
+  status?: number | null
+  /** True when the failure was a user-initiated abort (never retryable). */
+  aborted?: boolean
+  /** Structured retryable override (e.g. already-decided upstream). */
+  retryable?: boolean | null
+}
+
+/**
+ * Stable marker the AI proxy embeds in stream-error messages so the
+ * retryable flag + code survive transport into pi-ai's `errorMessage`.
+ * Keep this format in sync with `apps/api/src/routes/ai-proxy.ts`.
+ */
+const STREAM_ERROR_MARKER = /\[shogo:retryable=(true|false);code=([a-z0-9_]+)\]/i
+
+export interface StreamErrorMarker {
+  retryable: boolean
+  code: string
+}
+
+/** Parse the proxy's `[shogo:retryable=...;code=...]` marker, if present. */
+export function parseStreamErrorMarker(message?: string | null): StreamErrorMarker | null {
+  if (!message) return null
+  const m = STREAM_ERROR_MARKER.exec(message)
+  if (!m) return null
+  return { retryable: m[1].toLowerCase() === 'true', code: m[2].toLowerCase() }
+}
+
+/** Strip the proxy marker so user-facing error text stays clean. */
+export function stripStreamErrorMarker(message?: string | null): string {
+  if (!message) return ''
+  return message.replace(/\s*\[shogo:retryable=[^\]]*\]/gi, '').trim()
+}
+
+function codeToReason(code: string): RetryReason {
+  switch (code) {
+    case 'idle_timeout':
+      return 'idle_timeout'
+    case 'upstream_truncated':
+      return 'truncated'
+    case 'upstream_error':
+      return 'upstream_error'
+    case 'econnreset':
+    case 'econnrefused':
+    case 'epipe':
+    case 'network_error':
+      return 'network'
+    case 'etimedout':
+    case 'timeout':
+      return 'timeout'
+    default:
+      return 'unknown'
+  }
+}
+
+function classifyByStatus(status: number): RetryClassification | null {
+  if (status === 408 || status === 425) return { retryable: true, reason: 'timeout' }
+  if (status === 429) return { retryable: true, reason: 'overloaded' }
+  if (status >= 500 && status <= 599) return { retryable: true, reason: 'server_5xx' }
+  if (status === 401 || status === 403) return { retryable: false, reason: 'auth' }
+  if (status === 402) return { retryable: false, reason: 'billing' }
+  if (status === 400 || status === 404 || status === 422) return { retryable: false, reason: 'invalid_request' }
+  return null
+}
+
+// Non-retryable patterns take precedence over retryable ones so that, e.g.,
+// "401 connection" is treated as auth rather than network.
+const NON_RETRYABLE_PATTERNS: Array<[RegExp, RetryReason]> = [
+  [/\bunauthorized\b|invalid[_\s-]?api[_\s-]?key|authentication|permission denied|\b401\b|\b403\b/i, 'auth'],
+  [/content[_\s-]?(policy|filter)|moderation|safety (system|filter)|stop_reason["'\s:]+content_filter/i, 'content_policy'],
+  [/billing|insufficient[_\s]?(credits|funds|balance)|payment required|\b402\b|quota (exceeded|reached)|usage limit/i, 'billing'],
+  [/invalid[_\s-]?request|\b400\b|\bunprocessable\b|\b422\b|prompt is too long|maximum context length|context (length|window) (exceeded|too)/i, 'invalid_request'],
+]
+
+const RETRYABLE_PATTERNS: Array<[RegExp, RetryReason]> = [
+  [/idle[_\s-]?timeout/i, 'idle_timeout'],
+  [/(ended|stopped|closed|dropped) (without|before) (a )?message_stop|upstream_truncated|truncat(ed|ion)|premature (close|end)|unexpected end of/i, 'truncated'],
+  [/\b429\b|rate[_\s-]?limit|overloaded|too many requests|capacity/i, 'overloaded'],
+  [/\b50[0-9]\b|\b502\b|\b503\b|\b504\b|internal server error|bad gateway|service unavailable|gateway timeout|server error/i, 'server_5xx'],
+  [/econnreset|econnrefused|enotfound|ehostunreach|enetunreach|epipe|socket hang up|fetch failed|network (error|failure)|connection (reset|closed|refused|error|lost|aborted|terminated)|stream (error|dropped|interrupted|faulted)|terminated|read econnreset/i, 'network'],
+  [/etimedout|timed out|stream timed out|request timeout|deadline exceeded/i, 'timeout'],
+]
+
+/**
+ * Classify whether an inference failure is safe to retry.
+ *
+ * Decision order:
+ *   1. User abort -> never retryable.
+ *   2. Proxy marker (authoritative structured signal).
+ *   3. Explicit `retryable` override.
+ *   4. HTTP status.
+ *   5. Non-retryable text patterns, then retryable text patterns.
+ *   6. Default: non-retryable / unknown (conservative — don't burn tokens or
+ *      loop on errors we don't recognize).
+ */
+export function classifyRetryability(input: RetryClassifyInput): RetryClassification {
+  if (input.aborted || input.stopReason === 'aborted') {
+    return { retryable: false, reason: 'aborted' }
+  }
+
+  const marker = parseStreamErrorMarker(input.message)
+  if (marker) {
+    return { retryable: marker.retryable, reason: codeToReason(marker.code) }
+  }
+
+  if (typeof input.retryable === 'boolean') {
+    // Honor the structured flag; still derive a best-effort reason from text.
+    const derived = deriveReasonFromText(input.message)
+    return { retryable: input.retryable, reason: derived ?? (input.retryable ? 'network' : 'unknown') }
+  }
+
+  if (typeof input.status === 'number' && Number.isFinite(input.status)) {
+    const byStatus = classifyByStatus(input.status)
+    if (byStatus) return byStatus
+  }
+
+  const msg = input.message ?? ''
+  for (const [re, reason] of NON_RETRYABLE_PATTERNS) {
+    if (re.test(msg)) return { retryable: false, reason }
+  }
+  for (const [re, reason] of RETRYABLE_PATTERNS) {
+    if (re.test(msg)) return { retryable: true, reason }
+  }
+
+  return { retryable: false, reason: 'unknown' }
+}
+
+function deriveReasonFromText(message?: string | null): RetryReason | null {
+  if (!message) return null
+  for (const [re, reason] of NON_RETRYABLE_PATTERNS) {
+    if (re.test(message)) return reason
+  }
+  for (const [re, reason] of RETRYABLE_PATTERNS) {
+    if (re.test(message)) return reason
+  }
+  return null
+}

--- a/packages/shared-app/src/chat/message-helpers.ts
+++ b/packages/shared-app/src/chat/message-helpers.ts
@@ -70,25 +70,38 @@ export function isTunnelDisconnectError(message: string): boolean {
     CONNECTION_ERROR_PATTERNS.some((p) => p.test(raw))
 }
 
+/**
+ * Internal retryability marker the AI proxy embeds in stream-error messages
+ * (see `apps/api/src/routes/ai-proxy.ts` / `packages/agent/src/retry-classifier.ts`).
+ * It is meant for the server-side retry classifier, never for users, so we
+ * strip it before rendering any error text.
+ */
+const STREAM_ERROR_MARKER_PATTERN = /\s*\[shogo:retryable=[^\]]*\]/gi
+
+export function stripInternalErrorMarkers(message: string): string {
+  return message.replace(STREAM_ERROR_MARKER_PATTERN, '').trim()
+}
+
 export function formatErrorMessage(rawMessage: string): string {
+  const cleaned = stripInternalErrorMarkers(rawMessage)
   try {
-    const parsed = JSON.parse(rawMessage)
+    const parsed = JSON.parse(cleaned)
     if (parsed?.error?.code && ERROR_CODE_MESSAGES[parsed.error.code]) {
       return ERROR_CODE_MESSAGES[parsed.error.code]
     }
     if (parsed?.error?.message) {
-      return parsed.error.message
+      return stripInternalErrorMarkers(parsed.error.message)
     }
     if (parsed?.message) {
-      return parsed.message
+      return stripInternalErrorMarkers(parsed.message)
     }
   } catch {
     // Not JSON
   }
-  if (CONNECTION_ERROR_PATTERNS.some((p) => p.test(rawMessage))) {
+  if (CONNECTION_ERROR_PATTERNS.some((p) => p.test(cleaned))) {
     return 'Connection interrupted. Please tap Retry to continue.'
   }
-  return rawMessage
+  return cleaned
 }
 
 /**

--- a/packages/shared-runtime/src/__tests__/lfs.test.ts
+++ b/packages/shared-runtime/src/__tests__/lfs.test.ts
@@ -16,7 +16,6 @@ import {
   lfsObjectKey,
   lfsKeyPrefix,
   buildLfsEndpointUrl,
-  isLfsEnabled,
   buildManagedAttributesBlock,
   writeManagedGitAttributes,
 } from '../lfs'
@@ -56,15 +55,6 @@ describe('buildLfsEndpointUrl', () => {
     expect(buildLfsEndpointUrl('https://api.shogo.ai/', 'p1')).toBe(
       'https://api.shogo.ai/api/projects/p1/git/info/lfs',
     )
-  })
-})
-
-describe('isLfsEnabled', () => {
-  it('is true only for "true"/"1"', () => {
-    expect(isLfsEnabled({ LFS_ENABLED: 'true' } as any)).toBe(true)
-    expect(isLfsEnabled({ LFS_ENABLED: '1' } as any)).toBe(true)
-    expect(isLfsEnabled({ LFS_ENABLED: 'false' } as any)).toBe(false)
-    expect(isLfsEnabled({} as any)).toBe(false)
   })
 })
 

--- a/packages/shared-runtime/src/__tests__/lfs.test.ts
+++ b/packages/shared-runtime/src/__tests__/lfs.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Unit tests for the pure / fs-level helpers in `lfs.ts`. The git-spawning
+ * transfer helpers (push/pull/track) need a real git+git-lfs and are covered
+ * by integration, not here.
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  isValidLfsOid,
+  lfsObjectKey,
+  lfsKeyPrefix,
+  buildLfsEndpointUrl,
+  isLfsEnabled,
+  buildManagedAttributesBlock,
+  writeManagedGitAttributes,
+} from '../lfs'
+
+const OID = 'a'.repeat(64)
+
+describe('isValidLfsOid', () => {
+  it('accepts a 64-char lowercase hex digest', () => {
+    expect(isValidLfsOid(OID)).toBe(true)
+  })
+  it('rejects wrong length, uppercase, and non-hex', () => {
+    expect(isValidLfsOid('abc')).toBe(false)
+    expect(isValidLfsOid('A'.repeat(64))).toBe(false)
+    expect(isValidLfsOid('g'.repeat(64))).toBe(false)
+    expect(isValidLfsOid('../../etc/passwd')).toBe(false)
+  })
+})
+
+describe('lfsObjectKey', () => {
+  it('shards by the first two byte-pairs of the oid', () => {
+    expect(lfsObjectKey('p1', OID, 'lfs/objects')).toBe(`p1/lfs/objects/aa/aa/${OID}`)
+  })
+  it('throws on an invalid oid (no key-namespace escape)', () => {
+    expect(() => lfsObjectKey('p1', 'not-an-oid')).toThrow()
+  })
+})
+
+describe('lfsKeyPrefix', () => {
+  it('defaults to lfs/objects and honors S3_LFS_PREFIX', () => {
+    expect(lfsKeyPrefix({} as any)).toBe('lfs/objects')
+    expect(lfsKeyPrefix({ S3_LFS_PREFIX: '/custom/lfs/' } as any)).toBe('custom/lfs')
+  })
+})
+
+describe('buildLfsEndpointUrl', () => {
+  it('builds the LFS base the client appends /objects/batch to', () => {
+    expect(buildLfsEndpointUrl('https://api.shogo.ai/', 'p1')).toBe(
+      'https://api.shogo.ai/api/projects/p1/git/info/lfs',
+    )
+  })
+})
+
+describe('isLfsEnabled', () => {
+  it('is true only for "true"/"1"', () => {
+    expect(isLfsEnabled({ LFS_ENABLED: 'true' } as any)).toBe(true)
+    expect(isLfsEnabled({ LFS_ENABLED: '1' } as any)).toBe(true)
+    expect(isLfsEnabled({ LFS_ENABLED: 'false' } as any)).toBe(false)
+    expect(isLfsEnabled({} as any)).toBe(false)
+  })
+})
+
+describe('buildManagedAttributesBlock', () => {
+  it('wraps curated patterns in managed markers', () => {
+    const block = buildManagedAttributesBlock()
+    expect(block).toContain('# >>> shogo git-lfs (managed) >>>')
+    expect(block).toContain('# <<< shogo git-lfs (managed) <<<')
+    expect(block).toContain('*.png filter=lfs diff=lfs merge=lfs -text')
+    expect(block).toContain('*.safetensors filter=lfs diff=lfs merge=lfs -text')
+  })
+})
+
+describe('writeManagedGitAttributes', () => {
+  let dir: string
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('creates .gitattributes with the managed block', () => {
+    dir = mkdtempSync(join(tmpdir(), 'lfs-attr-'))
+    writeManagedGitAttributes(dir)
+    const content = readFileSync(join(dir, '.gitattributes'), 'utf-8')
+    expect(content).toContain('*.mp4 filter=lfs diff=lfs merge=lfs -text')
+  })
+
+  it('preserves user content and is idempotent', () => {
+    dir = mkdtempSync(join(tmpdir(), 'lfs-attr-'))
+    const attrPath = join(dir, '.gitattributes')
+    writeFileSync(attrPath, '*.custom text\n')
+    writeManagedGitAttributes(dir)
+    writeManagedGitAttributes(dir) // second call must not duplicate the block
+    const content = readFileSync(attrPath, 'utf-8')
+    expect(content).toContain('*.custom text')
+    const markerCount = content.split('# >>> shogo git-lfs (managed) >>>').length - 1
+    expect(markerCount).toBe(1)
+  })
+})

--- a/packages/shared-runtime/src/git-sync.ts
+++ b/packages/shared-runtime/src/git-sync.ts
@@ -125,6 +125,14 @@ export interface GitWorkspaceSyncConfig {
    * retry/degrade path as a failed push.
    */
   afterCommit?: (sha: string) => Promise<void> | void
+  /**
+   * Optional hook run at the start of every push cycle, BEFORE `git add -A`.
+   * In Git LFS mode the agent-runtime wires this to `autoTrackLargeFiles` so
+   * newly-introduced large files are `git lfs track`-ed before staging and
+   * the clean filter writes pointers instead of raw bytes. Best-effort: a
+   * throw is logged and ignored so it can never block the commit/push.
+   */
+  beforeStage?: () => Promise<void> | void
 }
 
 export interface SpawnGitFn {
@@ -194,7 +202,7 @@ function buildGitUrl(cloudApiUrl: string, projectId: string): string {
 
 export class GitWorkspaceSync {
   private readonly cfg: Required<Omit<GitWorkspaceSyncConfig,
-    'onDegrade' | 'onRecovered' | 'logger' | 'spawnGit' | 'authorEmail' | 'authorName' | 'afterCommit'>> & {
+    'onDegrade' | 'onRecovered' | 'logger' | 'spawnGit' | 'authorEmail' | 'authorName' | 'afterCommit' | 'beforeStage'>> & {
     onDegrade: (reason: string) => void
     onRecovered: () => void
     logger: Logger
@@ -202,6 +210,7 @@ export class GitWorkspaceSync {
     authorEmail: string
     authorName: string
     afterCommit: ((sha: string) => Promise<void> | void) | null
+    beforeStage: (() => Promise<void> | void) | null
   }
 
   private debounceTimer: ReturnType<typeof setTimeout> | null = null
@@ -232,6 +241,7 @@ export class GitWorkspaceSync {
       authorEmail: config.authorEmail ?? 'agent-runtime@shogo.ai',
       authorName: config.authorName ?? 'Shogo Agent',
       afterCommit: config.afterCommit ?? null,
+      beforeStage: config.beforeStage ?? null,
     }
   }
 
@@ -351,6 +361,17 @@ export class GitWorkspaceSync {
     }
 
     try {
+      // LFS hook: track newly-introduced large files before staging so the
+      // clean filter writes pointers, not raw bytes. Best-effort — never let
+      // it block the commit/push.
+      if (this.cfg.beforeStage) {
+        try {
+          await this.cfg.beforeStage()
+        } catch (hookErr: any) {
+          logger.warn(`[GitWorkspaceSync] beforeStage hook threw: ${hookErr?.message ?? hookErr}`)
+        }
+      }
+
       // Stage everything (respects `.gitignore`).
       await this.runGit(spawnGit, ['add', '-A'], workspaceDir, commitEnv)
 
@@ -503,7 +524,7 @@ export function resolveCloudSyncMode(env: NodeJS.ProcessEnv = process.env): Clou
  */
 export function createGitSyncFromEnv(
   workspaceDir: string,
-  opts: Pick<GitWorkspaceSyncConfig, 'onDegrade' | 'onRecovered' | 'debounceMs' | 'degradeAfterFailures' | 'logger' | 'localOnly' | 'afterCommit'> = {},
+  opts: Pick<GitWorkspaceSyncConfig, 'onDegrade' | 'onRecovered' | 'debounceMs' | 'degradeAfterFailures' | 'logger' | 'localOnly' | 'afterCommit' | 'beforeStage'> = {},
 ): GitWorkspaceSync | null {
   const cloudApiUrl = process.env.SHOGO_API_URL
   const runtimeAuthSecret = process.env.RUNTIME_AUTH_SECRET

--- a/packages/shared-runtime/src/index.ts
+++ b/packages/shared-runtime/src/index.ts
@@ -53,7 +53,6 @@ export {
 } from './large-file-sync'
 
 export {
-  isLfsEnabled,
   lfsKeyPrefix,
   isValidLfsOid,
   lfsObjectKey,

--- a/packages/shared-runtime/src/index.ts
+++ b/packages/shared-runtime/src/index.ts
@@ -46,9 +46,29 @@ export {
   restoreLargeFiles,
   largeFileThreshold,
   largeFileSyncConfigFromEnv,
+  hasManagedExclude,
+  clearManagedExclude,
   DEFAULT_LARGE_FILE_BYTES,
   type LargeFileSyncConfig,
 } from './large-file-sync'
+
+export {
+  isLfsEnabled,
+  lfsKeyPrefix,
+  isValidLfsOid,
+  lfsObjectKey,
+  buildLfsEndpointUrl,
+  buildManagedAttributesBlock,
+  writeManagedGitAttributes,
+  ensureLfsRepoSetup,
+  autoTrackLargeFiles,
+  lfsPushAll,
+  lfsPull,
+  lfsRemoteConfigFromEnv,
+  migrateOffloadedAssetsToLfs,
+  DEFAULT_LFS_EXTENSIONS,
+  type LfsRemoteConfig,
+} from './lfs'
 
 export {
   initializePostgresBackup,

--- a/packages/shared-runtime/src/large-file-sync.ts
+++ b/packages/shared-runtime/src/large-file-sync.ts
@@ -180,6 +180,28 @@ function updateGitExclude(workspaceDir: string, relPaths: string[]): void {
 }
 
 /**
+ * Whether `.git/info/exclude` still carries the managed large-file block.
+ * Used as the "not yet migrated to Git LFS" marker for a project.
+ */
+export function hasManagedExclude(workspaceDir: string): boolean {
+  const excludePath = join(workspaceDir, '.git', 'info', 'exclude')
+  try {
+    return readFileSync(excludePath, 'utf-8').includes(MANAGED_EXCLUDE_HEADER)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Remove the managed large-file block from `.git/info/exclude` so the
+ * previously-offloaded files can be staged (and re-tracked via Git LFS).
+ * Part of the one-time LFS migration in `lfs.ts`.
+ */
+export function clearManagedExclude(workspaceDir: string): void {
+  updateGitExclude(workspaceDir, [])
+}
+
+/**
  * Sync the current large-file set to object storage: upload new/changed
  * assets, prune assets no longer present, and refresh the git-exclude
  * block. Best-effort — logs and continues on per-file errors.

--- a/packages/shared-runtime/src/lfs.ts
+++ b/packages/shared-runtime/src/lfs.ts
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Git LFS support for the pod-owned `git_only` model.
+ *
+ * Replaces the size-based S3 offload in `large-file-sync.ts` with real
+ * Git LFS: large files are tracked via `.gitattributes`, stored as tiny
+ * pointer blobs in the commit DAG, and their bytes are offloaded to OCI
+ * Object Storage through the API's LFS batch endpoint
+ * (`apps/api/src/routes/git-lfs.ts`).
+ *
+ * Division of labour:
+ *   - The POD has the `git-lfs` binary (see `Dockerfile.base`). It runs the
+ *     clean filter on `git add` (writing pointers + local objects), pushes
+ *     objects to OCI via `git lfs push`, and pulls them back on cold start.
+ *   - The API has NO `git-lfs` binary. It only mints presigned OCI URLs in
+ *     the batch response, so bytes flow pod<->OCI directly and the API's
+ *     hydrate/`reset --hard` path leaves pointer files untouched (the commit
+ *     graph still shows the files).
+ *
+ * Auth: every `git lfs` invocation passes the runtime bearer via
+ * `-c http.extraHeader=...` and the LFS endpoint via `-c lfs.url=...`, so
+ * neither the token nor an environment-specific URL is ever persisted into
+ * `.git/config` (which rides along in the durable `.git` tarball).
+ *
+ * Smudge is skipped globally in the pod image (`git lfs install --system
+ * --skip-smudge`): checkout/`reset --hard` leaves pointers (fast, no
+ * network), and the runtime materializes content deterministically with an
+ * explicit {@link lfsPull}.
+ */
+
+import { spawn } from 'child_process'
+import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+import {
+  classifyLargeFiles,
+  largeFileThreshold,
+  hasManagedExclude,
+  clearManagedExclude,
+} from './large-file-sync'
+
+type Logger = Pick<Console, 'log' | 'warn' | 'error'>
+
+const GIT_TIMEOUT_MS = 5 * 60 * 1000
+
+// ---------------------------------------------------------------------------
+// Feature flag + storage layout (shared API <-> pod contract)
+// ---------------------------------------------------------------------------
+
+/** Whether real Git LFS is enabled for this pod. */
+export function isLfsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.LFS_ENABLED === 'true' || env.LFS_ENABLED === '1'
+}
+
+/** Object-storage key prefix for LFS objects within a project namespace. */
+export function lfsKeyPrefix(env: NodeJS.ProcessEnv = process.env): string {
+  return (env.S3_LFS_PREFIX || 'lfs/objects').replace(/^\/+|\/+$/g, '')
+}
+
+/** A Git LFS oid is a lowercase sha256 hex digest. */
+export function isValidLfsOid(oid: string): boolean {
+  return /^[0-9a-f]{64}$/.test(oid)
+}
+
+/**
+ * Build the object-storage key for an LFS object, sharded by the first two
+ * byte-pairs of the oid (the same layout git-lfs uses on disk):
+ *   `<projectId>/lfs/objects/<oid[0:2]>/<oid[2:4]>/<oid>`
+ *
+ * Throws on an invalid oid so a malformed batch request can't escape the
+ * project's key namespace.
+ */
+export function lfsObjectKey(
+  projectId: string,
+  oid: string,
+  prefix: string = lfsKeyPrefix(),
+): string {
+  if (!isValidLfsOid(oid)) throw new Error(`invalid lfs oid: ${oid}`)
+  return `${projectId}/${prefix}/${oid.slice(0, 2)}/${oid.slice(2, 4)}/${oid}`
+}
+
+/**
+ * Derive the LFS server base URL from the cloud API root + project id. The
+ * git-lfs client appends `/objects/batch` (and `/objects/verify`) to this.
+ *
+ * We set this explicitly via `-c lfs.url=` rather than letting git-lfs guess
+ * it from the remote URL: our smart-HTTP remote ends in `/git` (not `.git`),
+ * which git-lfs would mangle into `.../git.git/info/lfs`.
+ */
+export function buildLfsEndpointUrl(cloudApiUrl: string, projectId: string): string {
+  const base = cloudApiUrl.replace(/\/+$/, '')
+  return `${base}/api/projects/${projectId}/git/info/lfs`
+}
+
+/** Smart-HTTP git URL for the project (used as the `cloud` remote). */
+function buildGitUrl(cloudApiUrl: string, projectId: string): string {
+  const base = cloudApiUrl.replace(/\/+$/, '')
+  return `${base}/api/projects/${projectId}/git`
+}
+
+// ---------------------------------------------------------------------------
+// .gitattributes management
+// ---------------------------------------------------------------------------
+
+const ATTR_HEADER = '# >>> shogo git-lfs (managed) >>>'
+const ATTR_FOOTER = '# <<< shogo git-lfs (managed) <<<'
+
+/**
+ * Curated set of binary-ish extensions tracked by Git LFS. Files outside
+ * this list that still exceed the size threshold are caught at sync time by
+ * {@link autoTrackLargeFiles} (preserving the legacy "anything large" rule).
+ */
+export const DEFAULT_LFS_EXTENSIONS: readonly string[] = [
+  // images
+  'png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'tif', 'tiff', 'ico', 'heic', 'avif', 'psd', 'ai',
+  // video
+  'mp4', 'mov', 'avi', 'mkv', 'webm', 'm4v',
+  // audio
+  'mp3', 'wav', 'flac', 'ogg', 'm4a', 'aac',
+  // archives
+  'zip', 'gz', 'tgz', 'bz2', 'xz', 'zst', '7z', 'rar',
+  // documents
+  'pdf',
+  // fonts
+  'ttf', 'otf', 'woff', 'woff2', 'eot',
+  // 3d / graphics
+  'glb', 'gltf', 'fbx', 'obj', 'blend',
+  // native / wasm
+  'wasm', 'so', 'dylib', 'dll', 'node',
+  // ml / data
+  'bin', 'onnx', 'pt', 'pth', 'h5', 'npy', 'npz', 'safetensors', 'gguf', 'parquet',
+]
+
+function attributeLineFor(ext: string): string {
+  return `*.${ext} filter=lfs diff=lfs merge=lfs -text`
+}
+
+/** The managed `.gitattributes` block (header + curated patterns + footer). */
+export function buildManagedAttributesBlock(): string {
+  return [ATTR_HEADER, ...DEFAULT_LFS_EXTENSIONS.map(attributeLineFor), ATTR_FOOTER].join('\n')
+}
+
+/**
+ * Write/refresh the Shogo-managed block in `<workspaceDir>/.gitattributes`,
+ * preserving any user-authored entries outside the markers. Idempotent.
+ */
+export function writeManagedGitAttributes(workspaceDir: string): void {
+  const attrPath = join(workspaceDir, '.gitattributes')
+  let existing = ''
+  try {
+    existing = readFileSync(attrPath, 'utf-8')
+  } catch {
+    existing = ''
+  }
+  const start = existing.indexOf(ATTR_HEADER)
+  if (start !== -1) {
+    const end = existing.indexOf(ATTR_FOOTER)
+    if (end !== -1) {
+      existing = existing.slice(0, start) + existing.slice(end + ATTR_FOOTER.length)
+    }
+  }
+  existing = existing.replace(/\n{3,}/g, '\n\n').trim()
+  const next = [existing, buildManagedAttributesBlock()].filter(Boolean).join('\n\n') + '\n'
+  writeFileSync(attrPath, next)
+}
+
+// ---------------------------------------------------------------------------
+// git invocation
+// ---------------------------------------------------------------------------
+
+interface GitResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+function runGit(args: string[], cwd: string, env?: NodeJS.ProcessEnv): Promise<GitResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('git', args, {
+      cwd,
+      env: { ...process.env, ...(env ?? {}) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    const out: string[] = []
+    const err: string[] = []
+    child.stdout.setEncoding('utf-8')
+    child.stderr.setEncoding('utf-8')
+    child.stdout.on('data', (c: string) => out.push(c))
+    child.stderr.on('data', (c: string) => err.push(c))
+    const timer = setTimeout(() => {
+      try { child.kill('SIGKILL') } catch { /* ignore */ }
+      reject(new Error(`git ${args.join(' ')} timed out after ${GIT_TIMEOUT_MS}ms`))
+    }, GIT_TIMEOUT_MS)
+    child.on('error', (e) => { clearTimeout(timer); reject(e) })
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve({ exitCode: code ?? -1, stdout: out.join(''), stderr: err.join('') })
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Repo setup (pod side, git_only + LFS_ENABLED only)
+// ---------------------------------------------------------------------------
+
+/**
+ * Configure `<workspaceDir>` for Git LFS: enable the per-repo filter with
+ * smudge skipped (content is materialized explicitly via {@link lfsPull}),
+ * and write the managed `.gitattributes`. Idempotent and best-effort — a
+ * failure here must never crash the pod, just disable LFS for the session.
+ */
+export async function ensureLfsRepoSetup(
+  workspaceDir: string,
+  opts: { logger?: Logger } = {},
+): Promise<boolean> {
+  const logger = opts.logger ?? console
+  if (!existsSync(join(workspaceDir, '.git'))) return false
+  try {
+    // `--local --skip-smudge` is belt-and-suspenders on top of the image's
+    // `git lfs install --system --skip-smudge`; it makes local dev (no system
+    // install) behave identically to production.
+    await runGit(['lfs', 'install', '--local', '--skip-smudge'], workspaceDir)
+    writeManagedGitAttributes(workspaceDir)
+    return true
+  } catch (err: any) {
+    logger.warn(`[lfs] repo setup failed: ${err?.message ?? err}`)
+    return false
+  }
+}
+
+/**
+ * Track any file larger than `thresholdBytes` that isn't already matched by
+ * an LFS pattern, by appending a path-specific rule to `.gitattributes`.
+ * Preserves the legacy "offload anything over the threshold" behavior for
+ * extensions outside {@link DEFAULT_LFS_EXTENSIONS}. Best-effort.
+ *
+ * Returns the number of newly-tracked paths.
+ */
+export async function autoTrackLargeFiles(
+  workspaceDir: string,
+  thresholdBytes: number = largeFileThreshold(),
+  opts: { logger?: Logger } = {},
+): Promise<number> {
+  const logger = opts.logger ?? console
+  if (!existsSync(join(workspaceDir, '.git'))) return 0
+  let tracked = 0
+  const candidates = classifyLargeFiles(workspaceDir, thresholdBytes)
+  for (const rel of candidates) {
+    const relPosix = rel.split(/[\\/]/).join('/')
+    try {
+      const attr = await runGit(['check-attr', 'filter', '--', relPosix], workspaceDir)
+      if (attr.stdout.includes(': filter: lfs')) continue // already LFS-tracked
+      const res = await runGit(['lfs', 'track', '--', relPosix], workspaceDir)
+      if (res.exitCode === 0) tracked++
+    } catch (err: any) {
+      logger.warn(`[lfs] auto-track failed for ${relPosix}: ${err?.message ?? err}`)
+    }
+  }
+  if (tracked) logger.log(`[lfs] auto-tracked ${tracked} large file(s) over ${thresholdBytes}B`)
+  return tracked
+}
+
+// ---------------------------------------------------------------------------
+// Migration off the legacy size-based offload (`large-file-sync.ts`)
+// ---------------------------------------------------------------------------
+
+/**
+ * One-time, idempotent migration of a project from the legacy `assets/`
+ * offload to Git LFS. The managed block in `.git/info/exclude` marks a
+ * not-yet-migrated project; once cleared, this is a no-op.
+ *
+ * Assumes the legacy assets have already been restored to disk (the boot
+ * sequence calls `restoreLargeFiles` first). We simply un-exclude them and
+ * LFS-track them; the next sync commits the pointers and {@link lfsPushAll}
+ * uploads the bytes. The S3 `assets/` copies are left in place for safety —
+ * a later GC pass can reclaim them.
+ *
+ * Best-effort: never throws.
+ */
+export async function migrateOffloadedAssetsToLfs(
+  workspaceDir: string,
+  opts: { thresholdBytes?: number; logger?: Logger } = {},
+): Promise<{ migrated: boolean; tracked: number }> {
+  const logger = opts.logger ?? console
+  if (!existsSync(join(workspaceDir, '.git'))) return { migrated: false, tracked: 0 }
+  if (!hasManagedExclude(workspaceDir)) return { migrated: false, tracked: 0 }
+  try {
+    clearManagedExclude(workspaceDir)
+    const tracked = await autoTrackLargeFiles(
+      workspaceDir,
+      opts.thresholdBytes ?? largeFileThreshold(),
+      { logger },
+    )
+    logger.log(`[lfs] migrated project off legacy asset offload (tracked=${tracked})`)
+    return { migrated: true, tracked }
+  } catch (err: any) {
+    logger.warn(`[lfs] asset migration failed: ${err?.message ?? err}`)
+    return { migrated: false, tracked: 0 }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Object transfer (push / pull) via the API LFS batch endpoint
+// ---------------------------------------------------------------------------
+
+export interface LfsRemoteConfig {
+  workspaceDir: string
+  cloudApiUrl: string
+  runtimeAuthSecret: string
+  projectId: string
+  /** Remote name to (idempotently) point at the smart-HTTP URL. Default `cloud`. */
+  remoteName?: string
+  logger?: Logger
+}
+
+/** Build an {@link LfsRemoteConfig} from the runtime env, or null when unset. */
+export function lfsRemoteConfigFromEnv(
+  workspaceDir: string,
+  logger?: Logger,
+): LfsRemoteConfig | null {
+  const cloudApiUrl = process.env.SHOGO_API_URL
+  const runtimeAuthSecret = process.env.RUNTIME_AUTH_SECRET
+  const projectId = process.env.PROJECT_ID
+  if (!cloudApiUrl || !runtimeAuthSecret || !projectId) return null
+  return { workspaceDir, cloudApiUrl, runtimeAuthSecret, projectId, logger }
+}
+
+/** Ensure a remote named `remoteName` points at the project's smart-HTTP URL. */
+async function ensureCloudRemote(cfg: LfsRemoteConfig): Promise<string> {
+  const remote = cfg.remoteName ?? 'cloud'
+  const url = buildGitUrl(cfg.cloudApiUrl, cfg.projectId)
+  const probe = await runGit(['remote', 'get-url', remote], cfg.workspaceDir)
+  if (probe.exitCode === 0) {
+    if (probe.stdout.trim() !== url) {
+      await runGit(['remote', 'set-url', remote, url], cfg.workspaceDir)
+    }
+  } else {
+    await runGit(['remote', 'add', remote, url], cfg.workspaceDir)
+  }
+  return remote
+}
+
+/** Per-invocation `-c` overrides: explicit LFS url + bearer auth (never persisted). */
+function lfsConfigArgs(cfg: LfsRemoteConfig): string[] {
+  const lfsUrl = buildLfsEndpointUrl(cfg.cloudApiUrl, cfg.projectId)
+  const header = `http.extraHeader=Authorization: Bearer ${cfg.runtimeAuthSecret}`
+  return ['-c', `lfs.url=${lfsUrl}`, '-c', header]
+}
+
+/**
+ * Upload all local LFS objects to OCI via the batch endpoint. The server
+ * dedups (objects it already has return no upload action), so re-running is
+ * cheap. Returns true on success; never throws (durability falls back to the
+ * `.git` tarball when this fails — see {@link persistRepoToStore}).
+ */
+export async function lfsPushAll(cfg: LfsRemoteConfig): Promise<boolean> {
+  const logger = cfg.logger ?? console
+  if (!existsSync(join(cfg.workspaceDir, '.git'))) return false
+  try {
+    const remote = await ensureCloudRemote(cfg)
+    const res = await runGit(
+      [...lfsConfigArgs(cfg), 'lfs', 'push', '--all', remote],
+      cfg.workspaceDir,
+    )
+    if (res.exitCode !== 0) {
+      logger.warn(`[lfs] push failed (${res.exitCode}): ${(res.stderr || '').slice(0, 400)}`)
+      return false
+    }
+    return true
+  } catch (err: any) {
+    logger.warn(`[lfs] push threw: ${err?.message ?? err}`)
+    return false
+  }
+}
+
+/**
+ * Fetch the LFS objects referenced by the current checkout and materialize
+ * them into the working tree (`git lfs pull` = fetch + checkout). Used on
+ * cold start after the `.git` tarball is restored. Best-effort.
+ */
+export async function lfsPull(cfg: LfsRemoteConfig): Promise<boolean> {
+  const logger = cfg.logger ?? console
+  if (!existsSync(join(cfg.workspaceDir, '.git'))) return false
+  try {
+    const remote = await ensureCloudRemote(cfg)
+    const res = await runGit(
+      [...lfsConfigArgs(cfg), 'lfs', 'pull', remote],
+      cfg.workspaceDir,
+    )
+    if (res.exitCode !== 0) {
+      logger.warn(`[lfs] pull failed (${res.exitCode}): ${(res.stderr || '').slice(0, 400)}`)
+      return false
+    }
+    return true
+  } catch (err: any) {
+    logger.warn(`[lfs] pull threw: ${err?.message ?? err}`)
+    return false
+  }
+}

--- a/packages/shared-runtime/src/lfs.ts
+++ b/packages/shared-runtime/src/lfs.ts
@@ -45,13 +45,8 @@ type Logger = Pick<Console, 'log' | 'warn' | 'error'>
 const GIT_TIMEOUT_MS = 5 * 60 * 1000
 
 // ---------------------------------------------------------------------------
-// Feature flag + storage layout (shared API <-> pod contract)
+// Storage layout (shared API <-> pod contract)
 // ---------------------------------------------------------------------------
-
-/** Whether real Git LFS is enabled for this pod. */
-export function isLfsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
-  return env.LFS_ENABLED === 'true' || env.LFS_ENABLED === '1'
-}
 
 /** Object-storage key prefix for LFS objects within a project namespace. */
 export function lfsKeyPrefix(env: NodeJS.ProcessEnv = process.env): string {
@@ -201,7 +196,7 @@ function runGit(args: string[], cwd: string, env?: NodeJS.ProcessEnv): Promise<G
 }
 
 // ---------------------------------------------------------------------------
-// Repo setup (pod side, git_only + LFS_ENABLED only)
+// Repo setup (pod side, git_only only)
 // ---------------------------------------------------------------------------
 
 /**

--- a/packages/shared-runtime/src/repo-store.ts
+++ b/packages/shared-runtime/src/repo-store.ts
@@ -209,10 +209,18 @@ export async function repoExistsInStore(cfg: RepoStoreConfig): Promise<boolean> 
 /**
  * Persist `<workspaceDir>/.git` to object storage. Called after each
  * local commit and at shutdown. No-op when `.git` is absent.
+ *
+ * In Git LFS mode the large object bytes live in their own object-storage
+ * namespace (`<projectId>/lfs/objects/...`, uploaded via `git lfs push`), so
+ * pass `excludeLfsObjects: true` to keep the local `.git/lfs/objects` cache
+ * OUT of the tarball and stop it bloating every hydrate. Callers should only
+ * set this once the LFS push has succeeded — otherwise the bytes would exist
+ * nowhere durable, so the safe fallback is to leave them in the tarball.
  */
 export async function persistRepoToStore(
   workspaceDir: string,
   cfg: RepoStoreConfig,
+  opts: { excludeLfsObjects?: boolean } = {},
 ): Promise<{ ok: boolean; changed: boolean; reason?: string }> {
   const logger = cfg.logger ?? console
   if (!existsSync(join(workspaceDir, '.git'))) {
@@ -221,7 +229,12 @@ export async function persistRepoToStore(
   const client = makeClient(cfg)
   const tmpFile = join(tmpdir(), `repo-${cfg.projectId}-${randomUUID()}.tar.gz`)
   try {
-    await run('tar', ['-czf', tmpFile, '-C', workspaceDir, '.git'])
+    // `--exclude` must precede the `.git` operand. Paths are matched as they
+    // appear in the archive (`.git/lfs/objects/...`).
+    const tarArgs = ['-czf', tmpFile, '-C', workspaceDir]
+    if (opts.excludeLfsObjects) tarArgs.push('--exclude=.git/lfs/objects')
+    tarArgs.push('.git')
+    await run('tar', tarArgs)
     await client.send(
       new PutObjectCommand({
         Bucket: cfg.bucket,

--- a/terraform/modules/object-storage/main.tf
+++ b/terraform/modules/object-storage/main.tf
@@ -107,8 +107,8 @@ resource "oci_objectstorage_bucket" "schemas" {
 # -----------------------------------------------------------------------------
 # Workspaces Sync Bucket (project file persistence)
 # -----------------------------------------------------------------------------
-# NOTE (Git LFS): when LFS_ENABLED is set on the app, Git LFS objects are
-# stored in THIS bucket under `<projectId>/lfs/objects/<oid>` (content-addressed
+# NOTE (Git LFS): git_only-mode pods store Git LFS objects in THIS bucket
+# under `<projectId>/lfs/objects/<oid>` (content-addressed
 # sha256), alongside repo.git.tar.gz and the legacy assets/ namespace. LFS
 # objects are immutable and never overwritten, so usage grows monotonically:
 # a reachability-based GC job (enumerate live pointer oids per project, delete

--- a/terraform/modules/object-storage/main.tf
+++ b/terraform/modules/object-storage/main.tf
@@ -107,6 +107,13 @@ resource "oci_objectstorage_bucket" "schemas" {
 # -----------------------------------------------------------------------------
 # Workspaces Sync Bucket (project file persistence)
 # -----------------------------------------------------------------------------
+# NOTE (Git LFS): when LFS_ENABLED is set on the app, Git LFS objects are
+# stored in THIS bucket under `<projectId>/lfs/objects/<oid>` (content-addressed
+# sha256), alongside repo.git.tar.gz and the legacy assets/ namespace. LFS
+# objects are immutable and never overwritten, so usage grows monotonically:
+# a reachability-based GC job (enumerate live pointer oids per project, delete
+# unreferenced objects) is a required follow-up before this is load-bearing.
+# Set S3_LFS_BUCKET on the app to split LFS into a dedicated bucket instead.
 resource "oci_objectstorage_bucket" "workspaces" {
   compartment_id = coalesce(var.workspaces_compartment_id, var.compartment_id)
   namespace      = local.namespace


### PR DESCRIPTION
## Summary
After the catalog-uuid migration, stored model references became opaque UUIDs that leaked into the super-admin UI (analytics, evals, cost optimizer, heartbeats) instead of human-readable model names. This resolves them back to display names end-to-end.

- **Registry resolvers** (`apps/api/src/services/model-registry.service.ts`):
  - `resolveModelLabelSync(id)` — in-memory best-effort label for hot paths.
  - `resolveModelLabels(ids)` — batch; awaits a refresh when stale, then one targeted `model_definitions` lookup for UUIDs missing from the enabled-only snapshot (e.g. admin-disabled models); unknown ids map to themselves.
  - `resolveModelLabel(id)` — single async wrapper.
  - Resolution order: `shortDisplayName → displayName → apiModel → raw id`, alias-aware.
- **Applied across API surfaces** that emitted raw ids: usage log/summary/spend timeseries, eval runs/history/comparison/export, cost agent-breakdown / recommendations (incl. ids embedded in prose) / experiments / sub-agent overrides / optimizer-in-action, and heartbeat configs. For actionable fields (e.g. `recommendedModel`) a sibling `*Label` field is added rather than overwriting the id, so logic is unaffected.
- **Frontend** prefers the server-provided `*Label` and falls back to client-side `resolveShortName`/`getModelDisplayName`, covering runtime-emitted surfaces the API can't resolve (project status, sub-agent badges).
- Switched the registry's catalog import to a namespace import with an empty-catalog fallback so partial test mocks degrade gracefully instead of failing the ESM link.

## Test plan
- [x] New resolver unit tests (9 cases: DB id, alias, static-catalog, identity fallback, batch, UUID DB-fallback, orphan UUID) — `model-registry.service.test.ts` passes 24/24.
- [x] Full `apps/api` isolated suite: `8184 pass` (exactly +9 vs baseline). The 6 remaining failures are pre-existing flaky parallel-contention false-positives (git-http / tunnel / local-fs / local-projects / runtime-manager) — confirmed identical at baseline with changes stashed (`8175 pass`, same 6 files).
- [x] Typecheck (`apps/api` + `apps/mobile`): zero errors in any changed file.
- [ ] Manual: verify super-admin analytics, eval dashboard, cost optimizer, and heartbeats display model names (not UUIDs) in production-like data.

Made with [Cursor](https://cursor.com)