### PR TITLE
fix(instances): ignore stale WS close so a reconnect flap can't evict…

### DIFF
--- a/apps/api/src/__tests__/instances-ws-handlers.test.ts
+++ b/apps/api/src/__tests__/instances-ws-handlers.test.ts
@@ -199,6 +199,67 @@ describe('instance WebSocket handlers', () => {
     expect(unregistered).toEqual(['inst-1'])
     expect(instanceUpdates[0]).toMatchObject({ where: { id: 'inst-1' }, data: { status: 'offline' } })
   })
+
+  test('close ignores a stale socket that was superseded by a newer connection', async () => {
+    // Reconnect-flap race: the first socket drops (1006) and the worker
+    // reconnects, but the old socket's close event is delivered AFTER the new
+    // socket has already taken over the registry. The stale close must NOT
+    // evict the live tunnel, drop Redis ownership, or flip the DB offline.
+    const oldWs = fakeWs({ instanceId: 'inst-1', workspaceId: 'ws-1' })
+    await handleInstanceWsOpen(oldWs)
+
+    const newWs = fakeWs({ instanceId: 'inst-1', workspaceId: 'ws-1' })
+    await handleInstanceWsOpen(newWs)
+
+    // The live registry entry now belongs to the new socket.
+    expect(_testing.tunnels.get('inst-1')!.ws).toBe(newWs)
+
+    // Only observe side effects produced by the stale close below.
+    instanceUpdates.length = 0
+    unregistered.length = 0
+
+    const logs: string[] = []
+    const originalLog = console.log
+    console.log = ((...args: unknown[]) => { logs.push(args.join(' ')) }) as typeof console.log
+    try {
+      handleInstanceWsClose(oldWs, 1006, 'Connection ended')
+    } finally {
+      console.log = originalLog
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // Live tunnel preserved.
+    expect(_testing.tunnels.has('inst-1')).toBe(true)
+    expect(_testing.tunnels.get('inst-1')!.ws).toBe(newWs)
+    // Redis ownership and DB status untouched by the stale close.
+    expect(unregistered).toEqual([])
+    expect(instanceUpdates).toEqual([])
+    // Close code/reason is logged for diagnosability.
+    expect(logs.some((line) => line.includes('stale WS close ignored') && line.includes('code=1006') && line.includes('reason=Connection ended'))).toBe(true)
+  })
+
+  test('close tears down the live socket and logs the close code/reason', async () => {
+    const ws = fakeWs({ instanceId: 'inst-1', workspaceId: 'ws-1' })
+    await handleInstanceWsOpen(ws)
+
+    instanceUpdates.length = 0
+    unregistered.length = 0
+
+    const logs: string[] = []
+    const originalLog = console.log
+    console.log = ((...args: unknown[]) => { logs.push(args.join(' ')) }) as typeof console.log
+    try {
+      handleInstanceWsClose(ws, 1000, 'Idle timeout')
+    } finally {
+      console.log = originalLog
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(_testing.tunnels.has('inst-1')).toBe(false)
+    expect(unregistered).toEqual(['inst-1'])
+    expect(instanceUpdates[0]).toMatchObject({ where: { id: 'inst-1' }, data: { status: 'offline' } })
+    expect(logs.some((line) => line.includes('disconnected') && line.includes('code=1000') && line.includes('reason=Idle timeout'))).toBe(true)
+  })
 })
 
 describe('authenticateInstanceWs', () => {

--- a/apps/api/src/routes/instances.ts
+++ b/apps/api/src/routes/instances.ts
@@ -357,11 +357,27 @@ export function handleInstanceWsMessage(ws: WebSocket & { data?: any }, raw: str
   }
 }
 
-export function handleInstanceWsClose(ws: WebSocket & { data?: any }) {
+export function handleInstanceWsClose(
+  ws: WebSocket & { data?: any },
+  code?: number,
+  reason?: string,
+) {
   const { instanceId } = ws.data || {}
   if (!instanceId) return
 
+  const closeInfo = `code=${code ?? 'none'} reason=${reason || 'none'}`
+
   const conn = tunnels.get(instanceId)
+
+  // Ignore a stale close: during a reconnect flap a newer socket may already
+  // own the registry entry, and tearing down here would evict the live tunnel.
+  if (conn && conn.ws !== ws) {
+    console.log(
+      `[RemoteControl] Instance ${instanceId} stale WS close ignored — superseded by a newer connection (${closeInfo})`,
+    )
+    return
+  }
+
   if (conn) {
     for (const [, pending] of conn.pendingRequests) {
       clearTimeout(pending.timeout)
@@ -384,7 +400,7 @@ export function handleInstanceWsClose(ws: WebSocket & { data?: any }) {
     data: { status: 'offline' },
   }).catch(() => {})
 
-  console.log(`[RemoteControl] Instance ${instanceId} disconnected`)
+  console.log(`[RemoteControl] Instance ${instanceId} disconnected (${closeInfo})`)
 }
 
 /**


### PR DESCRIPTION
## Description (Required)
Fixes a race in the on-demand tunnel that left self-hosted worker machines stuck "connecting" in the Remote Control picker.

When a worker's WebSocket drops abnormally (e.g. a 1006 close from the regional tunnel ingress) the worker reconnects. The new socket takes over the in-memory tunnel registry and re-registers Redis ownership, but the *old* socket's close event can be delivered afterwards. `handleInstanceWsClose` keyed teardown off `instanceId` alone, so that late close deleted the live tunnel entry, dropped Redis ownership, and flipped the DB row to `offline` — even though the worker still held an open, usable socket. The picker (which derives `online` from tunnel presence) then polled forever.

Changes:
- Only tear down on close when the closing socket is still the live registry entry (`conn.ws === ws`); ignore stale closes from superseded sockets.
- Log the WebSocket close `code`/`reason` (already forwarded by the server but previously discarded) for future diagnosability.

No behavior change for the normal single-socket connect/disconnect path. Scope is limited to the close handler.

## Related Issue (Required)
https://odin-ai.atlassian.net/browse/EN-3990

## Type of Change (Required)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring (no functional changes, no test changes)
- [ ] Added new tests

## How Has This Been Tested? (Required)
Added two regression tests in `apps/api/src/__tests__/instances-ws-handlers.test.ts`:
- `close ignores a stale socket that was superseded by a newer connection` — opens two sockets for the same instance, fires the *old* socket's close with `code=1006`, and asserts the live tunnel is preserved, Redis ownership is **not** unregistered, the DB is **not** marked offline, and the close code/reason is logged. (Fails against the previous handler.)
- `close tears down the live socket and logs the close code/reason` — confirms the normal close path still tears down and now logs `code`/`reason`.

Run:
bun test apps/api/src/tests/instances-ws-handlers.test.ts

Result: 8 pass, 0 fail. Full instances route suite (`instances-routes.test.ts` + `instances-ws-handlers.test.ts`) also green: 51 pass, 0 fail. No new lint errors.

