### PR TITLE
feat(publish): wire production-us for custom domains (gated, off by default)

### DIFF
--- a/docs/custom-domains.md
+++ b/docs/custom-domains.md
@@ -154,12 +154,30 @@ the feature on for staging:
 
 ### Production
 
-Production owns `shogo.one` outright but the same per-zone-singleton rule
-applies: pick a dedicated `custom_domains_zone` for production (it may be
-`shogo.one` itself only if production is the *sole* owner of that zone's SaaS
-config) and wire `production-us` the same way. The composite `oci-region`
-module does not yet forward `enable_custom_domains`; either call
-`publish-hosting-oci` directly or add the passthrough when enabling prod.
+Production owns `shogo.one` outright, but the same per-zone-singleton rule
+applies — and the module precondition **rejects** `custom_domains_zone ==
+shogo.one`, because a `*/*` route there would hijack every `*.shogo.one`
+published app plus the apex. So production also needs a dedicated zone.
+
+`production-us` is wired (gated, off by default): the `oci-region` composite
+forwards `enable_custom_domains` + `custom_domains_zone` to the publish
+submodule, and `k8s/overlays/production-us/api-service.yaml` carries the same
+inert `custom-domains-config` env block. To enable:
+
+1. Add a dedicated production custom-domains zone to Cloudflare.
+2. Set `enable_custom_domains = true` + `custom_domains_zone = "<that zone>"`
+   on the `production-us` env (tfvars / `TF_VAR_*` GH vars) and run
+   `terraform apply` for `production-us` via the Terraform workflow
+   (`workflow_dispatch`, prod approval required). Terraform is NOT applied by
+   the tag/deploy pipeline.
+3. Create the `custom-domains-config` secret in `shogo-production-system` from
+   the env outputs (`terraform output custom_domains_zone_id`,
+   `custom_domains_kv_namespace_id`, `custom_domain_fallback_origin`) + a
+   SaaS-scoped token, then restart the api.
+
+A `v*` tag only ships the (inert) code and runs the `custom_domains` migration;
+it does not enable the feature. EU/India serve published apps via the US
+worker, so custom domains run through production-us only.
 
 ## Notes & limits
 

--- a/k8s/overlays/production-us/api-service.yaml
+++ b/k8s/overlays/production-us/api-service.yaml
@@ -198,6 +198,48 @@ spec:
               value: "shogo-published-apps-production"
             - name: PUBLISH_DOMAIN
               value: "shogo.one"
+            # --- Custom domains (Cloudflare for SaaS) ----------------------
+            # Bring-your-own hostnames for published apps. INERT until the
+            # `custom-domains-config` secret exists in shogo-production-system:
+            # the helper (cloudflare-custom-hostnames.ts) returns null config
+            # when the token/zone are missing, so the API reports the feature
+            # disabled and the UI hides the panel. Populate the secret from the
+            # production-us terraform outputs AFTER applying with
+            # `enable_custom_domains = true` + a DEDICATED `custom_domains_zone`
+            # (NOT shogo.one — the module precondition enforces this; a `*/*`
+            # route on shogo.one would hijack every published app + the apex).
+            # Token needs SSL+Certificates:Edit on that zone and Workers KV
+            # Storage:Edit on the account. See docs/custom-domains.md.
+            - name: CF_CUSTOM_HOSTNAMES_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: custom-domains-config
+                  key: CF_CUSTOM_HOSTNAMES_TOKEN
+                  optional: true
+            - name: CF_CUSTOM_DOMAIN_ZONE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: custom-domains-config
+                  key: CF_CUSTOM_DOMAIN_ZONE_ID
+                  optional: true
+            - name: CF_ACCOUNT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: custom-domains-config
+                  key: CF_ACCOUNT_ID
+                  optional: true
+            - name: CF_CUSTOM_DOMAIN_KV_NAMESPACE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: custom-domains-config
+                  key: CF_CUSTOM_DOMAIN_KV_NAMESPACE_ID
+                  optional: true
+            - name: CUSTOM_DOMAIN_FALLBACK_ORIGIN
+              valueFrom:
+                secretKeyRef:
+                  name: custom-domains-config
+                  key: CUSTOM_DOMAIN_FALLBACK_ORIGIN
+                  optional: true
             - name: BETTER_AUTH_URL
               value: "https://studio.shogo.ai"
             # User-browser-reachable frontend URL used to build links in

--- a/terraform/environments/production-us/main.tf
+++ b/terraform/environments/production-us/main.tf
@@ -222,6 +222,11 @@ module "us" {
   # publish zone by name so no explicit zone_id is needed.
   enable_publish_hosting = true
   publish_zone           = null # defaults to publish_domain="shogo.one"
+
+  # Bring-your-own custom hostnames (Cloudflare for SaaS). Off until a
+  # DEDICATED zone (separate from shogo.one) is supplied — see variables.tf.
+  enable_custom_domains = var.enable_custom_domains
+  custom_domains_zone   = var.custom_domains_zone
 }
 
 # =============================================================================
@@ -302,3 +307,9 @@ output "rpc_eu_id" {
 output "rpc_india_id" {
   value = var.enable_drg_peering_to_india ? module.drg_to_india[0].rpc_id : null
 }
+
+# Custom domains (null unless enable_custom_domains=true). Feed these into the
+# `custom-domains-config` secret for the production-us api namespace.
+output "custom_domains_zone_id" { value = module.us.custom_domains_zone_id }
+output "custom_domains_kv_namespace_id" { value = module.us.custom_domains_kv_namespace_id }
+output "custom_domain_fallback_origin" { value = module.us.custom_domain_fallback_origin }

--- a/terraform/environments/production-us/variables.tf
+++ b/terraform/environments/production-us/variables.tf
@@ -38,6 +38,24 @@ variable "cloudflare_account_id" {
   type = string
 }
 
+# Custom domains (Cloudflare for SaaS). Left off by default: production owns
+# `shogo.one`, but the SaaS fallback origin + `*/*` worker route are per-zone
+# singletons and a `*/*` route on `shogo.one` would intercept every published
+# app + the apex. Enabling requires a DEDICATED zone (the module precondition
+# rejects `custom_domains_zone == shogo.one`). Set both, `terraform apply`, then
+# create the `custom-domains-config` secret from the outputs.
+variable "enable_custom_domains" {
+  description = "Enable Cloudflare for SaaS custom hostnames for production-us. Requires `custom_domains_zone` set to a dedicated zone (NOT shogo.one). Defaults to false."
+  type        = bool
+  default     = false
+}
+
+variable "custom_domains_zone" {
+  description = "Dedicated Cloudflare zone NAME for production custom hostnames. MUST differ from the shared `shogo.one` publish zone. Required when `enable_custom_domains` is true."
+  type        = string
+  default     = null
+}
+
 variable "signoz_endpoint" {
   type    = string
   default = "ingest.us.signoz.cloud:443"

--- a/terraform/modules/oci-region/main.tf
+++ b/terraform/modules/oci-region/main.tf
@@ -232,6 +232,12 @@ module "publish_hosting" {
   oci_region            = var.region
   tags                  = local.region_tags
 
+  # Bring-your-own custom hostnames (Cloudflare for SaaS). Gated + defaulted
+  # off; when enabled, requires a dedicated zone distinct from the (shared)
+  # publish zone — see the submodule for the per-zone-singleton rationale.
+  enable_custom_domains = var.enable_custom_domains
+  custom_domains_zone   = var.custom_domains_zone
+
   # OCI Object Storage's PAR API has eventual consistency against bucket
   # creation. Without this depends_on, terraform parallelizes the
   # published_apps bucket creation and the PAR creation, and the PAR

--- a/terraform/modules/oci-region/outputs.tf
+++ b/terraform/modules/oci-region/outputs.tf
@@ -118,6 +118,26 @@ output "file_system_export_path" {
 }
 
 # -----------------------------------------------------------------------------
+# Custom domains (Cloudflare for SaaS) — null unless enabled. `one()` collapses
+# the counted publish_hosting submodule to its single instance (or null).
+# -----------------------------------------------------------------------------
+
+output "custom_domains_zone_id" {
+  description = "Dedicated custom-domains zone id (null when disabled). Wire into the api ksvc as CF_CUSTOM_DOMAIN_ZONE_ID."
+  value       = one(module.publish_hosting[*].custom_domains_zone_id)
+}
+
+output "custom_domains_kv_namespace_id" {
+  description = "Workers KV namespace id for the custom-domain routing map (null when disabled). Wire into the api ksvc as CF_CUSTOM_DOMAIN_KV_NAMESPACE_ID."
+  value       = one(module.publish_hosting[*].custom_domains_kv_namespace_id)
+}
+
+output "custom_domain_fallback_origin" {
+  description = "Fallback-origin hostname customers CNAME at (null when disabled). Wire into the api ksvc as CUSTOM_DOMAIN_FALLBACK_ORIGIN."
+  value       = one(module.publish_hosting[*].custom_domain_fallback_origin)
+}
+
+# -----------------------------------------------------------------------------
 # Database connection info
 # For Tier 1: local CNPG (configured separately via K8s manifests)
 # For Tier 2: points to the primary region's database

--- a/terraform/modules/oci-region/variables.tf
+++ b/terraform/modules/oci-region/variables.tf
@@ -258,6 +258,18 @@ variable "enable_publish_hosting" {
   default     = null
 }
 
+variable "enable_custom_domains" {
+  description = "Forwarded to `publish-hosting-oci`: enable Cloudflare for SaaS bring-your-own custom hostnames. Defaults to false. Requires `custom_domains_zone` to be a DEDICATED zone (distinct from the publish zone, which is shared across environments). Only effective when publish-hosting is enabled for this region."
+  type        = bool
+  default     = false
+}
+
+variable "custom_domains_zone" {
+  description = "Forwarded to `publish-hosting-oci`: dedicated Cloudflare zone NAME for custom hostnames (e.g. a separate domain). MUST differ from the publish domain — the SaaS fallback origin + `*/*` worker route are per-zone singletons and the publish zone is shared. Ignored unless `enable_custom_domains`."
+  type        = string
+  default     = null
+}
+
 # -----------------------------------------------------------------------------
 # Autoscaler IAM
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Makes the custom-domains feature **enableable in production-us** (it was completely unwired). Everything stays **off by default** and inert.

- **`oci-region` module**: forwards `enable_custom_domains` + `custom_domains_zone` to the `publish-hosting-oci` submodule, and surfaces `custom_domains_zone_id` / `custom_domains_kv_namespace_id` / `custom_domain_fallback_origin` outputs (via `one(...)`, null when disabled).
- **`production-us` env**: new `enable_custom_domains` (default `false`) + `custom_domains_zone` (default `null`) variables, passed into `module "us"`, plus the three outputs for building the secret.
- **`k8s/overlays/production-us/api-service.yaml`**: inert `custom-domains-config` env block (optional `secretKeyRef`s in `shogo-production-system`) mirroring staging.
- **docs**: updated the Production section now that the passthrough exists.

## Why

A `v*` tag ships the (inert) feature code and runs the `custom_domains` migration, but does **not** enable the feature — terraform isn't applied by the deploy pipeline, the `oci-region` composite didn't forward the flag, and the prod overlay had no env. This PR closes the wiring gap so prod can be enabled deliberately.

The module precondition rejects `custom_domains_zone == shogo.one` (a `*/*` route on the shared publish zone would hijack every `*.shogo.one` published app + the apex), so production requires a **dedicated** zone — same per-zone-singleton constraint as staging.

## Enabling (manual, not via tag)

1. Add a dedicated production custom-domains zone to Cloudflare.
2. Set `enable_custom_domains = true` + `custom_domains_zone = "<that zone>"` and `terraform apply` `production-us` via the Terraform workflow (`workflow_dispatch`, prod approval).
3. Create the `custom-domains-config` secret in `shogo-production-system` from `terraform output` (+ a SaaS-scoped token), then restart the api.

## Not in scope / follow-ups

- EU/India overlays are not wired. They serve published apps via the US worker, so custom domains run through production-us only; a user geo-routed to EU/India would see the feature reported disabled until those overlays are wired to the same SaaS zone/secret.

## Test plan

- [ ] `terraform plan` production-us with the flags **unset** → no diff (defaults off; existing publish-hosting unchanged).
- [ ] `terraform plan` production-us with `enable_custom_domains=true` + a dedicated `custom_domains_zone` → creates KV ns, fallback origin/record, `*/*` route in the dedicated zone only.
- [ ] `terraform plan` with `custom_domains_zone = "shogo.one"` → precondition fails (expected).
- [ ] After enabling: `bun apps/api/scripts/validate-custom-domains.ts` against the prod zone passes; add a throwaway domain end-to-end → `active` + 200.

Made with [Cursor](https://cursor.com)