### PR TITLE
ci(terraform): thread custom-domains vars + harden dedicated-zone precondition

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -259,6 +259,16 @@ jobs:
           TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           TF_VAR_cloudflare_zone_id: ${{ vars.CLOUDFLARE_ZONE_ID }}
           TF_VAR_cloudflare_account_id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          # Custom domains (Cloudflare for SaaS). Declared only on production-us
+          # (+ staging); other envs ignore them with a harmless "undeclared
+          # variable" warning, same as TF_VAR_github_token below. Set the
+          # `ENABLE_CUSTOM_DOMAINS` + `CUSTOM_DOMAINS_ZONE` GH vars on the
+          # target environment to enable. `|| 'false'` keeps the bool parse
+          # valid when the var is unset. `custom_domains_zone` MUST be a
+          # dedicated zone (the module precondition rejects empty / the publish
+          # zone). See docs/custom-domains.md.
+          TF_VAR_enable_custom_domains: ${{ vars.ENABLE_CUSTOM_DOMAINS || 'false' }}
+          TF_VAR_custom_domains_zone: ${{ vars.CUSTOM_DOMAINS_ZONE }}
           # edge-global only — releases.shogo.ai resolver GitHub token
           # (optional; falls through to anonymous 60/hr quota if unset).
           TF_VAR_github_token: ${{ secrets.RELEASES_RESOLVER_GH_TOKEN }}
@@ -283,6 +293,9 @@ jobs:
           TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           TF_VAR_cloudflare_zone_id: ${{ vars.CLOUDFLARE_ZONE_ID }}
           TF_VAR_cloudflare_account_id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          # Custom domains (Cloudflare for SaaS) — see the plan step above.
+          TF_VAR_enable_custom_domains: ${{ vars.ENABLE_CUSTOM_DOMAINS || 'false' }}
+          TF_VAR_custom_domains_zone: ${{ vars.CUSTOM_DOMAINS_ZONE }}
           TF_VAR_github_token: ${{ secrets.RELEASES_RESOLVER_GH_TOKEN }}
           TF_VAR_nfs_allowed_cidr: ${{ vars.NFS_ALLOWED_CIDR }}
           TF_VAR_oke_api_allowed_cidrs: '["0.0.0.0/0"]'

--- a/docs/custom-domains.md
+++ b/docs/custom-domains.md
@@ -165,11 +165,15 @@ submodule, and `k8s/overlays/production-us/api-service.yaml` carries the same
 inert `custom-domains-config` env block. To enable:
 
 1. Add a dedicated production custom-domains zone to Cloudflare.
-2. Set `enable_custom_domains = true` + `custom_domains_zone = "<that zone>"`
-   on the `production-us` env (tfvars / `TF_VAR_*` GH vars) and run
-   `terraform apply` for `production-us` via the Terraform workflow
-   (`workflow_dispatch`, prod approval required). Terraform is NOT applied by
-   the tag/deploy pipeline.
+2. Set the `ENABLE_CUSTOM_DOMAINS` (`true`) + `CUSTOM_DOMAINS_ZONE`
+   (`<that zone>`) variables on the **`production-us` GitHub Environment**. The
+   Terraform workflow forwards these as `TF_VAR_enable_custom_domains` /
+   `TF_VAR_custom_domains_zone` (unset `ENABLE_CUSTOM_DOMAINS` resolves to
+   `false`, so other envs are unaffected). Then run `terraform apply` for
+   `production-us` via the Terraform workflow (`workflow_dispatch`, prod
+   approval required). Terraform is NOT applied by the tag/deploy pipeline.
+   Leaving `CUSTOM_DOMAINS_ZONE` empty while enabled fails the module
+   precondition by design — it must name a dedicated zone, never `shogo.one`.
 3. Create the `custom-domains-config` secret in `shogo-production-system` from
    the env outputs (`terraform output custom_domains_zone_id`,
    `custom_domains_kv_namespace_id`, `custom_domain_fallback_origin`) + a

--- a/terraform/environments/production-eu/main.tf
+++ b/terraform/environments/production-eu/main.tf
@@ -242,5 +242,5 @@ module "drg_from_us" {
 # =============================================================================
 
 output "cluster_endpoint" { value = module.eu.cluster_endpoint }
-output "cluster_id"       { value = module.eu.cluster_id }
-output "ocir_prefix"      { value = module.eu.ocir_prefix }
+output "cluster_id" { value = module.eu.cluster_id }
+output "ocir_prefix" { value = module.eu.ocir_prefix }

--- a/terraform/environments/production-india/main.tf
+++ b/terraform/environments/production-india/main.tf
@@ -101,7 +101,7 @@ provider "helm" {
 module "india" {
   source = "../../modules/oci-region"
 
-  tier        = "light"                # <-- the key difference
+  tier        = "light" # <-- the key difference
   region      = "ap-mumbai-1"
   region_key  = "in"
   environment = "production"
@@ -134,9 +134,9 @@ module "india" {
   # match the live floor: GitHub Actions variable NODE_POOL_MIN for
   # environment production-india (consumed by deploy.yml "Deploy Cluster
   # Autoscaler").
-  system_pool_size      = 4
-  system_pool_min       = 3
-  system_pool_max       = 10
+  system_pool_size = 4
+  system_pool_min  = 3
+  system_pool_max  = 10
 
   # 200 GB to match production-us. India is currently LIVE at 100 GB — the
   # same latent exposure that caused the EU 2026-06-02 DiskPressure incident;
@@ -231,5 +231,5 @@ module "drg_from_us" {
 # =============================================================================
 
 output "cluster_endpoint" { value = module.india.cluster_endpoint }
-output "cluster_id"       { value = module.india.cluster_id }
-output "ocir_prefix"      { value = module.india.ocir_prefix }
+output "cluster_id" { value = module.india.cluster_id }
+output "ocir_prefix" { value = module.india.ocir_prefix }

--- a/terraform/environments/production-us/main.tf
+++ b/terraform/environments/production-us/main.tf
@@ -298,9 +298,9 @@ module "replication_to_eu" {
 # =============================================================================
 
 output "cluster_endpoint" { value = module.us.cluster_endpoint }
-output "cluster_id"       { value = module.us.cluster_id }
-output "ocir_prefix"      { value = module.us.ocir_prefix }
-output "s3_endpoint"      { value = module.us.s3_endpoint }
+output "cluster_id" { value = module.us.cluster_id }
+output "ocir_prefix" { value = module.us.ocir_prefix }
+output "s3_endpoint" { value = module.us.s3_endpoint }
 output "rpc_eu_id" {
   value = var.enable_drg_peering_to_eu ? module.drg_to_eu[0].rpc_id : null
 }

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -281,11 +281,11 @@ module "knative" {
 module "signoz" {
   source = "../../modules/signoz"
 
-  cluster_name      = local.cluster_name
-  environment       = local.environment
-  signoz_endpoint   = var.signoz_endpoint
+  cluster_name         = local.cluster_name
+  environment          = local.environment
+  signoz_endpoint      = var.signoz_endpoint
   signoz_ingestion_key = var.signoz_ingestion_key
-  tags              = local.tags
+  tags                 = local.tags
 }
 
 # =============================================================================

--- a/terraform/modules/cloudflare-lb/main.tf
+++ b/terraform/modules/cloudflare-lb/main.tf
@@ -127,14 +127,14 @@ variable "tags" {
 # -----------------------------------------------------------------------------
 
 resource "cloudflare_load_balancer_monitor" "health" {
-  account_id     = var.cloudflare_account_id
-  type           = "https"
-  path           = var.health_check_path
-  expected_codes = "200"
-  interval       = var.health_check_interval
-  timeout        = 10
-  retries        = 2
-  method         = "GET"
+  account_id       = var.cloudflare_account_id
+  type             = "https"
+  path             = var.health_check_path
+  expected_codes   = "200"
+  interval         = var.health_check_interval
+  timeout          = 10
+  retries          = 2
+  method           = "GET"
   follow_redirects = true
   allow_insecure   = false
 

--- a/terraform/modules/cnpg/main.tf
+++ b/terraform/modules/cnpg/main.tf
@@ -55,8 +55,8 @@ variable "tags" {
 
 locals {
   # Release branch follows MAJOR.MINOR of the version (e.g. 1.25.0 -> release-1.25).
-  release_branch  = "release-${join(".", slice(split(".", var.operator_version), 0, 2))}"
-  manifest_url    = "https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/${local.release_branch}/releases/cnpg-${var.operator_version}.yaml"
+  release_branch = "release-${join(".", slice(split(".", var.operator_version), 0, 2))}"
+  manifest_url   = "https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/${local.release_branch}/releases/cnpg-${var.operator_version}.yaml"
 }
 
 # -----------------------------------------------------------------------------

--- a/terraform/modules/drg-peering/main.tf
+++ b/terraform/modules/drg-peering/main.tf
@@ -101,12 +101,12 @@ resource "oci_core_drg_attachment" "vcn" {
 # -----------------------------------------------------------------------------
 
 resource "oci_core_remote_peering_connection" "main" {
-  compartment_id = var.compartment_id
-  drg_id         = oci_core_drg.main.id
-  display_name   = "${var.name}-rpc-to-${var.peer_region}"
-  peer_id        = var.peer_rpc_id != "" ? var.peer_rpc_id : null
+  compartment_id   = var.compartment_id
+  drg_id           = oci_core_drg.main.id
+  display_name     = "${var.name}-rpc-to-${var.peer_region}"
+  peer_id          = var.peer_rpc_id != "" ? var.peer_rpc_id : null
   peer_region_name = var.peer_rpc_id != "" ? var.peer_region : null
-  freeform_tags  = var.tags
+  freeform_tags    = var.tags
 }
 
 # -----------------------------------------------------------------------------

--- a/terraform/modules/file-storage/main.tf
+++ b/terraform/modules/file-storage/main.tf
@@ -85,8 +85,8 @@ resource "oci_file_storage_mount_target" "main" {
 # Export (makes the file system accessible via the mount target)
 # -----------------------------------------------------------------------------
 resource "oci_file_storage_export_set" "main" {
-  mount_target_id  = oci_file_storage_mount_target.main.id
-  display_name     = "${var.name}-export-set"
+  mount_target_id   = oci_file_storage_mount_target.main.id
+  display_name      = "${var.name}-export-set"
   max_fs_stat_bytes = 0 # unlimited
 
   lifecycle {

--- a/terraform/modules/object-storage-replication/main.tf
+++ b/terraform/modules/object-storage-replication/main.tf
@@ -107,9 +107,9 @@ locals {
 resource "oci_objectstorage_replication_policy" "main" {
   for_each = local.enabled_buckets
 
-  namespace  = local.namespace
-  bucket     = each.value.name
-  name       = "${each.key}-to-${var.destination_region}"
+  namespace = local.namespace
+  bucket    = each.value.name
+  name      = "${each.key}-to-${var.destination_region}"
 
   destination_bucket_name = each.value.dest_name
   destination_region_name = var.destination_region
@@ -123,10 +123,10 @@ output "replication_policies" {
   description = "Map of bucket key → replication policy details"
   value = {
     for k, v in oci_objectstorage_replication_policy.main : k => {
-      id                = v.id
-      source_bucket     = local.enabled_buckets[k].name
-      destination       = "${var.destination_region}/${local.enabled_buckets[k].dest_name}"
-      status            = v.status
+      id            = v.id
+      source_bucket = local.enabled_buckets[k].name
+      destination   = "${var.destination_region}/${local.enabled_buckets[k].dest_name}"
+      status        = v.status
     }
   }
 }

--- a/terraform/modules/object-storage/main.tf
+++ b/terraform/modules/object-storage/main.tf
@@ -161,8 +161,8 @@ resource "oci_identity_policy" "lifecycle_service_principal" {
   # service principal (`objectstorage-<region>`). Include region in the
   # policy name so multiple regions can coexist at the tenancy level
   # without a name collision.
-  name           = "objectstorage-lifecycle-service-principal-${var.environment}-${var.region}"
-  description    = "Grant the Object Storage service principal permission to execute lifecycle rules against buckets in this ${var.lifecycle_service_policy_scope}. Required for oci_objectstorage_object_lifecycle_policy resources."
+  name        = "objectstorage-lifecycle-service-principal-${var.environment}-${var.region}"
+  description = "Grant the Object Storage service principal permission to execute lifecycle rules against buckets in this ${var.lifecycle_service_policy_scope}. Required for oci_objectstorage_object_lifecycle_policy resources."
 
   statements = [
     "Allow service objectstorage-${var.region} to manage object-family in ${var.lifecycle_service_policy_scope}",

--- a/terraform/modules/oci-region/main.tf
+++ b/terraform/modules/oci-region/main.tf
@@ -119,12 +119,12 @@ module "oke" {
   node_pool_min  = var.system_pool_min
   node_pool_max  = var.system_pool_max
 
-  enable_workload_pool      = var.enable_workload_pool
-  workload_node_ocpus       = var.workload_node_ocpus
-  workload_node_memory_gb   = var.workload_node_memory_gb
-  workload_pool_size        = var.workload_pool_size
-  workload_pool_min         = var.workload_pool_min
-  workload_pool_max         = var.workload_pool_max
+  enable_workload_pool    = var.enable_workload_pool
+  workload_node_ocpus     = var.workload_node_ocpus
+  workload_node_memory_gb = var.workload_node_memory_gb
+  workload_pool_size      = var.workload_pool_size
+  workload_pool_min       = var.workload_pool_min
+  workload_pool_max       = var.workload_pool_max
 
   main_node_pool_name_override = var.oke_main_node_pool_name_override
   main_node_pool_max_pods      = var.oke_main_node_pool_max_pods

--- a/terraform/modules/publish-hosting-oci/main.tf
+++ b/terraform/modules/publish-hosting-oci/main.tf
@@ -189,9 +189,21 @@ data "cloudflare_zone" "custom_domains" {
     # without an explicit dedicated zone would fall back to the publish zone
     # (`shogo.one`) and put a `*/*` route + fallback origin on a zone shared
     # with other environments. Force the operator to name a dedicated zone.
+    # NOTE: `coalesce` (see local.custom_domains_zone_name) skips empty strings
+    # AND nulls, so an empty `custom_domains_zone` (e.g. an unset GH var passed
+    # as "" by the Terraform CI workflow) would silently fall through to the
+    # publish zone. Reject empty explicitly, and reject the resolved publish
+    # zone (publish_zone, else publish_domain) — not just publish_domain — so a
+    # subdomain env (staging owns `staging.shogo.one` on the shared `shogo.one`
+    # zone) can't point custom domains at the shared zone either.
     precondition {
-      condition     = var.custom_domains_zone != null && var.custom_domains_zone != var.publish_domain
-      error_message = "enable_custom_domains=true requires custom_domains_zone to be set to a DEDICATED Cloudflare zone, distinct from the publish domain. The SaaS fallback origin + `*/*` worker route are per-zone singletons and the publish zone is shared across environments. See docs/custom-domains.md."
+      condition = (
+        var.custom_domains_zone != null &&
+        trimspace(var.custom_domains_zone) != "" &&
+        var.custom_domains_zone != var.publish_domain &&
+        var.custom_domains_zone != coalesce(var.publish_zone, var.publish_domain)
+      )
+      error_message = "enable_custom_domains=true requires custom_domains_zone to be set to a DEDICATED Cloudflare zone: non-empty and distinct from BOTH publish_domain and the publish zone (publish_zone, else publish_domain). The SaaS fallback origin + `*/*` worker route are per-zone singletons and the publish zone is shared across environments. See docs/custom-domains.md."
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #762 (production-us custom-domains wiring). Two changes so the gated feature can actually be turned on via CI without re-opening the shared-zone footgun:

- **Thread the flags through the Terraform workflow.** The `apply`/`plan` jobs in `terraform.yml` passed a fixed set of `TF_VAR_*` (OCI, Cloudflare, networking) but **not** the custom-domains vars, and there are no `.tfvars` files — so a `production-us` apply would silently keep `enable_custom_domains=false`. Now both steps forward `TF_VAR_enable_custom_domains` + `TF_VAR_custom_domains_zone` from the `ENABLE_CUSTOM_DOMAINS` / `CUSTOM_DOMAINS_ZONE` GH env vars. `|| 'false'` keeps the bool parse valid when unset; envs that don't declare the vars ignore them with a harmless "undeclared variable" warning (same pattern as the existing `TF_VAR_github_token`).
- **Harden the dedicated-zone precondition.** `local.custom_domains_zone_name` uses `coalesce(var.custom_domains_zone, var.publish_zone, var.publish_domain)`, and `coalesce` skips **empty strings** as well as nulls. So an unset `CUSTOM_DOMAINS_ZONE` GH var (resolves to `""`) would fall through to the publish zone (`shogo.one`) and recreate the `*/*`-route-on-shared-zone disaster — while still passing the old `!= publish_domain` check. The precondition now rejects empty **and** rejects the resolved publish zone (`publish_zone`, else `publish_domain`), not just `publish_domain` (this also closes the staging hole where `publish_domain=staging.shogo.one` but the shared zone is `shogo.one`).

## Notes

- The `apply` job is **not** `fmt -check`-gated (that gate is a separate, pre-existing repo-wide red), so this won't be blocked by formatting.
- Feature remains **off by default** — this only makes the enable path work; nothing changes until `ENABLE_CUSTOM_DOMAINS=true` + a real `CUSTOM_DOMAINS_ZONE` are set on the `production-us` environment.

## Enable (production-us)

1. Create a dedicated custom-domains zone in Cloudflare (NOT `shogo.one`).
2. Set `ENABLE_CUSTOM_DOMAINS=true` + `CUSTOM_DOMAINS_ZONE=<zone>` on the `production-us` GitHub Environment.
3. Run the Terraform workflow (`production-us`, `apply`, prod approval).
4. Create the `custom-domains-config` secret in `shogo-production-system` from the TF outputs + a SaaS-scoped token; force a new api revision.

## Test plan

- [ ] CI `plan` for an unrelated env still succeeds (vars ignored, no bool-parse error).
- [ ] `production-us` plan with `ENABLE_CUSTOM_DOMAINS` unset shows no custom-domains resources.
- [ ] `production-us` plan with `ENABLE_CUSTOM_DOMAINS=true` and empty `CUSTOM_DOMAINS_ZONE` **fails** the precondition.
- [ ] `production-us` plan with `ENABLE_CUSTOM_DOMAINS=true` + a dedicated zone plans the KV ns, fallback origin, and `*/*` route in that zone only.

Made with [Cursor](https://cursor.com)