### PR TITLE
chore(composio): upgrade @composio/core 0.6.5 → 0.10.0 (resolve tools at latest version)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,7 +21,7 @@
     "@aws-sdk/client-ses": "^3.700.0",
     "@aws-sdk/s3-request-presigner": "^3.700.0",
     "@better-auth/expo": "^1.4.19",
-    "@composio/core": "^0.6.5",
+    "@composio/core": "^0.10.0",
     "@kubernetes/client-node": "^1.4.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.213.0",

--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -163,7 +163,9 @@ function getComposio(): Composio | null {
   if (composioClient) return composioClient
   const apiKey = process.env.COMPOSIO_API_KEY
   if (!apiKey) return null
-  composioClient = new Composio({ apiKey })
+  // Pin 'latest' so toolkit/connection listings match the agent-runtime's
+  // execute-time resolution (see packages/agent-runtime/src/composio.ts).
+  composioClient = new Composio({ apiKey, toolkitVersions: 'latest' })
   return composioClient
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,7 @@
         "@aws-sdk/client-ses": "^3.700.0",
         "@aws-sdk/s3-request-presigner": "^3.700.0",
         "@better-auth/expo": "^1.4.19",
-        "@composio/core": "^0.6.5",
+        "@composio/core": "^0.10.0",
         "@kubernetes/client-node": "^1.4.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.213.0",
@@ -225,7 +225,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.700.0",
-        "@composio/core": "^0.6.5",
+        "@composio/core": "^0.10.0",
         "@hono/node-server": "^1.13.1",
         "@kubernetes/client-node": "^1.4.0",
         "@mariozechner/pi-agent-core": "^0.73.1",
@@ -1539,9 +1539,9 @@
 
     "@codemirror/view": ["@codemirror/view@6.43.0", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA=="],
 
-    "@composio/client": ["@composio/client@0.1.0-alpha.61", "", {}, "sha512-VSU20mTtMe0TIPHkBBRdCU4IYSy3886U9O69PURU8+ItLXCD2MjIN0S8VTDL8wpA4zFXamUFnvtwQyow11O2KA=="],
+    "@composio/client": ["@composio/client@0.1.0-alpha.72", "", {}, "sha512-2WYXgdlMvhoaJCsaSfyMAYGQ2tS5l2Fqdh2cMRqNi8NybIoOkFZy2ApBJJOoQwqfpUr41VymMW6FtiNQm7JavQ=="],
 
-    "@composio/core": ["@composio/core@0.6.5", "", { "dependencies": { "@composio/client": "0.1.0-alpha.61", "@composio/json-schema-to-zod": "0.1.20", "@types/json-schema": "^7.0.15", "chalk": "^4.1.2", "openai": "^6.16.0", "pusher-js": "^8.4.0", "semver": "^7.7.2", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-BHaw60KFkza5PDJDGG2ATaYlwaH5D4VhQinRYo5wLmqjiI/mdnzzXRYatsn24WTaakdqNrf3jY5sQ2WIyex6Ow=="],
+    "@composio/core": ["@composio/core@0.10.0", "", { "dependencies": { "@composio/client": "0.1.0-alpha.72", "@composio/json-schema-to-zod": "0.1.20", "@types/json-schema": "^7.0.15", "chalk": "^4.1.2", "openai": "^6.16.0", "pusher-js": "^8.4.0", "semver": "^7.7.2", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-dG2BKF4NRiE8HHDzWLLgjMMo3FU4NJ6SxR961EpdLWWEKhkl+yP/mZlIN7p/4WnCR/fuDBKH1Qh+7kBdcHmEHA=="],
 
     "@composio/json-schema-to-zod": ["@composio/json-schema-to-zod@0.1.20", "", { "peerDependencies": { "zod": ">=3.25.76 <5" } }, "sha512-d4V34itLrUWG/VBh7ciznKcxF/T22MBLHmuEzHoX0zsBOHsUmjYz5qtDh20S2p3FE+HHvLZxpXiv8yfdd4yI+Q=="],
 
@@ -5854,8 +5854,6 @@
     "@babel/preset-flow/@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
 
     "@babel/preset-flow/@babel/plugin-transform-flow-strip-types": ["@babel/plugin-transform-flow-strip-types@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7", "@babel/plugin-syntax-flow": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-wRHeUjUjCZnMHmiO5bRgjFLcoEh7JyTdByOW11ahhwNa4V0bmeGEaIvt51yq0zQp2yWIpqfxXXPyUP6GFJZHOQ=="],
-
-    "@composio/core/openai": ["openai@6.25.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-mEh6VZ2ds2AGGokWARo18aPISI1OhlgdEIC1ewhkZr8pSIT31dec0ecr9Nhxx0JlybyOgoAT1sWeKtwPZzJyww=="],
 
     "@composio/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.700.0",
-    "@composio/core": "^0.6.5",
+    "@composio/core": "^0.10.0",
     "@hono/node-server": "^1.13.1",
     "@kubernetes/client-node": "^1.4.0",
     "@mariozechner/pi-agent-core": "^0.73.1",

--- a/packages/agent-runtime/src/composio-auto-bind.ts
+++ b/packages/agent-runtime/src/composio-auto-bind.ts
@@ -93,6 +93,11 @@ export async function fetchComposioToolSchemas(
     const params = new URLSearchParams({
       toolkit_slug: toolkitSlug,
       limit: String(pageLimit),
+      // Match the SDK's execute-time resolution (toolkitVersions: 'latest').
+      // Without this the v3 endpoint defaults to the base version `00000000_00`
+      // and returns only initial-release tools, so we'd bind a stale subset that
+      // mismatches what `tools.execute` can actually run against.
+      toolkit_versions: 'latest',
     })
     if (options?.important) params.set('important', 'true')
     if (cursor) params.set('cursor', cursor)

--- a/packages/agent-runtime/src/composio.ts
+++ b/packages/agent-runtime/src/composio.ts
@@ -248,8 +248,13 @@ function getComposioClient(): Composio | null {
   const proxyUrl = process.env.TOOLS_PROXY_URL
   const proxyToken = process.env.AI_PROXY_TOKEN
 
+  // Resolve tools/execution against the latest toolkit version. Under SDK 0.6.x
+  // (API v3) the default was the base pinned version `00000000_00`, which only
+  // contains a toolkit's initial-release tools — so newer slugs 404'd at execute
+  // ("Tool X not found" / "Unable to retrieve tool with slug"). SDK 0.10 + API
+  // v3.1 default to `latest`; we pin it explicitly so the behavior is obvious.
   if (apiKey) {
-    composioClient = new Composio({ apiKey })
+    composioClient = new Composio({ apiKey, toolkitVersions: 'latest' })
     console.log('[Composio] Client initialized (direct)')
     return composioClient
   }
@@ -258,6 +263,7 @@ function getComposioClient(): Composio | null {
     composioClient = new Composio({
       apiKey: proxyToken,
       baseURL: `${proxyUrl}/composio`,
+      toolkitVersions: 'latest',
     })
     console.log('[Composio] Client initialized (via proxy)')
     return composioClient

--- a/packages/agent-runtime/src/evals/composio-auto-bind.test.ts
+++ b/packages/agent-runtime/src/evals/composio-auto-bind.test.ts
@@ -64,10 +64,21 @@ describe('fetchComposioToolSchemas', () => {
     expect(out.properties.successful).toBeDefined()
     expect(out.properties.error).toBeDefined()
 
-    // The list tool should have data.items array
-    const dataProps = (out.properties.data as { properties: Record<string, unknown> }).properties
-    expect(dataProps.items).toBeDefined()
-    expect((dataProps.items as { type?: string }).type).toBe('array')
+    // The `data` wrapper holds the structured response. Newer toolkit versions
+    // (resolved via toolkit_versions=latest) express it as a $ref into $defs
+    // (e.g. EventsListResponse) rather than an inline `{ items: { type: array } }`,
+    // so assert the wrapper is a structured schema rather than a specific shape.
+    const data = out.properties.data as {
+      $ref?: string
+      type?: string
+      properties?: Record<string, unknown>
+    }
+    const isStructured =
+      typeof data.$ref === 'string' ||
+      data.type === 'object' ||
+      data.type === 'array' ||
+      (data.properties != null && Object.keys(data.properties).length > 0)
+    expect(isStructured).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Summary

Upgrades the Composio SDK to the latest (`0.6.5 → 0.10.0`) and fixes the root cause of the production **"tool not found" / "unable to retrieve tool with slug"** failures.

**Root cause:** Under SDK 0.6.x (API v3) the default toolkit version is the base pinned `00000000_00`, which only contains a toolkit's *initial-release* tools. Both the `GET /tools` listing and `tools.execute` resolved against that base version, so any slug added in a later toolkit version 404'd at execute time even though it was a real, connected tool. This matches upstream issues [#3290](https://github.com/ComposioHQ/composio/issues/3290) and [#2471](https://github.com/ComposioHQ/composio/issues/2471) (fixed in [PR #2518](https://github.com/ComposioHQ/composio/pull/2518)).

## Changes
- Bump `@composio/core` to `^0.10.0` in `agent-runtime` and `api`.
- Initialize the SDK with `toolkitVersions: 'latest'` (runtime + api); keep `dangerouslySkipVersionCheck: true` on execute (required by 0.10 when the resolved version is `latest`).
- Resolve the raw `GET /tools` schema fetch with `toolkit_versions=latest` so the bound proxy-tool set matches what `execute` can run.
- Update the live schema-shape test (latest versions express `data` via `$ref` into `$defs` rather than inline `{ items: array }`).

No webhook-verification or Mastra usage (the only TS breaking changes in this SDK range), so the upgrade is otherwise drop-in.

## Validation (live against prod Composio key, read-only)
- Schema fetch returns the full catalog: **shopify 28 → 394**, **github 823 → 867** tools.
- Previously-failing valid slugs (`SHOPIFY_GET_PRODUCT`, `JIRA_LIST_SPRINTS`, `GITHUB_LIST_PULL_REQUESTS`) now **resolve** (downstream 400, no longer 404).
- A genuine catalog phantom (`SHOPIFY_GET_PRODUCTS_COUNT`) and agent-invented slugs (`GITHUB_LIST_REPOSITORY_PULL_REQUESTS`) correctly remain 404.
- Composio unit suites green (88 pass + 13 pass).

## Relationship to the resilience PR
This is complementary to `fix/production-failure-fixes` (retry/classify/registration-repair). This PR removes the dominant *version-skew* not-found class at the source; the resilience layer still covers the true phantoms and any residual Composio-side transients.

## Test plan
- [ ] CI green
- [ ] Smoke a couple of live integrations (GitHub/Shopify) end-to-end in staging after connecting an account
- [ ] Confirm no regression in the integrations UI toolkit/connection listings

Made with [Cursor](https://cursor.com)