### PR TITLE
feat(admin): split analytics into Marketing and AI/engineering pages

### DIFF
--- a/apps/api/src/__tests__/admin-scoped-access.test.ts
+++ b/apps/api/src/__tests__/admin-scoped-access.test.ts
@@ -21,6 +21,8 @@ const superAdmin = { id: 'a', role: 'super_admin', adminScopes: [] as string[] }
 const analyticsAdmin = { id: 'b', role: 'user', adminScopes: ['analytics:read'] }
 const creatorsAdmin = { id: 'c', role: 'user', adminScopes: ['creators:read'] }
 const plainUser = { id: 'd', role: 'user', adminScopes: [] as string[] }
+const marketingAdmin = { id: 'e', role: 'user', adminScopes: ['marketing:read'] }
+const aiAdmin = { id: 'f', role: 'user', adminScopes: ['ai:read'] }
 
 let currentUser: typeof superAdmin = superAdmin
 
@@ -53,6 +55,7 @@ mock.module('../middleware/auth', () => ({
 mock.module('../services/analytics.service', () => ({
   getOverviewStats: async () => ({}),
   getUsageAnalytics: async () => ({}),
+  getUserFunnel: async () => ({}),
   getCreatorStats: async () => [],
   getCreatorProfileDetail: async () => ({ userId: 'x', listings: [], affiliate: null }),
 }))
@@ -71,6 +74,7 @@ beforeEach(() => {
 
 const OVERVIEW = '/api/admin/analytics/overview'
 const USAGE = '/api/admin/analytics/usage'
+const FUNNEL = '/api/admin/analytics/funnel'
 const CREATORS = '/api/admin/creators'
 const CREATOR_DETAIL = '/api/admin/creators/u_123'
 const INFRA = '/api/admin/analytics/infra-current'
@@ -85,15 +89,36 @@ describe('admin scoped access matrix', () => {
     expect((await app.request(CREATORS)).status).toBe(200)
   })
 
-  test('analytics:read admin sees analytics but not creators or infra/heartbeats', async () => {
+  test('analytics:read umbrella sees both marketing + ai analytics but not creators or infra/heartbeats', async () => {
     currentUser = analyticsAdmin
     const app = createApp()
     expect((await app.request(OVERVIEW)).status).toBe(200)
     expect((await app.request(USAGE)).status).toBe(200)
+    expect((await app.request(FUNNEL)).status).toBe(200)
     expect((await app.request(CREATORS)).status).toBe(403)
     expect((await app.request(CREATOR_DETAIL)).status).toBe(403)
     expect((await app.request(INFRA)).status).toBe(403)
     expect((await app.request(HEARTBEATS)).status).toBe(403)
+  })
+
+  test('marketing:read admin sees shared + marketing endpoints but not ai-only endpoints', async () => {
+    currentUser = marketingAdmin
+    const app = createApp()
+    expect((await app.request(OVERVIEW)).status).toBe(200)
+    expect((await app.request(FUNNEL)).status).toBe(200)
+    expect((await app.request(USAGE)).status).toBe(403)
+    expect((await app.request(CREATORS)).status).toBe(403)
+    expect((await app.request(INFRA)).status).toBe(403)
+  })
+
+  test('ai:read admin sees shared + ai endpoints but not marketing-only endpoints', async () => {
+    currentUser = aiAdmin
+    const app = createApp()
+    expect((await app.request(OVERVIEW)).status).toBe(200)
+    expect((await app.request(USAGE)).status).toBe(200)
+    expect((await app.request(FUNNEL)).status).toBe(403)
+    expect((await app.request(CREATORS)).status).toBe(403)
+    expect((await app.request(INFRA)).status).toBe(403)
   })
 
   test('creators:read admin sees creators list + detail but not analytics or infra', async () => {

--- a/apps/api/src/lib/__tests__/admin-scopes.test.ts
+++ b/apps/api/src/lib/__tests__/admin-scopes.test.ts
@@ -34,8 +34,10 @@ beforeEach(() => {
 })
 
 describe('ADMIN_SCOPES catalog', () => {
-  it('includes the analytics and creators scopes we ship today', () => {
+  it('includes the analytics, marketing, ai, and creators scopes we ship today', () => {
     expect(ADMIN_SCOPE_IDS).toContain('analytics:read')
+    expect(ADMIN_SCOPE_IDS).toContain('marketing:read')
+    expect(ADMIN_SCOPE_IDS).toContain('ai:read')
     expect(ADMIN_SCOPE_IDS).toContain('creators:read')
   })
 

--- a/apps/api/src/lib/admin-scopes.ts
+++ b/apps/api/src/lib/admin-scopes.ts
@@ -24,9 +24,21 @@ import { prisma } from "./prisma"
 export const ADMIN_SCOPES = [
   {
     id: "analytics:read",
-    label: "Usage analytics",
+    label: "Usage analytics (all)",
     description:
-      "View platform-wide usage and spend analytics, including the admin dashboard and analytics pages (read-only).",
+      "Umbrella scope: view both Marketing and AI/engineering analytics, plus the admin dashboard (read-only). Implies marketing:read and ai:read.",
+  },
+  {
+    id: "marketing:read",
+    label: "Marketing analytics",
+    description:
+      "View the Marketing analytics page: signup funnel, acquisition sources, template engagement, user activity, and AI insights digest (read-only).",
+  },
+  {
+    id: "ai:read",
+    label: "AI / engineering analytics",
+    description:
+      "View the AI/engineering analytics page: model spend, quality & efficiency, tool calls, usage logs, workspace activity, and chat metrics (read-only).",
   },
   {
     id: "creators:read",

--- a/apps/api/src/middleware/__tests__/admin-access.test.ts
+++ b/apps/api/src/middleware/__tests__/admin-access.test.ts
@@ -22,7 +22,7 @@ mock.module('../../lib/prisma', () => ({
   },
 }))
 
-const { requireAdminScope, requireAnyAdmin } = await import('../admin-access')
+const { requireAdminScope, requireAnyScope, requireAnyAdmin } = await import('../admin-access')
 
 interface FakeJsonResponse {
   body: any
@@ -114,6 +114,45 @@ describe('requireAdminScope', () => {
     const c = makeContext({ userId: 'user-1' })
     const res = (await requireAdminScope('analytics:read')(c, next)) as FakeJsonResponse
     expect(res.status).toBe(403)
+    expect(nextCalled).toBe(0)
+  })
+})
+
+describe('requireAnyScope', () => {
+  it('returns 401 when auth is missing', async () => {
+    const c = makeContext(undefined)
+    const res = (await requireAnyScope('marketing:read', 'ai:read')(c, next)) as FakeJsonResponse
+    expect(res.status).toBe(401)
+    expect(nextCalled).toBe(0)
+  })
+
+  it('lets a super_admin through for any listed scope', async () => {
+    findUniqueImpl = async () => ({ role: 'super_admin', adminScopes: [] })
+    const c = makeContext({ userId: 'admin-1' })
+    await requireAnyScope('marketing:read', 'ai:read')(c, next)
+    expect(nextCalled).toBe(1)
+  })
+
+  it('lets a user holding any one of the listed scopes through', async () => {
+    findUniqueImpl = async () => ({ role: 'user', adminScopes: ['marketing:read'] })
+    const c = makeContext({ userId: 'user-1' })
+    await requireAnyScope('analytics:read', 'marketing:read')(c, next)
+    expect(nextCalled).toBe(1)
+  })
+
+  it('lets the legacy umbrella analytics:read through any analytics gate', async () => {
+    findUniqueImpl = async () => ({ role: 'user', adminScopes: ['analytics:read'] })
+    const c = makeContext({ userId: 'user-1' })
+    await requireAnyScope('analytics:read', 'ai:read')(c, next)
+    expect(nextCalled).toBe(1)
+  })
+
+  it('forbids a user holding none of the listed scopes', async () => {
+    findUniqueImpl = async () => ({ role: 'user', adminScopes: ['marketing:read'] })
+    const c = makeContext({ userId: 'user-1' })
+    const res = (await requireAnyScope('ai:read')(c, next)) as FakeJsonResponse
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('forbidden')
     expect(nextCalled).toBe(0)
   })
 })

--- a/apps/api/src/middleware/admin-access.ts
+++ b/apps/api/src/middleware/admin-access.ts
@@ -56,6 +56,26 @@ export function requireAdminScope(scope: AdminScope) {
 }
 
 /**
+ * Require *any one* of the listed admin scopes. Returns 401 if unauthenticated,
+ * 403 if the user is neither a super_admin nor a holder of at least one of
+ * `scopes`. Use this for surfaces reachable by multiple roles, e.g. shared
+ * analytics endpoints viewable by both marketing and AI/engineering admins.
+ */
+export function requireAnyScope(...scopes: AdminScope[]) {
+  return async (c: Context, next: Next) => {
+    const auth = c.get("auth")
+    if (!auth?.userId) return unauthorized(c)
+
+    const access = await getAdminAccess(auth.userId)
+    if (access.isSuperAdmin || scopes.some((s) => access.scopes.includes(s))) {
+      await next()
+      return
+    }
+    return forbidden(c)
+  }
+}
+
+/**
  * Require *any* admin access: super_admin, or at least one granted scope.
  * Used to gate entry to the admin portal as a whole.
  */

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -12,7 +12,7 @@
 
 import { Hono } from 'hono'
 import { requireSuperAdmin } from '../middleware/super-admin'
-import { requireAdminScope } from '../middleware/admin-access'
+import { requireAdminScope, requireAnyScope } from '../middleware/admin-access'
 import { ADMIN_SCOPES, isAdminScope, normalizeAdminScopes, type AdminScope } from '../lib/admin-scopes'
 import { authMiddleware, requireAuth } from '../middleware/auth'
 import * as analytics from '../services/analytics.service'
@@ -62,7 +62,43 @@ export function adminRoutes(): Hono {
   // router's blanket super-admin gate doesn't 403 scoped admins first.
   router.use('/creators', requireAdminScope('creators:read'))
   router.use('/creators/*', requireAdminScope('creators:read'))
-  router.use('/analytics/*', requireAdminScope('analytics:read'))
+
+  // Analytics is split across two pages with independent scopes. The broad
+  // entry gate admits any analytics-type scope (so shared endpoints used by
+  // the dashboard — overview, growth, active-users, usage-summary — stay
+  // reachable). The narrower per-path gates below then restrict page-specific
+  // endpoints to the matching scope. `analytics:read` is an umbrella that
+  // passes every gate; super_admin always passes.
+  router.use('/analytics/*', requireAnyScope('analytics:read', 'marketing:read', 'ai:read'))
+
+  // Marketing-only analytics endpoints.
+  for (const p of [
+    '/analytics/funnel',
+    '/analytics/user-activity',
+    '/analytics/template-engagement',
+    '/analytics/source-breakdown',
+    '/analytics/active-users-timeseries',
+    '/analytics/activity-timeseries',
+    '/analytics/ai-digest',
+    '/analytics/ai-digest/*',
+  ]) {
+    router.use(p, requireAnyScope('analytics:read', 'marketing:read'))
+  }
+
+  // AI / engineering-only analytics endpoints.
+  for (const p of [
+    '/analytics/spend-timeseries',
+    '/analytics/quality-timeseries',
+    '/analytics/workspace-activity',
+    '/analytics/tool-calls',
+    '/analytics/chat',
+    '/analytics/usage',
+    '/analytics/usage-log',
+    '/analytics/projects',
+    '/analytics/billing',
+  ]) {
+    router.use(p, requireAnyScope('analytics:read', 'ai:read'))
+  }
 
   // --------------------------------------------------------------------------
   // Platform Analytics (scope-free = platform-wide)

--- a/apps/mobile/app/(admin)/_analytics-shared.tsx
+++ b/apps/mobile/app/(admin)/_analytics-shared.tsx
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Shared helpers for the admin analytics pages.
+ *
+ * The analytics surface is split into two sibling pages — Marketing
+ * (analytics.tsx) and AI / engineering (ai-analytics.tsx). Both share the same
+ * data-fetch helper and the page header (title + period selector + internal
+ * toggle), extracted here to avoid duplication. Files prefixed with `_` are
+ * ignored by expo-router, so this is not registered as a route.
+ */
+
+import { View, Text, Switch } from 'react-native'
+import { cn } from '@shogo/shared-ui/primitives'
+import { API_URL } from '../../lib/api'
+import { type AnalyticsPeriod, PeriodSelector } from '../../components/analytics/SharedAnalytics'
+
+export const API_BASE = `${API_URL}/api/admin`
+
+/** Fetch an admin analytics endpoint, returning `json.data` or null on error. */
+export async function fetchAdminJson<T>(
+  path: string,
+  params?: Record<string, string>,
+): Promise<T | null> {
+  const qs = params ? '?' + new URLSearchParams(params).toString() : ''
+  try {
+    const res = await fetch(`${API_BASE}${path}${qs}`, { credentials: 'include' })
+    if (!res.ok) return null
+    const json = await res.json()
+    return json.data ?? null
+  } catch {
+    return null
+  }
+}
+
+/** Shared page header: title + subtitle, period selector, and internal toggle. */
+export function AnalyticsHeader({
+  title,
+  subtitle,
+  isWide,
+  period,
+  onPeriodChange,
+  excludeInternal,
+  onExcludeInternalChange,
+}: {
+  title: string
+  subtitle: string
+  isWide: boolean
+  period: AnalyticsPeriod
+  onPeriodChange: (p: AnalyticsPeriod) => void
+  excludeInternal: boolean
+  onExcludeInternalChange: (v: boolean) => void
+}) {
+  return (
+    <>
+      <View className="flex-row items-center justify-between mb-4">
+        <View>
+          <Text className={cn('font-bold text-foreground', isWide ? 'text-2xl' : 'text-lg')}>
+            {title}
+          </Text>
+          <Text className="text-xs text-muted-foreground">{subtitle}</Text>
+        </View>
+      </View>
+
+      <View className="flex-row items-center justify-between mb-4">
+        <PeriodSelector value={period} onChange={onPeriodChange} />
+        <View className="flex-row items-center gap-2">
+          <Text className="text-[10px] text-muted-foreground">Exclude internal</Text>
+          <Switch
+            value={excludeInternal}
+            onValueChange={onExcludeInternalChange}
+            trackColor={{ false: '#767577', true: '#6366f1' }}
+          />
+        </View>
+      </View>
+    </>
+  )
+}

--- a/apps/mobile/app/(admin)/_layout.tsx
+++ b/apps/mobile/app/(admin)/_layout.tsx
@@ -37,6 +37,7 @@ import {
   KeyRound,
   Sparkles,
   Clapperboard,
+  Activity,
 } from 'lucide-react-native'
 import { cn } from '@shogo/shared-ui/primitives'
 import { useAuth } from '../../contexts/auth'
@@ -49,6 +50,7 @@ type UserRole = 'user' | 'super_admin'
 /**
  * Nav item access markers:
  *   - `scope`     → visible to super admins OR holders of that admin scope
+ *   - `scopes`    → visible to super admins OR holders of *any* listed scope
  *   - `anyAdmin`  → visible to anyone with *some* admin access (e.g. Dashboard)
  *   - neither     → super_admin only
  */
@@ -57,6 +59,7 @@ type AdminNavItem = {
   icon: any
   label: string
   scope?: string
+  scopes?: readonly string[]
   anyAdmin?: boolean
 }
 
@@ -74,13 +77,13 @@ const NAV_SECTIONS: readonly AdminNavSection[] = [
   {
     title: 'Overview',
     items: [
-      { href: '/(admin)', icon: LayoutDashboard, label: 'Dashboard', scope: 'analytics:read' },
+      { href: '/(admin)', icon: LayoutDashboard, label: 'Dashboard', scopes: ['analytics:read', 'marketing:read', 'ai:read'] },
     ],
   },
   {
     title: 'Growth & Marketing',
     items: [
-      { href: '/(admin)/analytics', icon: BarChart3, label: 'Analytics', scope: 'analytics:read' },
+      { href: '/(admin)/analytics', icon: BarChart3, label: 'Marketing Analytics', scopes: ['analytics:read', 'marketing:read'] },
       { href: '/(admin)/creators', icon: Sparkles, label: 'Creators', scope: 'creators:read' },
       { href: '/(admin)/affiliate-content', icon: Clapperboard, label: 'Affiliate CPM' },
     ],
@@ -116,6 +119,7 @@ const NAV_SECTIONS: readonly AdminNavSection[] = [
   {
     title: 'System',
     items: [
+      { href: '/(admin)/ai-analytics', icon: Activity, label: 'AI Analytics', scopes: ['analytics:read', 'ai:read'] },
       { href: '/(admin)/evals', icon: FlaskConical, label: 'Evals' },
       { href: '/(admin)/general', icon: Settings, label: 'General' },
       { href: '/(admin)/settings', icon: BrainCircuit, label: 'AI' },
@@ -130,13 +134,15 @@ const ALL_NAV_ITEMS: readonly AdminNavItem[] = NAV_SECTIONS.flatMap((s) => s.ite
 function canSeeNavItem(item: AdminNavItem, isSuperAdmin: boolean, scopes: string[]): boolean {
   if (isSuperAdmin) return true
   if (item.anyAdmin) return true
+  if (item.scopes) return item.scopes.some((s) => scopes.includes(s))
   if (item.scope) return scopes.includes(item.scope)
   return false
 }
 
 const LOCAL_MAIN_ITEMS = [
   { href: '/(admin)/projects', icon: FolderKanban, label: 'Projects' },
-  { href: '/(admin)/analytics', icon: BarChart3, label: 'Analytics' },
+  { href: '/(admin)/analytics', icon: BarChart3, label: 'Marketing Analytics' },
+  { href: '/(admin)/ai-analytics', icon: Activity, label: 'AI Analytics' },
   { href: '/(admin)/heartbeats', icon: Heart, label: 'Heartbeats' },
   { href: '/(admin)/evals', icon: FlaskConical, label: 'Evals' },
 ] as const
@@ -426,7 +432,8 @@ function getPageTitle(pathname: string): string {
   if (pathname.startsWith('/marketplace')) return 'Marketplace Review'
   if (pathname.startsWith('/projects/')) return 'Project Detail'
   if (pathname.includes('projects')) return 'Projects'
-  if (pathname.includes('analytics')) return 'Analytics'
+  if (pathname.includes('ai-analytics')) return 'AI Analytics'
+  if (pathname.includes('analytics')) return 'Marketing Analytics'
   if (pathname.startsWith('/creators/')) return 'Creator Profile'
   if (pathname.includes('creators')) return 'Creators'
   if (pathname.includes('affiliate-content')) return 'Affiliate CPM'

--- a/apps/mobile/app/(admin)/ai-analytics.tsx
+++ b/apps/mobile/app/(admin)/ai-analytics.tsx
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Admin AI / Engineering Analytics - model spend, quality, and usage.
+ *
+ * The engineering-facing half of the split analytics surface (see
+ * analytics.tsx for the Marketing half). Focuses on consumption/spend,
+ * quality & efficiency, tool calls, workspace activity, raw usage logs, and
+ * chat metrics.
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+import {
+  View,
+  ScrollView,
+  RefreshControl,
+  useWindowDimensions,
+} from 'react-native'
+import {
+  type AnalyticsPeriod,
+  type UsageSummaryData,
+  type UsageLogData,
+  type ChatAnalyticsData,
+  type UsageBreakdownData,
+  type SpendTimeseriesData,
+  type SpendGroupBy,
+  type SpendMetric,
+  type QualityTimeseriesPoint,
+  type ToolCallAnalyticsData,
+  type WorkspaceActivityData,
+  UsageTableSection,
+  ChatAnalyticsSection,
+  UsageBreakdownSection,
+  UsageTimeseriesChart,
+  QualityTimeseriesChart,
+  ToolCallAnalyticsPanel,
+  WorkspaceActivityTable,
+} from '../../components/analytics/SharedAnalytics'
+import { fetchAdminJson, AnalyticsHeader } from './_analytics-shared'
+
+// =============================================================================
+// Main Page
+// =============================================================================
+
+export default function AdminAIAnalyticsPage() {
+  const { width } = useWindowDimensions()
+  const isWide = width >= 900
+
+  const [period, setPeriod] = useState<AnalyticsPeriod>('30d')
+  const [logPage, setLogPage] = useState(1)
+  const [summaryPage, setSummaryPage] = useState(1)
+  const [workspacePage, setWorkspacePage] = useState(1)
+  const [spendGroupBy, setSpendGroupBy] = useState<SpendGroupBy>('model')
+  const [spendMetric, setSpendMetric] = useState<SpendMetric>('spend')
+  const [refreshing, setRefreshing] = useState(false)
+  const [excludeInternal, setExcludeInternal] = useState(true)
+
+  const [spendTs, setSpendTs] = useState<{ data: SpendTimeseriesData | null; loading: boolean }>({ data: null, loading: true })
+  const [qualityTs, setQualityTs] = useState<{ data: QualityTimeseriesPoint[] | null; loading: boolean }>({ data: null, loading: true })
+  const [toolCalls, setToolCalls] = useState<{ data: ToolCallAnalyticsData | null; loading: boolean }>({ data: null, loading: true })
+  const [workspaceActivity, setWorkspaceActivity] = useState<{ data: WorkspaceActivityData | null; loading: boolean }>({ data: null, loading: true })
+  const [usage, setUsage] = useState<{ data: UsageBreakdownData | null; loading: boolean }>({ data: null, loading: true })
+  const [usageSummary, setUsageSummary] = useState<{ data: UsageSummaryData | null; loading: boolean }>({ data: null, loading: true })
+  const [usageLog, setUsageLog] = useState<{ data: UsageLogData | null; loading: boolean }>({ data: null, loading: true })
+  const [chatStats, setChatStats] = useState<{ data: ChatAnalyticsData | null; loading: boolean }>({ data: null, loading: true })
+
+  const internalParam = excludeInternal ? 'true' : 'false'
+
+  const loadAll = useCallback(async () => {
+    const pParams = { period, excludeInternal: internalParam }
+
+    setSpendTs((s) => ({ ...s, loading: true }))
+    setQualityTs((s) => ({ ...s, loading: true }))
+    setToolCalls((s) => ({ ...s, loading: true }))
+    setWorkspaceActivity((s) => ({ ...s, loading: true }))
+    setUsage((s) => ({ ...s, loading: true }))
+    setUsageSummary((s) => ({ ...s, loading: true }))
+    setUsageLog((s) => ({ ...s, loading: true }))
+    setChatStats((s) => ({ ...s, loading: true }))
+
+    const [sp, qual, tc, wsAct, us, uSum, uLog, ch] = await Promise.all([
+      fetchAdminJson<SpendTimeseriesData>('/analytics/spend-timeseries', { ...pParams, groupBy: spendGroupBy, metric: spendMetric }),
+      fetchAdminJson<QualityTimeseriesPoint[]>('/analytics/quality-timeseries', pParams),
+      fetchAdminJson<ToolCallAnalyticsData>('/analytics/tool-calls', pParams),
+      fetchAdminJson<WorkspaceActivityData>('/analytics/workspace-activity', { ...pParams, page: String(workspacePage), limit: '20' }),
+      fetchAdminJson<UsageBreakdownData>('/analytics/usage', pParams),
+      fetchAdminJson<UsageSummaryData>('/analytics/usage-summary', { ...pParams, page: String(summaryPage), limit: '25' }),
+      fetchAdminJson<UsageLogData>('/analytics/usage-log', { ...pParams, page: String(logPage), limit: '50' }),
+      fetchAdminJson<ChatAnalyticsData>('/analytics/chat', pParams),
+    ])
+
+    setSpendTs({ data: sp, loading: false })
+    setQualityTs({ data: qual, loading: false })
+    setToolCalls({ data: tc, loading: false })
+    setWorkspaceActivity({ data: wsAct, loading: false })
+    setUsage({ data: us, loading: false })
+    setUsageSummary({ data: uSum, loading: false })
+    setUsageLog({ data: uLog, loading: false })
+    setChatStats({ data: ch, loading: false })
+  }, [period, logPage, summaryPage, workspacePage, spendGroupBy, spendMetric, internalParam])
+
+  useEffect(() => {
+    loadAll()
+  }, [loadAll])
+
+  const onRefresh = async () => {
+    setRefreshing(true)
+    await loadAll()
+    setRefreshing(false)
+  }
+
+  return (
+    <ScrollView
+      className="flex-1 bg-background"
+      contentContainerStyle={{
+        padding: isWide ? 32 : 16,
+        paddingBottom: 40,
+        width: '100%',
+        alignSelf: 'center' as const,
+      }}
+      showsVerticalScrollIndicator={false}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+    >
+      <AnalyticsHeader
+        title="AI Analytics"
+        subtitle="Model spend, quality, and usage metrics"
+        isWide={isWide}
+        period={period}
+        onPeriodChange={setPeriod}
+        excludeInternal={excludeInternal}
+        onExcludeInternalChange={setExcludeInternal}
+      />
+
+      {/* Consumption by model / workspace */}
+      <View className="mb-4">
+        <UsageTimeseriesChart
+          data={spendTs.data}
+          loading={spendTs.loading}
+          groupBy={spendGroupBy}
+          metric={spendMetric}
+          onGroupByChange={setSpendGroupBy}
+          onMetricChange={setSpendMetric}
+          title="Consumption Over Time"
+          subtitle="Daily usage by model, workspace, user, or source"
+        />
+      </View>
+
+      {/* Quality & efficiency trend */}
+      <View className="mb-4">
+        <QualityTimeseriesChart data={qualityTs.data} loading={qualityTs.loading} />
+      </View>
+
+      {/* Workspace Activity Table */}
+      <View className="mb-4">
+        <WorkspaceActivityTable
+          data={workspaceActivity.data}
+          loading={workspaceActivity.loading}
+          page={workspacePage}
+          onPageChange={setWorkspacePage}
+        />
+      </View>
+
+      {/* Tool call analytics */}
+      <View className="mb-4">
+        <ToolCallAnalyticsPanel data={toolCalls.data} loading={toolCalls.loading} />
+      </View>
+
+      {/* Usage table (summary + event log) */}
+      <View className="mb-4">
+        <UsageTableSection
+          summaryData={usageSummary.data}
+          logData={usageLog.data}
+          summaryLoading={usageSummary.loading}
+          logLoading={usageLog.loading}
+          onLogPageChange={setLogPage}
+          logPage={logPage}
+          onSummaryPageChange={setSummaryPage}
+          summaryPage={summaryPage}
+        />
+      </View>
+
+      {/* Chat analytics */}
+      <View className="mb-4">
+        <ChatAnalyticsSection data={chatStats.data} loading={chatStats.loading} />
+      </View>
+
+      {/* Usage breakdown */}
+      <View>
+        <UsageBreakdownSection data={usage.data} loading={usage.loading} />
+      </View>
+    </ScrollView>
+  )
+}

--- a/apps/mobile/app/(admin)/analytics.tsx
+++ b/apps/mobile/app/(admin)/analytics.tsx
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2026 Shogo Technologies, Inc.
 /**
- * Admin Analytics - Comprehensive platform analytics with usage tables and chat metrics.
+ * Admin Marketing Analytics - growth & acquisition insights.
  *
- * Converted from apps/web/src/components/admin/pages/AdminAnalytics.tsx
- * Charts are replaced with View-based bar displays and stat cards.
+ * One half of the split analytics surface (see ai-analytics.tsx for the
+ * AI / engineering half). Focuses on funnel, acquisition sources, template
+ * engagement, per-user activity, and the AI insights digest.
  */
 
 import { useState, useEffect, useCallback } from 'react'
@@ -13,7 +14,6 @@ import {
   Text,
   ScrollView,
   RefreshControl,
-  Switch,
   useWindowDimensions,
 } from 'react-native'
 import {
@@ -25,49 +25,29 @@ import {
   CalendarDays,
 } from 'lucide-react-native'
 import { cn } from '@shogo/shared-ui/primitives'
-import { API_URL } from '../../lib/api'
 import {
   type AnalyticsPeriod,
-  type UsageSummaryData,
-  type UsageLogData,
-  type ChatAnalyticsData,
-  type UsageBreakdownData,
   type FunnelData,
   type UserActivityData,
   type TemplateEngagementData,
   type SourceBreakdownData,
   type AIDigestData,
   type AIDigestListItem,
-  type SpendTimeseriesData,
-  type SpendGroupBy,
-  type SpendMetric,
   type ActivityTimeseriesPoint,
   type ActiveUsersTimeseriesPoint,
-  type QualityTimeseriesPoint,
-  type ToolCallAnalyticsData,
-  type WorkspaceActivityData,
-  PeriodSelector,
   StatCard,
-  UsageTableSection,
-  ChatAnalyticsSection,
-  UsageBreakdownSection,
   FunnelSection,
   UserActivityTable,
   TemplateEngagementPanel,
   SourceBreakdownPanel,
   AIInsightsPanel,
-  UsageTimeseriesChart,
   ActivityTrendsChart,
   ActiveUsersTrendChart,
-  QualityTimeseriesChart,
-  ToolCallAnalyticsPanel,
-  WorkspaceActivityTable,
 } from '../../components/analytics/SharedAnalytics'
-
-const API_BASE = `${API_URL}/api/admin`
+import { API_BASE, fetchAdminJson, AnalyticsHeader } from './_analytics-shared'
 
 // =============================================================================
-// Admin-specific types
+// Marketing-specific types
 // =============================================================================
 
 interface OverviewData {
@@ -86,23 +66,7 @@ interface ActiveUsersData {
 }
 
 // =============================================================================
-// API helpers
-// =============================================================================
-
-async function fetchAdminJson<T>(path: string, params?: Record<string, string>): Promise<T | null> {
-  const qs = params ? '?' + new URLSearchParams(params).toString() : ''
-  try {
-    const res = await fetch(`${API_BASE}${path}${qs}`, { credentials: 'include' })
-    if (!res.ok) return null
-    const json = await res.json()
-    return json.data ?? null
-  } catch {
-    return null
-  }
-}
-
-// =============================================================================
-// Admin-specific components
+// Marketing-specific components
 // =============================================================================
 
 function OverviewCards({ data, loading }: { data: OverviewData | null; loading: boolean }) {
@@ -180,33 +144,20 @@ function ActiveUsersSection({ data, loading }: { data: ActiveUsersData | null; l
 // Main Page
 // =============================================================================
 
-export default function AdminAnalyticsPage() {
+export default function AdminMarketingAnalyticsPage() {
   const { width } = useWindowDimensions()
   const isWide = width >= 900
 
   const [period, setPeriod] = useState<AnalyticsPeriod>('30d')
-  const [logPage, setLogPage] = useState(1)
   const [userPage, setUserPage] = useState(1)
-  const [summaryPage, setSummaryPage] = useState(1)
-  const [workspacePage, setWorkspacePage] = useState(1)
-  const [spendGroupBy, setSpendGroupBy] = useState<SpendGroupBy>('model')
-  const [spendMetric, setSpendMetric] = useState<SpendMetric>('spend')
   const [refreshing, setRefreshing] = useState(false)
   const [excludeInternal, setExcludeInternal] = useState(true)
   const [generating, setGenerating] = useState(false)
 
   const [overview, setOverview] = useState<{ data: OverviewData | null; loading: boolean }>({ data: null, loading: true })
   const [activeUsers, setActiveUsers] = useState<{ data: ActiveUsersData | null; loading: boolean }>({ data: null, loading: true })
-  const [spendTs, setSpendTs] = useState<{ data: SpendTimeseriesData | null; loading: boolean }>({ data: null, loading: true })
   const [activityTs, setActivityTs] = useState<{ data: ActivityTimeseriesPoint[] | null; loading: boolean }>({ data: null, loading: true })
   const [activeUsersTs, setActiveUsersTs] = useState<{ data: ActiveUsersTimeseriesPoint[] | null; loading: boolean }>({ data: null, loading: true })
-  const [qualityTs, setQualityTs] = useState<{ data: QualityTimeseriesPoint[] | null; loading: boolean }>({ data: null, loading: true })
-  const [toolCalls, setToolCalls] = useState<{ data: ToolCallAnalyticsData | null; loading: boolean }>({ data: null, loading: true })
-  const [workspaceActivity, setWorkspaceActivity] = useState<{ data: WorkspaceActivityData | null; loading: boolean }>({ data: null, loading: true })
-  const [usage, setUsage] = useState<{ data: UsageBreakdownData | null; loading: boolean }>({ data: null, loading: true })
-  const [usageSummary, setUsageSummary] = useState<{ data: UsageSummaryData | null; loading: boolean }>({ data: null, loading: true })
-  const [usageLog, setUsageLog] = useState<{ data: UsageLogData | null; loading: boolean }>({ data: null, loading: true })
-  const [chatStats, setChatStats] = useState<{ data: ChatAnalyticsData | null; loading: boolean }>({ data: null, loading: true })
   const [funnel, setFunnel] = useState<{ data: FunnelData | null; loading: boolean }>({ data: null, loading: true })
   const [userActivity, setUserActivity] = useState<{ data: UserActivityData | null; loading: boolean }>({ data: null, loading: true })
   const [templateEng, setTemplateEng] = useState<{ data: TemplateEngagementData | null; loading: boolean }>({ data: null, loading: true })
@@ -221,16 +172,8 @@ export default function AdminAnalyticsPage() {
 
     setOverview((s) => ({ ...s, loading: true }))
     setActiveUsers((s) => ({ ...s, loading: true }))
-    setSpendTs((s) => ({ ...s, loading: true }))
     setActivityTs((s) => ({ ...s, loading: true }))
     setActiveUsersTs((s) => ({ ...s, loading: true }))
-    setQualityTs((s) => ({ ...s, loading: true }))
-    setToolCalls((s) => ({ ...s, loading: true }))
-    setWorkspaceActivity((s) => ({ ...s, loading: true }))
-    setUsage((s) => ({ ...s, loading: true }))
-    setUsageSummary((s) => ({ ...s, loading: true }))
-    setUsageLog((s) => ({ ...s, loading: true }))
-    setChatStats((s) => ({ ...s, loading: true }))
     setFunnel((s) => ({ ...s, loading: true }))
     setUserActivity((s) => ({ ...s, loading: true }))
     setTemplateEng((s) => ({ ...s, loading: true }))
@@ -238,19 +181,11 @@ export default function AdminAnalyticsPage() {
     setAiDigest((s) => ({ ...s, loading: true }))
     setDigestList((s) => ({ ...s, loading: true }))
 
-    const [ov, au, sp, act, auTs, qual, tc, wsAct, us, uSum, uLog, ch, fn, ua, te, sb, dig, dl] = await Promise.all([
+    const [ov, au, act, auTs, fn, ua, te, sb, dig, dl] = await Promise.all([
       fetchAdminJson<OverviewData>('/analytics/overview'),
       fetchAdminJson<ActiveUsersData>('/analytics/active-users', pParams),
-      fetchAdminJson<SpendTimeseriesData>('/analytics/spend-timeseries', { ...pParams, groupBy: spendGroupBy, metric: spendMetric }),
       fetchAdminJson<ActivityTimeseriesPoint[]>('/analytics/activity-timeseries', pParams),
       fetchAdminJson<ActiveUsersTimeseriesPoint[]>('/analytics/active-users-timeseries', pParams),
-      fetchAdminJson<QualityTimeseriesPoint[]>('/analytics/quality-timeseries', pParams),
-      fetchAdminJson<ToolCallAnalyticsData>('/analytics/tool-calls', pParams),
-      fetchAdminJson<WorkspaceActivityData>('/analytics/workspace-activity', { ...pParams, page: String(workspacePage), limit: '20' }),
-      fetchAdminJson<UsageBreakdownData>('/analytics/usage', pParams),
-      fetchAdminJson<UsageSummaryData>('/analytics/usage-summary', { ...pParams, page: String(summaryPage), limit: '25' }),
-      fetchAdminJson<UsageLogData>('/analytics/usage-log', { ...pParams, page: String(logPage), limit: '50' }),
-      fetchAdminJson<ChatAnalyticsData>('/analytics/chat', pParams),
       fetchAdminJson<FunnelData>('/analytics/funnel', pParams),
       fetchAdminJson<UserActivityData>('/analytics/user-activity', { ...pParams, page: String(userPage), limit: '20' }),
       fetchAdminJson<TemplateEngagementData>('/analytics/template-engagement', { excludeInternal: internalParam }),
@@ -261,23 +196,15 @@ export default function AdminAnalyticsPage() {
 
     setOverview({ data: ov, loading: false })
     setActiveUsers({ data: au, loading: false })
-    setSpendTs({ data: sp, loading: false })
     setActivityTs({ data: act, loading: false })
     setActiveUsersTs({ data: auTs, loading: false })
-    setQualityTs({ data: qual, loading: false })
-    setToolCalls({ data: tc, loading: false })
-    setWorkspaceActivity({ data: wsAct, loading: false })
-    setUsage({ data: us, loading: false })
-    setUsageSummary({ data: uSum, loading: false })
-    setUsageLog({ data: uLog, loading: false })
-    setChatStats({ data: ch, loading: false })
     setFunnel({ data: fn, loading: false })
     setUserActivity({ data: ua, loading: false })
     setTemplateEng({ data: te, loading: false })
     setSourceBreakdown({ data: sb, loading: false })
     setAiDigest({ data: dig, loading: false })
     setDigestList({ data: dl, loading: false })
-  }, [period, logPage, userPage, summaryPage, workspacePage, spendGroupBy, spendMetric, internalParam])
+  }, [period, userPage, internalParam])
 
   const handleGenerateDigest = useCallback(async () => {
     setGenerating(true)
@@ -325,30 +252,15 @@ export default function AdminAnalyticsPage() {
       showsVerticalScrollIndicator={false}
       refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
     >
-      {/* Header */}
-      <View className="flex-row items-center justify-between mb-4">
-        <View>
-          <Text className={cn('font-bold text-foreground', isWide ? 'text-2xl' : 'text-lg')}>
-            Analytics
-          </Text>
-          <Text className="text-xs text-muted-foreground">
-            Comprehensive platform analytics and insights
-          </Text>
-        </View>
-      </View>
-
-      {/* Period selector + Internal toggle */}
-      <View className="flex-row items-center justify-between mb-4">
-        <PeriodSelector value={period} onChange={setPeriod} />
-        <View className="flex-row items-center gap-2">
-          <Text className="text-[10px] text-muted-foreground">Exclude internal</Text>
-          <Switch
-            value={excludeInternal}
-            onValueChange={setExcludeInternal}
-            trackColor={{ false: '#767577', true: '#6366f1' }}
-          />
-        </View>
-      </View>
+      <AnalyticsHeader
+        title="Marketing Analytics"
+        subtitle="Growth, acquisition, and engagement insights"
+        isWide={isWide}
+        period={period}
+        onPeriodChange={setPeriod}
+        excludeInternal={excludeInternal}
+        onExcludeInternalChange={setExcludeInternal}
+      />
 
       {/* Overview cards */}
       <View className="mb-4">
@@ -365,20 +277,6 @@ export default function AdminAnalyticsPage() {
         <ActiveUsersSection data={activeUsers.data} loading={activeUsers.loading} />
       </View>
 
-      {/* Consumption by model / workspace */}
-      <View className="mb-4">
-        <UsageTimeseriesChart
-          data={spendTs.data}
-          loading={spendTs.loading}
-          groupBy={spendGroupBy}
-          metric={spendMetric}
-          onGroupByChange={setSpendGroupBy}
-          onMetricChange={setSpendMetric}
-          title="Consumption Over Time"
-          subtitle="Daily usage by model, workspace, user, or source"
-        />
-      </View>
-
       {/* Activity + active-user trends: side-by-side on desktop */}
       <View className={cn('gap-4 mb-4', isWide && 'flex-row')}>
         <View className={cn(isWide && 'flex-1')}>
@@ -389,11 +287,6 @@ export default function AdminAnalyticsPage() {
         </View>
       </View>
 
-      {/* Quality & efficiency trend */}
-      <View className="mb-4">
-        <QualityTimeseriesChart data={qualityTs.data} loading={qualityTs.loading} />
-      </View>
-
       {/* User Activity Table */}
       <View className="mb-4">
         <UserActivityTable
@@ -402,21 +295,6 @@ export default function AdminAnalyticsPage() {
           page={userPage}
           onPageChange={setUserPage}
         />
-      </View>
-
-      {/* Workspace Activity Table */}
-      <View className="mb-4">
-        <WorkspaceActivityTable
-          data={workspaceActivity.data}
-          loading={workspaceActivity.loading}
-          page={workspacePage}
-          onPageChange={setWorkspacePage}
-        />
-      </View>
-
-      {/* Tool call analytics */}
-      <View className="mb-4">
-        <ToolCallAnalyticsPanel data={toolCalls.data} loading={toolCalls.loading} />
       </View>
 
       {/* Template + Source: side-by-side on desktop */}
@@ -430,7 +308,7 @@ export default function AdminAnalyticsPage() {
       </View>
 
       {/* AI Insights */}
-      <View className="mb-4">
+      <View>
         <AIInsightsPanel
           data={aiDigest.data}
           digestList={digestList.data}
@@ -439,30 +317,6 @@ export default function AdminAnalyticsPage() {
           onGenerate={handleGenerateDigest}
           generating={generating}
         />
-      </View>
-
-      {/* Usage table (summary + event log) */}
-      <View className="mb-4">
-        <UsageTableSection
-          summaryData={usageSummary.data}
-          logData={usageLog.data}
-          summaryLoading={usageSummary.loading}
-          logLoading={usageLog.loading}
-          onLogPageChange={setLogPage}
-          logPage={logPage}
-          onSummaryPageChange={setSummaryPage}
-          summaryPage={summaryPage}
-        />
-      </View>
-
-      {/* Chat analytics */}
-      <View className="mb-4">
-        <ChatAnalyticsSection data={chatStats.data} loading={chatStats.loading} />
-      </View>
-
-      {/* Usage breakdown */}
-      <View>
-        <UsageBreakdownSection data={usage.data} loading={usage.loading} />
       </View>
     </ScrollView>
   )


### PR DESCRIPTION
## Summary

The super-admin Analytics page conflated growth/marketing metrics (funnel, acquisition sources, template engagement) with AI/engineering metrics (model spend, quality, tool calls, usage logs). This splits it into two focused, independently-accessible pages.

- **Marketing Analytics** keeps the `/(admin)/analytics` route: Overview, Funnel, Active Users (+ trend), Activity Trends, User Activity, Template Engagement, Source Breakdown, AI Insights digest.
- **AI Analytics** is a new `/(admin)/ai-analytics` page: Consumption/Spend, Quality & Efficiency, Workspace Activity, Tool Calls, Usage Summary + Log, Chat, Usage Breakdown.
- Shared `fetchAdminJson` + page header (period selector / internal toggle) extracted to `_analytics-shared.tsx`.

### Access control
- New `marketing:read` and `ai:read` admin scopes. `analytics:read` is retained as a backward-compatible umbrella that grants both, so existing partial-admin grants keep working (no migration).
- New `requireAnyScope(...)` middleware. Analytics endpoints are gated as **shared** (any analytics scope — keeps the dashboard working), **marketing-only**, or **ai-only**. Infra endpoints stay super-admin only.
- The grant UI auto-surfaces the new scopes via the existing `/admin-scopes` catalog endpoint.

### Sidebar
- "Marketing Analytics" stays under **Growth & Marketing**; "AI Analytics" added under **System**.
- Nav items now support an any-of `scopes[]` marker; the Dashboard is visible to any analytics scope.

## Test plan
- [x] `bun test apps/api/src/lib/__tests__/admin-scopes.test.ts` (catalog includes the 4 scopes)
- [x] `bun test apps/api/src/middleware/__tests__/admin-access.test.ts` (new `requireAnyScope` coverage)
- [x] `bun test apps/api/src/__tests__/admin-scoped-access.test.ts` (marketing-only / ai-only / umbrella matrix)
- [x] `bun test apps/api/src/__tests__/analytics-routes.test.ts`
- [x] `bun test apps/api/src/__tests__/admin-router-mount-leakage.test.ts`
- [x] `tsc` clean on edited backend files (mobile typecheck requires Expo env; imports verified against `SharedAnalytics.tsx`)
- [ ] Manual: verify a `marketing:read`-only admin sees Marketing Analytics but is 403'd on AI endpoints, and vice versa

Made with [Cursor](https://cursor.com)