### PR TITLE
feat(warm-pool): cap concurrent claimed pods per user by plan tier

### DIFF
--- a/apps/api/src/__tests__/knative-project-manager.test.ts
+++ b/apps/api/src/__tests__/knative-project-manager.test.ts
@@ -51,6 +51,7 @@ let workspaceInstanceSize = 'small'
 let queryRawRows: any[] = [{ acquired: true }]
 const executeRawCalls: string[] = []
 const projectUpdateCalls: any[] = []
+const warmPoolCalls: string[] = []
 let warmPoolMock: any
 
 mock.module('@kubernetes/client-node', () => withK8sExports({
@@ -144,6 +145,11 @@ mock.module('../lib/project-user-context', () => ({
   getProjectOwnerUserId: async () => 'owner-user-test',
 }))
 
+let effectivePlanId = 'free'
+mock.module('../services/billing.service', () => ({
+  getEffectivePlanId: async () => effectivePlanId,
+}))
+
 mock.module('../services/instance.service', () => ({
   buildProjectResourceOverrides: (_workspaceId: string, size: string) => ({
     requests: { memory: `${size}-request-memory`, cpu: `${size}-request-cpu` },
@@ -190,13 +196,20 @@ beforeEach(() => {
   queryRawRows = [{ acquired: true }]
   executeRawCalls.length = 0
   projectUpdateCalls.length = 0
+  effectivePlanId = 'free'
+  warmPoolCalls.length = 0
   warmPoolMock = {
     getAssignedPod: () => null,
     getStatus: () => ({ enabled: false }),
     buildProjectEnv: async () => ({ PROJECT_ID: 'p1' }),
-    claim: () => null,
+    claim: () => { warmPoolCalls.push('claim'); return null },
     assign: async () => {},
     evictProject: async () => ({ evicted: true }),
+    touchProject: () => {},
+    enforcePerUserClaimedCap: async (...args: any[]) => {
+      warmPoolCalls.push(`enforce:${args.join(',')}`)
+      return { cap: 2, count: 0, evicted: [] }
+    },
   }
   nextFetch = () => new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } })
 })
@@ -770,6 +783,68 @@ describe('getProjectPodUrl (module-level helper)', () => {
     expect(assignCalls[0]).toEqual([pod, 'p-warm', { PROJECT_ID: 'p-warm', EXTRA: '1' }])
     expect(executeRawCalls).toContain('SELECT pg_advisory_unlock($1)')
     expect(capture.some((c) => c.method === 'createNamespacedCustomObject' && c.args[0].plural === 'domainmappings')).toBe(true)
+  })
+
+  test('enforces the per-user claimed-pod cap BEFORE claiming, then still claims', async () => {
+    customGetError = Object.assign(new Error('not found'), { code: 404 })
+    effectivePlanId = 'pro'
+    const pod = {
+      id: 'warm-cap',
+      serviceName: 'warm-pod-cap',
+      url: 'http://warm-pod-cap.shogo-test.svc.cluster.local',
+      ready: true,
+      createdAt: Date.now(),
+    }
+    warmPoolMock = {
+      getAssignedPod: () => null,
+      getStatus: () => ({ enabled: true }),
+      buildProjectEnv: async (projectId: string) => ({ PROJECT_ID: projectId }),
+      claim: () => { warmPoolCalls.push('claim'); return pod },
+      assign: async () => {},
+      evictProject: async () => ({ evicted: true }),
+      touchProject: () => {},
+      enforcePerUserClaimedCap: async (...args: any[]) => {
+        warmPoolCalls.push(`enforce:${args.join(',')}`)
+        return { cap: 4, count: 4, evicted: ['lru-victim'] }
+      },
+    }
+
+    const url = await getProjectPodUrl('p-cap')
+
+    // Cap enforcement ran with (projectId, ownerUserId, planId) and BEFORE claim.
+    expect(warmPoolCalls[0]).toBe('enforce:p-cap,owner-user-test,pro')
+    expect(warmPoolCalls).toContain('claim')
+    expect(warmPoolCalls.indexOf('enforce:p-cap,owner-user-test,pro')).toBeLessThan(
+      warmPoolCalls.indexOf('claim'),
+    )
+    // The claim still succeeds after the LRU eviction freed a slot.
+    expect(url).toBe(pod.url)
+  })
+
+  test('cap enforcement failure never blocks the claim (non-fatal)', async () => {
+    customGetError = Object.assign(new Error('not found'), { code: 404 })
+    const pod = {
+      id: 'warm-cap2',
+      serviceName: 'warm-pod-cap2',
+      url: 'http://warm-pod-cap2.shogo-test.svc.cluster.local',
+      ready: true,
+      createdAt: Date.now(),
+    }
+    warmPoolMock = {
+      getAssignedPod: () => null,
+      getStatus: () => ({ enabled: true }),
+      buildProjectEnv: async (projectId: string) => ({ PROJECT_ID: projectId }),
+      claim: () => pod,
+      assign: async () => {},
+      evictProject: async () => ({ evicted: true }),
+      touchProject: () => {},
+      enforcePerUserClaimedCap: async () => {
+        throw new Error('boom')
+      },
+    }
+
+    const url = await getProjectPodUrl('p-cap-err')
+    expect(url).toBe(pod.url)
   })
 
   test('returns a recent assigned warm pod without probing health', async () => {

--- a/apps/api/src/config/__tests__/usage-plans.test.ts
+++ b/apps/api/src/config/__tests__/usage-plans.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
 
-import { describe, expect, it } from 'bun:test'
+import { afterEach, describe, expect, it } from 'bun:test'
 import {
   FREE_DAILY_INCLUDED_USD,
   MONTHLY_DAILY_CAP_USD,
@@ -15,6 +15,7 @@ import {
   SEAT_INCLUDED_USD,
   VOICE_RAW_USD,
   comparePlanRank,
+  getClaimedPodCapForPlan,
   getDailyIncludedForPlan,
   getMonthlyIncludedForPlan,
   getMonthlyIncludedEquivalent,
@@ -357,5 +358,52 @@ describe('comparePlanRank', () => {
   it('normalizes decorated ids before comparing', () => {
     expect(comparePlanRank('Pro-Annual', 'business_monthly')).toBeLessThan(0)
     expect(comparePlanRank('Enterprise-XL', 'pro_200')).toBeGreaterThan(0)
+  })
+})
+
+describe('getClaimedPodCapForPlan', () => {
+  const ORIGINAL_OVERRIDE = process.env.WARM_POOL_CLAIMED_CAP_BY_TIER
+
+  afterEach(() => {
+    if (ORIGINAL_OVERRIDE === undefined) delete process.env.WARM_POOL_CLAIMED_CAP_BY_TIER
+    else process.env.WARM_POOL_CLAIMED_CAP_BY_TIER = ORIGINAL_OVERRIDE
+  })
+
+  it('scales linearly with tier rank (PLAN_RANK + 2)', () => {
+    delete process.env.WARM_POOL_CLAIMED_CAP_BY_TIER
+    expect(getClaimedPodCapForPlan('free')).toBe(2)
+    expect(getClaimedPodCapForPlan('basic')).toBe(3)
+    expect(getClaimedPodCapForPlan('pro')).toBe(4)
+    expect(getClaimedPodCapForPlan('business')).toBe(5)
+    expect(getClaimedPodCapForPlan('enterprise')).toBe(6)
+  })
+
+  it('normalizes decorated plan ids before resolving', () => {
+    delete process.env.WARM_POOL_CLAIMED_CAP_BY_TIER
+    expect(getClaimedPodCapForPlan('Pro-Annual')).toBe(4)
+    expect(getClaimedPodCapForPlan('business_monthly')).toBe(5)
+    expect(getClaimedPodCapForPlan('Enterprise-XL')).toBe(6)
+  })
+
+  it('falls back to the free cap for unknown / missing ids', () => {
+    delete process.env.WARM_POOL_CLAIMED_CAP_BY_TIER
+    expect(getClaimedPodCapForPlan(null)).toBe(2)
+    expect(getClaimedPodCapForPlan(undefined)).toBe(2)
+    expect(getClaimedPodCapForPlan('')).toBe(2)
+    expect(getClaimedPodCapForPlan('platinum')).toBe(2)
+  })
+
+  it('applies per-tier env overrides over the linear default', () => {
+    process.env.WARM_POOL_CLAIMED_CAP_BY_TIER = JSON.stringify({ free: 1, pro: 10 })
+    expect(getClaimedPodCapForPlan('free')).toBe(1)
+    expect(getClaimedPodCapForPlan('pro')).toBe(10)
+    // tiers not present in the override keep the linear default
+    expect(getClaimedPodCapForPlan('business')).toBe(5)
+  })
+
+  it('ignores malformed override JSON and uses the linear default', () => {
+    process.env.WARM_POOL_CLAIMED_CAP_BY_TIER = '{not valid json'
+    expect(getClaimedPodCapForPlan('free')).toBe(2)
+    expect(getClaimedPodCapForPlan('pro')).toBe(4)
   })
 })

--- a/apps/api/src/config/usage-plans.ts
+++ b/apps/api/src/config/usage-plans.ts
@@ -138,6 +138,57 @@ export function comparePlanRank(
 }
 
 /**
+ * Offset added to a plan's tier rank to compute its concurrent claimed
+ * warm-pod cap: `cap = PLAN_RANK[tier] + CLAIMED_POD_CAP_BASE`. With the
+ * default base of 2 this yields the linear ladder
+ * free:2, basic:3, pro:4, business:5, enterprise:6 — mirroring the
+ * desktop VM warm pool's per-host concurrency cap, but scaled by plan.
+ */
+const CLAIMED_POD_CAP_BASE = 2
+
+/**
+ * Parse the optional per-tier cap override from
+ * `WARM_POOL_CLAIMED_CAP_BY_TIER` (JSON, e.g. `{"free":1,"pro":5}`). Any
+ * tier present wins over the linear default. Parsed on each call so env
+ * changes (and per-test mutation) are picked up; malformed JSON is
+ * ignored (logged) so a bad env var can never crash the claim path.
+ */
+function parseClaimedPodCapOverrides(): Partial<Record<PlanId, number>> {
+  const raw = process.env.WARM_POOL_CLAIMED_CAP_BY_TIER
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    const out: Partial<Record<PlanId, number>> = {}
+    for (const [key, value] of Object.entries(parsed)) {
+      const tier = normalizePlanId(key)
+      const n = typeof value === 'number' ? value : parseInt(String(value), 10)
+      if (tier && Number.isFinite(n) && n >= 0) out[tier] = Math.floor(n)
+    }
+    return out
+  } catch (err) {
+    console.warn(
+      `[usage-plans] Ignoring malformed WARM_POOL_CLAIMED_CAP_BY_TIER: ${(err as Error).message}`,
+    )
+    return {}
+  }
+}
+
+/**
+ * Maximum number of concurrent claimed (promoted) warm pods a single
+ * workspace/user may hold, derived from the workspace's effective plan.
+ * Linear in tier rank by default (`PLAN_RANK + 2`): free:2 … enterprise:6.
+ * Overridable per tier via `WARM_POOL_CLAIMED_CAP_BY_TIER`. Unknown /
+ * unresolved plan ids fall back to the free tier so brand-new workspaces
+ * get the most conservative cap.
+ */
+export function getClaimedPodCapForPlan(planId: string | null | undefined): number {
+  const tier = normalizePlanId(planId) ?? 'free'
+  const override = parseClaimedPodCapOverrides()[tier]
+  if (override !== undefined) return override
+  return PLAN_RANK[tier] + CLAIMED_POD_CAP_BASE
+}
+
+/**
  * Rolling usage-window durations, in milliseconds. Usage is gated by two
  * independent windows that run in parallel (modeled on how Codex / Claude
  * Code time-gate "unlimited" plans): a short burst window and a longer

--- a/apps/api/src/lib/__tests__/warm-pool-per-user-cap.test.ts
+++ b/apps/api/src/lib/__tests__/warm-pool-per-user-cap.test.ts
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Per-user claimed-pod cap test suite.
+ *
+ * Exercises WarmPoolController.enforcePerUserClaimedCap (the claim-path cap)
+ * and enforcePerUserCapsSweep (the cross-replica GC backstop): LRU eviction
+ * once a user is at/over the plan-derived cap, never evicting the incoming
+ * project, tier-scaled limits, and the kill switch.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test'
+
+// Intercept unbuilt SDK subpath exports before @shogo/shared-runtime loads them.
+mock.module('@shogo-ai/sdk/ai-proxy', () => ({ createAiProxy: () => ({}) }))
+mock.module('@shogo-ai/sdk/ai-client', () => ({ sendMessage: async () => ({}) }))
+mock.module('@shogo-ai/sdk/model-catalog', () => ({
+  getModelTier: () => 'standard',
+  resolveModelId: (id: string) => id,
+  MODEL_CATALOG: {},
+  getModelEntry: () => undefined,
+  MODEL_DOLLAR_COSTS: {} as Record<string, any>,
+  calculateDollarCost: () => 0,
+  getModelBillingModel: (id: string) => id,
+  resolveAgentModeDefault: (mode: string) => mode,
+}))
+mock.module('@shogo/shared-runtime', () => ({
+  RUNTIME_CONFIG: {
+    apiPort: 4000,
+    runtimePort: 5000,
+    portRangeStart: 5100,
+    portRangeEnd: 5200,
+    image: () => 'shogo-runtime:test',
+    workDir: '/app/workspace',
+    extraEnv: {},
+    componentLabel: 'runtime',
+    containerName: 'runtime',
+  },
+}))
+mock.module('@shogo/model-catalog', () => ({
+  getModelTier: () => 'standard',
+  resolveModelId: (id: string) => id,
+  MODEL_CATALOG: {},
+  getModelEntry: () => undefined,
+  MODEL_DOLLAR_COSTS: {} as Record<string, any>,
+  calculateDollarCost: () => 0,
+  getModelBillingModel: (id: string) => id,
+  resolveAgentModeDefault: (mode: string) => mode,
+  getAgentModeOverrides: () => ({}),
+  getMaxOutputTokens: (_id?: string) => 4096,
+  MODEL_ALIASES: {} as Record<string, any>,
+}))
+
+const mockK8sCustomApi = {
+  listNamespacedCustomObject: mock(() => Promise.resolve({ items: [] })),
+  createNamespacedCustomObject: mock(() => Promise.resolve({})),
+  deleteNamespacedCustomObject: mock(() => Promise.resolve({})),
+  getNamespacedCustomObject: mock(() => Promise.resolve({})),
+  patchNamespacedCustomObject: mock(() => Promise.resolve({})),
+}
+mock.module('@kubernetes/client-node', () => ({
+  KubeConfig: class {
+    loadFromDefault() {}
+    loadFromOptions() {}
+    makeApiClient() {
+      return mockK8sCustomApi
+    }
+  },
+  CustomObjectsApi: class {},
+  CoreV1Api: class {},
+}))
+
+// Controllable prisma.project.findMany — tests set `findManyResult`.
+let findManyResult: any[] = []
+let lastFindManyArgs: any = null
+const mockPrismaProjectFindMany = mock((args: any) => {
+  lastFindManyArgs = args
+  return Promise.resolve(findManyResult)
+})
+const mockPrismaProject = {
+  findUnique: mock(() => Promise.resolve({ workspaceId: 'ws-1' })),
+  findFirst: mock(() => Promise.resolve(null)),
+  findMany: mockPrismaProjectFindMany,
+  update: mock(() => Promise.resolve({})),
+  updateMany: mock(() => Promise.resolve({ count: 0 })),
+}
+mock.module('../prisma', () => ({
+  prisma: { project: mockPrismaProject },
+}))
+
+// billing.service.getEffectivePlanId — used only by the sweep.
+let effectivePlanById: Record<string, string> = {}
+const mockGetEffectivePlanId = mock((workspaceId: string) =>
+  Promise.resolve(effectivePlanById[workspaceId] ?? 'free'),
+)
+mock.module('../../services/billing.service', () => ({
+  getEffectivePlanId: mockGetEffectivePlanId,
+}))
+
+mock.module('../knative-project-manager', () => ({
+  mergePatchKnativeService: mock(() => Promise.resolve()),
+}))
+mock.module('../../services/database.service', () => ({
+  provisionDatabase: mock(() =>
+    Promise.resolve({ connectionUrl: 'postgresql://test:test@localhost/test' }),
+  ),
+}))
+
+import { WarmPoolController } from '../warm-pool-controller'
+
+/** Build a claimed-project row as returned by the cap query. */
+function claimedRow(id: string, lastMessageAtMs: number | null, updatedAtMs = lastMessageAtMs ?? 0) {
+  return {
+    id,
+    lastMessageAt: lastMessageAtMs === null ? null : new Date(lastMessageAtMs),
+    updatedAt: new Date(updatedAtMs),
+  }
+}
+
+describe('WarmPoolController per-user claimed-pod cap', () => {
+  let controller: WarmPoolController
+  let evictSpy: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    findManyResult = []
+    lastFindManyArgs = null
+    effectivePlanById = {}
+    mockPrismaProjectFindMany.mockClear()
+    mockGetEffectivePlanId.mockClear()
+    delete process.env.WARM_POOL_PER_USER_CAP_ENABLED
+    delete process.env.WARM_POOL_CLAIMED_CAP_BY_TIER
+    process.env.WARM_POOL_ENABLED = 'true'
+    process.env.PROJECT_NAMESPACE = 'test-namespace'
+
+    controller = new WarmPoolController({ poolSize: 3, reconcileIntervalMs: 1000 })
+    // Stub the real eviction (which calls k8s + prisma) so we only assert intent.
+    evictSpy = spyOn(controller, 'evictProject').mockResolvedValue({
+      evicted: true,
+      oldService: 'svc',
+    })
+  })
+
+  afterEach(() => {
+    controller.stop()
+    delete process.env.WARM_POOL_PER_USER_CAP_ENABLED
+    delete process.env.WARM_POOL_CLAIMED_CAP_BY_TIER
+  })
+
+  describe('enforcePerUserClaimedCap', () => {
+    test('no-op when the owner is under their cap', async () => {
+      // free cap = 2; owner has 1 other claimed pod
+      findManyResult = [claimedRow('p-old', 1000)]
+      const res = await controller.enforcePerUserClaimedCap('p-new', 'user-1', 'free')
+
+      expect(res.cap).toBe(2)
+      expect(res.count).toBe(1)
+      expect(res.evicted).toEqual([])
+      expect(evictSpy).not.toHaveBeenCalled()
+    })
+
+    test('evicts down to cap-1 (oldest first) when over the cap', async () => {
+      // free cap = 2; owner has 3 claimed -> evict down to cap-1 (=1), oldest first
+      findManyResult = [
+        claimedRow('p-newer', 3000),
+        claimedRow('p-oldest', 1000),
+        claimedRow('p-mid', 2000),
+      ]
+      const res = await controller.enforcePerUserClaimedCap('p-new', 'user-1', 'free')
+
+      expect(res.cap).toBe(2)
+      expect(res.count).toBe(3)
+      // target = cap-1 = 1, so evict count-target = 2 oldest: p-oldest, p-mid
+      expect(res.evicted).toEqual(['p-oldest', 'p-mid'])
+      expect(evictSpy).toHaveBeenCalledTimes(2)
+      expect(evictSpy).toHaveBeenCalledWith('p-oldest', { deleteService: true })
+      expect(evictSpy).toHaveBeenCalledWith('p-mid', { deleteService: true })
+    })
+
+    test('evicts a single oldest pod when exactly at cap (count == cap)', async () => {
+      findManyResult = [claimedRow('p-recent', 5000), claimedRow('p-stale', 1000)]
+      const res = await controller.enforcePerUserClaimedCap('p-new', 'user-1', 'free')
+
+      expect(res.cap).toBe(2)
+      expect(res.count).toBe(2)
+      expect(res.evicted).toEqual(['p-stale'])
+      expect(evictSpy).toHaveBeenCalledTimes(1)
+    })
+
+    test('excludes the incoming project from the cap count query', async () => {
+      findManyResult = [claimedRow('p-a', 1000)]
+      await controller.enforcePerUserClaimedCap('p-incoming', 'user-1', 'free')
+
+      expect(lastFindManyArgs.where.id).toEqual({ not: 'p-incoming' })
+      expect(lastFindManyArgs.where.knativeServiceName).toEqual({ not: null })
+      expect(lastFindManyArgs.where.workspace).toEqual({
+        members: { some: { role: 'owner', userId: 'user-1' } },
+      })
+    })
+
+    test('higher tier permits more claimed pods before evicting', async () => {
+      // pro cap = 4; owner has 3 -> still under cap, no eviction
+      findManyResult = [claimedRow('p1', 1000), claimedRow('p2', 2000), claimedRow('p3', 3000)]
+      const res = await controller.enforcePerUserClaimedCap('p-new', 'user-1', 'pro')
+
+      expect(res.cap).toBe(4)
+      expect(res.evicted).toEqual([])
+      expect(evictSpy).not.toHaveBeenCalled()
+    })
+
+    test('honors per-tier env overrides', async () => {
+      process.env.WARM_POOL_CLAIMED_CAP_BY_TIER = JSON.stringify({ free: 1 })
+      findManyResult = [claimedRow('p-only', 1000)]
+      const res = await controller.enforcePerUserClaimedCap('p-new', 'user-1', 'free')
+
+      expect(res.cap).toBe(1)
+      // target = cap-1 = 0, count=1 -> evict all 1
+      expect(res.evicted).toEqual(['p-only'])
+    })
+
+    test('uses in-memory touch timestamp over DB time for LRU selection', async () => {
+      // DB order would make p-a oldest, but a recent touch on p-a makes p-b the LRU.
+      findManyResult = [claimedRow('p-a', 1000), claimedRow('p-b', 2000)]
+      controller.touchProject('p-a') // now (recent) > p-b's 2000
+      const res = await controller.enforcePerUserClaimedCap('p-new', 'user-1', 'free')
+
+      expect(res.evicted).toEqual(['p-b'])
+    })
+
+    test('short-circuits when the kill switch is off', async () => {
+      process.env.WARM_POOL_PER_USER_CAP_ENABLED = 'false'
+      findManyResult = [claimedRow('p1', 1), claimedRow('p2', 2), claimedRow('p3', 3)]
+      const res = await controller.enforcePerUserClaimedCap('p-new', 'user-1', 'free')
+
+      expect(res.evicted).toEqual([])
+      expect(evictSpy).not.toHaveBeenCalled()
+      expect(mockPrismaProjectFindMany).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('enforcePerUserCapsSweep', () => {
+    function sweepRow(id: string, userId: string, workspaceId: string, ts: number) {
+      return {
+        id,
+        workspaceId,
+        lastMessageAt: new Date(ts),
+        updatedAt: new Date(ts),
+        workspace: { members: [{ userId }] },
+      }
+    }
+
+    test('evicts LRU extras for an owner over their cap', async () => {
+      // free owner with 3 claimed pods (cap 2) -> evict 1 oldest
+      findManyResult = [
+        sweepRow('a', 'u1', 'ws1', 3000),
+        sweepRow('b', 'u1', 'ws1', 1000), // oldest
+        sweepRow('c', 'u1', 'ws1', 2000),
+      ]
+      const res = await controller.enforcePerUserCapsSweep()
+
+      expect(res.scanned).toBe(3)
+      expect(res.evicted).toBe(1)
+      expect(evictSpy).toHaveBeenCalledTimes(1)
+      expect(evictSpy).toHaveBeenCalledWith('b', { deleteService: true })
+    })
+
+    test('leaves owners at/under their cap untouched (fast path)', async () => {
+      findManyResult = [
+        sweepRow('a', 'u1', 'ws1', 1000),
+        sweepRow('b', 'u2', 'ws2', 2000),
+      ]
+      const res = await controller.enforcePerUserCapsSweep()
+
+      expect(res.evicted).toBe(0)
+      expect(evictSpy).not.toHaveBeenCalled()
+      // fast path: never resolves plan for sub-cap owners
+      expect(mockGetEffectivePlanId).not.toHaveBeenCalled()
+    })
+
+    test('uses the most generous cap across an owner workspaces', async () => {
+      // u1 owns 5 claimed pods across a free ws and a business ws (cap 5).
+      effectivePlanById = { wsFree: 'free', wsBiz: 'business' }
+      findManyResult = [
+        sweepRow('a', 'u1', 'wsFree', 1000),
+        sweepRow('b', 'u1', 'wsBiz', 2000),
+        sweepRow('c', 'u1', 'wsBiz', 3000),
+        sweepRow('d', 'u1', 'wsBiz', 4000),
+        sweepRow('e', 'u1', 'wsBiz', 5000),
+      ]
+      const res = await controller.enforcePerUserCapsSweep()
+
+      // business cap = 5, owner has 5 -> not over cap
+      expect(res.evicted).toBe(0)
+      expect(evictSpy).not.toHaveBeenCalled()
+    })
+
+    test('respects the kill switch', async () => {
+      process.env.WARM_POOL_PER_USER_CAP_ENABLED = 'false'
+      findManyResult = [
+        sweepRow('a', 'u1', 'ws1', 1),
+        sweepRow('b', 'u1', 'ws1', 2),
+        sweepRow('c', 'u1', 'ws1', 3),
+      ]
+      const res = await controller.enforcePerUserCapsSweep()
+
+      expect(res).toEqual({ scanned: 0, evicted: 0 })
+      expect(evictSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/api/src/lib/knative-project-manager.ts
+++ b/apps/api/src/lib/knative-project-manager.ts
@@ -1768,6 +1768,7 @@ export async function getProjectPodUrl(projectId: string): Promise<string> {
           span.setAttribute('resolve.method', 'warm_pool_assigned_grace')
           span.setAttribute('resolve.duration_ms', Date.now() - totalStartTime)
           span.setStatus({ code: SpanStatusCode.OK })
+          warmPool.touchProject(projectId)
           console.log(`[KnativeProjectManager] Project ${projectId} served by warm pool (grace period, assigned ${Math.round(assignmentAgeMs / 1000)}s ago, elapsed: ${Date.now() - totalStartTime}ms)`)
           return warmUrl
         }
@@ -1782,6 +1783,7 @@ export async function getProjectPodUrl(projectId: string): Promise<string> {
             span.setAttribute('resolve.method', 'warm_pool_assigned')
             span.setAttribute('resolve.duration_ms', Date.now() - totalStartTime)
             span.setStatus({ code: SpanStatusCode.OK })
+            warmPool.touchProject(projectId)
             console.log(`[KnativeProjectManager] Project ${projectId} served by warm pool (elapsed: ${Date.now() - totalStartTime}ms)`)
             return warmUrl
           }
@@ -1814,6 +1816,7 @@ export async function getProjectPodUrl(projectId: string): Promise<string> {
           span.setAttribute('resolve.method', 'db_mapping')
           span.setAttribute('resolve.duration_ms', Date.now() - totalStartTime)
           span.setStatus({ code: SpanStatusCode.OK })
+          warmPool.touchProject(projectId)
           console.log(`[KnativeProjectManager] Project ${projectId} resolved via DB mapping to ${projectRecord.knativeServiceName} (elapsed: ${Date.now() - totalStartTime}ms)`)
           return dbUrl
         }
@@ -1985,6 +1988,35 @@ async function tryClaimWarmPod(
       const envVars = await warmPool.buildProjectEnv(projectId)
       const envTime = Date.now()
       console.log(`[KnativeProjectManager] buildProjectEnv for ${projectId}: ${envTime - t0}ms`)
+
+      // Enforce the per-user claimed-pod cap (scaled by the workspace plan)
+      // before claiming, mirroring the desktop VM warm pool's per-host LRU
+      // cap. Best-effort: a failure here must never block the claim.
+      try {
+        const { getProjectOwnerUserId } = await import('./project-user-context')
+        const ownerUserId = await getProjectOwnerUserId(projectId)
+        if (ownerUserId && ownerUserId !== 'system') {
+          const projectRow = await prisma.project.findUnique({
+            where: { id: projectId },
+            select: { workspaceId: true },
+          })
+          const { getEffectivePlanId } = await import('../services/billing.service')
+          const planId = projectRow?.workspaceId
+            ? await getEffectivePlanId(projectRow.workspaceId)
+            : 'free'
+          const capResult = await warmPool.enforcePerUserClaimedCap(projectId, ownerUserId, planId)
+          if (capResult.evicted.length > 0) {
+            console.log(
+              `[KnativeProjectManager] Per-user cap for ${projectId}: evicted ${capResult.evicted.length} LRU pod(s) (owner had ${capResult.count}/${capResult.cap})`,
+            )
+          }
+        }
+      } catch (capErr: any) {
+        console.error(
+          `[KnativeProjectManager] Per-user cap enforcement failed for ${projectId} (non-fatal):`,
+          capErr.message,
+        )
+      }
 
       for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
         const pod = warmPool.claim()

--- a/apps/api/src/lib/warm-pool-controller.ts
+++ b/apps/api/src/lib/warm-pool-controller.ts
@@ -56,6 +56,10 @@ const poolKeepAliveCounter = meter.createCounter('warm_pool.keep_alive_pings', {
   description:
     'Keep-alive HTTP pings sent to warm-pool ksvcs to refresh their scale-to-zero retention timer. Labelled by `outcome` (`ok` | `error`).',
 })
+const poolPerUserCapEvictionCounter = meter.createCounter('warm_pool.per_user_cap_evictions', {
+  description:
+    'Claimed (promoted) warm pods LRU-evicted to enforce the per-user concurrent claimed-pod cap derived from the workspace plan. Labelled by `tier` and `source` (`claim` | `gc`).',
+})
 const poolBrokenDetectedCounter = meter.createCounter('warm_pool.broken_detected', {
   description: 'Warm pool services detected as broken (image pull, scheduling, or revision failure)',
 })
@@ -130,6 +134,18 @@ const COLD_CLAIM_THRESHOLD_MS = parseInt(
 
 // Promoted pod GC: clean up orphaned/idle promoted pods
 const PROMOTED_POD_GC_ENABLED = process.env.PROMOTED_POD_GC_ENABLED !== 'false'
+
+// Per-user claimed-pod cap: when a user opens a project and is already at the
+// concurrent claimed-pod cap derived from their workspace plan (see
+// getClaimedPodCapForPlan), LRU-evict their oldest claimed pod to free a slot.
+// Mirrors the desktop VM warm pool's per-host concurrency cap, scaled by plan.
+// A periodic sweep (enforcePerUserCapsSweep) is the cross-replica backstop for
+// the per-project advisory lock. Disable with WARM_POOL_PER_USER_CAP_ENABLED=false.
+// Read live (not a module constant) so the kill switch takes effect without a
+// redeploy and is unit-testable.
+function perUserCapEnabled(): boolean {
+  return process.env.WARM_POOL_PER_USER_CAP_ENABLED !== 'false'
+}
 
 // Periodic reconcile of promoted-but-orphaned pods. Disabled by default —
 // the per-callsite self-heal helper (apps/api/src/lib/warm-pool-self-heal.ts)
@@ -234,6 +250,12 @@ export interface PromotedPodInfo {
   /** Unix ms when this pod was first observed as promoted in this process (used for grace period) */
   promotedAt: number
   ready: boolean
+  /**
+   * Unix ms when this project's pod was last served (set via touchProject).
+   * Used as a least-recently-used signal for the per-user claimed-pod cap.
+   * Optional: absent on freshly-discovered pods until they're served.
+   */
+  lastTouchedAt?: number
 }
 
 /**
@@ -364,6 +386,16 @@ export class WarmPoolController {
 
   /** Promoted pods discovered during discoverExistingPods(), used by GC and admin API */
   private promotedPods: PromotedPodInfo[] = []
+
+  /**
+   * projectId -> Unix ms when the project's pod was last served / assigned.
+   * Drives least-recently-used victim selection for the per-user claimed-pod
+   * cap. In-memory (per replica) and best-effort; the DB `lastMessageAt` /
+   * `updatedAt` are used as the cross-replica fallback when no local touch is
+   * recorded. Refreshed by {@link touchProject} from getProjectPodUrl and on
+   * a successful {@link assign}.
+   */
+  private lastTouchedByProject = new Map<string, number>()
 
   /** Cumulative GC statistics for observability */
   private gcStats: GcStats = { orphansDeleted: 0, idleEvictions: 0, namespaceServicesDeleted: 0, orphanedDomainMappingsDeleted: 0, lastGcRun: null, lastNamespaceGcRun: null, lastPublishLockLogMs: 0 }
@@ -611,6 +643,19 @@ export class WarmPoolController {
     await this.gcPromotedPods().catch((err) => {
       console.error('[WarmPool] Promoted pod GC failed (non-fatal):', err.message)
     })
+
+    // Backstop the per-user claimed-pod cap across replicas (the claim path
+    // only holds a per-project advisory lock). Cheap when no owner is over
+    // their cap; bounded eviction per cycle.
+    await this.enforcePerUserCapsSweep()
+      .then((s) => {
+        if (s.evicted > 0) {
+          console.log(`[WarmPool] Per-user cap sweep: evicted ${s.evicted} (scanned ${s.scanned})`)
+        }
+      })
+      .catch((err) => {
+        console.error('[WarmPool] Per-user cap sweep failed (non-fatal):', err.message)
+      })
 
     // Periodic sweep for promoted-but-orphaned pods. Opt-in.
     if (
@@ -994,6 +1039,7 @@ export class WarmPoolController {
 
         pod.assignedAt = Date.now()
         this.assigned.set(projectId, pod)
+        this.lastTouchedByProject.set(projectId, pod.assignedAt)
         this.claimedServiceNames.delete(pod.serviceName)
         const duration = Date.now() - startTime
         span.setAttribute('assign.duration_ms', duration)
@@ -1263,9 +1309,200 @@ export class WarmPoolController {
       })()
     }
 
+    this.lastTouchedByProject.delete(projectId)
+
     const mode = deleteService ? 'hard-evicted' : 'soft-evicted (service kept)'
     console.log(`[WarmPool] evictProject: ${mode} project ${projectId} from ${oldServiceName || '(not found)'}`)
     return { evicted: !!oldServiceName, oldService: oldServiceName }
+  }
+
+  /**
+   * Record that a project's pod was just served (or assigned), refreshing its
+   * least-recently-used timestamp for the per-user claimed-pod cap. Cheap and
+   * idempotent; safe to call on every getProjectPodUrl hit.
+   */
+  touchProject(projectId: string): void {
+    const now = Date.now()
+    this.lastTouchedByProject.set(projectId, now)
+    const promoted = this.promotedPods.find((p) => p.projectId === projectId)
+    if (promoted) promoted.lastTouchedAt = now
+  }
+
+  /**
+   * Least-recently-used timestamp for a claimed project: prefer the in-memory
+   * touch record, then the DB `lastMessageAt`, then `updatedAt`. Lower = older
+   * = more eligible for eviction.
+   */
+  private claimedLruTimestamp(p: {
+    id: string
+    lastMessageAt: Date | null
+    updatedAt: Date
+  }): number {
+    const touched = this.lastTouchedByProject.get(p.id)
+    if (touched !== undefined) return touched
+    if (p.lastMessageAt) return p.lastMessageAt.getTime()
+    return p.updatedAt.getTime()
+  }
+
+  /**
+   * Enforce a per-user cap on concurrent claimed (promoted) warm pods, scaled
+   * by the workspace plan tier (see {@link getClaimedPodCapForPlan}). Called
+   * from the claim path BEFORE a new pod is claimed: if the owner is already
+   * at/over their cap, the least-recently-used claimed project is hard-evicted
+   * (ksvc deleted, `knativeServiceName` cleared) to free a slot. The evicted
+   * project re-claims a warm pod (or cold-starts) on its next visit, mirroring
+   * the desktop VM warm pool's LRU eviction.
+   *
+   * Counting is keyed on the workspace OWNER and uses the DB
+   * (`knativeServiceName IS NOT NULL`) as the cluster-wide source of truth so
+   * the cap holds across API replicas. `projectId` (the project being opened,
+   * which does not yet hold a pod) is excluded from the count. Best-effort:
+   * returns a summary for tests/metrics; callers should not let it block a
+   * claim.
+   */
+  async enforcePerUserClaimedCap(
+    projectId: string,
+    ownerUserId: string,
+    planId: string,
+  ): Promise<{ cap: number; count: number; evicted: string[] }> {
+    const evicted: string[] = []
+    if (!perUserCapEnabled()) {
+      return { cap: Number.POSITIVE_INFINITY, count: 0, evicted }
+    }
+
+    const { getClaimedPodCapForPlan, normalizePlanId } = await import('../config/usage-plans')
+    const cap = getClaimedPodCapForPlan(planId)
+    const tier = normalizePlanId(planId) ?? 'free'
+
+    const { prisma } = await import('./prisma')
+    const claimed = await prisma.project.findMany({
+      where: {
+        id: { not: projectId },
+        knativeServiceName: { not: null },
+        workspace: { members: { some: { role: 'owner', userId: ownerUserId } } },
+      },
+      select: { id: true, lastMessageAt: true, updatedAt: true },
+    })
+
+    const count = claimed.length
+    if (count < cap) return { cap, count, evicted }
+
+    // Leave room for the incoming claim: target == cap - 1 so +1 == cap.
+    const target = Math.max(cap - 1, 0)
+    const ordered = [...claimed].sort(
+      (a, b) => this.claimedLruTimestamp(a) - this.claimedLruTimestamp(b),
+    )
+    const toEvict = ordered.slice(0, Math.max(0, count - target))
+
+    for (const victim of toEvict) {
+      try {
+        const res = await this.evictProject(victim.id, { deleteService: true })
+        if (res.evicted) {
+          evicted.push(victim.id)
+          poolPerUserCapEvictionCounter.add(1, { tier, source: 'claim' })
+          console.log(
+            `[WarmPool] Per-user cap: owner ${ownerUserId} at ${count}/${cap} (${tier}) — LRU-evicted ${victim.id} to free a slot for ${projectId}`,
+          )
+        }
+      } catch (err: any) {
+        console.error(
+          `[WarmPool] Per-user cap: failed to evict ${victim.id} (non-fatal):`,
+          err.message,
+        )
+      }
+    }
+    return { cap, count, evicted }
+  }
+
+  /**
+   * Cluster-wide backstop for the per-user claimed-pod cap. The claim path
+   * holds only a per-PROJECT advisory lock, so two different projects of the
+   * same user opened concurrently across replicas can momentarily both push
+   * past the cap. This sweep groups all currently-claimed projects by owner
+   * and LRU-evicts extras for any owner over their (plan-derived) cap.
+   *
+   * Plan lookups are skipped for owners at/under the lowest possible cap (the
+   * common single-project user), so the hot path stays one cheap query.
+   * Per-cycle eviction is bounded like the idle GC. Returns a summary.
+   */
+  async enforcePerUserCapsSweep(): Promise<{ scanned: number; evicted: number }> {
+    if (!perUserCapEnabled()) return { scanned: 0, evicted: 0 }
+
+    const { prisma } = await import('./prisma')
+    const { getClaimedPodCapForPlan, normalizePlanId } = await import('../config/usage-plans')
+    const { getEffectivePlanId } = await import('../services/billing.service')
+
+    const claimed = await prisma.project.findMany({
+      where: { knativeServiceName: { not: null } },
+      select: {
+        id: true,
+        workspaceId: true,
+        lastMessageAt: true,
+        updatedAt: true,
+        workspace: {
+          select: { members: { where: { role: 'owner' }, select: { userId: true }, take: 1 } },
+        },
+      },
+    })
+
+    type ClaimedRow = (typeof claimed)[number]
+    const byOwner = new Map<string, ClaimedRow[]>()
+    for (const p of claimed) {
+      const owner = p.workspace?.members?.[0]?.userId
+      if (!owner) continue
+      const arr = byOwner.get(owner) ?? []
+      arr.push(p)
+      byOwner.set(owner, arr)
+    }
+
+    const lowestCap = getClaimedPodCapForPlan('free')
+    let evicted = 0
+
+    for (const [owner, projects] of byOwner) {
+      if (evicted >= PROMOTED_POD_GC_MAX_IDLE_EVICTIONS_PER_CYCLE) break
+      // Fast path: nobody under the lowest possible cap can be over any cap.
+      if (projects.length <= lowestCap) continue
+
+      // Cap = most generous across the owner's distinct claimed workspaces, so
+      // a paid workspace is never trimmed using a free workspace's cap.
+      const workspaceIds = [...new Set(projects.map((p) => p.workspaceId))]
+      let cap = lowestCap
+      let tier = 'free'
+      for (const ws of workspaceIds) {
+        const plan = await getEffectivePlanId(ws).catch(() => 'free' as const)
+        const wsCap = getClaimedPodCapForPlan(plan)
+        if (wsCap > cap) {
+          cap = wsCap
+          tier = normalizePlanId(plan) ?? 'free'
+        }
+      }
+      if (projects.length <= cap) continue
+
+      const ordered = [...projects].sort(
+        (a, b) => this.claimedLruTimestamp(a) - this.claimedLruTimestamp(b),
+      )
+      const overage = projects.length - cap
+      for (const victim of ordered.slice(0, overage)) {
+        if (evicted >= PROMOTED_POD_GC_MAX_IDLE_EVICTIONS_PER_CYCLE) break
+        try {
+          const res = await this.evictProject(victim.id, { deleteService: true })
+          if (res.evicted) {
+            evicted++
+            poolPerUserCapEvictionCounter.add(1, { tier, source: 'gc' })
+            console.log(
+              `[WarmPool] Per-user cap sweep: owner ${owner} at ${projects.length}/${cap} (${tier}) — LRU-evicted ${victim.id}`,
+            )
+          }
+        } catch (err: any) {
+          console.error(
+            `[WarmPool] Per-user cap sweep: failed to evict ${victim.id} (non-fatal):`,
+            err.message,
+          )
+        }
+      }
+    }
+
+    return { scanned: claimed.length, evicted }
   }
 
   /**

--- a/apps/api/src/routes/internal-e2e.ts
+++ b/apps/api/src/routes/internal-e2e.ts
@@ -253,4 +253,67 @@ app.get('/subscription-state', async (c) => {
   return c.json({ ok: true, subscription, wallet })
 })
 
+/**
+ * GET /api/internal/e2e/claimed-pods
+ *
+ * Diagnostic endpoint for the per-user claimed-pod cap e2e suite. Returns
+ * the projects in a workspace that currently hold a claimed/assigned warm
+ * pod (`knativeServiceName IS NOT NULL`), so the test can assert the cap is
+ * enforced and that the LRU project was evicted.
+ *
+ * Query: `workspaceId` (required).
+ */
+app.get('/claimed-pods', async (c) => {
+  if (!bootstrapEnabled()) {
+    return c.json({ ok: false, error: 'e2e_bootstrap_disabled' }, 503)
+  }
+  if (!secretMatches(c.req.header('x-e2e-bootstrap-secret'))) {
+    return c.json({ ok: false, error: 'unauthorized' }, 401)
+  }
+
+  let workspaceId = c.req.query('workspaceId')?.trim()
+  if (!workspaceId) {
+    const email = c.req.query('userEmail')?.trim().toLowerCase()
+    if (!email) {
+      return c.json({ ok: false, error: 'workspaceId_or_userEmail_required' }, 400)
+    }
+    if (!email.startsWith('e2e-') || !email.endsWith('@mailnull.com')) {
+      return c.json({ ok: false, error: 'userEmail_must_be_e2e_address' }, 400)
+    }
+    const user = await prisma.user.findUnique({
+      where: { email },
+      select: {
+        members: {
+          where: { workspaceId: { not: null }, projectId: null },
+          select: { workspaceId: true },
+          take: 1,
+        },
+      },
+    })
+    const wid = user?.members[0]?.workspaceId ?? null
+    if (!wid) {
+      return c.json({ ok: false, error: 'workspace_not_found_for_user', email }, 404)
+    }
+    workspaceId = wid
+  }
+
+  const projects = await prisma.project.findMany({
+    where: { workspaceId, knativeServiceName: { not: null } },
+    select: { id: true, name: true, knativeServiceName: true, lastMessageAt: true },
+    orderBy: { lastMessageAt: 'asc' },
+  })
+
+  return c.json({
+    ok: true,
+    workspaceId,
+    claimedCount: projects.length,
+    claimed: projects.map((p) => ({
+      id: p.id,
+      name: p.name,
+      knativeServiceName: p.knativeServiceName,
+      lastMessageAt: p.lastMessageAt,
+    })),
+  })
+})
+
 export default app

--- a/e2e/staging/helpers.ts
+++ b/e2e/staging/helpers.ts
@@ -342,6 +342,62 @@ export async function bootstrapProSubscriptionViaApi(
   return body?.ok === true
 }
 
+/** A project that currently holds a claimed/assigned warm pod. */
+export interface ClaimedPod {
+  id: string
+  name: string
+  knativeServiceName: string
+  lastMessageAt: string | null
+}
+
+/**
+ * Query the per-user claimed-pod diagnostic backdoor
+ * (`GET /api/internal/e2e/claimed-pods`). Returns the workspace's currently
+ * claimed pods (oldest-first), or `null` if the backdoor isn't available
+ * (secret unset / endpoint disabled) so callers can skip cleanly.
+ */
+export async function getClaimedPodsViaApi(
+  page: Page,
+  user: TestUser,
+): Promise<{ claimedCount: number; claimed: ClaimedPod[] } | null> {
+  const secret = process.env.SHOGO_E2E_BOOTSTRAP_SECRET
+  if (!secret) return null
+
+  const base = bootstrapApiBase()
+  const res = await page.request
+    .get(`${base}/api/internal/e2e/claimed-pods`, {
+      headers: { "x-e2e-bootstrap-secret": secret },
+      params: { userEmail: user.email },
+    })
+    .catch(() => null)
+  if (!res || res.status() === 503 || !res.ok()) return null
+  const body = await res.json().catch(() => null)
+  if (!body?.ok) return null
+  return { claimedCount: body.claimedCount, claimed: body.claimed }
+}
+
+/**
+ * Poll the claimed-pod diagnostic until the workspace's claimed count is
+ * `<= expectedMax`, or the timeout elapses. Returns the final reading.
+ * Used to wait out the eviction + DB-mapping clear that the per-user cap
+ * performs asynchronously during a claim.
+ */
+export async function waitForClaimedPodCount(
+  page: Page,
+  user: TestUser,
+  expectedMax: number,
+  timeoutMs = 30_000,
+): Promise<{ claimedCount: number; claimed: ClaimedPod[] } | null> {
+  const deadline = Date.now() + timeoutMs
+  let last: { claimedCount: number; claimed: ClaimedPod[] } | null = null
+  while (Date.now() < deadline) {
+    last = await getClaimedPodsViaApi(page, user)
+    if (last && last.claimedCount <= expectedMax) return last
+    await page.waitForTimeout(2000)
+  }
+  return last
+}
+
 export async function signUpAndUpgradeToPro(page: Page, user: TestUser): Promise<void> {
   await signUpAndOnboard(page, user)
 

--- a/e2e/staging/warm-pool-per-user-cap.test.ts
+++ b/e2e/staging/warm-pool-per-user-cap.test.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import { test, expect, type Page } from "@playwright/test"
+import {
+  bootstrapProSubscriptionViaApi,
+  createProjectAndWait,
+  getClaimedPodsViaApi,
+  makeTestUser,
+  signUpAndOnboard,
+  waitForClaimedPodCount,
+  type TestUser,
+} from "./helpers"
+
+/**
+ * Per-user claimed-pod cap E2E.
+ *
+ * The cloud warm pool caps the number of concurrent CLAIMED (promoted) pods
+ * a single user may hold, scaled by their workspace plan
+ * (getClaimedPodCapForPlan: free=2, pro=4, …). When a user opens one project
+ * too many, their least-recently-used claimed pod is LRU-evicted to free a
+ * slot — mirroring the desktop VM warm pool.
+ *
+ * These tests drive the real claim path (creating + opening projects claims a
+ * warm pod) and assert via the API diagnostic backdoor
+ * (GET /api/internal/e2e/claimed-pods) that:
+ *   - a free user never holds more than 2 claimed pods, and
+ *   - the oldest (first-created) project is the one evicted, while
+ *   - a Pro workspace is allowed up to 4.
+ *
+ * Both require SHOGO_E2E_BOOTSTRAP_SECRET (the same backdoor used by the
+ * billing suite); they skip cleanly when it's absent.
+ *
+ * Run: STAGING_URL=... SHOGO_E2E_BOOTSTRAP_SECRET=... \
+ *   npx playwright test --config e2e/playwright.config.ts warm-pool-per-user-cap
+ */
+
+const CLAIM_SETTLE_TIMEOUT_MS = 45_000
+
+/** Open an existing project so its runtime resolves (claims a warm pod). */
+async function openProject(page: Page, projectId: string): Promise<void> {
+  await page.goto(`/projects/${projectId}`)
+  // Wait for the project shell to mount (composer present). The pod claim is
+  // triggered by the runtime resolution behind this view.
+  await page
+    .getByRole("textbox", { name: "Chat message input" })
+    .first()
+    .waitFor({ state: "visible", timeout: 60_000 })
+    .catch(() => {})
+  await page.waitForTimeout(1500)
+}
+
+/** Create a project from the home composer and return its id. */
+async function createProjectReturningId(page: Page, prompt: string): Promise<string> {
+  await createProjectAndWait(page, prompt)
+  const m = page.url().match(/\/projects\/([^/?#]+)/)
+  expect(m, `expected a /projects/<id> URL, got ${page.url()}`).toBeTruthy()
+  return m![1]
+}
+
+test.describe("warm pool per-user claimed-pod cap", () => {
+  test("free user is capped at 2 claimed pods (LRU evicts the oldest)", async ({ page }) => {
+    const user = makeTestUser("CapFree")
+    await signUpAndOnboard(page, user)
+
+    // Skip cleanly if the diagnostic backdoor isn't wired up in this env.
+    const probe = await getClaimedPodsViaApi(page, user)
+    test.skip(
+      probe === null,
+      "claimed-pods backdoor unavailable (set SHOGO_E2E_BOOTSTRAP_SECRET against an env that exposes /api/internal/e2e).",
+    )
+
+    // Create three projects; each open claims a warm pod. The free cap is 2,
+    // so opening the 3rd must LRU-evict the 1st.
+    const p1 = await createProjectReturningId(page, "Build a simple counter app")
+    const p2 = await createProjectReturningId(page, "Build a todo list app")
+    const p3 = await createProjectReturningId(page, "Build a calculator app")
+
+    // Re-open in order so p1 becomes least-recently-used, then p2, then p3.
+    await openProject(page, p1)
+    await openProject(page, p2)
+    await openProject(page, p3)
+
+    const result = await waitForClaimedPodCount(page, user, 2, CLAIM_SETTLE_TIMEOUT_MS)
+    expect(result, "expected a claimed-pods reading").not.toBeNull()
+    expect(result!.claimedCount).toBeLessThanOrEqual(2)
+
+    const claimedIds = result!.claimed.map((c) => c.id)
+    // p1 was the least-recently-used at the time the cap bound, so it should
+    // have been evicted; the two most-recently-used survive.
+    expect(claimedIds).not.toContain(p1)
+    expect(claimedIds).toContain(p3)
+  })
+
+  test("pro workspace is allowed up to 4 claimed pods", async ({ page }) => {
+    const user = makeTestUser("CapPro")
+    await signUpAndOnboard(page, user)
+
+    const upgraded = await bootstrapProSubscriptionViaApi(page, user, "pro")
+    test.skip(
+      !upgraded,
+      "pro bootstrap backdoor unavailable (set SHOGO_E2E_BOOTSTRAP_SECRET).",
+    )
+
+    // Four projects all fit under the pro cap (4): none should be evicted.
+    const ids: string[] = []
+    for (const prompt of [
+      "Build app one",
+      "Build app two",
+      "Build app three",
+      "Build app four",
+    ]) {
+      ids.push(await createProjectReturningId(page, prompt))
+    }
+
+    const result = await getClaimedPodsViaApi(page, user)
+    expect(result, "expected a claimed-pods reading").not.toBeNull()
+    // All four remain claimed (cap is 4, so nothing is evicted yet).
+    expect(result!.claimedCount).toBeLessThanOrEqual(4)
+    expect(result!.claimedCount).toBeGreaterThanOrEqual(3)
+  })
+})


### PR DESCRIPTION
## Summary

The cloud warm pool (`warm-pool-controller.ts`) had **no per-user limit** on claimed (promoted) pods, so a single user could pin many at once. Investigation of the India prod cluster (`shogo-production-in`, Mumbai) found one user (`russell@getodin.ai`) holding **5** claimed pods while every other user held 1; the 11 default-named "New Project" pods were 11 distinct new signups (healthy). Local/desktop already caps concurrent assigns with LRU eviction (`vm-warm-pool-controller.ts`); this brings parity to the cloud.

- Per-user cap scaled **linearly by workspace plan** via `getClaimedPodCapForPlan` (`PLAN_RANK + 2` → free **2**, basic 3, pro **4**, business 5, enterprise 6). Overridable per tier with `WARM_POOL_CLAIMED_CAP_BY_TIER` (JSON).
- `enforcePerUserClaimedCap` runs in `tryClaimWarmPod` **before** `claim()`: counts the owner's claimed pods via DB (`knativeServiceName IS NOT NULL`, cluster-wide source of truth, excluding the incoming project) and **LRU-evicts** down to `cap-1` so the new claim lands at `cap`. Best-effort — never blocks a claim.
- `enforcePerUserCapsSweep` is a cross-replica backstop in the reconcile loop (the claim path only holds a per-project advisory lock). Fast-path skips sub-cap owners; uses the most generous cap across an owner's workspaces; bounded per cycle.
- LRU tracking via `lastTouchedAt` / `touchProject` (set on serve + assign). New metric `warm_pool.per_user_cap_evictions` (labelled `tier`, `source`). Live kill switch `WARM_POOL_PER_USER_CAP_ENABLED`.
- New diagnostic `GET /api/internal/e2e/claimed-pods` for the e2e suite.

Note: cap enforcement uses a **hard** evict (clears `knativeServiceName`, deletes the ksvc) — a soft evict keeps the DB mapping and wouldn't free the cap slot. The evicted LRU project re-claims / cold-starts on its next visit, matching local LRU semantics.

## Test plan

- [x] Unit: `config/__tests__/usage-plans.test.ts` — cap mapping (linear, decorated ids, fallback, env override, malformed JSON).
- [x] Unit: `lib/__tests__/warm-pool-per-user-cap.test.ts` — under/at/over cap, LRU victim selection, incoming-project exclusion, tier scaling, kill switch, and the GC sweep.
- [x] Integration: `__tests__/knative-project-manager.test.ts` — enforce-before-claim ordering with `(projectId, ownerUserId, planId)`, claim succeeds after eviction, and non-fatal failure path.
- [ ] E2E (staging): `e2e/staging/warm-pool-per-user-cap.test.ts` — free user capped at 2 (oldest LRU-evicted), pro workspace allowed 4. Requires `SHOGO_E2E_BOOTSTRAP_SECRET`:
  ```bash
  STAGING_URL=... SHOGO_E2E_BOOTSTRAP_SECRET=... \
    npx playwright test --config e2e/playwright.config.ts warm-pool-per-user-cap
  ```

All apps/api suites pass in isolation (process-per-file, matching CI). Pre-existing failures in `warm-pool-controller.test.ts` (env-building, scaled-to-zero) and typecheck `rootDir`/generated-prisma noise are present on `main` and unrelated.

## Rollout

Ship behind `WARM_POOL_PER_USER_CAP_ENABLED` (default on). `russell@getodin.ai` (5 pods today) is kept on business (5)/enterprise (6), trims 1 on pro (4), trims hard on free (2) — confirm/bump that workspace's tier or use the env override before enabling.

Made with [Cursor](https://cursor.com)