### PR TITLE
fix(agent-runtime): restore Composio file upload + block broken YOUTUBE_UPLOAD_VIDEO

### DIFF
--- a/packages/agent-runtime/scripts/test-youtube-upload.ts
+++ b/packages/agent-runtime/scripts/test-youtube-upload.ts
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Repro + verification harness for the Composio file-upload regression that
+ * broke YOUTUBE_UPLOAD_VIDEO / YOUTUBE_MULTIPART_UPLOAD_VIDEO after the
+ * @composio/core 0.6.5 -> 0.10.0 upgrade.
+ *
+ * SDK 0.10 turns automatic file upload OFF by default
+ * (`dangerouslyAllowAutoUploadDownloadFiles` defaults to false). A raw local
+ * path passed to a `file_uploadable` field is then forwarded as-is and the
+ * backend mis-reads it as an existing `s3key`, failing with:
+ *   "Failed to download file with s3key '…': storage returned HTTP 404"
+ *
+ * This script proves the regression and that the flag fixes it, end-to-end,
+ * against a *throwaway* YouTube channel. Uploads are private/unlisted.
+ *
+ * Usage (run from packages/agent-runtime):
+ *   # 1. Start the OAuth flow for a throwaway test user, then open the URL,
+ *   #    sign in with a throwaway Google account, and grant YouTube scope.
+ *   COMPOSIO_API_KEY=… bun scripts/test-youtube-upload.ts connect
+ *
+ *   # 2. Poll until the connection is active.
+ *   COMPOSIO_API_KEY=… bun scripts/test-youtube-upload.ts wait
+ *
+ *   # 3a. Reproduce the bug (flag OFF): expect the s3key HTTP 404.
+ *   COMPOSIO_API_KEY=… bun scripts/test-youtube-upload.ts upload --mode=off
+ *
+ *   # 3b. Verify the fix (flag ON): expect an unlisted video id, no s3key error.
+ *   COMPOSIO_API_KEY=… bun scripts/test-youtube-upload.ts upload --mode=on
+ *
+ *   # 3c. Same as 3b but pass a RELATIVE path (cwd = the media dir) to see
+ *   #     whether relative file args also need fixing.
+ *   COMPOSIO_API_KEY=… bun scripts/test-youtube-upload.ts upload --mode=on --relative
+ *
+ * Optional flags:
+ *   --slug=YOUTUBE_UPLOAD_VIDEO | YOUTUBE_MULTIPART_UPLOAD_VIDEO  (default: both)
+ *   --user=<composioUserId>   (default: shogo_test_youtube_upload)
+ *   --file=<path to mp4>      (default: <mediaDir>/test.mp4)
+ *   --dir=<media dir>         (default: /tmp/shogo-test)
+ */
+
+import { Composio } from '@composio/core'
+
+const TOOLKIT = 'youtube'
+const DEFAULT_USER = 'shogo_test_youtube_upload'
+const DEFAULT_DIR = '/tmp/shogo-test'
+const FILE_FIELD: Record<string, string> = {
+  YOUTUBE_UPLOAD_VIDEO: 'videoFilePath',
+  YOUTUBE_MULTIPART_UPLOAD_VIDEO: 'videoFile',
+}
+
+function loadDotEnv() {
+  const fs = require('node:fs') as typeof import('node:fs')
+  const candidates = ['.env.local', '.env', '../../.env.local', '../../.env']
+  for (const path of candidates) {
+    if (!fs.existsSync(path)) continue
+    const text = fs.readFileSync(path, 'utf8')
+    for (const line of text.split('\n')) {
+      const m = line.match(/^([A-Z][A-Z0-9_]*)=(.*)$/)
+      if (!m) continue
+      const key = m[1]
+      let value = m[2]
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1)
+      }
+      if (process.env[key] === undefined) process.env[key] = value
+    }
+  }
+}
+
+function arg(name: string, fallback?: string): string | undefined {
+  const hit = process.argv.find(a => a.startsWith(`--${name}=`))
+  if (hit) return hit.slice(name.length + 3)
+  return fallback
+}
+
+function hasFlag(name: string): boolean {
+  return process.argv.includes(`--${name}`)
+}
+
+function requireApiKey(): string {
+  const apiKey = process.env.COMPOSIO_API_KEY
+  if (!apiKey) {
+    console.error('COMPOSIO_API_KEY not set. Aborting.')
+    process.exit(1)
+  }
+  return apiKey
+}
+
+function userId(): string {
+  return arg('user', DEFAULT_USER)!
+}
+
+function mediaDir(): string {
+  return arg('dir', DEFAULT_DIR)!
+}
+
+function fileUploadDirs(): string[] {
+  const home = process.env.HOME
+  const dirs = [mediaDir()]
+  if (home) dirs.push(`${home}/.composio/temp`)
+  return dirs
+}
+
+function targetSlugs(): string[] {
+  const one = arg('slug')
+  if (one) return [one]
+  return ['YOUTUBE_UPLOAD_VIDEO', 'YOUTUBE_MULTIPART_UPLOAD_VIDEO']
+}
+
+function ensureTestFile(): string {
+  const fs = require('node:fs') as typeof import('node:fs')
+  const path = require('node:path') as typeof import('node:path')
+  const { execSync } = require('node:child_process') as typeof import('node:child_process')
+  const dir = mediaDir()
+  const file = arg('file', path.join(dir, 'test.mp4'))!
+  if (fs.existsSync(file)) return file
+  fs.mkdirSync(dir, { recursive: true })
+  try {
+    execSync(
+      `ffmpeg -y -f lavfi -i testsrc=duration=3:size=320x240:rate=10 -pix_fmt yuv420p "${file}"`,
+      { stdio: 'ignore' },
+    )
+  } catch {
+    console.error(
+      `Could not create a test clip with ffmpeg, and no file at ${file}.\n` +
+        `Install ffmpeg or pass --file=<path to a small .mp4>.`,
+    )
+    process.exit(1)
+  }
+  return file
+}
+
+async function cmdConnect() {
+  const apiKey = requireApiKey()
+  const uid = userId()
+  const composio = new Composio({ apiKey })
+  await composio.create(uid)
+  const session = await composio.create(uid)
+  const connection = await session.authorize(TOOLKIT, {})
+  const redirectUrl =
+    (connection as any)?.redirectUrl || (connection as any)?.redirect_url
+  console.log(`\nComposio test user: ${uid}`)
+  if (redirectUrl) {
+    console.log(`\nOpen this URL, sign in with a THROWAWAY Google/YouTube account, and grant access:\n`)
+    console.log(`  ${redirectUrl}\n`)
+    console.log(`Then run:  bun scripts/test-youtube-upload.ts wait`)
+  } else {
+    console.log('Already connected (no redirect URL returned).')
+  }
+}
+
+async function cmdWait() {
+  const apiKey = requireApiKey()
+  const uid = userId()
+  const composio = new Composio({ apiKey })
+  const deadline = Date.now() + 5 * 60 * 1000
+  process.stdout.write(`Waiting for "${TOOLKIT}" to become active for ${uid} `)
+  while (Date.now() < deadline) {
+    const list = await composio.connectedAccounts.list({
+      userIds: [uid],
+      toolkitSlugs: [TOOLKIT],
+    })
+    const items: any[] = (list as any).items ?? (list as any).data ?? []
+    const active = items.find(a => a.status?.toLowerCase() === 'active')
+    if (active) {
+      console.log(`\nActive. account id=${active.id}`)
+      return
+    }
+    process.stdout.write('.')
+    await new Promise(r => setTimeout(r, 3000))
+  }
+  console.log('\nTimed out waiting for an active connection.')
+  process.exit(1)
+}
+
+async function cmdUpload() {
+  const apiKey = requireApiKey()
+  const uid = userId()
+  const mode = arg('mode', 'on') // 'on' | 'off'
+  const relative = hasFlag('relative')
+  const path = require('node:path') as typeof import('node:path')
+  const absFile = ensureTestFile()
+  const passPath = relative ? path.basename(absFile) : absFile
+  const cwdForRelative = relative ? path.dirname(absFile) : process.cwd()
+
+  if (relative) process.chdir(cwdForRelative)
+
+  const composio =
+    mode === 'off'
+      ? new Composio({ apiKey, toolkitVersions: 'latest' })
+      : new Composio({
+          apiKey,
+          toolkitVersions: 'latest',
+          dangerouslyAllowAutoUploadDownloadFiles: true,
+          fileUploadDirs: fileUploadDirs(),
+        })
+
+  console.log(
+    `\nmode=${mode} relative=${relative} file=${passPath} cwd=${process.cwd()}\n` +
+      `fileUploadDirs=${mode === 'on' ? JSON.stringify(fileUploadDirs()) : '(default)'}\n`,
+  )
+
+  for (const slug of targetSlugs()) {
+    const field = FILE_FIELD[slug]
+    if (!field) {
+      console.log(`[${slug}] unknown file field, skipping`)
+      continue
+    }
+    const args: Record<string, unknown> = {
+      title: `shogo upload test ${new Date().toISOString()}`,
+      description: 'Automated test upload (composio file-upload regression).',
+      categoryId: '22',
+      privacyStatus: 'unlisted',
+      [field]: passPath,
+    }
+    if (slug === 'YOUTUBE_UPLOAD_VIDEO') args.tags = ['shogo-test']
+
+    console.log(`\n=== ${slug} (${field}) ===`)
+    try {
+      const result = await composio.tools.execute(slug, {
+        userId: uid,
+        arguments: args,
+        dangerouslySkipVersionCheck: true,
+      })
+      const ok = (result as any).successful
+      const summary = JSON.stringify((result as any).data ?? result).slice(0, 600)
+      const errText = JSON.stringify((result as any).error ?? '').slice(0, 600)
+      console.log(`  successful=${ok}`)
+      if (ok) console.log(`  data: ${summary}`)
+      else console.log(`  error: ${errText || summary}`)
+    } catch (err: any) {
+      const cause = err?.cause
+      console.log(`  THREW: ${err?.message}`)
+      if (cause) console.log(`  cause: ${JSON.stringify(cause?.error ?? cause?.message ?? cause).slice(0, 600)}`)
+    }
+  }
+}
+
+async function cmdDetails() {
+  const apiKey = requireApiKey()
+  const uid = userId()
+  const ids = (arg('ids') || '').split(',').map(s => s.trim()).filter(Boolean)
+  if (ids.length === 0) {
+    console.error('Pass --ids=ID1,ID2,…')
+    process.exit(1)
+  }
+  const composio = new Composio({ apiKey, toolkitVersions: 'latest' })
+  const result = await composio.tools.execute('YOUTUBE_GET_VIDEO_DETAILS_BATCH', {
+    userId: uid,
+    arguments: { id: ids.join(','), part: 'status,processingDetails,snippet' },
+    dangerouslySkipVersionCheck: true,
+  })
+  const data: any = (result as any).data ?? result
+  const items: any[] = data?.response_data?.items ?? data?.items ?? []
+  if (items.length === 0) {
+    console.log(JSON.stringify(data).slice(0, 1500))
+    return
+  }
+  for (const v of items) {
+    console.log(
+      `${v.id}  uploadStatus=${v.status?.uploadStatus}  ` +
+        `failureReason=${v.status?.failureReason ?? '-'}  ` +
+        `processing=${v.processingDetails?.processingStatus ?? '-'}  ` +
+        `title="${v.snippet?.title ?? ''}"`,
+    )
+  }
+}
+
+async function main() {
+  loadDotEnv()
+  const cmd = process.argv[2]
+  switch (cmd) {
+    case 'connect':
+      return cmdConnect()
+    case 'wait':
+      return cmdWait()
+    case 'upload':
+      return cmdUpload()
+    case 'details':
+      return cmdDetails()
+    default:
+      console.log(
+        'Usage: bun scripts/test-youtube-upload.ts <connect|wait|upload> [--mode=on|off] [--relative] [--slug=…] [--user=…] [--file=…] [--dir=…]',
+      )
+      process.exit(1)
+  }
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/agent-runtime/src/__tests__/composio.test.ts
+++ b/packages/agent-runtime/src/__tests__/composio.test.ts
@@ -404,6 +404,21 @@ describe('registerToolkitProxyTools', () => {
     expect(mgr.calls).toHaveLength(1)
   })
 
+  // YOUTUBE_UPLOAD_VIDEO is on the upstream-broken denylist: the API accepts the
+  // upload but YouTube can't process the result ("Processing abandoned"). It must
+  // never be bound; YOUTUBE_MULTIPART_UPLOAD_VIDEO is the working path.
+  it('filters out upstream-broken slugs (YOUTUBE_UPLOAD_VIDEO)', async () => {
+    mockedSchemas = [
+      { slug: 'YOUTUBE_UPLOAD_VIDEO', description: 'upload', is_deprecated: false },
+      { slug: 'YOUTUBE_MULTIPART_UPLOAD_VIDEO', description: 'multipart upload', is_deprecated: false },
+      { slug: 'YOUTUBE_LIST_CHANNEL_VIDEOS', description: 'list', is_deprecated: false },
+    ]
+    const mgr = fakeMcpMgr()
+    const r = await registerToolkitProxyTools(mgr, 'youtube')
+    expect(r.toolNames).not.toContain('YOUTUBE_UPLOAD_VIDEO')
+    expect(r.toolNames.sort()).toEqual(['YOUTUBE_LIST_CHANNEL_VIDEOS', 'YOUTUBE_MULTIPART_UPLOAD_VIDEO'])
+  })
+
   it('dedups across calls — re-registering the same toolkit is a no-op on the manager', async () => {
     mockedSchemas = [
       { slug: 'GITHUB_LIST', description: 'list', is_deprecated: false },

--- a/packages/agent-runtime/src/composio.ts
+++ b/packages/agent-runtime/src/composio.ts
@@ -241,6 +241,27 @@ function getAuthConfigs(): ComposioAuthConfigs {
 
 let composioClient: Composio | null = null
 
+/**
+ * Directories the SDK is allowed to read local files from during *automatic*
+ * file upload (when `dangerouslyAllowAutoUploadDownloadFiles` is on). Passing a
+ * value REPLACES the SDK default (`~/.composio/temp`), so we re-add it and add
+ * the agent's workspace root — that's where the agent writes the media it then
+ * passes to `file_uploadable` tool fields (e.g. YOUTUBE_UPLOAD_VIDEO's
+ * `videoFilePath`). `WORKSPACE_DIR` mirrors the resolution in server.ts. The
+ * built-in sensitive-path denylist (`.ssh`, `.aws`, `.env`, …) stays on.
+ */
+function getComposioFileUploadDirs(): string[] {
+  const workspaceDir =
+    process.env.WORKSPACE_DIR ||
+    process.env.AGENT_DIR ||
+    process.env.PROJECT_DIR ||
+    '/app/workspace'
+  const home = process.env.HOME
+  const dirs = [workspaceDir]
+  if (home) dirs.push(`${home}/.composio/temp`)
+  return dirs
+}
+
 function getComposioClient(): Composio | null {
   if (composioClient) return composioClient
 
@@ -253,8 +274,20 @@ function getComposioClient(): Composio | null {
   // contains a toolkit's initial-release tools — so newer slugs 404'd at execute
   // ("Tool X not found" / "Unable to retrieve tool with slug"). SDK 0.10 + API
   // v3.1 default to `latest`; we pin it explicitly so the behavior is obvious.
+  //
+  // `dangerouslyAllowAutoUploadDownloadFiles` re-enables automatic staging of
+  // local files for `file_uploadable` tool fields. SDK 0.6.5 did this by
+  // default; SDK 0.10 turns it OFF by default, so a raw local path was forwarded
+  // as-is and Composio's backend mis-read it as an existing `s3key`, failing with
+  // "Failed to download file with s3key '…': storage returned HTTP 404" (broke
+  // YOUTUBE_UPLOAD_VIDEO / YOUTUBE_MULTIPART_UPLOAD_VIDEO post-upgrade).
   if (apiKey) {
-    composioClient = new Composio({ apiKey, toolkitVersions: 'latest' })
+    composioClient = new Composio({
+      apiKey,
+      toolkitVersions: 'latest',
+      dangerouslyAllowAutoUploadDownloadFiles: true,
+      fileUploadDirs: getComposioFileUploadDirs(),
+    })
     console.log('[Composio] Client initialized (direct)')
     return composioClient
   }
@@ -264,6 +297,8 @@ function getComposioClient(): Composio | null {
       apiKey: proxyToken,
       baseURL: `${proxyUrl}/composio`,
       toolkitVersions: 'latest',
+      dangerouslyAllowAutoUploadDownloadFiles: true,
+      fileUploadDirs: getComposioFileUploadDirs(),
     })
     console.log('[Composio] Client initialized (via proxy)')
     return composioClient
@@ -561,6 +596,21 @@ function textResult(data: any): AgentToolResult<any> {
 }
 
 /**
+ * Composio tools the catalog exposes but that are broken upstream — we never
+ * bind them, so the agent can't discover or call them.
+ *
+ * - `YOUTUBE_UPLOAD_VIDEO`: the API accepts the upload and returns a video id,
+ *   but its non-resumable media transfer yields a file YouTube cannot process
+ *   ("Processing abandoned"). Verified end-to-end against the real SDK for both
+ *   a tiny synthetic clip and a proper 720p H.264/AAC file — 3/3 abandoned,
+ *   while `YOUTUBE_MULTIPART_UPLOAD_VIDEO` processed successfully every time.
+ *   Agents should use `YOUTUBE_MULTIPART_UPLOAD_VIDEO` instead.
+ */
+const COMPOSIO_BLOCKED_SLUGS = new Set<string>([
+  'YOUTUBE_UPLOAD_VIDEO',
+])
+
+/**
  * Dynamically register proxy AgentTools for each action in a Composio toolkit.
  * Each proxy tool executes via the Composio SDK directly.
  * Tool names are the raw Composio slugs (e.g. GOOGLECALENDAR_CREATE_EVENT).
@@ -579,7 +629,9 @@ export async function registerToolkitProxyTools(
   // for the life of the runtime. addProxyTools dedupes by name, so re-running is
   // cheap and self-heals: it appends only the slugs that were missing.
   const schemas = await fetchComposioToolSchemas(toolkitSlug)
-  const nonDeprecated = schemas.filter(s => !s.is_deprecated)
+  const nonDeprecated = schemas.filter(
+    s => !s.is_deprecated && !COMPOSIO_BLOCKED_SLUGS.has(s.slug),
+  )
 
   if (nonDeprecated.length === 0) {
     // Don't discard a prior good registration on a transient empty fetch.
@@ -618,6 +670,17 @@ function createProxyTool(schema: ComposioToolSchema): AgentTool {
     parameters = Type.Object(props)
   }
 
+  // Fields the catalog marks `file_uploadable` (e.g. YOUTUBE_UPLOAD_VIDEO's
+  // `videoFilePath`). The SDK's auto-upload reads a local *path* arg and stages
+  // it to Composio storage — but it resolves a relative path against
+  // `process.cwd()`, which is not the agent's workspace. The agent typically
+  // passes a workspace-relative path ("uploads/clip.mp4"), so we rebase those
+  // onto WORKSPACE_DIR before execute. URLs and already-staged descriptors are
+  // left untouched.
+  const fileUploadableFields = Object.entries(schema.input_parameters?.properties ?? {})
+    .filter(([, prop]) => (prop as any)?.file_uploadable === true)
+    .map(([key]) => key)
+
   return {
     name: schema.slug,
     description: schema.description || `Composio tool: ${schema.slug}`,
@@ -629,6 +692,29 @@ function createProxyTool(schema: ComposioToolSchema): AgentTool {
         return textResult({ error: 'Composio not initialized. Call connect first.' })
       }
       const args = (params && typeof params === 'object') ? params as Record<string, any> : {}
+
+      // Rebase relative file paths onto the workspace so the SDK's auto-upload
+      // (which resolves against process.cwd()) can read them. Absolute paths,
+      // URLs, and pre-staged { s3key } descriptors pass through unchanged.
+      if (fileUploadableFields.length > 0) {
+        const path = require('node:path') as typeof import('node:path')
+        const workspaceDir =
+          process.env.WORKSPACE_DIR ||
+          process.env.AGENT_DIR ||
+          process.env.PROJECT_DIR ||
+          '/app/workspace'
+        for (const field of fileUploadableFields) {
+          const value = args[field]
+          if (
+            typeof value === 'string' &&
+            value &&
+            !/^[a-z][a-z0-9+.-]*:\/\//i.test(value) &&
+            !path.isAbsolute(value)
+          ) {
+            args[field] = path.resolve(workspaceDir, value)
+          }
+        }
+      }
 
       // A single execute attempt, normalized to a discriminated result so the
       // throw path and the `!successful` path share one classification.


### PR DESCRIPTION
## Summary

YouTube video uploads broke in production after the `@composio/core` 0.6.5 -> 0.10.0 upgrade (v1.10.11): **69 failures / 12 sessions** since the deploy, only 3 successful uploads ever.

Root cause: SDK 0.10 turns automatic file upload **off** by default (`dangerouslyAllowAutoUploadDownloadFiles`), where 0.6.5 had it on. A local path passed to a `file_uploadable` field (e.g. `YOUTUBE_UPLOAD_VIDEO.videoFilePath`) was then forwarded as-is, and Composio's backend rejected it as an unstaged file:
> requires a FileUploadable object … You must first upload the file to S3 to get an s3key
> Failed to download file with s3key '…': storage returned HTTP 404

This is unrelated to the 8 slug renames documented in the upgrade findings.

## Changes
- **Re-enable auto file upload** on both Composio clients (`packages/agent-runtime/src/composio.ts`) with `dangerouslyAllowAutoUploadDownloadFiles: true`, scoped via `fileUploadDirs` to `WORKSPACE_DIR` + `~/.composio/temp` (the list replaces the SDK default, so both are included). Sensitive-path denylist stays on.
- **Rebase relative file args** onto `WORKSPACE_DIR` in `createProxyTool` before execute — the SDK resolves relative paths against `process.cwd()`, not the agent workspace. URLs and pre-staged `{s3key}` descriptors pass through untouched.
- **Block `YOUTUBE_UPLOAD_VIDEO`** at binding via a new `COMPOSIO_BLOCKED_SLUGS` denylist. It's broken upstream independent of this fix (see verification); `YOUTUBE_MULTIPART_UPLOAD_VIDEO` is the working path.
- Add `scripts/test-youtube-upload.ts` repro/verify harness + a regression test.

## Verification (live Composio, throwaway YouTube connection)
| Tool | File | API accept | YouTube processing |
|---|---|---|---|
| `YOUTUBE_MULTIPART_UPLOAD_VIDEO` | tiny clip | yes | processed / succeeded |
| `YOUTUBE_MULTIPART_UPLOAD_VIDEO` | 720p H.264/AAC | yes | processed / succeeded |
| `YOUTUBE_UPLOAD_VIDEO` | tiny clip (abs) | yes | Processing abandoned |
| `YOUTUBE_UPLOAD_VIDEO` | tiny clip (relative) | yes | Processing abandoned |
| `YOUTUBE_UPLOAD_VIDEO` | 720p H.264/AAC | yes | Processing abandoned |

- Flag OFF reproduces the backend "must first upload to S3" rejection for both slugs.
- Flag ON stages the file and the upload is accepted for both; only `MULTIPART` is processed successfully by YouTube (3/3 abandoned for `YOUTUBE_UPLOAD_VIDEO`, with both a degenerate and a proper file) — hence the denylist.
- 78/78 Composio unit tests pass.

## Test plan
- [ ] CI green (typecheck + agent-runtime tests)
- [ ] Confirm `YOUTUBE_UPLOAD_VIDEO` no longer appears in bound tools for a YouTube-connected session
- [ ] Spot-check a real agent-driven `YOUTUBE_MULTIPART_UPLOAD_VIDEO` upload of a workspace file

## Follow-ups (out of scope)
- File the `YOUTUBE_UPLOAD_VIDEO` "Processing abandoned" defect with Composio.

Made with [Cursor](https://cursor.com)