### PR TITLE
fix(mobile): align iOS billing with App Store review

### DIFF
--- a/apps/mobile/app/(app)/billing.tsx
+++ b/apps/mobile/app/(app)/billing.tsx
@@ -108,6 +108,8 @@ export default observer(function BillingPage() {
 
   const http = useDomainHttp()
   const currentWorkspace = useActiveWorkspace()
+  const billingWorkspace = currentWorkspace ?? workspaces?.all?.[0] ?? null
+  const isWorkspaceLoading = Boolean(user?.id && workspaces?.isLoading && !billingWorkspace)
 
   const {
     subscription,
@@ -117,7 +119,7 @@ export default observer(function BillingPage() {
     refetchUsageWallet,
     planSource,
     usageWindows,
-  } = useBillingData(currentWorkspace?.id)
+  } = useBillingData(billingWorkspace?.id)
   // A grant-conferred plan has no Stripe customer / portal, so hide
   // "Manage" / Stripe-only affordances and let "Free Plan"-style copy
   // adapt by checking `planSource === 'subscription'` instead of just
@@ -141,6 +143,7 @@ export default observer(function BillingPage() {
   const contentHorizontalPadding = isTabletWidth ? 24 : 16
   // Wider container on iPad portrait so the new 2-column plan grid breathes.
   const contentMaxWidth = width >= 1280 ? 1200 : width >= 768 ? 920 : 720
+  const canRedeemLicenseKeys = Platform.OS !== 'ios'
 
   type IapToastVariant = 'success' | 'error' | 'info'
   const showIapToast = useCallback((variant: IapToastVariant, title: string, description: string) => {
@@ -158,9 +161,11 @@ export default observer(function BillingPage() {
     })
   }, [toast])
 
-  // Deep-link landing: shogo://billing?redeem=CODE (or <web>/billing?redeem=CODE)
-  // prefills the license-key field and focuses it so the recipient just taps Redeem.
+  // Deep-link landing outside iOS prefills the license-key field. iOS must
+  // not unlock paid digital features through mechanisms other than App Store
+  // In-App Purchase.
   useEffect(() => {
+    if (!canRedeemLicenseKeys) return
     const code = Array.isArray(redeemParam) ? redeemParam[0] : redeemParam
     if (!code) return
     setLicenseCode(code.trim().toUpperCase())
@@ -169,12 +174,13 @@ export default observer(function BillingPage() {
     clearPendingLicenseCode()
     const t = setTimeout(() => licenseInputRef.current?.focus(), 350)
     return () => clearTimeout(t)
-  }, [redeemParam])
+  }, [canRedeemLicenseKeys, redeemParam])
 
   const handleRedeemLicense = useCallback(async () => {
+    if (!canRedeemLicenseKeys) return
     const code = licenseCode.trim()
     if (!code) return
-    const workspaceId = currentWorkspace?.id
+    const workspaceId = billingWorkspace?.id
     if (!workspaceId) {
       showIapToast('error', 'No workspace selected', 'Pick a workspace before redeeming a key.')
       return
@@ -204,7 +210,7 @@ export default observer(function BillingPage() {
     } finally {
       setIsRedeeming(false)
     }
-  }, [licenseCode, currentWorkspace?.id, http, refetchSubscription, refetchUsageWallet, showIapToast])
+  }, [canRedeemLicenseKeys, licenseCode, billingWorkspace?.id, http, refetchSubscription, refetchUsageWallet, showIapToast])
 
   const getIapTransactionKey = useCallback((purchase: IapPurchaseResult) => {
     const transactionId = purchase.transactionId?.trim()
@@ -224,7 +230,7 @@ export default observer(function BillingPage() {
       onVerified?: () => void
     } = {},
   ): Promise<'processed' | 'duplicate' | 'failed'> => {
-    const workspaceId = currentWorkspace?.id
+    const workspaceId = billingWorkspace?.id
     if (!workspaceId) return 'failed'
 
     const key = getIapTransactionKey(purchase)
@@ -275,14 +281,14 @@ export default observer(function BillingPage() {
     } finally {
       iapTransactionsInFlightRef.current.delete(key)
     }
-  }, [currentWorkspace?.id, getIapTransactionKey, http, refetchSubscription, refetchUsageWallet, showIapToast])
+  }, [billingWorkspace?.id, getIapTransactionKey, http, refetchSubscription, refetchUsageWallet, showIapToast])
 
   // Global StoreKit listener — finishes any pending transaction that gets
   // delivered async (Ask to Buy approval, app relaunched mid-purchase, etc.).
   // Without this, transactions sit in the StoreKit queue forever and Apple
   // rejects the build for "unfinished transactions on relaunch."
   useEffect(() => {
-    if (Platform.OS !== 'ios' || !currentWorkspace?.id) return
+    if (Platform.OS !== 'ios' || !billingWorkspace?.id) return
     const teardown = initIapListeners(
       async (purchase) => {
         await processIapPurchase(purchase, {
@@ -298,10 +304,10 @@ export default observer(function BillingPage() {
       },
     )
     return teardown
-  }, [currentWorkspace?.id, processIapPurchase, showIapToast])
+  }, [billingWorkspace?.id, processIapPurchase, showIapToast])
 
   const handleRestorePurchases = useCallback(async () => {
-    if (Platform.OS !== 'ios' || !currentWorkspace?.id) return
+    if (Platform.OS !== 'ios' || !billingWorkspace?.id) return
     setIsRestoreLoading(true)
     try {
       const purchases = await restorePurchases()
@@ -327,7 +333,7 @@ export default observer(function BillingPage() {
     } finally {
       setIsRestoreLoading(false)
     }
-  }, [currentWorkspace?.id, processIapPurchase, showIapToast])
+  }, [billingWorkspace?.id, processIapPurchase, showIapToast])
 
 
   useEffect(() => {
@@ -371,7 +377,7 @@ export default observer(function BillingPage() {
   }, [regionalPricing])
 
   const handleCheckout = useCallback(async (planType: 'pro' | 'business' | 'basic', seats: number) => {
-    if (!currentWorkspace?.id) return
+    if (!billingWorkspace?.id) return
     setIsCheckoutLoading(true)
     try {
       const planId = planType
@@ -387,11 +393,11 @@ export default observer(function BillingPage() {
       // ============================================================
       if (Platform.OS === 'ios') {
         try {
-          trackInitiateCheckout({ planId, billingInterval, seats: 1, workspaceId: currentWorkspace.id })
+          trackInitiateCheckout({ planId, billingInterval, seats: 1, workspaceId: billingWorkspace.id })
           const result = await purchaseSubscription({
             plan: planType,
             interval: billingInterval,
-            workspaceId: currentWorkspace.id,
+            workspaceId: billingWorkspace.id,
           })
           const purchaseResult = await processIapPurchase(result, {
             successTitle: 'Subscription activated',
@@ -400,7 +406,7 @@ export default observer(function BillingPage() {
               planId,
               billingInterval,
               seats: 1,
-              workspaceId: currentWorkspace.id,
+              workspaceId: billingWorkspace.id,
               sessionId: result.transactionId,
             }),
           })
@@ -430,18 +436,18 @@ export default observer(function BillingPage() {
         ? ExpoLinking.createURL('billing')
         : (typeof window !== 'undefined' ? window.location.origin : undefined)
       console.log('[Billing] checkout start', { planId, seats: safeSeats, billingInterval, isNative, redirectBase })
-      trackInitiateCheckout({ planId, billingInterval, seats: safeSeats, workspaceId: currentWorkspace.id })
+      trackInitiateCheckout({ planId, billingInterval, seats: safeSeats, workspaceId: billingWorkspace.id })
 
       const data = await api.createCheckoutSession(http, {
-        workspaceId: currentWorkspace.id,
+        workspaceId: billingWorkspace.id,
         planId,
         seats: safeSeats,
         billingInterval,
         userEmail: user?.email,
         referralId: getRewardfulReferral(),
         ...(redirectBase && {
-          successUrl: `${redirectBase}/?workspace=${currentWorkspace.id}&checkout=success&session_id={CHECKOUT_SESSION_ID}`,
-          cancelUrl: `${redirectBase}/?workspace=${currentWorkspace.id}&checkout=canceled`,
+          successUrl: `${redirectBase}/?workspace=${billingWorkspace.id}&checkout=success&session_id={CHECKOUT_SESSION_ID}`,
+          cancelUrl: `${redirectBase}/?workspace=${billingWorkspace.id}&checkout=canceled`,
         }),
       })
       console.log('[Billing] checkout session created', { url: data.url ? '(received)' : '(missing)' })
@@ -469,7 +475,7 @@ export default observer(function BillingPage() {
                   const verifyResult = await api.verifyCheckout(http, sessionId)
                   console.log('[Billing] verify result:', verifyResult)
                   if (checkout === 'success') {
-                    trackPurchase({ planId: verifyResult.planId, billingInterval, seats: (verifyResult as { seats?: number }).seats ?? safeSeats, workspaceId: currentWorkspace?.id, sessionId })
+                    trackPurchase({ planId: verifyResult.planId, billingInterval, seats: (verifyResult as { seats?: number }).seats ?? safeSeats, workspaceId: billingWorkspace?.id, sessionId })
                   }
                 } catch (verifyErr) {
                   console.warn('[Billing] verify failed (webhook will handle):', verifyErr)
@@ -490,10 +496,10 @@ export default observer(function BillingPage() {
     } finally {
       setIsCheckoutLoading(false)
     }
-  }, [http, currentWorkspace?.id, billingInterval, user?.email, router, refetchSubscription, refetchUsageWallet])
+  }, [http, billingWorkspace?.id, billingInterval, user?.email, router, refetchSubscription, refetchUsageWallet])
 
   const handleManageSubscription = useCallback(async () => {
-    if (!currentWorkspace?.id) return
+    if (!billingWorkspace?.id) return
     setIsPortalLoading(true)
     try {
       // iOS: route to native App Store subscriptions screen (Apple requirement).
@@ -513,7 +519,7 @@ export default observer(function BillingPage() {
         : window.location.href
       console.log('[Billing] portal start', { isNative, returnUrl })
 
-      const data = await api.createPortalSession(http, currentWorkspace.id, returnUrl)
+      const data = await api.createPortalSession(http, billingWorkspace.id, returnUrl)
       if (data.url) {
         if (!isNative) {
           window.location.href = data.url
@@ -531,7 +537,7 @@ export default observer(function BillingPage() {
     } finally {
       setIsPortalLoading(false)
     }
-  }, [http, currentWorkspace?.id, refetchSubscription, refetchUsageWallet])
+  }, [http, billingWorkspace?.id, refetchSubscription, refetchUsageWallet])
 
   const handleManageBillingOnWeb = useCallback(() => {
     openWebAppSession('/billing').catch((err) =>
@@ -539,7 +545,7 @@ export default observer(function BillingPage() {
     )
   }, [])
 
-  if (isAuthLoading || isBillingLoading) {
+  if (isAuthLoading || isWorkspaceLoading || isBillingLoading) {
     return (
       <View className="flex-1 bg-background p-6">
         <View className="gap-4">
@@ -551,7 +557,7 @@ export default observer(function BillingPage() {
     )
   }
 
-  if (!user || !currentWorkspace) {
+  if (!user || !billingWorkspace) {
     return (
       <View className="flex-1 bg-background p-6">
         <View className="items-center justify-center py-12">
@@ -609,7 +615,7 @@ export default observer(function BillingPage() {
             <View className="flex-row items-center gap-3 flex-1">
               <View className="h-10 w-10 rounded-full bg-primary/10 items-center justify-center">
                 <Text className="text-lg font-semibold text-primary">
-                  {currentWorkspace.name?.[0]?.toUpperCase() || 'W'}
+                  {billingWorkspace.name?.[0]?.toUpperCase() || 'W'}
                 </Text>
               </View>
               <View className="flex-1">
@@ -648,42 +654,43 @@ export default observer(function BillingPage() {
       </Card>
 
       {/* Billing history (recent Stripe invoices) */}
-      <BillingHistory workspaceId={currentWorkspace.id} />
+      <BillingHistory workspaceId={billingWorkspace.id} />
 
-      {/* Redeem a license key */}
-      <Card className="mb-4">
-        <CardContent className="p-4 gap-3">
-          <View className="flex-row items-center gap-2">
-            <KeyRound size={16} className="text-primary" />
-            <Text className="text-sm font-medium text-foreground">Redeem a license key</Text>
-          </View>
-          <Text className="text-xs text-muted-foreground">
-            Have a license key? Redeem it to upgrade this workspace.
-          </Text>
-          <View className="flex-row items-center gap-2">
-            <TextInput
-              ref={licenseInputRef}
-              value={licenseCode}
-              onChangeText={setLicenseCode}
-              placeholder="SHGO-PRO-XXXX-XXXX-XXXX"
-              placeholderTextColor="#9ca3af"
-              autoCapitalize="characters"
-              autoCorrect={false}
-              editable={!isRedeeming}
-              onSubmitEditing={handleRedeemLicense}
-              returnKeyType="done"
-              className="flex-1 border border-border rounded-lg px-3 py-2 text-sm font-mono text-foreground bg-background"
-            />
-            <Button
-              size="sm"
-              onPress={handleRedeemLicense}
-              disabled={isRedeeming || !licenseCode.trim()}
-            >
-              {isRedeeming ? 'Redeeming...' : 'Redeem'}
-            </Button>
-          </View>
-        </CardContent>
-      </Card>
+      {canRedeemLicenseKeys && (
+        <Card className="mb-4">
+          <CardContent className="p-4 gap-3">
+            <View className="flex-row items-center gap-2">
+              <KeyRound size={16} className="text-primary" />
+              <Text className="text-sm font-medium text-foreground">Redeem a license key</Text>
+            </View>
+            <Text className="text-xs text-muted-foreground">
+              Have a license key? Redeem it to upgrade this workspace.
+            </Text>
+            <View className="flex-row items-center gap-2">
+              <TextInput
+                ref={licenseInputRef}
+                value={licenseCode}
+                onChangeText={setLicenseCode}
+                placeholder="SHGO-PRO-XXXX-XXXX-XXXX"
+                placeholderTextColor="#9ca3af"
+                autoCapitalize="characters"
+                autoCorrect={false}
+                editable={!isRedeeming}
+                onSubmitEditing={handleRedeemLicense}
+                returnKeyType="done"
+                className="flex-1 border border-border rounded-lg px-3 py-2 text-sm font-mono text-foreground bg-background"
+              />
+              <Button
+                size="sm"
+                onPress={handleRedeemLicense}
+                disabled={isRedeeming || !licenseCode.trim()}
+              >
+                {isRedeeming ? 'Redeeming...' : 'Redeem'}
+              </Button>
+            </View>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Usage Display — time-gated rolling windows */}
       <Card className="mb-8">

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -353,12 +353,10 @@ const HomeScreen = observer(function HomeScreen() {
       })
   }, [currentWorkspace?.id, user?.id])
 
-  // Deep-link: a license-key redeem link stashed before sign-up/onboarding
-  // (lib/pending-license.ts). Now that the user is authenticated with a
-  // workspace, route them to billing with the code prefilled so they can
-  // complete the redemption.
+  // Deep-link: a non-iOS license-key redeem link stashed before
+  // sign-up/onboarding. iOS upgrades must use App Store In-App Purchase only.
   useEffect(() => {
-    if (!currentWorkspace?.id || !user?.id) return
+    if (Platform.OS === 'ios' || !currentWorkspace?.id || !user?.id) return
     const code = getPendingLicenseCode()
     if (!code) return
     clearPendingLicenseCode()

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -131,13 +131,13 @@ function useCaptureTemplateDeepLink() {
   }, [])
 }
 
-// Capture a license-key redeem code from the deep link before the (app)
-// auth guard can redirect an unauthenticated user to sign-in (which drops
-// the query param). The home screen consumes it once the user is signed in
-// and has a workspace. See lib/pending-license.ts.
+// Capture a non-iOS license-key redeem code before the (app) auth guard can
+// redirect an unauthenticated user to sign-in. iOS upgrades must use App Store
+// In-App Purchase only.
 function useCaptureRedeemDeepLink() {
   const nativeUrl = ExpoLinking.useURL()
   useEffect(() => {
+    if (Platform.OS === 'ios') return
     if (Platform.OS === 'web') {
       if (typeof window === 'undefined') return
       const params = new URLSearchParams(window.location.search)

--- a/apps/mobile/lib/iap.ts
+++ b/apps/mobile/lib/iap.ts
@@ -16,7 +16,7 @@
  *     UUIDs in the receipt response — comparing strictly fails otherwise).
  *
  * App Store Connect product IDs (must match exactly):
- *   ai.shogo.{basic|pro|business}.{monthly|annual}
+ *   ai.shogo.app.{basic|pro|business}.{monthly|annual}
  */
 import { Platform } from 'react-native'
 
@@ -209,17 +209,21 @@ export async function purchaseSubscription(args: {
   const appAccountToken = normalizeAccountToken(args.workspaceId)
 
   try {
-    const products = await RNIap.getSubscriptions({ skus: [productId] })
-    if (!Array.isArray(products) || products.length === 0) {
+    const products = await RNIap.getSubscriptions({ skus: ALL_PRODUCT_IDS })
+    const product = Array.isArray(products)
+      ? products.find((p: any) => p?.productId === productId || p?.id === productId)
+      : null
+    if (!product) {
       throw new IapError(
         'product_not_available',
-        `Subscription "${productId}" is not configured in App Store Connect yet.`,
+        'This subscription is temporarily unavailable from the App Store. Please try again in a few minutes.',
       )
     }
 
     const purchase = await RNIap.requestSubscription({
       sku: productId,
       appAccountToken,
+      andDangerouslyFinishTransactionAutomaticallyIOS: false,
     })
 
     const p = Array.isArray(purchase) ? purchase[0] : purchase

--- a/apps/mobile/lib/pending-license.ts
+++ b/apps/mobile/lib/pending-license.ts
@@ -2,10 +2,10 @@
 // Copyright (C) 2026 Shogo Technologies, Inc.
 
 /**
- * Stash for a license-key redeem code captured from a deep link
- * (`/billing?redeem=CODE` / `shogo://billing?redeem=CODE`).
+ * Stash for a license-key redeem code captured from a non-iOS deep link
+ * (`/billing?redeem=CODE` or a native Android link with `redeem=CODE`).
  *
- * A brand-new user who opens a redeem link is bounced through
+ * A brand-new non-iOS user who opens a redeem link is bounced through
  * sign-up + onboarding, which drops the `redeem` query param. We stash
  * the code at app load (root layout) and consume it once the user is
  * authenticated and has a workspace, routing them to billing with the


### PR DESCRIPTION
## Summary

Closes #776.

This PR aligns the iOS mobile billing flow with App Store review expectations by ensuring reviewers can reliably reach Apple In-App Purchase subscription options and by removing license-key redemption paths from iOS.

The main App Review blocker was that Billing could show a false `No Workspace Selected` state even when the authenticated app had already loaded a workspace. This prevented reviewers from reaching subscription plans and the Apple purchase sheet. The fix resolves Billing against the active workspace when available and falls back to the first loaded workspace while keeping the page in a loading state until workspace data has resolved.

## Why this is needed

Apple review needs a deterministic path for digital subscription purchase:

```txt
Login → Workspace loads → Upgrade to Pro / Billing → Subscription plans → Apple purchase sheet
```

Before this PR, the review path could fail in two important ways:

1. **Billing workspace resolution could be too strict**
   - Billing required `currentWorkspace`.
   - If `currentWorkspace` was temporarily missing but the workspace list had loaded, the page displayed `No Workspace Selected`.
   - That state blocked purchase testing and could make App Review think subscriptions were unavailable.

2. **iOS still had non-IAP license redemption paths nearby**
   - License-key redemption is not appropriate for iOS digital subscription upgrades.
   - iOS should not display the manual redeem UI, process redeem deep links, or perform pending license handoff.
   - Keeping iOS focused on IAP avoids reviewer confusion and keeps the subscription flow compliant.

## What changed

### Billing workspace fallback

Updated Billing so all billing actions resolve a stable billing workspace:

- Prefer `currentWorkspace` when it exists.
- Fall back to the first loaded workspace when `currentWorkspace` is temporarily missing.
- Treat workspace data as loading while the workspace list/current workspace is still resolving.
- Avoid rendering a false `No Workspace Selected` state when workspace data is available.

This resolved workspace is now used consistently across:

- Checkout creation
- IAP transaction verification
- Restore purchases
- Billing history loading
- Billing analytics loading
- Customer portal access
- Checkout redirect handling
- Success/cancel/error redirect handling

### iOS license-key gating

Hardened iOS-specific behavior so license redemption is not available on iOS:

- Hide manual license-key redemption UI on iOS.
- Disable license-key redeem behavior on iOS.
- Skip pending license redemption handoff on iOS.
- Ignore license redeem deep links on iOS.
- Keep license redemption behavior available only for non-iOS platforms where appropriate.

### StoreKit product handling

Adjusted StoreKit product lookup for subscription purchases:

- Fetch all configured subscription product IDs.
- Select the requested product from the returned product list.
- This better matches App Store Connect / StoreKit behavior in review-like environments.

### Transaction finishing

Updated the StoreKit IAP setup so automatic transaction finishing is disabled:

- Transactions are not finished before backend/server verification.
- Verification flow controls when the transaction should be considered complete.

## Files changed

```txt
apps/mobile/app/(app)/billing.tsx
apps/mobile/app/(app)/index.tsx
apps/mobile/app/_layout.tsx
apps/mobile/lib/iap.ts
apps/mobile/lib/pending-license.ts
```

## Reviewer test path

Recommended App Review path after this PR:

1. Launch the iOS app.
2. Sign in with the reviewer/demo account.
3. Ensure a workspace exists or allow the app to create/load one.
4. Tap `Upgrade to Pro` or open Billing.
5. Confirm subscription plans render.
6. Select a plan.
7. Confirm the Apple In-App Purchase sheet opens.
8. Confirm `Restore Purchases` is available.
9. Confirm no license-key redemption UI is shown on iOS.

## Acceptance criteria

- [x] Billing resolves a workspace even if `currentWorkspace` is temporarily missing but workspace data is loaded.
- [x] Billing waits during workspace loading instead of immediately showing an empty state.
- [x] `No Workspace Selected` is not shown when a workspace is available.
- [x] Checkout and restore paths use the resolved billing workspace.
- [x] Billing history, analytics, customer portal, and redirect handling use the resolved billing workspace.
- [x] iOS hides and disables license-key redemption UI/logic.
- [x] iOS ignores pending license redemption handoff.
- [x] iOS ignores license redeem deep links.
- [x] StoreKit fetches configured subscription products before selecting the requested product.
- [x] StoreKit automatic transaction finishing is disabled so verification controls completion.

## Verification

Targeted billing configuration test:

```txt
bun --cwd apps/mobile test lib/__tests__/billing-config.test.ts
```

Result:

```txt
41 pass
0 fail
```

Whitespace check:

```txt
git diff --check
```

Result: passed.

Release simulator build/install/launch was verified before commit on simulator:

```txt
702F18E2-2051-4D7A-93F9-86D9D3A1A86F
```

## Known notes

The broad mobile test suite currently has unrelated existing failures outside the billing/IAP change area:

```txt
1822 pass
1 skip
12 fail
11 errors
```

Those failures were not introduced by this PR. The targeted billing/IAP test and whitespace validation passed for this fix.
