### PR TITLE
feat(admin): chart dashboard stats over time (cumulative/daily)

### DIFF
--- a/apps/api/src/__tests__/analytics-service-postgres-branches.test.ts
+++ b/apps/api/src/__tests__/analytics-service-postgres-branches.test.ts
@@ -37,6 +37,7 @@ const {
   getUserActivityTable,
   getTemplateEngagement,
   getChatConversations,
+  getGrowthTimeSeries,
 } = await import('../services/analytics.service')
 
 beforeEach(() => {
@@ -78,6 +79,16 @@ describe('analytics.service.ts — Postgres dialect branches (SHOGO_LOCAL_MODE u
     expect(q).toContain('1000')
     // Postgres uses positional parameters $1 instead of sqlite's ?
     expect(q).toContain('$1')
+  })
+
+  test('getGrowthTimeSeries (platform) buckets by day in SQL for the four core tables', async () => {
+    await getGrowthTimeSeries()
+    // One grouped COUNT per table: users, workspaces, projects, chat_sessions.
+    expect(captured.length).toBe(4)
+    expect(captured.every((sql) => sql.includes(`date_trunc('day', "createdAt")`))).toBe(true)
+    expect(captured.every((sql) => sql.includes('$1'))).toBe(true)
+    const tables = captured.map((sql) => sql.match(/FROM "(\w+)"/)?.[1])
+    expect(tables).toEqual(['users', 'workspaces', 'projects', 'chat_sessions'])
   })
 
 })

--- a/apps/api/src/__tests__/analytics-service.expanded.test.ts
+++ b/apps/api/src/__tests__/analytics-service.expanded.test.ts
@@ -284,12 +284,20 @@ describe('getGrowthTimeSeries', () => {
     expect(out.length).toBeGreaterThanOrEqual(1)
   })
 
-  test('platform scope returns users + workspaces + projects', async () => {
-    store.users.push({ id: 'u-1', createdAt: new Date() })
-    store.workspaces.push({ id: 'w-1', createdAt: new Date() })
+  test('platform scope returns users + workspaces + projects + sessions', async () => {
+    const now = new Date()
+    store.users.push({ id: 'u-1', createdAt: now })
+    store.workspaces.push({ id: 'w-1', createdAt: now })
+    store.projects.push({ id: 'p-1', workspaceId: 'w-1', createdAt: now })
+    store.chatSessions.push({ id: 's-1', contextId: 'p-1', createdAt: now })
     rebuildModels()
-    const out = await analytics.getGrowthTimeSeries()
+    const out = (await analytics.getGrowthTimeSeries()) as Array<Record<string, unknown>>
     expect(Array.isArray(out)).toBe(true)
+    const day = out[out.length - 1]
+    expect(day.users).toBe(1)
+    expect(day.workspaces).toBe(1)
+    expect(day.projects).toBe(1)
+    expect(day.sessions).toBe(1)
   })
 })
 

--- a/apps/api/src/services/analytics.service.ts
+++ b/apps/api/src/services/analytics.service.ts
@@ -288,29 +288,56 @@ export async function getGrowthTimeSeries(
     })
   }
 
-  // Platform-wide: new users, workspaces, projects over time
-  const [users, workspaces, projects] = await Promise.all([
-    prisma.user.findMany({
-      where: { createdAt: { gte: since } },
-      select: { createdAt: true },
-      orderBy: { createdAt: 'asc' },
-    }),
-    prisma.workspace.findMany({
-      where: { createdAt: { gte: since } },
-      select: { createdAt: true },
-      orderBy: { createdAt: 'asc' },
-    }),
-    prisma.project.findMany({
-      where: { createdAt: { gte: since } },
-      select: { createdAt: true },
-      orderBy: { createdAt: 'asc' },
-    }),
+  // Platform-wide: new users, workspaces, projects, and chat sessions per day.
+  //
+  // On Postgres (production) we bucket by day in SQL so the query returns at
+  // most one row per day instead of streaming every entity's createdAt back to
+  // the app — this keeps the long (90d / 1y) windows cheap as the tables grow.
+  // The WHERE "createdAt" >= … filter is backed by the @@index([createdAt]) on
+  // each table. SQLite (local / tests) keeps the simple findMany+JS path: data
+  // volumes are tiny and Prisma's SQLite DateTime storage doesn't play nicely
+  // with strftime, so there's no win and real risk in raw-bucketing it there.
+  if (isSqlite) {
+    const [users, workspaces, projects, sessions] = await Promise.all([
+      prisma.user.findMany({ where: { createdAt: { gte: since } }, select: { createdAt: true }, orderBy: { createdAt: 'asc' } }),
+      prisma.workspace.findMany({ where: { createdAt: { gte: since } }, select: { createdAt: true }, orderBy: { createdAt: 'asc' } }),
+      prisma.project.findMany({ where: { createdAt: { gte: since } }, select: { createdAt: true }, orderBy: { createdAt: 'asc' } }),
+      prisma.chatSession.findMany({ where: { createdAt: { gte: since } }, select: { createdAt: true }, orderBy: { createdAt: 'asc' } }),
+    ])
+    return mergeTimeSeries({
+      users: groupByDate(users),
+      workspaces: groupByDate(workspaces),
+      projects: groupByDate(projects),
+      sessions: groupByDate(sessions),
+    })
+  }
+
+  // Postgres: one grouped COUNT per table. createdAt is a UTC `timestamp(3)`,
+  // so date_trunc('day', …) yields the same UTC day buckets as the JS path.
+  const bucketByDay = (table: string) =>
+    prisma.$queryRawUnsafe<{ date: string; count: number | bigint }[]>(
+      `SELECT to_char(date_trunc('day', "createdAt"), 'YYYY-MM-DD') AS "date", COUNT(*) AS "count"
+       FROM "${table}"
+       WHERE "createdAt" >= $1
+       GROUP BY 1
+       ORDER BY 1`,
+      since,
+    )
+  const toPoints = (rows: { date: string; count: number | bigint }[]): TimeSeriesPoint[] =>
+    rows.map((r) => ({ date: r.date, count: toNum(r.count) }))
+
+  const [users, workspaces, projects, sessions] = await Promise.all([
+    bucketByDay('users'),
+    bucketByDay('workspaces'),
+    bucketByDay('projects'),
+    bucketByDay('chat_sessions'),
   ])
 
   return mergeTimeSeries({
-    users: groupByDate(users),
-    workspaces: groupByDate(workspaces),
-    projects: groupByDate(projects),
+    users: toPoints(users),
+    workspaces: toPoints(workspaces),
+    projects: toPoints(projects),
+    sessions: toPoints(sessions),
   })
 }
 

--- a/apps/mobile/app/(admin)/index.tsx
+++ b/apps/mobile/app/(admin)/index.tsx
@@ -32,6 +32,15 @@ import {
 import { useRouter } from 'expo-router'
 import { cn } from '@shogo/shared-ui/primitives'
 import { API_URL } from '../../lib/api'
+import {
+  PlatformGrowthChart,
+  ActiveUsersTrendChart,
+  UsageTimeseriesChart,
+  type ActiveUsersTimeseriesPoint,
+  type SpendTimeseriesData,
+  type SpendGroupBy,
+  type SpendMetric,
+} from '../../components/analytics/SharedAnalytics'
 
 const API_BASE = `${API_URL}/api/admin`
 
@@ -64,6 +73,7 @@ interface GrowthDataPoint {
   users: number
   workspaces: number
   projects: number
+  sessions: number
 }
 
 interface InfraLiveData {
@@ -366,74 +376,6 @@ function SystemHealthCard({ data, loading }: { data: InfraLiveData | null; loadi
   )
 }
 
-function GrowthSummary({ data, loading }: { data: GrowthDataPoint[] | null; loading: boolean }) {
-  if (loading) {
-    return (
-      <View className="rounded-xl border border-border bg-card p-5">
-        <View className="h-4 w-32 bg-muted rounded mb-4" />
-        <View className="h-40 bg-muted/50 rounded" />
-      </View>
-    )
-  }
-
-  if (!data || data.length === 0) {
-    return (
-      <View className="rounded-xl border border-border bg-card p-5">
-        <View className="flex-row items-center gap-2 mb-3">
-          <TrendingUp size={16} className="text-foreground" />
-          <Text className="text-sm font-semibold text-foreground">Growth Trends</Text>
-        </View>
-        <View className="h-32 items-center justify-center">
-          <Text className="text-sm text-muted-foreground">No growth data available</Text>
-        </View>
-      </View>
-    )
-  }
-
-  const latest = data[data.length - 1]
-  const earliest = data[0]
-  const metrics = [
-    { label: 'Users', current: latest.users, start: earliest.users, color: 'bg-primary' },
-    { label: 'Workspaces', current: latest.workspaces, start: earliest.workspaces, color: 'bg-blue-500' },
-    { label: 'Projects', current: latest.projects, start: earliest.projects, color: 'bg-emerald-500' },
-  ]
-
-  const maxVal = Math.max(...data.map((d) => Math.max(d.users, d.workspaces, d.projects)), 1)
-
-  return (
-    <View className="rounded-xl border border-border bg-card p-5">
-      <View className="flex-row items-center gap-2 mb-4">
-        <TrendingUp size={16} className="text-foreground" />
-        <Text className="text-sm font-semibold text-foreground">Growth Trends</Text>
-      </View>
-      <View className="gap-4">
-        {metrics.map((m) => {
-          const growth = m.start > 0 ? (((m.current - m.start) / m.start) * 100).toFixed(0) : '—'
-          const barWidth = Math.max((m.current / maxVal) * 100, 5)
-          return (
-            <View key={m.label} className="gap-1.5">
-              <View className="flex-row items-center justify-between">
-                <Text className="text-sm font-medium text-foreground">{m.label}</Text>
-                <View className="flex-row items-center gap-2">
-                  <Text className="text-sm font-bold text-foreground">
-                    {m.current.toLocaleString()}
-                  </Text>
-                  {growth !== '—' && (
-                    <Text className="text-xs font-medium text-green-500">+{growth}%</Text>
-                  )}
-                </View>
-              </View>
-              <View className="h-2.5 bg-muted rounded-full overflow-hidden">
-                <View className={cn('h-full rounded-full', m.color)} style={{ width: `${barWidth}%` }} />
-              </View>
-            </View>
-          )
-        })}
-      </View>
-    </View>
-  )
-}
-
 function AIUsageSummaryCard({ data, loading }: { data: UsageSummaryData | null; loading: boolean }) {
   if (loading) {
     return (
@@ -684,6 +626,16 @@ export default function AdminDashboard() {
     data: null,
     loading: true,
   })
+  const [activeUsersTs, setActiveUsersTs] = useState<{ data: ActiveUsersTimeseriesPoint[] | null; loading: boolean }>({
+    data: null,
+    loading: true,
+  })
+  const [spendTs, setSpendTs] = useState<{ data: SpendTimeseriesData | null; loading: boolean }>({
+    data: null,
+    loading: true,
+  })
+  const [spendGroupBy, setSpendGroupBy] = useState<SpendGroupBy>('model')
+  const [spendMetric, setSpendMetric] = useState<SpendMetric>('spend')
 
   // Infrastructure + GC are super_admin-only. Partial admins (analytics:read)
   // see the usage/growth half of the dashboard; the infra half is hidden so
@@ -704,6 +656,8 @@ export default function AdminDashboard() {
     setActiveUsers((s) => ({ ...s, loading: true }))
     setGrowth((s) => ({ ...s, loading: true }))
     setUsage((s) => ({ ...s, loading: true }))
+    setActiveUsersTs((s) => ({ ...s, loading: true }))
+    setSpendTs((s) => ({ ...s, loading: true }))
 
     const canSeeInfra = isSuperAdmin === true
     if (canSeeInfra) {
@@ -714,27 +668,43 @@ export default function AdminDashboard() {
       setInfraHistory({ data: null, loading: false })
     }
 
-    const [overviewData, activeData, growthData, usageData, infraData, infraHistoryData] =
-      await Promise.all([
-        fetchAdminJson<OverviewData>('/analytics/overview'),
-        fetchAdminJson<ActiveUsersData>('/analytics/active-users', { period }),
-        fetchAdminJson<GrowthDataPoint[]>('/analytics/growth', { period }),
-        fetchAdminJson<UsageSummaryData>('/analytics/usage-summary', { period }),
-        canSeeInfra ? fetchAdminJson<InfraLiveData>('/analytics/infra-current') : Promise.resolve(null),
-        canSeeInfra
-          ? fetchAdminJson<InfraHistoryPoint[]>('/analytics/infra-history', { period: '24h' })
-          : Promise.resolve(null),
-      ])
+    const [
+      overviewData,
+      activeData,
+      growthData,
+      usageData,
+      activeUsersTsData,
+      spendTsData,
+      infraData,
+      infraHistoryData,
+    ] = await Promise.all([
+      fetchAdminJson<OverviewData>('/analytics/overview'),
+      fetchAdminJson<ActiveUsersData>('/analytics/active-users', { period }),
+      fetchAdminJson<GrowthDataPoint[]>('/analytics/growth', { period }),
+      fetchAdminJson<UsageSummaryData>('/analytics/usage-summary', { period }),
+      fetchAdminJson<ActiveUsersTimeseriesPoint[]>('/analytics/active-users-timeseries', { period }),
+      fetchAdminJson<SpendTimeseriesData>('/analytics/spend-timeseries', {
+        period,
+        groupBy: spendGroupBy,
+        metric: spendMetric,
+      }),
+      canSeeInfra ? fetchAdminJson<InfraLiveData>('/analytics/infra-current') : Promise.resolve(null),
+      canSeeInfra
+        ? fetchAdminJson<InfraHistoryPoint[]>('/analytics/infra-history', { period: '24h' })
+        : Promise.resolve(null),
+    ])
 
     setOverview({ data: overviewData, loading: false })
     setActiveUsers({ data: activeData, loading: false })
     setGrowth({ data: growthData, loading: false })
     setUsage({ data: usageData, loading: false })
+    setActiveUsersTs({ data: activeUsersTsData, loading: false })
+    setSpendTs({ data: spendTsData, loading: false })
     if (canSeeInfra) {
       setInfra({ data: infraData, loading: false })
       setInfraHistory({ data: infraHistoryData, loading: false })
     }
-  }, [period, isSuperAdmin])
+  }, [period, isSuperAdmin, spendGroupBy, spendMetric])
 
   useEffect(() => {
     loadData()
@@ -854,17 +824,39 @@ export default function AdminDashboard() {
         )}
       </View>
 
-      {/* Row 3: Growth Trends + AI Usage */}
-      <View className={cn('gap-4 mb-6', isWide ? 'flex-row' : '')}>
-        <View className={isWide ? 'flex-1' : ''}>
-          <GrowthSummary data={growth.data} loading={growth.loading} />
-        </View>
-        <View className={isWide ? 'flex-1' : ''}>
-          <AIUsageSummaryCard data={usage.data} loading={usage.loading} />
-        </View>
+      {/* Row 3: Growth over time (Daily / Cumulative) */}
+      <View className="mb-6">
+        <PlatformGrowthChart
+          data={growth.data}
+          totals={overview.data}
+          loading={growth.loading}
+        />
       </View>
 
-      {/* Row 4 + 5: Infra history + quick actions (super-admin only) */}
+      {/* Row 4: Active users trend (DAU / WAU / MAU over time) */}
+      <View className="mb-6">
+        <ActiveUsersTrendChart data={activeUsersTs.data} loading={activeUsersTs.loading} />
+      </View>
+
+      {/* Row 5: AI usage — summary + over time */}
+      <View className="mb-6">
+        <AIUsageSummaryCard data={usage.data} loading={usage.loading} />
+      </View>
+      <View className="mb-6">
+        <UsageTimeseriesChart
+          data={spendTs.data}
+          loading={spendTs.loading}
+          groupBy={spendGroupBy}
+          metric={spendMetric}
+          onGroupByChange={setSpendGroupBy}
+          onMetricChange={setSpendMetric}
+          allowCumulative
+          title="AI Usage Over Time"
+          subtitle="Daily spend / tokens / requests"
+        />
+      </View>
+
+      {/* Row 6 + 7: Infra history + quick actions (super-admin only) */}
       {isSuperAdmin && (
         <>
           <View className="mb-6">

--- a/apps/mobile/components/analytics/SharedAnalytics.tsx
+++ b/apps/mobile/components/analytics/SharedAnalytics.tsx
@@ -1426,6 +1426,7 @@ export function UsageTimeseriesChart({
   groupByOptions,
   height = 260,
   showTotals = true,
+  allowCumulative = false,
 }: {
   data: SpendTimeseriesData | null
   loading?: boolean
@@ -1439,9 +1440,25 @@ export function UsageTimeseriesChart({
   groupByOptions?: readonly SpendGroupBy[]
   height?: number
   showTotals?: boolean
+  /** When true, show a Daily/Cumulative toggle that accumulates each series over the window. */
+  allowCumulative?: boolean
 }) {
+  const [mode, setMode] = useState<'daily' | 'cumulative'>('daily')
   const series = buildSpendSeries(data)
-  const chartDays: StackedDay[] = (data?.days ?? []).map((d) => ({ date: d.date, values: d.byModel }))
+  const dailyDays: StackedDay[] = (data?.days ?? []).map((d) => ({ date: d.date, values: d.byModel }))
+  const isCumulative = allowCumulative && mode === 'cumulative'
+  const chartDays = useMemo<StackedDay[]>(() => {
+    if (!isCumulative) return dailyDays
+    const running: Record<string, number> = {}
+    return dailyDays.map((d) => {
+      const values: Record<string, number> = {}
+      for (const s of series) {
+        running[s.id] = (running[s.id] ?? 0) + (d.values[s.id] ?? 0)
+        values[s.id] = running[s.id]
+      }
+      return { date: d.date, values }
+    })
+  }, [dailyDays, series, isCumulative])
 
   return (
     <View className="rounded-xl border border-border bg-card p-4 gap-3">
@@ -1450,7 +1467,17 @@ export function UsageTimeseriesChart({
           <Text className="text-sm font-semibold text-foreground">{title}</Text>
           <Text className="text-xs text-muted-foreground">{subtitle}</Text>
         </View>
-        <View className="flex-row items-center gap-2">
+        <View className="flex-row items-center gap-2 flex-wrap">
+          {allowCumulative ? (
+            <MetricToggle
+              value={mode}
+              onChange={setMode}
+              options={[
+                { id: 'daily', label: 'Daily' },
+                { id: 'cumulative', label: 'Cumulative' },
+              ]}
+            />
+          ) : null}
           <GroupBySelect value={groupBy} onChange={onGroupByChange} options={groupByOptions} />
           <MetricSelect value={metric} onChange={onMetricChange} />
         </View>
@@ -1515,6 +1542,8 @@ export function MetricTrendChart({
   days,
   metrics,
   height = 240,
+  allowCumulative = false,
+  baselines,
 }: {
   title: string
   subtitle?: string
@@ -1522,13 +1551,32 @@ export function MetricTrendChart({
   days: StackedDay[]
   metrics: TrendMetricOption[]
   height?: number
+  /** When true, show a Daily/Cumulative toggle that turns the series into a running total. */
+  allowCumulative?: boolean
+  /**
+   * Starting value for the cumulative line per metric id (e.g. entities that
+   * existed before the window). The cumulative series ends at
+   * `baseline + sum(window)`, so it lines up with a "Total X" stat card.
+   */
+  baselines?: Record<string, number>
 }) {
   const [selected, setSelected] = useState<string>(metrics[0]?.id ?? '')
+  const [mode, setMode] = useState<'daily' | 'cumulative'>('daily')
   const metric = metrics.find((m) => m.id === selected) ?? metrics[0]
   const series: StackedSeries[] = metric
     ? [{ id: metric.id, label: metric.label, color: metric.color ?? STACKED_PALETTE[0] }]
     : []
   const fmt = metric?.format ?? ((n: number) => formatNumber(n))
+
+  const isCumulative = allowCumulative && mode === 'cumulative'
+  const chartDays = useMemo<StackedDay[]>(() => {
+    if (!isCumulative || !metric) return days
+    let running = baselines?.[metric.id] ?? 0
+    return days.map((d) => {
+      running += d.values[metric.id] ?? 0
+      return { ...d, values: { ...d.values, [metric.id]: running } }
+    })
+  }, [days, isCumulative, metric, baselines])
 
   return (
     <View className="rounded-xl border border-border bg-card p-4 gap-3">
@@ -1537,11 +1585,23 @@ export function MetricTrendChart({
           <Text className="text-sm font-semibold text-foreground">{title}</Text>
           {subtitle ? <Text className="text-xs text-muted-foreground">{subtitle}</Text> : null}
         </View>
-        <MetricToggle
-          value={selected}
-          onChange={setSelected}
-          options={metrics.map((m) => ({ id: m.id, label: m.label }))}
-        />
+        <View className="flex-row items-center gap-2 flex-wrap">
+          {allowCumulative ? (
+            <MetricToggle
+              value={mode}
+              onChange={setMode}
+              options={[
+                { id: 'daily', label: 'Daily' },
+                { id: 'cumulative', label: 'Cumulative' },
+              ]}
+            />
+          ) : null}
+          <MetricToggle
+            value={selected}
+            onChange={setSelected}
+            options={metrics.map((m) => ({ id: m.id, label: m.label }))}
+          />
+        </View>
       </View>
 
       {loading ? (
@@ -1552,7 +1612,7 @@ export function MetricTrendChart({
         </View>
       ) : (
         <StackedAreaChart
-          days={days}
+          days={chartDays}
           series={series}
           height={height}
           formatY={fmt}
@@ -1617,6 +1677,82 @@ export function ActivityTrendsChart({
       loading={loading}
       days={days}
       metrics={metrics}
+    />
+  )
+}
+
+// =============================================================================
+// Platform growth (users / workspaces / projects / sessions over time)
+// =============================================================================
+
+export interface PlatformGrowthPoint {
+  date: string
+  users: number
+  workspaces: number
+  projects: number
+  sessions: number
+}
+
+/** Current platform totals, used to anchor the cumulative line to the cards. */
+export interface PlatformGrowthTotals {
+  totalUsers?: number
+  totalWorkspaces?: number
+  totalProjects?: number
+  totalChatSessions?: number
+}
+
+/**
+ * Core-entity growth chart with a Daily/Cumulative toggle. Daily mode shows new
+ * entities per day; cumulative mode shows a running total that ends at the
+ * matching "Total X" stat card (baseline = current total minus what was created
+ * inside the window).
+ */
+export function PlatformGrowthChart({
+  data,
+  totals,
+  loading,
+  title = 'Growth',
+}: {
+  data: PlatformGrowthPoint[] | null
+  totals?: PlatformGrowthTotals | null
+  loading?: boolean
+  title?: string
+}) {
+  const rows = data ?? []
+  const days: StackedDay[] = rows.map((d) => ({
+    date: d.date,
+    values: {
+      users: d.users ?? 0,
+      workspaces: d.workspaces ?? 0,
+      projects: d.projects ?? 0,
+      sessions: d.sessions ?? 0,
+    },
+  }))
+  const sum = (key: 'users' | 'workspaces' | 'projects' | 'sessions') =>
+    rows.reduce((acc, d) => acc + (d[key] ?? 0), 0)
+  const baseline = (total: number | undefined, windowSum: number) =>
+    Math.max((total ?? windowSum) - windowSum, 0)
+  const baselines: Record<string, number> = {
+    users: baseline(totals?.totalUsers, sum('users')),
+    workspaces: baseline(totals?.totalWorkspaces, sum('workspaces')),
+    projects: baseline(totals?.totalProjects, sum('projects')),
+    sessions: baseline(totals?.totalChatSessions, sum('sessions')),
+  }
+  const metrics: TrendMetricOption[] = [
+    { id: 'users', label: 'Users', color: STACKED_PALETTE[1], format: formatNumber },
+    { id: 'workspaces', label: 'Workspaces', color: STACKED_PALETTE[3], format: formatNumber },
+    { id: 'projects', label: 'Projects', color: STACKED_PALETTE[2], format: formatNumber },
+    { id: 'sessions', label: 'Sessions', color: STACKED_PALETTE[0], format: formatNumber },
+  ]
+  return (
+    <MetricTrendChart
+      title={title}
+      subtitle="New per day, or cumulative running total"
+      loading={loading}
+      days={days}
+      metrics={metrics}
+      allowCumulative
+      baselines={baselines}
     />
   )
 }

--- a/prisma/migrations/20260620000000_add_createdat_indexes/migration.sql
+++ b/prisma/migrations/20260620000000_add_createdat_indexes/migration.sql
@@ -1,0 +1,11 @@
+-- CreateIndex
+CREATE INDEX "users_createdAt_idx" ON "users"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "workspaces_createdAt_idx" ON "workspaces"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "projects_createdAt_idx" ON "projects"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "chat_sessions_createdAt_idx" ON "chat_sessions"("createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,7 @@ model User {
   affiliateAttribution AffiliateAttribution?
   projectAuthSignIns   ProjectAuthSignIn[]
 
+  @@index([createdAt])
   @@map("users")
 }
 
@@ -161,6 +162,7 @@ model Workspace {
   chatSessions           ChatSession[]
   modelVisibility        WorkspaceModelVisibility[]
 
+  @@index([createdAt])
   @@map("workspaces")
 }
 
@@ -288,6 +290,7 @@ model Project {
   @@index([workspaceId])
   @@index([folderId])
   @@index([preferredInstanceId])
+  @@index([createdAt])
   @@map("projects")
 }
 
@@ -1039,6 +1042,7 @@ model ChatSession {
 
   @@index([contextType, contextId])
   @@index([workspaceId])
+  @@index([createdAt])
   @@map("chat_sessions")
 }
 


### PR DESCRIPTION
## Summary
- Replaces the static "Growth Trends" bars on the super-admin Dashboard (`apps/mobile/app/(admin)/index.tsx`) with real over-time charts:
  - **Growth** — users / workspaces / projects / sessions, with a **Daily / Cumulative** toggle
  - **Active Users** — DAU / WAU / MAU over time (daily; rolling metrics)
  - **AI Usage** — spend / tokens / requests over time, with a **Daily / Cumulative** toggle
- Cumulative lines are anchored via `/analytics/overview` totals (`baseline = total - sum(window)`), so the line ends exactly at the matching "Total X" stat card.
- Adds reusable `allowCumulative` support to `MetricTrendChart` / `UsageTimeseriesChart` and a new exported `PlatformGrowthChart` in `SharedAnalytics.tsx`. Existing Marketing/AI pages and workspace usage tabs are unaffected (new props are opt-in).

## Backend (performance)
- `getGrowthTimeSeries` platform branch now buckets by day **in SQL on Postgres** (`date_trunc('day', "createdAt")`, ≤366 rows) instead of streaming every row and bucketing in JS. SQLite (local/tests) keeps the `findMany` path. Adds a `sessions` series.
- New migration adds `@@index([createdAt])` to `users`, `workspaces`, `projects`, `chat_sessions` to back the `WHERE "createdAt" >= …` window scans (only `usage_events` had one before).

## Notes
- No new storage required — charts are reconstructed from existing `createdAt` timestamps. There are no soft-deletes, so the cumulative baseline reflects currently-existing rows.
- Partial admins outside a chart's scope get a graceful "No data" state (existing 403 -> null behavior).
- Desktop SQLite schema intentionally left untouched (admin analytics is a cloud feature; local mode uses the JS-bucket path).

## Test plan
- [x] `analytics-service.expanded.test.ts` — growth returns the new `sessions` field (SQLite path)
- [x] `analytics-service-postgres-branches.test.ts` — growth emits day-bucketed SQL across the four tables (Postgres path)
- [x] `prisma validate` + `prisma generate` pass; migration adds the four indexes only
- [x] Lints clean on all edited files
- [ ] Manual: load Dashboard as super_admin, toggle Daily/Cumulative + period (incl. 1y), confirm cumulative Users line ends at the "Total Users" card value

Made with [Cursor](https://cursor.com)