### PR TITLE
fix(desktop): resolve bundled bun for Shogo IDE setup

### DIFF
--- a/apps/desktop/src/shogo-ide.ts
+++ b/apps/desktop/src/shogo-ide.ts
@@ -6,6 +6,7 @@ import { spawn, spawnSync } from 'child_process'
 import { createHash } from 'crypto'
 import fs from 'fs'
 import path from 'path'
+import { getBunPath, getProjectRoot } from './paths'
 
 export interface ShogoIdeStatus {
   ok: true
@@ -70,7 +71,7 @@ let setupPromise: Promise<void> | null = null
 function resolveRepoRoot(): string {
   if (process.env.SHOGO_REPO_ROOT) return path.resolve(process.env.SHOGO_REPO_ROOT)
   if (process.env.SHOGO_IDE_REPO_ROOT) return path.resolve(process.env.SHOGO_IDE_REPO_ROOT)
-  return path.resolve(app.getAppPath(), '..', '..')
+  return getProjectRoot()
 }
 
 function pathNeedsNativeBuildWorkaround(candidate: string): boolean {
@@ -106,10 +107,36 @@ function appendSetupLog(workspacePath: string, message: string): void {
   fs.appendFileSync(logPath, `[${new Date().toISOString()}] ${message}\n`)
 }
 
+function setupCommandEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env }
+  const pathKey = process.platform === 'win32' ? 'Path' : 'PATH'
+  const pathSep = process.platform === 'win32' ? ';' : ':'
+  const bunPath = getBunPath()
+  const bunDir = path.isAbsolute(bunPath) ? path.dirname(bunPath) : null
+  const defaultPaths = process.platform === 'win32'
+    ? []
+    : ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin']
+  const existingPath = env[pathKey] || env.PATH || env.Path || ''
+  const pathEntries = [bunDir, ...defaultPaths, ...existingPath.split(pathSep)]
+    .filter((entry): entry is string => !!entry)
+  env[pathKey] = Array.from(new Set(pathEntries)).join(pathSep)
+  env.PATH = env[pathKey]
+  env.SHOGO_BUN_PATH = bunPath
+  if (!env.HOME && process.platform !== 'win32') env.HOME = app.getPath('home')
+  return env
+}
+
+function resolveSetupCommand(command: string): string {
+  if (command !== 'bun') return command
+  const bunPath = getBunPath()
+  return path.isAbsolute(bunPath) && fs.existsSync(bunPath) ? bunPath : command
+}
+
 function runSetupCommand(workspacePath: string, command: string, args: string[], cwd: string): Promise<void> {
+  const resolvedCommand = resolveSetupCommand(command)
   appendSetupLog(workspacePath, `$ ${[command, ...args].join(' ')}`)
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] })
+    const child = spawn(resolvedCommand, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'], env: setupCommandEnv() })
     child.stdout.on('data', (chunk) => appendSetupLog(workspacePath, String(chunk).trimEnd()))
     child.stderr.on('data', (chunk) => appendSetupLog(workspacePath, String(chunk).trimEnd()))
     child.on('error', reject)
@@ -131,6 +158,7 @@ function resolveNpmCliPath(): string | null {
   const globalNpmRoot = spawnSync('npm', ['root', '-g'], {
     encoding: 'utf8',
     timeout: 5_000,
+    env: setupCommandEnv(),
   })
 
   const candidates = [
@@ -253,7 +281,7 @@ function ensureBundledExtensionBuilt(workspacePath: string, sourcePath: string, 
   if (!manifest.scripts?.build) return
 
   appendSetupLog(workspacePath, `Building bundled extension: ${sourcePath}`)
-  const result = spawnSync('npm', ['run', 'build'], { cwd: sourcePath, encoding: 'utf8' })
+  const result = spawnSync('npm', ['run', 'build'], { cwd: sourcePath, encoding: 'utf8', env: setupCommandEnv() })
   if (result.stdout) appendSetupLog(workspacePath, result.stdout.trimEnd())
   if (result.stderr) appendSetupLog(workspacePath, result.stderr.trimEnd())
   if (result.status !== 0) {


### PR DESCRIPTION
## Summary

Fixes #785.

This PR fixes a production Shogo IDE / Code OSS launch failure where the desktop app can show:

```text
Could not open Shogo IDE
spawn bun ENOENT
```

or fail during Shogo IDE setup with:

```text
bun run distribution:materialize exited with code 1
```

The fix makes the Shogo IDE setup path use the packaged app's own Bun/runtime path resolution instead of depending on the user's shell `PATH` or a fragile app-path-relative repo-root fallback.

## Root cause

The Shogo IDE setup flow in `apps/desktop/src/shogo-ide.ts` may run setup commands before opening the Code OSS web server, including:

```bash
bun run distribution:materialize
bun run hardening:report
```

Previously, that code spawned bare command names such as:

```ts
spawn('bun', args, ...)
```

This is unreliable in packaged Electron apps, especially on macOS, because apps launched from Finder, Spotlight, or the Dock do not necessarily inherit the user's terminal shell environment. That means a user can have Bun installed and working in Terminal, while the Electron process still fails to resolve `bun`.

When Node/Electron cannot find the executable, it raises:

```text
spawn bun ENOENT
```

The same setup path also resolved the repo/resource root using a fallback based on `app.getAppPath()`:

```ts
path.resolve(app.getAppPath(), '..', '..')
```

That is brittle for packaged Electron layouts because `app.getAppPath()` may point into the packaged app structure rather than the resource root where bundled app assets live. The desktop app already has centralized path helpers for this in `apps/desktop/src/paths.ts`, so Shogo IDE setup should use those helpers instead of duplicating a fragile path assumption.

## What changed

This PR updates `apps/desktop/src/shogo-ide.ts` to:

1. Use `getProjectRoot()` for Shogo IDE repo/resource-root resolution.
2. Use `getBunPath()` to resolve the bundled Bun binary when available.
3. Add a setup command environment that prepends:
   - the bundled Bun directory, when absolute
   - `/opt/homebrew/bin`
   - `/usr/local/bin`
   - `/usr/bin`
   - `/bin`
   - `/usr/sbin`
   - `/sbin`
4. Set `SHOGO_BUN_PATH` in the setup command environment.
5. Pass the same stable environment to setup-related `spawn`/`spawnSync` calls.

This keeps existing dev behavior and environment overrides intact while making packaged production behavior deterministic.

## Why this is a root fix

This does not hide the error, retry the same failing command, or suppress the alert. It changes the execution path so the app no longer depends on a user-global `bun` executable being discoverable from a GUI-launched Electron process.

The packaged app already bundles Bun. The setup path now has a way to use that bundled runtime directly.

It also removes the fragile `app.getAppPath()/../..` repo-root assumption in favor of the existing production-aware root resolver.

## Validation performed

Verified the branch is clean and pushed:

```text
fix/shogo-ide-not-opening
01d975f4 fix(desktop): resolve bundled bun for Shogo IDE setup
```

Ran the desktop TypeScript check successfully:

```bash
apps/desktop/node_modules/.bin/tsc -p apps/desktop/tsconfig.json --noEmit
```

Ran Shogo IDE hardening validation successfully during local verification:

```bash
bun run --cwd apps/shogo-ide phase6:check
```

Also confirmed that the currently installed app contains a bundled Bun binary that can run even with a stripped shell path:

```bash
env -i HOME="$HOME" PATH="/usr/bin:/bin" /Applications/Shogo.app/Contents/Resources/bun/bun --version
```

Output:

```text
1.3.11
```

A temporary debug-log run, later reverted before this PR, confirmed the ShowByID/open flow reaches the expected Shogo IDE launch path:

```text
openIdeWindow: requested
openIdeWindow: resolved workspace path
startIdeServer: requested
ensureShogoIdeSetup: starting
startIdeServer: launching Code OSS web server
startIdeServer: resolved server URL
openIdeWindow: opened new window
```

In that dev run, setup artifacts already existed, so `distribution:materialize` was skipped; therefore final production confidence should still include a packaged-app test.

## Recommended release validation

Before final release, validate with a packaged macOS app built from this branch:

1. Install/open the packaged app normally from Finder/Spotlight/Dock, not from Terminal.
2. Use a machine or user account where Bun is not globally installed, if possible.
3. Click ShowByID / Shogo IDE.
4. Confirm the IDE opens.
5. Confirm no alert appears with:

```text
spawn bun ENOENT
```

or:

```text
bun run distribution:materialize exited with code 1
```

## Risk assessment

Risk is low-to-moderate:

- The change is isolated to Shogo IDE setup command resolution.
- The existing environment variable overrides remain supported.
- Dev behavior remains compatible because bare `bun` is still used when no absolute bundled Bun path exists.
- The new PATH additions are standard macOS binary locations and are only applied to setup commands launched by this path.

The main remaining validation requirement is packaged-app testing, because the original failure is production/Electron-environment specific.
