### PR TITLE
Move Shogo IDE CTA into IDE tab

### DIFF
--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -2772,6 +2772,7 @@ export default observer(function ProjectLayout() {
             if (base) window.open(`${base}/`, '_blank', 'noopener,noreferrer')
           }
         : undefined,
+    onOpenCodeWorkbench: handleOpenCodeWorkbench,
     ideEmbed: isIdeChatEmbed,
   }
 
@@ -3300,7 +3301,6 @@ export default observer(function ProjectLayout() {
                 projectId={projectId!}
                 projectName={project.name}
                 agentUrl={agentUrl}
-                onOpenCodeWorkbench={handleOpenCodeWorkbench}
                 isExternalProject={isExternalProject}
                 folderPath={primaryFolderPath ?? undefined}
               />

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -3300,9 +3300,9 @@ export default observer(function ProjectLayout() {
                 projectId={projectId!}
                 projectName={project.name}
                 agentUrl={agentUrl}
+                onOpenCodeWorkbench={handleOpenCodeWorkbench}
                 isExternalProject={isExternalProject}
                 folderPath={primaryFolderPath ?? undefined}
-                onOpenCodeWorkbench={handleOpenCodeWorkbench}
               />
             </PanelErrorBoundary>
             <PanelErrorBoundary panelName="Files">

--- a/apps/mobile/components/project/ProjectTopBar.tsx
+++ b/apps/mobile/components/project/ProjectTopBar.tsx
@@ -191,6 +191,7 @@ export interface ProjectTopBarProps {
   canvasThemeSupported?: boolean | null
   onCanvasRefresh?: () => void
   onCanvasOpenInNewTab?: () => void
+  onOpenCodeWorkbench?: () => void
   ideEmbed?: boolean
 }
 
@@ -363,6 +364,7 @@ export function ProjectTopBar({
   canvasThemeSupported,
   onCanvasRefresh,
   onCanvasOpenInNewTab,
+  onOpenCodeWorkbench,
   ideEmbed = false,
 }: ProjectTopBarProps) {
   const router = useRouter()
@@ -404,6 +406,7 @@ export function ProjectTopBar({
   }, [activeChatSessionId, chatRenameValue, onRenameChat])
 
   const isCanvasActive = activeTab === 'canvas'
+  const isIdeActive = activeTab === 'ide'
 
   // Workspace Trust badge: external (folder-linked) projects only, and
   // only when the parent wired up a toggle handler + a known trust level.
@@ -922,6 +925,19 @@ export function ProjectTopBar({
               onToggle={onToggleTrust!}
               busy={trustBusy}
             />
+          )}
+          {isIdeActive && onOpenCodeWorkbench && (
+            <Pressable
+              onPress={onOpenCodeWorkbench}
+              className="h-8 flex-row items-center gap-1.5 rounded-lg border border-orange-500/40 bg-orange-500/10 px-3 active:bg-orange-500/15"
+              accessibilityRole="button"
+              accessibilityLabel="Open in Shogo IDE"
+            >
+              <ExternalLink size={14} className="text-orange-400" />
+              <Text className="text-xs font-semibold text-orange-400">
+                {isWide ? 'Open in Shogo IDE' : 'Open in IDE'}
+              </Text>
+            </Pressable>
           )}
           {isCanvasActive && (
             <PublishDropdown

--- a/apps/mobile/components/project/panels/IDEPanel.tsx
+++ b/apps/mobile/components/project/panels/IDEPanel.tsx
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { useEffect, useMemo, useState } from 'react'
-import { Platform, View, Text, Pressable } from 'react-native'
-import { Code2, ExternalLink } from 'lucide-react-native'
+import { Platform, View, Text } from 'react-native'
+import { Code2 } from 'lucide-react-native'
 import { Workbench } from './ide/Workbench'
 import { sdkFsFor } from './ide/workspace/sdkFs'
 import { DesktopFs, getDesktopFsBridge } from './ide/workspace/desktopFs'
@@ -14,7 +14,6 @@ interface IDEPanelProps {
   projectId: string
   projectName?: string | null
   agentUrl?: string | null
-  onOpenCodeWorkbench?: () => void
   isExternalProject?: boolean
   folderPath?: string | null
 }
@@ -37,7 +36,6 @@ export function IDEPanel({
   projectId,
   projectName,
   agentUrl,
-  onOpenCodeWorkbench,
   isExternalProject,
   folderPath,
 }: IDEPanelProps) {
@@ -110,23 +108,6 @@ export function IDEPanel({
 
   return (
     <View style={{ flex: 1, minHeight: 0, display: visible ? 'flex' : 'none' }}>
-      {onOpenCodeWorkbench && (
-        <View className="h-10 flex-row items-center justify-between border-b border-border bg-background px-3">
-          <View className="flex-row items-center gap-2">
-            <Code2 size={14} className="text-muted-foreground" />
-            <Text className="text-xs font-semibold text-foreground">IDE</Text>
-          </View>
-          <Pressable
-            onPress={onOpenCodeWorkbench}
-            className="h-7 flex-row items-center gap-1.5 rounded-md border border-orange-500/40 bg-orange-500/10 px-2.5 active:bg-orange-500/15"
-            accessibilityRole="button"
-            accessibilityLabel="Open full Shogo IDE"
-          >
-            <ExternalLink size={12} className="text-orange-400" />
-            <Text className="text-[10px] font-semibold text-orange-400">Open full Shogo IDE</Text>
-          </Pressable>
-        </View>
-      )}
       <div style={{ flex: 1, minHeight: 0 }}>
         <Workbench
           agentService={agentService}

--- a/apps/mobile/components/project/panels/IDEPanel.tsx
+++ b/apps/mobile/components/project/panels/IDEPanel.tsx
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2026 Shogo Technologies, Inc.
 import { useEffect, useMemo, useState } from 'react'
-import { Platform, View, Text } from 'react-native'
-import { Code2 } from 'lucide-react-native'
+import { Platform, View, Text, Pressable } from 'react-native'
+import { Code2, ExternalLink } from 'lucide-react-native'
 import { Workbench } from './ide/Workbench'
 import { sdkFsFor } from './ide/workspace/sdkFs'
 import { DesktopFs, getDesktopFsBridge } from './ide/workspace/desktopFs'
@@ -30,7 +30,7 @@ interface IDEPanelProps {
  * exposes those routes (follow-up phase).
  *
  * In Shogo Desktop, this IDE tab remains the in-app editing surface while
- * the footer can open/focus the managed external Shogo-IDE window.
+ * its header can open/focus the managed external Shogo-IDE window.
  */
 export function IDEPanel({
   visible,
@@ -110,7 +110,24 @@ export function IDEPanel({
 
   return (
     <View style={{ flex: 1, minHeight: 0, display: visible ? 'flex' : 'none' }}>
-      <div style={{ position: 'absolute', inset: 0 }}>
+      {onOpenCodeWorkbench && (
+        <View className="h-10 flex-row items-center justify-between border-b border-border bg-background px-3">
+          <View className="flex-row items-center gap-2">
+            <Code2 size={14} className="text-muted-foreground" />
+            <Text className="text-xs font-semibold text-foreground">IDE</Text>
+          </View>
+          <Pressable
+            onPress={onOpenCodeWorkbench}
+            className="h-7 flex-row items-center gap-1.5 rounded-md border border-orange-500/40 bg-orange-500/10 px-2.5 active:bg-orange-500/15"
+            accessibilityRole="button"
+            accessibilityLabel="Open full Shogo IDE"
+          >
+            <ExternalLink size={12} className="text-orange-400" />
+            <Text className="text-[10px] font-semibold text-orange-400">Open full Shogo IDE</Text>
+          </Pressable>
+        </View>
+      )}
+      <div style={{ flex: 1, minHeight: 0 }}>
         <Workbench
           agentService={agentService}
           agentLabel={projectName || `project/${projectId}`}
@@ -120,7 +137,6 @@ export function IDEPanel({
           fetchImpl={agentFetch}
           isExternalProject={isExternalProject}
           folderPath={folderPath}
-          onOpenCodeWorkbench={onOpenCodeWorkbench}
         />
       </div>
     </View>

--- a/apps/mobile/components/project/panels/ide/StatusBar.tsx
+++ b/apps/mobile/components/project/panels/ide/StatusBar.tsx
@@ -1,11 +1,10 @@
-import { ArrowDown, ArrowUp, Check, ExternalLink, GitBranch, Loader2, RefreshCw } from "lucide-react-native";
+import { ArrowDown, ArrowUp, Check, GitBranch, Loader2, RefreshCw } from "lucide-react-native";
 import { useState } from "react";
 
 import { BranchPicker } from "./git/BranchPicker";
 import type { GitSnapshot } from "./git/bridge";
 import type { ExtensionRuntimeStatusBarItem } from "./extensions/types";
 import { getDesktopGitBridge } from "./git/bridge";
-import { isDesktopRuntime } from "./terminal/pty-factory";
 
 export function StatusBar({
   language,
@@ -16,7 +15,6 @@ export function StatusBar({
   workspaceRoot,
   extensionItems = [],
   onRunExtensionCommand,
-  onOpenCodeWorkbench,
 }: {
   language: string;
   line: number;
@@ -35,14 +33,12 @@ export function StatusBar({
   workspaceRoot?: string | null;
   extensionItems?: ExtensionRuntimeStatusBarItem[];
   onRunExtensionCommand?: (commandId: string, args?: unknown[]) => void;
-  onOpenCodeWorkbench?: () => void;
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const [syncError, setSyncError] = useState<string | null>(null);
 
   const bridge = getDesktopGitBridge();
-  const canOpenCodeWorkbench = !!onOpenCodeWorkbench && isDesktopRuntime();
   const handleSync = async () => {
     if (!bridge || !workspaceRoot) return;
     setSyncing(true);
@@ -100,18 +96,6 @@ export function StatusBar({
               </span>
             )}
           </>
-        ) : null}
-        {canOpenCodeWorkbench ? (
-          <button
-            type="button"
-            onClick={onOpenCodeWorkbench}
-            title="Open or focus Shogo IDE"
-            aria-label="Open or focus Shogo IDE"
-            className="-mx-1 flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-orange-400 hover:bg-white/15 hover:text-orange-300"
-          >
-            <ExternalLink size={11} />
-            <span className="hidden sm:inline">Shogo IDE</span>
-          </button>
         ) : null}
         {leftExtensionItems.map((item) => (
           <ExtensionStatusBarButton key={item.id} item={item} onRunCommand={onRunExtensionCommand} />

--- a/apps/mobile/components/project/panels/ide/Workbench.tsx
+++ b/apps/mobile/components/project/panels/ide/Workbench.tsx
@@ -210,7 +210,6 @@ export function Workbench({
   fetchImpl,
   isExternalProject = true,
   folderPath,
-  onOpenCodeWorkbench,
 }: {
   agentService: WorkspaceService;
   agentLabel?: string;
@@ -242,8 +241,6 @@ export function Workbench({
   isExternalProject?: boolean;
   /** Absolute path to the project's primary folder (for external/open-folder projects). */
   folderPath?: string | null;
-  /** Open/focus the managed external Shogo-IDE window from the status bar. */
-  onOpenCodeWorkbench?: () => void;
 }) {
   const themeMode = useResolvedTheme();
   const [activity, setActivity] = useState<ActivityId>("files");
@@ -2267,7 +2264,6 @@ export function Workbench({
         workspaceRoot={gitWorkspaceRoot}
         extensionItems={extensionsSummary.statusBarItems}
         onRunExtensionCommand={runExtensionCommand}
-        onOpenCodeWorkbench={onOpenCodeWorkbench}
       />
 
 


### PR DESCRIPTION
## Summary

<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/21589ce7-d73a-47c4-9adb-b13a8d7c6760" />


Closes #790

This PR updates the Shogo IDE launcher placement so the full Code-OSS based Shogo IDE is discovered from the `IDE` tab instead of appearing as a separate top-level project toolbar CTA or a hidden footer/status-bar shortcut.

The change follows the product framing that **Shogo IDE is a dedicated project code workspace window**, not an agent window and not a global app mode. The embedded `IDE` tab remains the lightweight in-app coding surface, while the new `Open full Shogo IDE` CTA lets users move from that context into the dedicated desktop/code window when they need more space or a full IDE experience.

## Why this change

The previous exploration surfaced two competing problems:

1. A footer/status-bar `Shogo IDE` shortcut was too hidden. Users do not naturally look in an editor status bar for a major workspace action like opening a full IDE window.
2. A top project toolbar CTA next to the `IDE` tab created duplicate, visually similar IDE entry points. This made the navigation feel like it had two identical IDE icons/actions and blurred the distinction between the embedded IDE tab and the full Shogo IDE window.

The clearer use case is: a user who wants the code window is already likely to click the `IDE` tab. From there, opening the full Shogo IDE is contextual and understandable.

## UX behavior after this PR

Top project navigation stays focused on project surfaces:

```text
Chat | Canvas | Preview | IDE | Plans | Settings
```

Inside the `IDE` tab, users now see the full IDE/window launcher in context:

```text
IDE                                      [Open full Shogo IDE]
```

This creates a cleaner hierarchy:

- `IDE` tab: lightweight embedded project code surface.
- `Open full Shogo IDE`: opens/focuses the dedicated Code-OSS based Shogo IDE window.
- Shogo Chat/Agent: remains a sidecar inside the IDE experience, not the identity of the full IDE window.

## Implementation details

### `apps/mobile/components/project/panels/IDEPanel.tsx`

- Adds a compact IDE panel header.
- Adds an `Open full Shogo IDE` button in that header.
- Wires the button to the existing `onOpenCodeWorkbench` callback.
- Uses the existing desktop open/focus behavior rather than introducing a new launcher path.

### `apps/mobile/app/(app)/projects/[id]/_layout.tsx`

- Passes `handleOpenCodeWorkbench` into `IDEPanel` so the CTA lives inside the IDE tab.
- Removes the top-toolbar launcher wiring so the action is no longer duplicated next to the `IDE` tab.

### `apps/mobile/components/project/panels/ide/StatusBar.tsx`

- Removes the footer/status-bar `Shogo IDE` launcher.
- Removes now-unused imports/runtime checks associated with that footer shortcut.

### `apps/mobile/components/project/panels/ide/Workbench.tsx`

- Stops forwarding the Code Workbench opener into the status bar.

## Product rationale

This keeps the user journey intentional:

1. User wants code-related functionality.
2. User opens the `IDE` tab.
3. User can stay in the embedded editor or choose `Open full Shogo IDE` for the larger desktop code workspace.

That avoids forcing the full IDE/window concept into global navigation while still making it easier to find than the old footer shortcut.

## Verification

- Ran `git diff --check` successfully.
- Ran `bun run --cwd apps/mobile typecheck`; the command exited successfully with the repository's existing message: `Skipping: requires Expo native environment`.

## Screens / review notes

The intended visual result is that the full IDE launcher appears only inside the `IDE` tab header, while the top project toolbar and footer/status bar no longer show a competing Shogo IDE launcher.
