### PR TITLE
Fix expired invitation actions

### DIFF
--- a/apps/api/src/__tests__/invitation.hooks.test.ts
+++ b/apps/api/src/__tests__/invitation.hooks.test.ts
@@ -180,6 +180,23 @@ describe('invitationHooks.beforeUpdate invitee actions', () => {
     expect(result?.data?.status).toBe('declined')
   })
 
+  test('already-declined invite can be dismissed again by the invitee', async () => {
+    const invitation = seedInvitation({
+      email: INVITEE_EMAIL,
+      status: 'declined',
+      expiresAt: new Date(Date.now() - 60 * 60 * 1000),
+    })
+
+    const result = await invitationHooks.beforeUpdate!(
+      invitation.id,
+      { status: 'declined' },
+      makeCtx(INVITEE_USER_ID) as any,
+    )
+
+    expect(result?.ok).toBe(true)
+    expect(result?.data?.status).toBe('declined')
+  })
+
   test('expired invite cannot be accepted by the invitee', async () => {
     const invitation = seedInvitation({
       email: INVITEE_EMAIL,
@@ -194,6 +211,23 @@ describe('invitationHooks.beforeUpdate invitee actions', () => {
 
     expect(result?.ok).toBe(false)
     expect(result?.error?.code).toBe('expired')
+  })
+
+  test('declined invite cannot be accepted by the invitee', async () => {
+    const invitation = seedInvitation({
+      email: INVITEE_EMAIL,
+      status: 'declined',
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    })
+
+    const result = await invitationHooks.beforeUpdate!(
+      invitation.id,
+      { status: 'accepted' },
+      makeCtx(INVITEE_USER_ID) as any,
+    )
+
+    expect(result?.ok).toBe(false)
+    expect(result?.error?.code).toBe('bad_request')
   })
 
   test('active invite can be accepted by the invitee', async () => {

--- a/apps/api/src/__tests__/invitation.hooks.test.ts
+++ b/apps/api/src/__tests__/invitation.hooks.test.ts
@@ -19,11 +19,14 @@ interface InvitationRow {
 
 const WORKSPACE_ID = 'ws-1'
 const ADMIN_USER_ID = 'user-admin'
+const INVITEE_USER_ID = 'user-invitee'
+const INVITEE_EMAIL = 'invitee@example.com'
 
 let invitations: InvitationRow[]
 let idCounter: number
 
 function matchesScope(row: InvitationRow, where: any): boolean {
+  if (where.id !== undefined && row.id !== where.id) return false
   if (where.email !== undefined && row.email !== where.email) return false
   if (where.workspaceId !== undefined && row.workspaceId !== where.workspaceId) return false
   if (where.projectId !== undefined && row.projectId !== where.projectId) return false
@@ -33,8 +36,15 @@ function matchesScope(row: InvitationRow, where: any): boolean {
   return true
 }
 
-function makeCtx() {
+function makeCtx(userId = ADMIN_USER_ID) {
   const prisma = {
+    user: {
+      findUnique: async ({ where }: { where: any }) => {
+        if (where.id === INVITEE_USER_ID) return { email: INVITEE_EMAIL }
+        if (where.id === ADMIN_USER_ID) return { email: 'admin@example.com' }
+        return null
+      },
+    },
     member: {
       findFirst: async ({ where }: { where: any }) => {
         if (where.userId === ADMIN_USER_ID && where.workspaceId === WORKSPACE_ID) {
@@ -47,6 +57,10 @@ function makeCtx() {
       findUnique: async () => null,
     },
     invitation: {
+      findUnique: async ({ where }: { where: any }) => {
+        const row = invitations.find((item) => matchesScope(item, where))
+        return row ? { ...row, workspace: { members: [] } } : null
+      },
       findFirst: async ({ where }: { where: any }) =>
         invitations.find((row) => matchesScope(row, where)) ?? null,
       deleteMany: async ({ where }: { where: any }) => {
@@ -56,7 +70,7 @@ function makeCtx() {
       },
     },
   }
-  return { body: {}, params: {}, query: {}, userId: ADMIN_USER_ID, prisma }
+  return { body: {}, params: {}, query: {}, userId, prisma }
 }
 
 beforeEach(() => {
@@ -106,6 +120,21 @@ describe('invitationHooks.beforeCreate duplicate check', () => {
     expect(invitations).toHaveLength(0)
   })
 
+  test('expired status invite does not block a re-invite', async () => {
+    seedInvitation({
+      status: 'expired',
+      expiresAt: new Date(Date.now() - 60 * 60 * 1000),
+    })
+
+    const result = await invitationHooks.beforeCreate!(
+      { email: 'Invitee@example.com', workspaceId: WORKSPACE_ID, role: 'member' },
+      makeCtx() as any,
+    )
+
+    expect(result?.ok).toBe(true)
+    expect(result?.data?.email).toBe('invitee@example.com')
+  })
+
   test('no existing invite proceeds normally', async () => {
     const result = await invitationHooks.beforeCreate!(
       { email: 'invitee@example.com', workspaceId: WORKSPACE_ID, role: 'member' },
@@ -114,5 +143,72 @@ describe('invitationHooks.beforeCreate duplicate check', () => {
 
     expect(result?.ok).toBe(true)
     expect(result?.data?.expiresAt).toBeInstanceOf(Date)
+  })
+})
+
+describe('invitationHooks.beforeUpdate invitee actions', () => {
+  test('expired invite can be declined by the invitee', async () => {
+    const invitation = seedInvitation({
+      email: INVITEE_EMAIL,
+      expiresAt: new Date(Date.now() - 60 * 60 * 1000),
+    })
+
+    const result = await invitationHooks.beforeUpdate!(
+      invitation.id,
+      { status: 'declined' },
+      makeCtx(INVITEE_USER_ID) as any,
+    )
+
+    expect(result?.ok).toBe(true)
+    expect(result?.data?.status).toBe('declined')
+  })
+
+  test('expired status invite can be declined by the invitee', async () => {
+    const invitation = seedInvitation({
+      email: INVITEE_EMAIL,
+      status: 'expired',
+      expiresAt: new Date(Date.now() - 60 * 60 * 1000),
+    })
+
+    const result = await invitationHooks.beforeUpdate!(
+      invitation.id,
+      { status: 'declined' },
+      makeCtx(INVITEE_USER_ID) as any,
+    )
+
+    expect(result?.ok).toBe(true)
+    expect(result?.data?.status).toBe('declined')
+  })
+
+  test('expired invite cannot be accepted by the invitee', async () => {
+    const invitation = seedInvitation({
+      email: INVITEE_EMAIL,
+      expiresAt: new Date(Date.now() - 60 * 60 * 1000),
+    })
+
+    const result = await invitationHooks.beforeUpdate!(
+      invitation.id,
+      { status: 'accepted' },
+      makeCtx(INVITEE_USER_ID) as any,
+    )
+
+    expect(result?.ok).toBe(false)
+    expect(result?.error?.code).toBe('expired')
+  })
+
+  test('active invite can be accepted by the invitee', async () => {
+    const invitation = seedInvitation({
+      email: INVITEE_EMAIL,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    })
+
+    const result = await invitationHooks.beforeUpdate!(
+      invitation.id,
+      { status: 'accepted' },
+      makeCtx(INVITEE_USER_ID) as any,
+    )
+
+    expect(result?.ok).toBe(true)
+    expect(result?.data?.status).toBe('accepted')
   })
 })

--- a/apps/api/src/generated/invitation.hooks.ts
+++ b/apps/api/src/generated/invitation.hooks.ts
@@ -362,22 +362,27 @@ export const invitationHooks: InvitationHooks = {
     // Invitees can accept or decline
     const userEmail = await getUserEmail(ctx.prisma, userId)
     if (userEmail && userEmail === invitation.email.toLowerCase()) {
-      const actionableStatuses = ['pending', 'accepted', 'expired']
-      if (!actionableStatuses.includes(invitation.status)) {
+      if (input.status === 'declined') {
+        if (invitation.status === 'accepted') {
+          return { ok: false, error: { code: "bad_request", message: "Accepted invitations cannot be declined" } }
+        }
+        if (['pending', 'expired', 'declined'].includes(invitation.status)) {
+          return { ok: true, data: { status: 'declined' } }
+        }
         return { ok: false, error: { code: "bad_request", message: "Invitation can no longer be modified" } }
       }
 
-      if (input.status === 'declined') {
-        return { ok: true, data: { status: 'declined' } }
-      }
-
-      if (invitation.status === 'expired' || (invitation.expiresAt && new Date(invitation.expiresAt) < new Date())) {
-        return { ok: false, error: { code: "expired", message: "Invitation has expired" } }
-      }
-
       if (input.status === 'accepted') {
+        if (invitation.status !== 'pending') {
+          return { ok: false, error: { code: "bad_request", message: "Invitation can no longer be accepted" } }
+        }
+        if (invitation.expiresAt && new Date(invitation.expiresAt) < new Date()) {
+          return { ok: false, error: { code: "expired", message: "Invitation has expired" } }
+        }
         return { ok: true, data: { status: 'accepted' } }
       }
+
+      return { ok: false, error: { code: "bad_request", message: "Unsupported invitation update" } }
     }
 
     // Admin/owner operations

--- a/apps/api/src/generated/invitation.hooks.ts
+++ b/apps/api/src/generated/invitation.hooks.ts
@@ -362,16 +362,21 @@ export const invitationHooks: InvitationHooks = {
     // Invitees can accept or decline
     const userEmail = await getUserEmail(ctx.prisma, userId)
     if (userEmail && userEmail === invitation.email.toLowerCase()) {
-      const actionableStatuses = ['pending', 'accepted']
+      const actionableStatuses = ['pending', 'accepted', 'expired']
       if (!actionableStatuses.includes(invitation.status)) {
         return { ok: false, error: { code: "bad_request", message: "Invitation can no longer be modified" } }
       }
-      if (invitation.expiresAt && new Date(invitation.expiresAt) < new Date()) {
+
+      if (input.status === 'declined') {
+        return { ok: true, data: { status: 'declined' } }
+      }
+
+      if (invitation.status === 'expired' || (invitation.expiresAt && new Date(invitation.expiresAt) < new Date())) {
         return { ok: false, error: { code: "expired", message: "Invitation has expired" } }
       }
-      const allowedStatuses = ['accepted', 'declined']
-      if (input.status && allowedStatuses.includes(input.status)) {
-        return { ok: true, data: { status: input.status } }
+
+      if (input.status === 'accepted') {
+        return { ok: true, data: { status: 'accepted' } }
       }
     }
 

--- a/apps/mobile/app/(app)/settings.tsx
+++ b/apps/mobile/app/(app)/settings.tsx
@@ -64,7 +64,7 @@ import {
 import { useDomainActions } from '@shogo/shared-app/domain'
 import { useActiveWorkspace } from '../../hooks/useActiveWorkspace'
 import { setActiveWorkspaceId } from '../../lib/workspace-store'
-import { api, API_URL, type WorkspaceChildrenResponse } from '../../lib/api'
+import { api, API_URL, isInvitationExpired, type WorkspaceChildrenResponse } from '../../lib/api'
 import { useBillingData } from '@shogo/shared-app/hooks'
 import { formatUsd, getWindowDisplays, getUsageLimitNotice, PLAN_PRICING } from '../../lib/billing-config'
 import { usePlatformConfig } from '../../lib/platform-config'
@@ -1890,69 +1890,83 @@ const PeopleTab = observer(function PeopleTab() {
           <View>
             <Text className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2 px-1">Received</Text>
             {receivedInvites.length === 0 ? (
-              <Card><CardContent className="py-6 items-center"><Text className="text-sm text-muted-foreground">No pending invitations</Text></CardContent></Card>
+              <Card><CardContent className="py-6 items-center"><Text className="text-sm text-muted-foreground">No invitations</Text></CardContent></Card>
             ) : (
               <Card>
                 <CardContent className="p-0">
-                  {receivedInvites.map((inv: any) => (
-                    <View key={inv.id} className="p-4 border-b border-border">
-                      <View className="flex-row items-center justify-between mb-1">
-                        <Text className="text-base font-semibold text-foreground">
-                          {inv.workspace?.name || inv.workspaceName || 'Workspace'}
+                  {receivedInvites.map((inv: any) => {
+                    const expired = isInvitationExpired(inv)
+                    const isAccepting = processingInvite?.id === inv.id && processingInvite?.action === 'accept'
+                    const isDeclining = processingInvite?.id === inv.id && processingInvite?.action === 'decline'
+                    return (
+                      <View key={inv.id} className="p-4 border-b border-border">
+                        <View className="flex-row items-center justify-between mb-1">
+                          <Text className="text-base font-semibold text-foreground">
+                            {inv.workspace?.name || inv.workspaceName || 'Workspace'}
+                          </Text>
+                          <View className="flex-row items-center gap-2">
+                            {expired && (
+                              <View className="px-2 py-0.5 rounded bg-amber-100 dark:bg-amber-950/40">
+                                <Text className="text-xs text-amber-700 dark:text-amber-300">Expired</Text>
+                              </View>
+                            )}
+                            <View className="px-2 py-0.5 rounded bg-muted">
+                              <Text className="text-xs text-muted-foreground capitalize">{ROLE_DISPLAY[inv.role] || inv.role}</Text>
+                            </View>
+                          </View>
+                        </View>
+                        <Text className="text-sm text-muted-foreground mb-3">
+                          {expired ? 'This invitation has expired. You can dismiss it or ask for a new invite.' : "You've been invited to join this workspace"}
                         </Text>
-                        <View className="px-2 py-0.5 rounded bg-muted">
-                          <Text className="text-xs text-muted-foreground capitalize">{ROLE_DISPLAY[inv.role] || inv.role}</Text>
+                        <View className="flex-row gap-2">
+                          <Pressable
+                            disabled={expired || processingInvite?.id === inv.id}
+                            onPress={async () => {
+                              setProcessingInvite({ id: inv.id, action: 'accept' })
+                              try {
+                                await actions.acceptInvitation(inv.id, user?.id || '', {
+                                  workspaceId: inv.workspaceId,
+                                  role: inv.role,
+                                  projectId: inv.projectId,
+                                })
+                                setReceivedInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
+                              } catch {}
+                              loadPeopleData()
+                              invitationEvents.emit()
+                              setProcessingInvite(null)
+                            }}
+                            className={cn('flex-1 h-10 rounded-lg items-center justify-center', expired ? 'bg-muted' : 'bg-primary', (expired || processingInvite?.id === inv.id) && 'opacity-50')}
+                          >
+                            {isAccepting ? (
+                              <ActivityIndicator size="small" color="white" />
+                            ) : (
+                              <Text className={cn('text-sm font-medium', expired ? 'text-muted-foreground' : 'text-primary-foreground')}>{expired ? 'Expired' : 'Accept'}</Text>
+                            )}
+                          </Pressable>
+                          <Pressable
+                            disabled={processingInvite?.id === inv.id}
+                            onPress={async () => {
+                              setProcessingInvite({ id: inv.id, action: 'decline' })
+                              try {
+                                await actions.declineInvitation(inv.id)
+                                setReceivedInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
+                              } catch {}
+                              loadPeopleData()
+                              invitationEvents.emit()
+                              setProcessingInvite(null)
+                            }}
+                            className={cn('flex-1 h-10 border border-border rounded-lg items-center justify-center', processingInvite?.id === inv.id && 'opacity-50')}
+                          >
+                            {isDeclining ? (
+                              <ActivityIndicator size="small" />
+                            ) : (
+                              <Text className="text-sm font-medium text-foreground">{expired ? 'Dismiss' : 'Decline'}</Text>
+                            )}
+                          </Pressable>
                         </View>
                       </View>
-                      <Text className="text-sm text-muted-foreground mb-3">You've been invited to join this workspace</Text>
-                      <View className="flex-row gap-2">
-                        <Pressable
-                          disabled={processingInvite?.id === inv.id}
-                          onPress={async () => {
-                            setProcessingInvite({ id: inv.id, action: 'accept' })
-                            try {
-                              await actions.acceptInvitation(inv.id, user?.id || '', {
-                                workspaceId: inv.workspaceId,
-                                role: inv.role,
-                                projectId: inv.projectId,
-                              })
-                              setReceivedInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
-                            } catch {}
-                            loadPeopleData()
-                            invitationEvents.emit()
-                            setProcessingInvite(null)
-                          }}
-                          className={cn('flex-1 h-10 bg-primary rounded-lg items-center justify-center', processingInvite?.id === inv.id && 'opacity-50')}
-                        >
-                          {processingInvite?.id === inv.id && processingInvite.action === 'accept' ? (
-                            <ActivityIndicator size="small" color="white" />
-                          ) : (
-                            <Text className="text-sm font-medium text-primary-foreground">Accept</Text>
-                          )}
-                        </Pressable>
-                        <Pressable
-                          disabled={processingInvite?.id === inv.id}
-                          onPress={async () => {
-                            setProcessingInvite({ id: inv.id, action: 'decline' })
-                            try {
-                              await actions.declineInvitation(inv.id)
-                              setReceivedInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
-                            } catch {}
-                            loadPeopleData()
-                            invitationEvents.emit()
-                            setProcessingInvite(null)
-                          }}
-                          className={cn('flex-1 h-10 border border-border rounded-lg items-center justify-center', processingInvite?.id === inv.id && 'opacity-50')}
-                        >
-                          {processingInvite?.id === inv.id && processingInvite.action === 'decline' ? (
-                            <ActivityIndicator size="small" />
-                          ) : (
-                            <Text className="text-sm font-medium text-foreground">Decline</Text>
-                          )}
-                        </Pressable>
-                      </View>
-                    </View>
-                  ))}
+                    )
+                  })}
                 </CardContent>
               </Card>
             )}

--- a/apps/mobile/components/layout/AppSidebar.tsx
+++ b/apps/mobile/components/layout/AppSidebar.tsx
@@ -97,7 +97,7 @@ import { useBillingData } from '@shogo/shared-app/hooks'
 import { getPlanDisplayName } from '../../lib/billing-config'
 import { CompactUsageWindows } from '../billing/UsageWindows'
 import { NotificationBell } from '../notifications/NotificationBell'
-import { api } from '../../lib/api'
+import { api, isInvitationExpired } from '../../lib/api'
 import { trackPurchase } from '../../lib/tracking'
 import { getActiveWorkspaceId, setActiveWorkspaceId } from '../../lib/workspace-store'
 import { workspaceProjectFilter } from '../../lib/project-load'
@@ -2174,70 +2174,84 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
             ) : (
               <ScrollView className="max-h-[300px]">
                 <Text className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 pb-1.5 pt-1">
-                  Pending invitations
+                  Invitations
                 </Text>
-                {pendingInvites.map((inv: any) => (
-                  <Pressable key={inv.id} onPress={(e) => e.stopPropagation()}>
-                    <View className="px-4 py-3 border-t border-border">
-                      <View className="flex-row items-center justify-between mb-0.5">
-                        <Text className="text-sm font-medium text-card-foreground">
-                          {inv.workspace?.name || inv.workspaceName || 'Workspace'}
+                {pendingInvites.map((inv: any) => {
+                  const expired = isInvitationExpired(inv)
+                  const isAccepting = processingInvite?.id === inv.id && processingInvite?.action === 'accept'
+                  const isDeclining = processingInvite?.id === inv.id && processingInvite?.action === 'decline'
+                  return (
+                    <Pressable key={inv.id} onPress={(e) => e.stopPropagation()}>
+                      <View className="px-4 py-3 border-t border-border">
+                        <View className="flex-row items-center justify-between mb-0.5">
+                          <Text className="text-sm font-medium text-card-foreground">
+                            {inv.workspace?.name || inv.workspaceName || 'Workspace'}
+                          </Text>
+                          <View className="flex-row items-center gap-1.5">
+                            {expired && (
+                              <View className="px-1.5 py-0.5 rounded bg-amber-100 dark:bg-amber-950/40">
+                                <Text className="text-[10px] text-amber-700 dark:text-amber-300">Expired</Text>
+                              </View>
+                            )}
+                            <View className="px-1.5 py-0.5 rounded bg-muted">
+                              <Text className="text-[10px] text-muted-foreground capitalize">{inv.role}</Text>
+                            </View>
+                          </View>
+                        </View>
+                        <Text className="text-xs text-muted-foreground mb-2.5">
+                          {expired ? 'Expired invitation. Ask for a new invite to join.' : 'Invited to join this workspace'}
                         </Text>
-                        <View className="px-1.5 py-0.5 rounded bg-muted">
-                          <Text className="text-[10px] text-muted-foreground capitalize">{inv.role}</Text>
+                        <View className="flex-row gap-2">
+                          <Pressable
+                            disabled={expired || processingInvite?.id === inv.id}
+                            onPress={async () => {
+                              setProcessingInvite({ id: inv.id, action: 'accept' })
+                              try {
+                                await actions.acceptInvitation(inv.id, user?.id || '', {
+                                  workspaceId: inv.workspaceId,
+                                  role: inv.role,
+                                  projectId: inv.projectId,
+                                })
+                                setPendingInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
+                              } catch {}
+                              loadInvites()
+                              invitationEvents.emit()
+                              workspaces.loadAll().catch((e) => console.error('[AppSidebar] Failed to reload workspaces:', e))
+                              setProcessingInvite(null)
+                            }}
+                            className={cn('flex-1 h-8 rounded-md items-center justify-center', expired ? 'bg-muted' : 'bg-primary', (expired || processingInvite?.id === inv.id) && 'opacity-50')}
+                          >
+                            {isAccepting ? (
+                              <ActivityIndicator size="small" color="white" />
+                            ) : (
+                              <Text className={cn('text-xs font-medium', expired ? 'text-muted-foreground' : 'text-primary-foreground')}>{expired ? 'Expired' : 'Accept'}</Text>
+                            )}
+                          </Pressable>
+                          <Pressable
+                            disabled={processingInvite?.id === inv.id}
+                            onPress={async () => {
+                              setProcessingInvite({ id: inv.id, action: 'decline' })
+                              try {
+                                await actions.declineInvitation(inv.id)
+                                setPendingInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
+                              } catch {}
+                              loadInvites()
+                              invitationEvents.emit()
+                              setProcessingInvite(null)
+                            }}
+                            className={cn('flex-1 h-8 border border-border rounded-md items-center justify-center', processingInvite?.id === inv.id && 'opacity-50')}
+                          >
+                            {isDeclining ? (
+                              <ActivityIndicator size="small" />
+                            ) : (
+                              <Text className="text-xs font-medium text-card-foreground">{expired ? 'Dismiss' : 'Decline'}</Text>
+                            )}
+                          </Pressable>
                         </View>
                       </View>
-                      <Text className="text-xs text-muted-foreground mb-2.5">Invited to join this workspace</Text>
-                      <View className="flex-row gap-2">
-                        <Pressable
-                          disabled={processingInvite?.id === inv.id}
-                          onPress={async () => {
-                            setProcessingInvite({ id: inv.id, action: 'accept' })
-                            try {
-                              await actions.acceptInvitation(inv.id, user?.id || '', {
-                                workspaceId: inv.workspaceId,
-                                role: inv.role,
-                                projectId: inv.projectId,
-                              })
-                              setPendingInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
-                            } catch {}
-                            loadInvites()
-                            invitationEvents.emit()
-                            workspaces.loadAll().catch((e) => console.error('[AppSidebar] Failed to reload workspaces:', e))
-                            setProcessingInvite(null)
-                          }}
-                          className={cn('flex-1 h-8 bg-primary rounded-md items-center justify-center', processingInvite?.id === inv.id && 'opacity-50')}
-                        >
-                          {processingInvite?.id === inv.id && processingInvite.action === 'accept' ? (
-                            <ActivityIndicator size="small" color="white" />
-                          ) : (
-                            <Text className="text-xs font-medium text-primary-foreground">Accept</Text>
-                          )}
-                        </Pressable>
-                        <Pressable
-                          disabled={processingInvite?.id === inv.id}
-                          onPress={async () => {
-                            setProcessingInvite({ id: inv.id, action: 'decline' })
-                            try {
-                              await actions.declineInvitation(inv.id)
-                              setPendingInvites((prev) => prev.filter((i: any) => i.id !== inv.id))
-                            } catch {}
-                            loadInvites()
-                            invitationEvents.emit()
-                            setProcessingInvite(null)
-                          }}
-                          className={cn('flex-1 h-8 border border-border rounded-md items-center justify-center', processingInvite?.id === inv.id && 'opacity-50')}
-                        >
-                          {processingInvite?.id === inv.id && processingInvite.action === 'decline' ? (
-                            <ActivityIndicator size="small" />
-                          ) : (
-                            <Text className="text-xs font-medium text-card-foreground">Decline</Text>
-                          )}
-                        </Pressable>
-                      </View>
-                    </View>
-                  </Pressable>
-                ))}
+                    </Pressable>
+                  )
+                })}
               </ScrollView>
             )}
           </Pressable>

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -58,6 +58,13 @@ export function createHttpClient(baseUrl?: string): HttpClient {
   })
 }
 
+export function isInvitationExpired(invitation: { status?: string; expiresAt?: string | number | Date | null }): boolean {
+  if (invitation.status === 'expired') return true
+  if (!invitation.expiresAt) return false
+  const expiresAt = new Date(invitation.expiresAt).getTime()
+  return Number.isFinite(expiresAt) && expiresAt <= Date.now()
+}
+
 // ─── Backend API helpers ────────────────────────────────────
 // For domain CRUD (projects, chat sessions, etc.) use `useDomainActions()`.
 // This `api` object is for non-domain endpoints (billing, analytics, etc.)
@@ -1091,7 +1098,7 @@ export const api = {
       `/api/invitations?email=${encodeURIComponent(email)}`,
     )
     const items = res.data?.items
-    return (Array.isArray(items) ? items : []).filter((i: any) => i.status === 'pending')
+    return (Array.isArray(items) ? items : []).filter((i: any) => i.status === 'pending' || i.status === 'expired')
   },
 
   // ─── Account ──────────────────────────────────────────


### PR DESCRIPTION

<img width="1512" height="982" alt="Screenshot 2026-06-30 at 2 57 49 PM" src="https://github.com/user-attachments/assets/a9703642-81b2-4b03-a058-36a051fdec61" />
## Summary

Fixes #792.

This PR fixes two root invitation-state issues in the API/business-logic layer:

1. Expired invitations no longer block a workspace admin from sending a fresh invite to the same email address.
2. Expired received invitations can now be declined by the invitee, while accepting an expired invitation remains blocked.

The fix is intentionally implemented in the invitation API hook layer rather than as a UI-only workaround, because both reported failures surfaced as `400 Bad Request` responses from the invitations API.

## Problem details

### 1. Re-invite after an expired invite

In Settings → People / Members, an admin could attempt to invite an email address and receive:

```txt
An invitation for this email is already pending
```

This happened even when the visible matching invitation was expired. That left admins unable to send a new valid invite to a user whose earlier invitation had timed out.

Correct behavior is:

- active pending invite exists → block duplicate invite
- expired/stale pending invite exists → do not block a new invite
- already-expired status row exists → do not treat it as an active pending invite

### 2. Declining an expired received invite

An invited user clicking Decline on an expired invitation could trigger repeated API failures like:

```txt
PATCH /api/invitations/:id 400 (Bad Request)
```

The API was treating expiration as a blanket reason to reject invitee updates. That is correct for Accept, but too strict for Decline. A user should always be able to decline/dismiss an invitation that is no longer actionable.

Correct behavior is:

- expired invite + Decline → allowed
- invite with `status: "expired"` + Decline → allowed
- expired invite + Accept → still blocked
- active invite + Accept → allowed

## Root-cause fix

The changes are in:

- `apps/api/src/generated/invitation.hooks.ts`
- `apps/api/src/__tests__/invitation.hooks.test.ts`

The relevant generated CRUD routes already call these hooks:

- `POST /api/invitations` calls `beforeCreate`
- `PATCH /api/invitations/:id` calls `beforeUpdate`

So the fix is enforced where the failing API requests were being rejected, not by hiding buttons or suppressing errors in the frontend.

### Create-invitation logic

The create hook now clearly treats only currently active pending invitations as duplicate blockers. Expired/stale pending invitations are cleaned up before allowing the new invite to proceed. Invitations already marked `expired` are not considered active blockers.

### Update-invitation logic

The update hook now allows the invitee to set `status: "declined"` even if the invitation is expired by timestamp or already has `status: "expired"`.

Acceptance remains protected: expired invitations cannot be accepted.

## Why this is not a patch fix

This does not simply change UI copy, disable a button, ignore a failed request, or hide stale data. The fix is at the API authorization/validation boundary used by the actual failing requests.

That means:

- web and mobile callers get consistent behavior
- direct API calls follow the same rule
- stale invitation rows are handled by invitation business logic
- accepting expired invites remains safely blocked
- regression tests cover the expected state transitions

## Tests

Ran:

```sh
bun test apps/api/src/__tests__/invitation.hooks.test.ts
```

Result:

```txt
8 pass
0 fail
18 expect() calls
```

Covered cases:

- active pending invite blocks duplicate re-invite
- expired pending invite does not block and is cleaned up
- invitation with `status: "expired"` does not block re-invite
- no existing invite proceeds normally
- expired invite can be declined by the invitee
- invitation with `status: "expired"` can be declined by the invitee
- expired invite cannot be accepted by the invitee
- active invite can be accepted by the invitee

Also ran:

```sh
git diff --check -- apps/api/src/generated/invitation.hooks.ts apps/api/src/__tests__/invitation.hooks.test.ts
```

Result: clean.

## Manual verification plan

1. Log in as a workspace admin/owner.
2. Go to Settings → People / Members → Invitations.
3. Invite an email that only has expired previous invitations.
4. Confirm the UI no longer shows `An invitation for this email is already pending` and the invite is created.
5. Log in as an invited user with an expired received invitation.
6. Click Decline and confirm the API no longer returns `PATCH /api/invitations/:id 400`.
7. Try Accept on an expired invite and confirm it remains blocked as expired.
