### PR TITLE
fix(mobile): bound Monaco workspace models to stop listener leak

### DIFF
--- a/apps/mobile/components/project/panels/ide/__tests__/workspaceModels.test.ts
+++ b/apps/mobile/components/project/panels/ide/__tests__/workspaceModels.test.ts
@@ -114,6 +114,17 @@ describe("workspaceModels — upsertModelFromContent", () => {
     mod.upsertModelFromContent("root2", "a.ts", "// in root2");
     expect(monacoMock.editor.getModels()).toHaveLength(2);
   });
+
+  test("bounds live-agent background models so long edit sessions do not leak Monaco listeners", () => {
+    for (let i = 0; i < 120; i += 1) {
+      mod.upsertModelFromContent("agent", `src/generated/file-${i}.ts`, `export const n = ${i};`);
+    }
+
+    const models = monacoMock.editor.getModels();
+    expect(models.length).toBeLessThanOrEqual(64);
+    expect(models.some((m: any) => m.uri.path === "/src/generated/file-119.ts")).toBe(true);
+    expect(models.some((m: any) => m.uri.path === "/src/generated/file-0.ts")).toBe(false);
+  });
 });
 
 describe("workspaceModels — upsertModelFromService", () => {

--- a/apps/mobile/components/project/panels/ide/monaco/workspaceModels.ts
+++ b/apps/mobile/components/project/panels/ide/monaco/workspaceModels.ts
@@ -24,6 +24,7 @@ let monacoRef: MonacoT | null = null;
 const modelsByRoot: Map<string, Set<string>> = new Map();
 
 const SUPPORTED_EXTS = /\.(tsx?|jsx?|d\.ts|json)$/;
+const MAX_MODELS_PER_ROOT = 64;
 
 export function setMonacoRef(m: MonacoT) {
   monacoRef = m;
@@ -45,6 +46,19 @@ function languageForPath(path: string): string {
   if (path.endsWith(".js")) return "javascript";
   if (path.endsWith(".json")) return "json";
   return "plaintext";
+}
+
+function enforceModelLimit(rootId: string, set: Set<string>): void {
+  const m = monacoRef;
+  if (!m) return;
+  while (set.size > MAX_MODELS_PER_ROOT) {
+    const uriStr = set.values().next().value as string | undefined;
+    if (!uriStr) return;
+    set.delete(uriStr);
+    const model = m.editor.getModel(m.Uri.parse(uriStr));
+    if (model) model.dispose();
+  }
+  if (set.size === 0) modelsByRoot.delete(rootId);
 }
 
 /**
@@ -95,9 +109,15 @@ export function upsertModel(
   if (!SUPPORTED_EXTS.test(path)) return;
 
   const uri = uriFor(m, rootId, path);
+  const uriStr = uri.toString();
   const existing = m.editor.getModel(uri);
   if (existing) {
     if (existing.getValue() !== content) existing.setValue(content);
+    const set = modelsByRoot.get(rootId);
+    if (set) {
+      set.delete(uriStr);
+      set.add(uriStr);
+    }
     return;
   }
   m.editor.createModel(content, language ?? languageForPath(path), uri);
@@ -106,7 +126,8 @@ export function upsertModel(
     set = new Set();
     modelsByRoot.set(rootId, set);
   }
-  set.add(uri.toString());
+  set.add(uriStr);
+  enforceModelLimit(rootId, set);
 }
 
 /** Remove a single model (file deleted). */


### PR DESCRIPTION
## Summary

Fixes the Sentry-reported Monaco listener leak in the mobile IDE live-agent edit path.

Closes #795

Sentry issue: https://shogo-ai.sentry.io/issues/7521169454/?query=is%3Aunresolved&referrer=issue-stream

## What was the error about?

Sentry reported this Monaco editor warning/error:

```txt
Error: [001] potential listener LEAK detected
```

Monaco represents every known file as a `model`. Each model owns internal listeners. The warning means Monaco detected that too many listeners were being retained, which usually indicates that editor/model resources are accumulating instead of being disposed.

In this case, the warning happened during live agent edits in the mobile IDE. It was not caused by a normal visible editor tab staying mounted. It came from background Monaco models created so the IDE can keep file contents synchronized while the agent edits files.

## Root cause analysis

The Sentry stack points to background Monaco model creation during live-agent file updates:

```txt
useLiveAgentEdits.ts
→ workspaceModels.ts upsertModelFromContent
→ workspaceModels.ts upsertModel
→ monaco.editor.createModel
→ Error: [001] potential listener LEAK detected
```

The issue was in `workspaceModels.ts`, where background Monaco models are created and retained for supported source files touched by agent edits:

```txt
.ts / .tsx / .js / .jsx / .d.ts / .json
```

During a long live-agent edit session, especially when generated or multi-file updates touch many different files, the app could create one Monaco model per touched file under the same workspace root:

```txt
file-1.ts   → Monaco model + listeners
file-2.ts   → Monaco model + listeners
file-3.ts   → Monaco model + listeners
...
file-120.ts → Monaco model + listeners
```

The previous code reused a model if the same URI was seen again, but there was no upper bound for how many different background models could remain retained for a root. Because Monaco attaches listeners per model, the retained model count could keep growing until Monaco raised its listener-leak detector.

## Why this matters

This was not just harmless log noise. If left unfixed, long agent edit sessions could cause:

- elevated Monaco listener count
- higher memory pressure in the IDE
- repeated Sentry noise from the same lifecycle path
- possible editor slowdown over time during large/generated file updates

## What changed

### `apps/mobile/components/project/panels/ide/monaco/workspaceModels.ts`

Added a per-root background model cap:

```ts
const MAX_MODELS_PER_ROOT = 64;
```

Added `enforceModelLimit(rootId, set)` to dispose the oldest retained Monaco models once a root exceeds the cap.

Updated existing-model handling so reused files are moved to the newest position in the set. This makes the registry behave like a small LRU cache:

- recently touched files stay alive
- stale background models are disposed
- each workspace root remains isolated
- retained Monaco model/listener count is bounded

### `apps/mobile/components/project/panels/ide/__tests__/workspaceModels.test.ts`

Added a regression test for the Sentry failure class:

- Simulates 120 live-agent `upsertModelFromContent` calls for generated TypeScript files.
- Verifies retained Monaco models are capped at 64.
- Verifies the newest model remains available.
- Verifies the oldest model is evicted/disposed.

Before the fix, this test reproduced the problem by retaining all 120 models. After the fix, the registry stays bounded.

## Why this is a root fix

This does not suppress Monaco's warning and does not add a narrow guard around one Sentry stack frame.

It fixes the lifecycle invariant for the shared Monaco background-model registry:

- the number of retained background Monaco models is bounded per workspace root
- old background models are disposed deterministically
- recent/reused models remain available
- long live-agent sessions can no longer grow Monaco listeners without bound through this path

If an old disposed file is needed again later, the existing `upsertModelFromContent` / `upsertModelFromService` path recreates the model normally.

## How to test the fix

### 1. Check out the branch

```sh
git checkout fix/sentry-potential-listener-LEAK
git pull
```

### 2. Run the targeted regression test

From the repo root:

```sh
bun test apps/mobile/components/project/panels/ide/__tests__/workspaceModels.test.ts
```

Expected result:

```txt
12 pass
0 fail
28 expect() calls
```

This test directly verifies the Sentry failure class by simulating many live-agent background model updates and asserting the retained model count stays capped.

### 3. Run the broader editor/listener tests

From the repo root:

```sh
cd apps/mobile
bun test components/project/panels/ide/__tests__/workspaceModels.test.ts components/project/panels/ide/__tests__/CodeEditor.listener.test.tsx
```

Expected result:

```txt
19 pass
0 fail
39 expect() calls
```

This verifies both:

- the background Monaco model cleanup behavior
- the existing CodeEditor listener lifecycle guards

### 4. Manual app verification

To manually verify behavior in the product:

1. Open the mobile IDE/editor.
2. Run a longer agent edit session that touches many TS/JS/JSON files, especially generated files.
3. Confirm file edits still apply and recently opened/edited files still work normally.
4. Watch Sentry/logs for this warning:

```txt
[001] potential listener LEAK detected
```

Expected result after this fix:

- agent edits still apply normally
- editor tabs still open files normally
- stale background models are disposed after the per-root cap
- this Monaco listener leak warning should not recur from the `workspaceModels.ts → createModel` path

## Verification performed for this PR

Ran targeted regression test from the repo root:

```sh
bun test apps/mobile/components/project/panels/ide/__tests__/workspaceModels.test.ts
```

Result:

```txt
12 pass
0 fail
28 expect() calls
```

Ran the related editor listener lifecycle tests from the mobile package root so the package's DOM test setup is loaded:

```sh
cd apps/mobile && bun test components/project/panels/ide/__tests__/workspaceModels.test.ts components/project/panels/ide/__tests__/CodeEditor.listener.test.tsx
```

Result:

```txt
19 pass
0 fail
39 expect() calls
```

Also verified the patch formatting:

```sh
git diff --check
```

## Commit

```txt
a692eaad fix(mobile): bound Monaco workspace models
```

## Risk

Low-to-medium. The change affects Monaco background model retention only. The main behavior change is that very old background models may be disposed after a root has more than 64 retained models. If an old file is touched again later, it will be recreated through the existing upsert path.
