### PR TITLE
fix(onboarding): stop provider discovery retry loop

### DIFF
--- a/apps/desktop/e2e/provider-discovery-loop.spec.ts
+++ b/apps/desktop/e2e/provider-discovery-loop.spec.ts
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Electron E2E coverage for the desktop onboarding provider-discovery loop.
+ *
+ * The regression path is:
+ * configured provider key → live model discovery fails → no models stored.
+ * The UI must surface the failure once and stop auto-retrying; otherwise React
+ * repeatedly updates state until it throws "Maximum update depth exceeded".
+ */
+import { _electron as electron, expect, test, type ElectronApplication, type Page } from '@playwright/test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..')
+const DESKTOP_DIR = path.resolve(__dirname, '..')
+
+function ensureDesktopBuild(): void {
+  const mainJs = path.join(DESKTOP_DIR, 'dist', 'main.js')
+  if (fs.existsSync(mainJs)) return
+  const { spawnSync } = require('child_process') as typeof import('child_process')
+  const result = spawnSync('npx', ['tsc'], { cwd: DESKTOP_DIR, stdio: 'inherit' })
+  if (result.status !== 0) throw new Error('apps/desktop tsc build failed')
+}
+
+async function installMockLocalApi(page: Page): Promise<{ getProviderCalls: () => number }> {
+  let providerModelCalls = 0
+
+  await page.route('**/api/**', async (route) => {
+    const url = new URL(route.request().url())
+    const pathname = url.pathname
+
+    const json = async (body: unknown, status = 200) => route.fulfill({
+      status,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    })
+
+    if (pathname === '/api/config') {
+      return json({
+        localMode: true,
+        needsSetup: true,
+        shogoKeyConnected: false,
+        features: {
+          billing: false,
+          admin: false,
+          oauth: false,
+          analytics: true,
+          publishing: false,
+          marketplace: false,
+          ezMode: true,
+          phoneChannel: false,
+        },
+      })
+    }
+
+    if (pathname.startsWith('/api/auth/')) {
+      return json({ data: null, ok: true })
+    }
+
+    if (pathname === '/api/local/auto-sign-in') return json({ ok: true })
+    if (pathname === '/api/local/cloud-login/status') return json({ signedIn: false })
+    if (pathname === '/api/local/api-keys') return json({ keys: { openai: 'sk-***' } })
+
+    if (pathname === '/api/admin/settings/providers/openai/models') {
+      providerModelCalls += 1
+      return json({ error: 'unauthorized' }, 401)
+    }
+
+    if (pathname === '/api/auth/update-user') return json({ ok: true })
+    if (pathname === '/api/me') return json({ data: { onboardingCompleted: false } })
+    if (pathname === '/api/onboarding/complete') return json({ ok: true })
+    if (pathname === '/api/vm/image/status') return json({ imagesPresent: true })
+
+    return json({ ok: true })
+  })
+
+  return { getProviderCalls: () => providerModelCalls }
+}
+
+test('desktop onboarding stops provider model auto-discovery after a failed request', async () => {
+  ensureDesktopBuild()
+
+  const tmpUserData = fs.mkdtempSync(path.join(os.tmpdir(), 'shogo-provider-discovery-e2e-'))
+  let app: ElectronApplication | null = null
+
+  const rendererErrors: string[] = []
+  const consoleErrors: string[] = []
+
+  try {
+    const electronEntry = require.resolve('electron', { paths: [DESKTOP_DIR] })
+    const electronModule = require(electronEntry) as unknown as string
+    const executablePath = typeof electronModule === 'string' ? electronModule : undefined
+    expect(executablePath, 'could not resolve electron executable').toBeTruthy()
+
+    app = await electron.launch({
+      executablePath,
+      args: ['.', `--user-data-dir=${tmpUserData}`, '--api-port=39100', '--no-sandbox'],
+      cwd: DESKTOP_DIR,
+      env: {
+        ...process.env,
+        SHOGO_SKIP_LOCAL_SERVER: 'true',
+        SHOGO_E2E: 'true',
+        ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
+      },
+      timeout: 60_000,
+    })
+
+    const page = await app.firstWindow({ timeout: 60_000 })
+    page.on('pageerror', (err) => rendererErrors.push(err.message))
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text())
+    })
+
+    const api = await installMockLocalApi(page)
+    await page.reload({ waitUntil: 'domcontentloaded' })
+
+    await expect(page.getByPlaceholder('Your name')).toBeVisible({ timeout: 30_000 })
+    await page.getByPlaceholder('Your name').fill('E2E User')
+    await page.getByPlaceholder('Your name').press('Enter')
+
+    await expect(page.getByText('Your Own API Keys')).toBeVisible({ timeout: 30_000 })
+    await page.getByText('Your Own API Keys').click()
+
+    await expect(page.getByText('unauthorized')).toBeVisible({ timeout: 30_000 })
+    await expect.poll(() => api.getProviderCalls(), { timeout: 5_000 }).toBe(1)
+    await page.waitForTimeout(1_500)
+
+    expect(api.getProviderCalls()).toBe(1)
+    expect(rendererErrors.join('\n')).not.toContain('Maximum update depth exceeded')
+    expect(consoleErrors.join('\n')).not.toContain('Maximum update depth exceeded')
+  } finally {
+    try { await app?.close() } catch { /* ignore */ }
+    try { fs.rmSync(tmpUserData, { recursive: true, force: true }) } catch { /* ignore */ }
+  }
+})

--- a/apps/mobile/components/admin/ModelsCard.tsx
+++ b/apps/mobile/components/admin/ModelsCard.tsx
@@ -777,9 +777,9 @@ export function ModelsCard({ platform, localMode }: { platform: PlatformApi; loc
     const p = form.provider
     if (!isDiscoveryProvider(p)) return
     if (KEY_GATED_DISCOVERY.has(p) && !keyState[p]?.configured) return
-    if (discovered[p] || discoveryLoading[p]) return
+    if (discovered[p] || discoveryLoading[p] || discoveryError[p]) return
     loadDiscovery(p)
-  }, [showForm, editingId, form.provider, keyState, discovered, discoveryLoading, loadDiscovery])
+  }, [showForm, editingId, form.provider, keyState, discovered, discoveryLoading, discoveryError, loadDiscovery])
 
   const applyDiscovered = useCallback((m: DiscoveredModel) => {
     setForm((f) => ({

--- a/apps/mobile/components/admin/ProviderSetupCard.tsx
+++ b/apps/mobile/components/admin/ProviderSetupCard.tsx
@@ -26,13 +26,20 @@ import {
 import { cn } from '@shogo/shared-ui/primitives'
 import { PlatformApi } from '@shogo-ai/sdk'
 import { invalidateVisibleModelsCache } from '../../lib/visible-models'
+import {
+  getProvidersNeedingModelDiscovery,
+  type ProviderKeyState,
+  type SetupProviderId,
+} from './providerModelDiscovery'
 
-export const SETUP_PROVIDERS = [
+export const SETUP_PROVIDERS: Array<{
+  id: SetupProviderId
+  name: string
+  placeholder: string
+}> = [
   { id: 'openai', name: 'OpenAI', placeholder: 'sk-…' },
   { id: 'anthropic', name: 'Anthropic', placeholder: 'sk-ant-…' },
-] as const
-
-export type SetupProviderId = (typeof SETUP_PROVIDERS)[number]['id']
+]
 
 interface DiscoveredProviderModel {
   id: string
@@ -90,7 +97,7 @@ export function ProviderSetupCard({
 }) {
   const [isLoading, setIsLoading] = useState(true)
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle')
-  const [keyState, setKeyState] = useState<Record<string, { configured: boolean; mask: string }>>({})
+  const [keyState, setKeyState] = useState<Record<string, ProviderKeyState>>({})
   const [drafts, setDrafts] = useState<Record<string, string>>({})
   const [enabledIds, setEnabledIds] = useState<Set<string>>(new Set())
   const [models, setModels] = useState<Record<string, DiscoveredProviderModel[]>>({})
@@ -155,12 +162,15 @@ export function ProviderSetupCard({
 
   // Once a provider's key is known to be configured, fetch its live model list.
   useEffect(() => {
-    for (const p of SETUP_PROVIDERS) {
-      if (keyState[p.id]?.configured && !models[p.id] && !loadingModels[p.id]) {
-        loadProviderModels(p.id)
-      }
+    for (const provider of getProvidersNeedingModelDiscovery({
+      keyState,
+      models,
+      loadingModels,
+      modelError,
+    })) {
+      loadProviderModels(provider)
     }
-  }, [keyState, models, loadingModels, loadProviderModels])
+  }, [keyState, models, loadingModels, modelError, loadProviderModels])
 
   const saveKey = useCallback(async (provider: SetupProviderId) => {
     const key = drafts[provider]

--- a/apps/mobile/components/admin/__tests__/ProviderSetupCard.test.tsx
+++ b/apps/mobile/components/admin/__tests__/ProviderSetupCard.test.tsx
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, expect, test } from 'bun:test'
+import React, { useCallback, useEffect, useState } from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import {
+  getProvidersNeedingModelDiscovery,
+  shouldLoadProviderModels,
+  type ProviderModelDiscoveryState,
+  type SetupProviderId,
+} from '../providerModelDiscovery'
+
+function baseState(
+  overrides: Partial<ProviderModelDiscoveryState> = {},
+): ProviderModelDiscoveryState {
+  return {
+    keyState: {},
+    models: {},
+    loadingModels: {},
+    modelError: {},
+    ...overrides,
+  }
+}
+
+function DiscoveryHarness({
+  discover,
+}: {
+  discover: (provider: SetupProviderId) => Promise<{ ok: boolean; models: unknown[]; error?: string }>
+}) {
+  const [keyState] = useState({ openai: { configured: true, mask: 'sk-***' } })
+  const [models, setModels] = useState<Record<string, unknown[]>>({})
+  const [loadingModels, setLoadingModels] = useState<Record<string, boolean>>({})
+  const [modelError, setModelError] = useState<Record<string, string | null>>({})
+
+  const loadProviderModels = useCallback(async (provider: SetupProviderId) => {
+    setLoadingModels((prev) => ({ ...prev, [provider]: true }))
+    setModelError((prev) => ({ ...prev, [provider]: null }))
+    try {
+      const result = await discover(provider)
+      if (result.ok) {
+        setModels((prev) => ({ ...prev, [provider]: result.models }))
+      } else {
+        setModelError((prev) => ({ ...prev, [provider]: result.error || 'Failed to fetch models' }))
+      }
+    } finally {
+      setLoadingModels((prev) => ({ ...prev, [provider]: false }))
+    }
+  }, [discover])
+
+  useEffect(() => {
+    for (const provider of getProvidersNeedingModelDiscovery({
+      keyState,
+      models,
+      loadingModels,
+      modelError,
+    })) {
+      loadProviderModels(provider)
+    }
+  }, [keyState, models, loadingModels, modelError, loadProviderModels])
+
+  return <div data-testid="error">{modelError.openai}</div>
+}
+
+describe('provider model discovery decision', () => {
+  test('loads a configured provider when no model, request, or error exists', () => {
+    expect(shouldLoadProviderModels('openai', baseState({
+      keyState: { openai: { configured: true, mask: 'sk-***' } },
+    }))).toBe(true)
+  })
+
+  test('does not load while a request is in flight, after models exist, or after an error', () => {
+    expect(shouldLoadProviderModels('openai', baseState({
+      keyState: { openai: { configured: true, mask: 'sk-***' } },
+      loadingModels: { openai: true },
+    }))).toBe(false)
+    expect(shouldLoadProviderModels('openai', baseState({
+      keyState: { openai: { configured: true, mask: 'sk-***' } },
+      models: { openai: [] },
+    }))).toBe(false)
+    expect(shouldLoadProviderModels('openai', baseState({
+      keyState: { openai: { configured: true, mask: 'sk-***' } },
+      modelError: { openai: 'provider unavailable' },
+    }))).toBe(false)
+  })
+
+  test('does not repeatedly refetch provider models after a failed discovery', async () => {
+    let calls = 0
+    const discover = async () => {
+      calls += 1
+      return { ok: false, models: [], error: 'provider unavailable' }
+    }
+
+    render(<DiscoveryHarness discover={discover} />)
+
+    await waitFor(() => expect(screen.getByTestId('error')).toHaveTextContent('provider unavailable'))
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(calls).toBe(1)
+  })
+})

--- a/apps/mobile/components/admin/providerModelDiscovery.ts
+++ b/apps/mobile/components/admin/providerModelDiscovery.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+export const SETUP_PROVIDER_IDS = ['openai', 'anthropic'] as const
+
+export type SetupProviderId = (typeof SETUP_PROVIDER_IDS)[number]
+
+export interface ProviderKeyState {
+  configured: boolean
+  mask: string
+}
+
+export interface ProviderModelDiscoveryState<TModel = unknown> {
+  keyState: Record<string, ProviderKeyState>
+  models: Record<string, TModel[]>
+  loadingModels: Record<string, boolean>
+  modelError: Record<string, string | null>
+}
+
+export function shouldLoadProviderModels<TModel>(
+  provider: SetupProviderId,
+  state: ProviderModelDiscoveryState<TModel>,
+): boolean {
+  return !!(
+    state.keyState[provider]?.configured &&
+    !state.models[provider] &&
+    !state.loadingModels[provider] &&
+    !state.modelError[provider]
+  )
+}
+
+export function getProvidersNeedingModelDiscovery<TModel>(
+  state: ProviderModelDiscoveryState<TModel>,
+): SetupProviderId[] {
+  return SETUP_PROVIDER_IDS.filter((provider) => shouldLoadProviderModels(provider, state))
+}


### PR DESCRIPTION
## Summary

Closes #797.

This PR fixes the desktop/local onboarding path where automatic provider model discovery could repeatedly retry after a failed provider models request. When a configured provider key exists but model discovery returns an error, the auto-discovery effect previously remained eligible to run again because there were still no models and no in-flight request. That state transition could repeatedly update React state and surface as `Maximum update depth exceeded` in the desktop renderer.

## What changed

### Provider setup discovery guard

- Added `apps/mobile/components/admin/providerModelDiscovery.ts` to centralize provider discovery eligibility.
- Added `modelError` to the eligibility check so failed discovery is treated as a terminal state for automatic retries.
- Updated `ProviderSetupCard` to use the helper instead of open-coded effect logic.
- Kept provider IDs typed through `SetupProviderId` so the helper and setup UI share the same provider contract.

### Model management discovery guard

- Updated `ModelsCard` auto-discovery to also stop automatic discovery when a discovery error already exists for the selected provider.
- Added `discoveryError` to the effect dependency list so React observes the guard state explicitly.

### Regression coverage

- Added focused Bun tests for the provider discovery decision helper and a React harness that reproduces the failed-discovery state transition.
- Added a desktop Electron Playwright E2E test that launches the real desktop app, drives onboarding, mocks a failed provider model response, and verifies no retry loop occurs.

## How I identified this as the root cause

I traced the failing behavior through the same automatic discovery path used by desktop onboarding, instead of only looking at the Sentry error text.

The important state transition was in `ProviderSetupCard`:

1. `keyState[provider].configured === true`, because the desktop/local setup flow reports that an API key exists.
2. `models[provider]` is empty/undefined, because no provider models have been loaded yet.
3. `loadingModels[provider]` becomes `true` while the fetch is in flight.
4. The request to `/api/admin/settings/providers/<provider>/models` fails, for example with `401`.
5. The failure path records `modelError[provider]`, but does not populate `models[provider]`.
6. The `finally` path clears `loadingModels[provider]` back to false.
7. On the next render the old effect condition is true again: configured key, no models, not loading.
8. The effect calls `loadProviderModels(provider)` again, repeating the same failed state update cycle.

Before this PR, the setup-card effect only guarded on:

```ts
keyState[p.id]?.configured && !models[p.id] && !loadingModels[p.id]
```

That condition ignored the already-known failure state. So after a failed request the component had no state saying “automatic discovery already failed; stop auto retrying.” That is exactly the kind of render/effect/state-update cycle that can produce React's `Maximum update depth exceeded` error.

I also checked the related model-management discovery flow in `ModelsCard` and found the same class of bug there: the auto-discovery guard stopped for existing results and in-flight requests, but not for a recorded discovery error. That is why this PR fixes both `ProviderSetupCard` and `ModelsCard` instead of patching only one call site.

## How I replicated the issue

I reproduced the issue through the real desktop Electron onboarding path, not just by unit testing a helper.

The added E2E test in `apps/desktop/e2e/provider-discovery-loop.spec.ts` does the following:

1. Launches the real desktop Electron app.
2. Uses the rebuilt mobile web bundle that desktop renders.
3. Forces local onboarding mode through mocked desktop/local API responses:
   - `/api/config` returns `localMode: true` and `needsSetup: true`.
   - `/api/local/api-keys` returns an OpenAI key as configured.
4. Drives the onboarding UI as a user would:
   - enters a name,
   - chooses **Your Own API Keys**.
5. Mocks the provider model discovery endpoint:

```txt
/api/admin/settings/providers/openai/models -> 401 { "error": "unauthorized" }
```

6. Waits for the UI to show the `unauthorized` failure.
7. Counts how many times the provider model discovery endpoint is called.
8. Waits again to detect automatic re-entry.
9. Asserts the call count remains `1`.
10. Asserts the renderer/console did not emit `Maximum update depth exceeded`.

This is the exact regression shape:

```txt
configured provider key -> model discovery fails -> no models stored -> effect must not auto-run again
```

## Why this is the correct root fix

The correct fix is to change the automatic discovery eligibility condition, not to suppress the React error or hide the failed request.

Provider model discovery is allowed to fail for legitimate reasons: invalid key, expired key, unauthorized provider response, local network issue, or provider outage. When that happens, the UI should keep the error visible and wait for a user action or a meaningful state change. It should not immediately retry from the same effect with the same inputs.

This PR adds the missing terminal guard:

```txt
configured key + no models + not loading + no recorded error => auto-discover
```

Once `modelError[provider]` or `discoveryError[provider]` exists, automatic discovery stops. That directly breaks the loop at the state machine level:

- Failed request still records the error.
- Loading still resets correctly.
- Models remain absent because discovery failed.
- But the recorded error now makes the effect ineligible to auto-run again.

This preserves the intended behavior while removing only the invalid behavior:

- First automatic discovery still happens when a configured key is found.
- Successful discovery still stores models and enables model selection.
- Failed discovery still surfaces the provider error to the user.
- Manual retry/state-change paths remain possible because this only blocks repeated automatic re-entry while the same error state is present.

The tests prove this fix at three levels:

1. **Pure decision logic**: `shouldLoadProviderModels` returns false when a provider already has a model error.
2. **React integration behavior**: a failed discovery request is not called repeatedly after state updates settle.
3. **Desktop E2E behavior**: the real Electron onboarding path makes exactly one failed discovery request and does not emit `Maximum update depth exceeded`.

Because the fix changes the effect eligibility condition that caused the repeated request, and the desktop E2E verifies the failing user path no longer loops, this is the root fix rather than a symptom-level workaround.

## Verification

I ran the focused mobile test suite:

```sh
cd apps/mobile
bun test components/admin/__tests__/ProviderSetupCard.test.tsx
```

Result:

```txt
3 pass
0 fail
7 expect() calls
```

I rebuilt the mobile web bundle used by desktop Electron:

```sh
cd apps/mobile
node scripts/copy-monaco-vs.mjs
npx expo export --platform web --source-maps
```

Result: export completed successfully and wrote the web bundle to `dist`.

I ran the targeted desktop Electron E2E:

```sh
cd /Users/ashutoshojha/Desktop/shogo-ai
PLAYWRIGHT_E2E=1 npx playwright test --config apps/desktop/e2e/playwright.config.ts apps/desktop/e2e/provider-discovery-loop.spec.ts
```

Result:

```txt
Running 1 test using 1 worker

✓ apps/desktop/e2e/provider-discovery-loop.spec.ts:82:5 › desktop onboarding stops provider model auto-discovery after a failed request (12.8s)

1 passed (13.5s)
```

I also ran whitespace validation:

```sh
git diff --check
```

Result: no whitespace errors.

## Risk and rollout notes

- Risk is low and localized to automatic provider model discovery eligibility.
- Manual retries or retries caused by genuine state changes remain possible because the fix only prevents repeated automatic re-entry while an error is already present.
- The desktop E2E specifically covers the Sentry failure class by asserting that `Maximum update depth exceeded` is not emitted by the renderer or console after a failed provider discovery request.
