### PR TITLE
fix(web): prevent browser translation DOM mutations

### DIFF
--- a/apps/mobile/app/+html.tsx
+++ b/apps/mobile/app/+html.tsx
@@ -5,10 +5,11 @@ import type { PropsWithChildren } from 'react'
 
 export default function Root({ children }: PropsWithChildren) {
   return (
-    <html lang="en">
+    <html lang="en" translate="no" className="notranslate">
       <head>
         <meta charSet="utf-8" />
         <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="google" content="notranslate" />
         <meta
           name="viewport"
           content="width=device-width, initial-scale=1, shrink-to-fit=no"

--- a/apps/mobile/scripts/inject-analytics.js
+++ b/apps/mobile/scripts/inject-analytics.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-// Injects analytics scripts (GA4, FB Pixel, Rewardful) into the exported
-// index.html. Runs as a post-export build step because Expo's "single" output
-// mode strips <script> tags from +html.tsx during export.
+// Injects analytics scripts (GA4, FB Pixel, Rewardful) and web shell
+// attributes into the exported index.html. Runs as a post-export build step
+// because Expo's "single" output mode strips some +html.tsx customizations.
 
 const fs = require('fs')
 const path = require('path')
@@ -9,6 +9,7 @@ const path = require('path')
 const HTML_PATH = path.resolve(__dirname, '..', 'dist', 'index.html')
 const GA4_ID = process.env.EXPO_PUBLIC_GA4_ID || ''
 const FB_PIXEL_ID = process.env.EXPO_PUBLIC_FB_PIXEL_ID || ''
+const GOOGLE_NOTRANSLATE_META = '<meta name="google" content="notranslate">'
 
 let snippets = ''
 
@@ -30,12 +31,32 @@ if (FB_PIXEL_ID) {
   console.log(`[inject-analytics] FB Pixel ${FB_PIXEL_ID} injected`)
 }
 
-if (!snippets) {
-  console.log('[inject-analytics] No analytics configured, skipping')
-  process.exit(0)
+let html = fs.readFileSync(HTML_PATH, 'utf8')
+
+html = html.replace(/<html([^>]*)>/, (_tag, attrs) => {
+  let nextAttrs = attrs
+  if (!/\btranslate=/.test(nextAttrs)) nextAttrs += ' translate="no"'
+  if (/\bclass=/.test(nextAttrs)) {
+    nextAttrs = nextAttrs.replace(/class="([^"]*)"/, (_match, classes) => {
+      const nextClasses = new Set(classes.split(/\s+/).filter(Boolean))
+      nextClasses.add('notranslate')
+      return `class="${Array.from(nextClasses).join(' ')}"`
+    })
+  } else {
+    nextAttrs += ' class="notranslate"'
+  }
+  return `<html${nextAttrs}>`
+})
+
+if (!html.includes('name="google" content="notranslate"')) {
+  html = html.replace('</head>', `${GOOGLE_NOTRANSLATE_META}</head>`)
 }
 
-let html = fs.readFileSync(HTML_PATH, 'utf8')
-html = html.replace('</head>', snippets + '</head>')
+if (snippets) {
+  html = html.replace('</head>', snippets + '</head>')
+} else {
+  console.log('[inject-analytics] No analytics configured, only injected shell guards')
+}
+
 fs.writeFileSync(HTML_PATH, html)
 console.log(`[inject-analytics] Done — wrote ${HTML_PATH}`)

--- a/apps/mobile/test/__tests__/html-translation-guard.test.tsx
+++ b/apps/mobile/test/__tests__/html-translation-guard.test.tsx
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+
+declare function describe(name: string, fn: () => void): void
+declare function test(name: string, fn: () => void | Promise<void>): void
+declare function expect(actual: unknown): { toContain(expected: string): void }
+
+describe('web html shell translation guard', () => {
+  test('opts the React root out of browser translation', () => {
+    const htmlSource = readFileSync(resolve(testDir, '../../app/+html.tsx'), 'utf8')
+    const postExportSource = readFileSync(resolve(testDir, '../../scripts/inject-analytics.js'), 'utf8')
+
+    expect(htmlSource).toContain('<html lang="en" translate="no" className="notranslate">')
+    expect(htmlSource).toContain('<meta name="google" content="notranslate" />')
+    expect(postExportSource).toContain('translate="no"')
+    expect(postExportSource).toContain('notranslate')
+    expect(postExportSource).toContain('name="google" content="notranslate"')
+  })
+})


### PR DESCRIPTION
## Summary

Closes #799.

This PR addresses Sentry issue https://shogo-ai.sentry.io/issues/7365221856/:

```txt
NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
```

The crash happens in `production_web` on the project page. The Sentry stack is inside React DOM's internal commit/deletion path, and the event breadcrumbs show browser-translated UI labels immediately before the crash. This PR prevents browser translation from mutating the React-managed DOM by adding translation opt-out guards to both the source web shell and the production post-export HTML path.

## What changed

### Expo web shell

Updated `apps/mobile/app/+html.tsx`:

```tsx
<html lang="en" translate="no" className="notranslate">
<meta name="google" content="notranslate" />
```

### Production post-export shell injection

Updated `apps/mobile/scripts/inject-analytics.js` so the production post-export step also injects the same translation guard into `dist/index.html`:

- Adds `translate="no"` to `<html>` when missing.
- Adds `notranslate` to the html class list when missing.
- Adds `<meta name="google" content="notranslate">` when missing.

This second path is important because Expo's web export did not carry the `+html.tsx` html attributes into the generated `dist/index.html` during verification.

### Regression coverage

Added `apps/mobile/test/__tests__/html-translation-guard.test.tsx` to keep both guard paths covered:

- Source shell: `app/+html.tsx`
- Production post-export injector: `scripts/inject-analytics.js`

## Why I believe this is the RCA

I did not infer the cause only from the exception text. I pulled and inspected the Sentry issue details, latest event, breadcrumbs, tags, and stack trace for issue `7365221856`.

### 1. The stack points to React DOM losing ownership of a child node

The thrown error is:

```txt
Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
```

This error occurs when React's virtual tree says a child node should be removed from a parent, but the real browser DOM no longer has that child under that parent. In other words, something outside React changed the DOM tree that React thought it owned.

The Sentry stack is in React DOM's internal commit/deletion code path, not in app code that directly calls `removeChild`. I also searched the repo for app-authored DOM mutation paths such as `removeChild`, `appendChild`, `insertBefore`, direct HTML injection, portals, and mutation observers. The latest Sentry event did not point to one of those app call sites.

### 2. Breadcrumbs show browser translation was active immediately before the crash

The latest event breadcrumbs show repeated interaction with the chat textarea. The textarea aria label in Sentry was:

```txt
aria-label="Chatnachrichteneingabe"
```

But the app source string is English:

```tsx
accessibilityLabel="Chat message input"
```

I sampled other events in the same Sentry issue and saw translated versions in multiple languages:

```txt
aria-label="إدخال رسالة الدردشة"
aria-label="चैट संदेश इनपुट"
aria-label="Entrada de mensagem de bate-papo"
```

That is strong evidence that browser translation was modifying app-owned DOM/attributes inside the React tree before the crash.

### 3. This is a known React failure mode

Browser translation, especially Chrome Translate and translation extensions, can wrap, replace, or mutate DOM/text nodes under React-managed roots. When React later tries to reconcile or delete nodes, its expected parent/child relationship can be wrong, causing exactly this `removeChild` `NotFoundError`.

So the RCA is:

```txt
Browser translation mutates React-owned DOM on the project page/chat surface.
React later tries to remove a node based on its virtual DOM ownership model.
The real DOM no longer matches React's expected parent/child structure.
React throws NotFoundError during commit deletion.
```

## How I replicated / validated the issue condition

The production mutation itself is performed by the browser's translation layer, which is not deterministic enough to rely on as a stable automated test. Instead, I validated the root precondition and the production mitigation path.

Validation path:

1. Exported the web app with Expo.
2. Inspected the generated `apps/mobile/dist/index.html`, which is what production serves.
3. Confirmed that before the production post-export fix, the generated HTML did **not** contain the browser translation opt-out markers:
   - `translate="no"`
   - `class="notranslate"`
   - `<meta name="google" content="notranslate">`
4. Added the guard in `app/+html.tsx`.
5. Re-exported and confirmed Expo export still did not preserve all shell attributes in `dist/index.html`.
6. Updated the production post-export injector, `scripts/inject-analytics.js`, so the deployed `dist/index.html` gets the guard regardless of Expo export behavior.
7. Re-exported, ran the post-export injector, and inspected `dist/index.html` again.

Final generated HTML verification output:

```txt
translate_no True
class_notranslate True
meta_google_notranslate True
```

This validates that the deployed HTML now blocks the external DOM mutation path indicated by Sentry.

## Why this is the correct root fix

A symptom-level fix would be catching/suppressing the exception or trying to guard one chat component. That would not address the real problem: React's DOM ownership can already be corrupted by the time `removeChild` throws.

The root fix is to prevent the browser translation layer from mutating the React-managed application DOM in the first place:

```html
<html translate="no" class="notranslate">
<meta name="google" content="notranslate">
```

This is the correct level of fix because:

1. The Sentry evidence points to external translation, not an app-authored DOM removal bug.
2. The crash happens inside React DOM internals after the DOM has already diverged.
3. The mitigation protects the entire React root, not only the one chat textarea observed in the latest event.
4. It covers project chat, panels, IDE surfaces, and any other React-owned node that could otherwise be translated/mutated.
5. It targets the production artifact actually served to users (`dist/index.html`), not just source code.

After this change, Chrome/browser translation should not rewrite the React app shell, so the parent/child mismatch that produced this Sentry issue should stop recurring after deployment.

## Testing and verification performed

### 1. Focused regression test

Command:

```sh
cd /Users/ashutoshojha/Desktop/shogo-ai/apps/mobile
bun test test/__tests__/html-translation-guard.test.tsx
```

Result:

```txt
1 pass
0 fail
5 expect() calls
```

This test checks that both guard paths remain present:

- `apps/mobile/app/+html.tsx`
- `apps/mobile/scripts/inject-analytics.js`

### 2. Production export / integration verification

Command:

```sh
cd /Users/ashutoshojha/Desktop/shogo-ai
git diff --check origin/main...HEAD

cd apps/mobile
node scripts/copy-monaco-vs.mjs
npx expo export --platform web --source-maps
node scripts/inject-analytics.js
python3 -c "from pathlib import Path; html=Path('dist/index.html').read_text(); print('translate_no', 'translate=\"no\"' in html); print('class_notranslate', 'class=\"notranslate\"' in html or ' notranslate' in html); print('meta_google_notranslate', '<meta name=\"google\" content=\"notranslate\"' in html); print('rewardful_script', 'data-rewardful=\"039716\"' in html)"
```

Result:

```txt
translate_no True
class_notranslate True
meta_google_notranslate True
rewardful_script True
```

This proves the production-exported HTML contains the translation guard and the existing Rewardful injection behavior still remains intact.

### 3. Syntax and lint checks

Command:

```sh
node --check apps/mobile/scripts/inject-analytics.js
```

Result: passed.

`read_lints` was also run on:

```txt
apps/mobile/app/+html.tsx
apps/mobile/test/__tests__/html-translation-guard.test.tsx
```

Result:

```txt
No errors
```

### 4. Full mobile test suite cross-check

Command:

```sh
cd apps/mobile
bun test
```

Result:

```txt
1926 pass
1 skip
26 fail
11 errors
```

The full suite is not currently green, but the failures are unrelated to this PR's changed files. They are in existing IDE/SCM/test-environment areas such as:

```txt
Workbench save Git refresh
chooseTransport
GraphSplitter localStorage
SourceControlViewlet sync changes UX
commit split menu contract
SyntaxError: Export named 'API_URL' not found in module apps/mobile/lib/api.ts
ENOENT: apps/mobile/components/project/panels/ide/scm/CommitInput.tsx
```

The focused regression test, lint/syntax checks, and production export verification for this PR all pass.

## Risk and rollout notes

- Risk is low: this changes only the web HTML shell and post-export HTML mutation step.
- The app UI is English-first and not currently relying on browser translation as a feature.
- The fix prevents an external browser mutation class rather than changing app business logic.
- Sentry issue `JAVASCRIPT-REACT-2` should be monitored after deployment. If it recurs with untranslated breadcrumbs, we should investigate a second DOM mutation source; if it stops, that confirms this RCA in production.
