### PR TITLE
fix(mobile): serialize home project renames

### DIFF
--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -43,6 +43,7 @@ import { getPendingLicenseCode, clearPendingLicenseCode } from '../../lib/pendin
 import type { AgentTileListing } from '../../components/marketplace/AgentTile'
 import { ProjectSourceMenu } from '../../components/project/ProjectSourceMenu'
 import { TechStackPicker } from '../../components/chat/TechStackPicker'
+import { startProjectNameRefinement } from '../../lib/home-project-rename'
 
 /**
  * Default tech stack for blank projects created from the home composer.
@@ -585,11 +586,6 @@ const HomeScreen = observer(function HomeScreen() {
         }
       }
 
-      // Update the draft project's name from the heuristic now that we
-      // actually have prompt text. Fire-and-forget — the AI rename below
-      // may overwrite this shortly.
-      actions.updateProject(draft.projectId, { name: projectName }).catch(() => {})
-
       trackEvent(posthog, EVENTS.PROJECT_CREATED, { source: 'prompt' })
 
       if (files && files.length > 0) {
@@ -611,23 +607,15 @@ const HomeScreen = observer(function HomeScreen() {
         },
       } as any)
 
-      // Fire-and-forget: replace heuristic name with AI-generated name
-      const pid = consumed.projectId
-      const sid = consumed.chatSessionId
-      const sidScope = consumed.chatScope
-      api.generateProjectName(http, text, currentWorkspace.id).then(({ name, description }) => {
-        if (name && name !== projectName) {
-          actions.updateProject(pid, { name, description: description || undefined })
-          // Only project-scoped sessions live in the local MST collection.
-          // Workspace sessions are created server-side (api.createWorkspaceSession)
-          // and aren't in `chatSessionCollection`, so updateChatSession would
-          // throw "Item not found" — skip the local rename for them.
-          if (sidScope === 'project') {
-            actions.updateChatSession(sid, { inferredName: name })
-          }
-        }
-      }).catch((err) => {
-        console.warn('[Home] AI project name generation failed, keeping heuristic name:', err)
+      startProjectNameRefinement({
+        actions,
+        projectId: consumed.projectId,
+        chatSessionId: consumed.chatSessionId,
+        chatScope: consumed.chatScope,
+        text,
+        heuristicName: projectName,
+        generateProjectName: (prompt) => api.generateProjectName(http, prompt, currentWorkspace.id),
+        onError: (message, error) => console.warn(message, error),
       })
     } finally {
       setIsCreating(false)

--- a/apps/mobile/lib/__tests__/home-project-rename.test.ts
+++ b/apps/mobile/lib/__tests__/home-project-rename.test.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+// @ts-ignore Bun resolves this module at test runtime; app tsconfig does not include Bun ambient types.
+import { expect, test } from 'bun:test'
+import { ProjectCollection } from '@shogo/domain-stores'
+import { startProjectNameRefinement } from '../home-project-rename'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+const baseProject = {
+  id: 'p1',
+  name: 'New Project',
+  workspaceId: 'w1',
+  updatedAt: 1,
+}
+
+test('ProjectCollection reproduces the Sentry race by rejecting overlapping updates for the same project', async () => {
+  const firstPatch = deferred<{ data: { ok: boolean; data: typeof baseProject } }>()
+  let patchCount = 0
+  const collection = ProjectCollection.create(
+    { items: { p1: baseProject } },
+    {
+      http: {
+        get: async () => ({ data: { ok: true } }),
+        post: async () => ({ data: { ok: true } }),
+        patch: async (_url: string, changes: Partial<typeof baseProject>) => {
+          patchCount += 1
+          if (patchCount === 1) return firstPatch.promise
+          return {
+            data: {
+              ok: true,
+              data: { ...baseProject, ...changes, updatedAt: Date.now() },
+            },
+          }
+        },
+        delete: async () => ({ data: { ok: true } }),
+      },
+    } as never,
+  )
+
+  const firstUpdate = collection.update('p1', { name: 'Counter Strike Game' })
+  await expect(collection.update('p1', { name: 'Counter Strike Mobile' })).rejects.toThrow(
+    'Update already in progress',
+  )
+
+  firstPatch.resolve({
+    data: {
+      ok: true,
+      data: { ...baseProject, name: 'Counter Strike Game', updatedAt: 2 },
+    },
+  })
+  await firstUpdate
+})
+
+test('home project name refinement waits for the heuristic rename before applying the AI rename', async () => {
+  const firstPatch = deferred<{ data: { ok: boolean; data: typeof baseProject } }>()
+  const patchChanges: Array<Partial<typeof baseProject> & { description?: string }> = []
+  const collection = ProjectCollection.create(
+    { items: { p1: baseProject } },
+    {
+      http: {
+        get: async () => ({ data: { ok: true } }),
+        post: async () => ({ data: { ok: true } }),
+        patch: async (_url: string, changes: Partial<typeof baseProject> & { description?: string }) => {
+          patchChanges.push(changes)
+          if (patchChanges.length === 1) return firstPatch.promise
+          return {
+            data: {
+              ok: true,
+              data: { ...baseProject, ...changes, updatedAt: Date.now() },
+            },
+          }
+        },
+        delete: async () => ({ data: { ok: true } }),
+      },
+    } as never,
+  )
+  const chatSessionUpdates: Array<{ inferredName?: string }> = []
+  const errors: unknown[] = []
+
+  const { heuristicRename, generatedRename } = startProjectNameRefinement({
+    actions: {
+      updateProject: (projectId, changes) => collection.update(projectId, changes as never),
+      updateChatSession: async (_chatSessionId, changes) => {
+        chatSessionUpdates.push(changes)
+      },
+    },
+    projectId: 'p1',
+    chatSessionId: 's1',
+    chatScope: 'project',
+    text: 'Create a shooting mobile game like counter strike',
+    heuristicName: 'Counter Strike Game',
+    generateProjectName: async () => ({
+      name: 'Counter Strike Mobile',
+      description: 'A premium tactical shooter',
+    }),
+    onError: (_message, error) => errors.push(error),
+  })
+
+  await Promise.resolve()
+  await Promise.resolve()
+  expect(patchChanges).toEqual([{ name: 'Counter Strike Game' }])
+
+  firstPatch.resolve({
+    data: {
+      ok: true,
+      data: { ...baseProject, name: 'Counter Strike Game', updatedAt: 2 },
+    },
+  })
+
+  await heuristicRename
+  await generatedRename
+
+  expect(errors).toEqual([])
+  expect(patchChanges).toEqual([
+    { name: 'Counter Strike Game' },
+    { name: 'Counter Strike Mobile', description: 'A premium tactical shooter' },
+  ])
+  expect(chatSessionUpdates).toEqual([{ inferredName: 'Counter Strike Mobile' }])
+})

--- a/apps/mobile/lib/home-project-rename.ts
+++ b/apps/mobile/lib/home-project-rename.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+type ChatScope = 'project' | 'workspace'
+
+type ProjectRenameActions = {
+  updateProject: (
+    projectId: string,
+    changes: { name?: string; description?: string | undefined },
+  ) => Promise<unknown>
+  updateChatSession: (
+    chatSessionId: string,
+    changes: { inferredName?: string },
+  ) => Promise<unknown>
+}
+
+type GenerateProjectName = (
+  text: string,
+) => Promise<{ name?: string | null; description?: string | null }>
+
+type StartProjectNameRefinementOptions = {
+  actions: ProjectRenameActions
+  projectId: string
+  chatSessionId: string
+  chatScope: ChatScope
+  text: string
+  heuristicName: string
+  generateProjectName: GenerateProjectName
+  onError?: (message: string, error: unknown) => void
+}
+
+export function startProjectNameRefinement({
+  actions,
+  projectId,
+  chatSessionId,
+  chatScope,
+  text,
+  heuristicName,
+  generateProjectName,
+  onError,
+}: StartProjectNameRefinementOptions) {
+  const heuristicRename = actions
+    .updateProject(projectId, { name: heuristicName })
+    .catch((error) => {
+      onError?.('[Home] Heuristic project rename failed:', error)
+    })
+
+  const generatedRename = generateProjectName(text)
+    .then(async ({ name, description }) => {
+      if (!name || name === heuristicName) return
+
+      await heuristicRename
+      await actions.updateProject(projectId, {
+        name,
+        description: description || undefined,
+      })
+
+      if (chatScope === 'project') {
+        await actions.updateChatSession(chatSessionId, { inferredName: name })
+      }
+    })
+    .catch((error) => {
+      onError?.('[Home] AI project name refinement failed, keeping heuristic name:', error)
+    })
+
+  return { heuristicRename, generatedRename }
+}


### PR DESCRIPTION
## Summary

Fixes the home composer project-name refinement race that can trigger Sentry issue `JAVASCRIPT-REACT-3R`:

- Sentry: https://shogo-ai.sentry.io/issues/7580937312/
- GitHub issue: Closes #803
- Error: `Update already in progress`
- Culprit: `packages/domain-stores/src/project.collection`

This PR serializes the heuristic project rename and the AI-generated project rename for newly created home-composer projects, then adds a regression test that reproduces the original race with the real `ProjectCollection`.

## Why I believe this is the RCA

Sentry reported:

```txt
Error: Update already in progress
Culprit: packages/domain-stores/src/project.collection
```

The project collection intentionally rejects overlapping updates for the same model id:

```ts
if (pendingUpdates.has(id)) {
  throw new Error('Update already in progress')
}
```

The Sentry stack pointed into the home project creation/name generation flow in `apps/mobile/app/(app)/index.tsx`, around the `api.generateProjectName(...).then(...)` callback.

Before this PR, that flow could start two updates for the same project id:

1. A heuristic project rename was started immediately after project creation:

```ts
actions.updateProject(draft.projectId, { name: projectName }).catch(() => {})
```

2. The AI-generated name callback could later start another project update for the same project id:

```ts
api.generateProjectName(...).then(({ name, description }) => {
  if (name && name !== projectName) {
    actions.updateProject(pid, { name, description: description || undefined })
    ...
  }
})
```

If `/api/generate-project-name` returned before the heuristic rename PATCH completed, the second update overlapped the first one and hit `pendingUpdates.has(id)`. Also, that second update promise was not awaited, returned, or caught inside the `.then(...)`, so the rejection surfaced as an unhandled promise rejection in Sentry.

That exact sequence explains the Sentry error, culprit, and stack path.

## Why this is a root fix

The root issue is not that `ProjectCollection` throws. The guard is valid and protects the store from concurrent conflicting updates to the same entity.

The root issue is that the home composer rename flow violated the store contract by starting two project updates for the same id concurrently.

This PR changes the flow to:

1. Start the heuristic rename.
2. Start AI name generation.
3. If the AI name is different, wait for the heuristic rename to settle first.
4. Apply the AI-generated project rename.
5. Update the project-scoped chat session inferred name.
6. Catch/log failures from the async chain to avoid unhandled rejections.

The key behavior is now:

```ts
await heuristicRename
await actions.updateProject(projectId, {
  name,
  description: description || undefined,
})
```

This removes the overlapping same-project update that triggers the domain-store guard. Catching and ignoring `Update already in progress` would only hide the Sentry symptom; serialization fixes the race.

## Implementation details

### `apps/mobile/lib/home-project-rename.ts`

Adds `startProjectNameRefinement(...)`, a small helper that owns the home composer rename orchestration:

- starts heuristic rename,
- runs AI name generation,
- waits for heuristic rename before AI rename,
- preserves project-scoped chat session inferred-name behavior,
- logs failures through the provided `onError` callback.

### `apps/mobile/app/(app)/index.tsx`

Replaces the previous ad hoc fire-and-forget rename chain with:

```ts
startProjectNameRefinement({
  actions,
  projectId: consumed.projectId,
  chatSessionId: consumed.chatSessionId,
  chatScope: consumed.chatScope,
  text,
  heuristicName: projectName,
  generateProjectName: (prompt) => api.generateProjectName(http, prompt, currentWorkspace.id),
  onError: (message, error) => console.warn(message, error),
})
```

### `apps/mobile/lib/__tests__/home-project-rename.test.ts`

Adds regression coverage for both the failure mode and the fixed behavior.

## How I replicated / validated the issue condition

I added a regression test that uses the real `ProjectCollection`, not a mocked replacement.

The test holds the first PATCH open and then attempts a second update for the same project id. This reproduces the exact Sentry failure condition:

```txt
ProjectCollection reproduces the Sentry race by rejecting overlapping updates for the same project
```

It verifies the old failure:

```txt
Update already in progress
```

That proves the suspected race is locally reproducible at the same domain-store boundary shown in Sentry.

## How I tested the fix

I added a second test for the fixed home rename orchestration:

```txt
home project name refinement waits for the heuristic rename before applying the AI rename
```

It verifies:

- the heuristic update starts first,
- the AI rename does not start while the heuristic update is still pending,
- the AI rename runs after the heuristic rename resolves,
- project-scoped chat session `inferredName` is still updated,
- no error callback is invoked in the fixed flow.

## Verification performed

Before committing, I ran:

```sh
cd ~/Desktop/shogo-ai
bun test apps/mobile/lib/__tests__/home-project-rename.test.ts packages/domain-stores/src/__tests__/update-detach.regression.test.ts
git diff --check
```

Result:

```txt
4 pass
0 fail
10 expect() calls
```

`git diff --check` also passed.

## Typecheck / broader verification note

I attempted mobile TypeScript verification earlier during investigation:

```sh
bun --no-env-file tsc --noEmit -p apps/mobile/tsconfig.json
```

That is currently blocked by existing repo-wide TypeScript issues unrelated to this PR, including TS 6 `baseUrl` deprecation and many existing errors across admin, marketplace, project layout, NativeWind typing, shared-ui, and existing test typing areas.

The focused regression tests for this fix pass, and the changed helper/app path has no lint diagnostics from the local lint check performed during investigation.

## Edge cases considered

Covered by this PR:

- AI-generated name returns before heuristic rename completes.
- AI-generated name differs from heuristic name.
- Project-scoped chat session inferred name is still updated after AI rename.
- Workspace-scoped sessions continue to avoid local chat-session update.
- Async failures in the refinement chain are caught/logged instead of becoming unhandled rejections.

Remaining caveats:

- This PR fixes the Sentry stack path from home composer project creation/name refinement. Other unrelated call sites could still trigger `ProjectCollection.update()` concurrently for the same project id and would need separate stack-specific fixes.
- This was validated with a focused integration-style regression using the real domain-store layer, not a full browser/E2E Expo UI flow.
- Final production confirmation should come from monitoring Sentry after deployment.
