### PR TITLE
fix(mobile): guard ChatInput repeated update loops

### DIFF
--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -63,13 +63,13 @@ import { useVoiceInput } from "./useVoiceInput"
 import { VoiceWaveform } from "./VoiceWaveform"
 import {
   analyzeContent,
-  extractLongPaste,
   kindLabel,
   LONG_PASTE_MIN_CHARS,
   MAX_PASTED_TEXTS,
   buildPastedAttachments,
   type PastedTextEntry,
 } from "./long-text-utils"
+import { resolveChatInputTextChange } from "./chat-input-text-change"
 import { FileViewerModal } from "./FileViewerModal"
 import { PastedTextChip } from "./PastedTextChip"
 import { useChatBridgeOptional } from "../voice-mode/ChatBridgeContext"
@@ -614,6 +614,7 @@ function ChatInputImpl({
   // The active "@" token's range in the input, so selecting an item can strip
   // exactly that token regardless of where the caret is.
   const mentionTokenRef = useRef<{ start: number; end: number } | null>(null)
+  const activeMentionStateRef = useRef<{ start: number; end: number; query: string } | null>(null)
   // One-shot caret override: after inserting an inline "@mention" we move the
   // caret to just past it, then release control so normal typing isn't pinned.
   const [selectionOverride, setSelectionOverride] = useState<
@@ -628,6 +629,7 @@ function ChatInputImpl({
     setMentionQuery("")
     setMentionIndex(0)
     mentionTokenRef.current = null
+    activeMentionStateRef.current = null
   }, [])
 
   // Re-evaluate the active "@" token whenever the text or caret changes.
@@ -637,12 +639,26 @@ function ChatInputImpl({
       if (!token) {
         if (mentionTokenRef.current) {
           mentionTokenRef.current = null
+          activeMentionStateRef.current = null
           setShowMentionMenu(false)
           setMentionQuery("")
           setMentionIndex(0)
         }
         return
       }
+
+      const nextState = { start: token.start, end: caret, query: token.query }
+      const currentState = activeMentionStateRef.current
+      if (
+        currentState &&
+        currentState.start === nextState.start &&
+        currentState.end === nextState.end &&
+        currentState.query === nextState.query
+      ) {
+        return
+      }
+
+      activeMentionStateRef.current = nextState
       mentionTokenRef.current = { start: token.start, end: caret }
       setShowMentionMenu(true)
       setMentionIndex(0)
@@ -1094,46 +1110,41 @@ function ChatInputImpl({
 
   const handleChangeText = useCallback(
     (text: string) => {
-      // If the DOM paste listener already handled this event, skip the
-      // fallback detection to avoid creating duplicate chips.
-      if (pasteHandledRef.current) {
-        pasteHandledRef.current = false
+      const change = resolveChatInputTextChange(
+        inputValueRef.current,
+        text,
+        pasteHandledRef.current,
+      )
+      pasteHandledRef.current = false
+
+      if (change.type === "paste-handled" || change.type === "unchanged") {
         return
       }
 
-      // Fallback paste detection for platforms where we can't intercept
-      // the clipboard event (native, and any web path that bypasses the
-      // DOM paste listener). If a large chunk was just inserted, pull it
-      // out into a chip instead of keeping it in the TextInput.
-      const paste = extractLongPaste(inputValueRef.current, text)
-      if (paste) {
-        addPastedText(paste.inserted)
-        inputValueRef.current = paste.restored
-        setInputValue(paste.restored)
+      if (change.type === "long-paste") {
+        addPastedText(change.inserted)
+        inputValueRef.current = change.restored
+        setInputValue(change.restored)
         setShowSkillPicker(false)
         closeMentionMenu()
         return
       }
 
-      // Keep the ref in sync synchronously so onSelectionChange (which fires
-      // right after with the authoritative caret) sees the latest text.
-      inputValueRef.current = text
-      setInputValue(text)
-      if (text.length === 0) {
+      inputValueRef.current = change.text
+      setInputValue(change.text)
+      if (change.resetHeight) {
         setInputHeight(MIN_INPUT_HEIGHT)
       }
 
-      if (text.startsWith("/") && !text.includes(" ")) {
+      if (change.skillPicker.open) {
         setShowSkillPicker(true)
-        setFilterText(text.slice(1).toLowerCase())
+        setFilterText(change.skillPicker.filterText ?? "")
         setSelectedIndex(0)
       } else {
         setShowSkillPicker(false)
       }
 
-      // Provisional mention detection using the end of the text as the caret;
-      // onSelectionChange refines this with the real caret position.
-      updateMentionState(text, text.length)
+      updateMentionState(change.text, change.mentionCaret)
     },
     [addPastedText, closeMentionMenu, updateMentionState]
   )

--- a/apps/mobile/components/chat/__tests__/ChatInput.integration.test.tsx
+++ b/apps/mobile/components/chat/__tests__/ChatInput.integration.test.tsx
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+// @ts-ignore Bun resolves this module at test runtime; app tsconfig does not include Bun ambient types.
+import { afterEach, describe, expect, mock, test } from "bun:test"
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
+import React, { Profiler } from "react"
+
+const Host = React.forwardRef<HTMLElement, any>(function Host(
+  {
+    accessibilityLabel,
+    children,
+    keyboardShouldPersistTaps: _keyboardShouldPersistTaps,
+    onPress,
+    style: _style,
+    testID,
+    ...props
+  },
+  ref,
+) {
+  return React.createElement(
+    "div",
+    {
+      ...props,
+      "aria-label": accessibilityLabel,
+      "data-testid": testID,
+      onClick: onPress ?? props.onClick,
+      ref,
+    },
+    children,
+  )
+})
+
+const TextInput = React.forwardRef<HTMLTextAreaElement, any>(function TextInput(
+  {
+    accessibilityLabel,
+    blurOnSubmit: _blurOnSubmit,
+    editable = true,
+    multiline: _multiline,
+    onChange,
+    onChangeText,
+    onContentSizeChange: _onContentSizeChange,
+    onKeyPress,
+    onSelectionChange,
+    onSubmitEditing,
+    placeholderTextColor: _placeholderTextColor,
+    style: _style,
+    testID,
+    textAlignVertical: _textAlignVertical,
+    ...props
+  },
+  ref,
+) {
+  return (
+    <textarea
+      {...props}
+      aria-label={accessibilityLabel}
+      data-testid={testID}
+      disabled={!editable}
+      ref={ref}
+      onChange={(event) => {
+        onChange?.(event)
+        onChangeText?.(event.currentTarget.value)
+      }}
+      onKeyDown={(event) => {
+        const nativeEvent = { key: event.key, shiftKey: event.shiftKey }
+        const wrappedEvent = {
+          nativeEvent,
+          preventDefault: () => event.preventDefault(),
+        }
+        onKeyPress?.(wrappedEvent)
+        if (event.key === "Enter" && !event.shiftKey) {
+          onSubmitEditing?.(wrappedEvent)
+        }
+      }}
+      onSelect={(event) => {
+        onSelectionChange?.({
+          nativeEvent: {
+            selection: {
+              start: event.currentTarget.selectionStart,
+              end: event.currentTarget.selectionEnd,
+            },
+            text: event.currentTarget.value,
+          },
+        })
+      }}
+    />
+  )
+})
+
+mock.module("react-native", () => ({
+  Image: Host,
+  Platform: { OS: "web" },
+  Pressable: Host,
+  ScrollView: Host,
+  Text: Host,
+  TextInput,
+  View: Host,
+}))
+
+const StubIcon = () => null
+mock.module("lucide-react-native", () => ({
+  __esModule: true,
+  ArrowUp: StubIcon,
+  Plus: StubIcon,
+  Square: StubIcon,
+  X: StubIcon,
+  Zap: StubIcon,
+  Lock: StubIcon,
+  File: StubIcon,
+  FileText: StubIcon,
+  FolderGit2: StubIcon,
+  Image: StubIcon,
+  ChevronDown: StubIcon,
+  ChevronUp: StubIcon,
+  Trash2: StubIcon,
+  Pencil: StubIcon,
+  SendHorizontal: StubIcon,
+  Bot: StubIcon,
+  ClipboardList: StubIcon,
+  MessageCircleQuestion: StubIcon,
+  Check: StubIcon,
+  Mic: StubIcon,
+  Sparkles: StubIcon,
+  Languages: StubIcon,
+}))
+
+mock.module("@shogo/shared-ui/primitives", () => ({
+  cn: (...args: any[]) => args.filter(Boolean).join(" "),
+}))
+
+mock.module("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  PopoverBackdrop: () => null,
+  PopoverContent: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}))
+
+mock.module("../../../lib/platform-config", () => ({
+  usePlatformConfig: () => ({ features: { billing: false, ezMode: false } }),
+}))
+
+mock.module("../useVoiceInput", () => ({
+  useVoiceInput: () => ({
+    isBusy: false,
+    isRecording: false,
+    liveTranscript: "",
+    start: mock(async () => {}),
+    stop: mock(async () => {}),
+  }),
+}))
+
+mock.module("../VoiceWaveform", () => ({ VoiceWaveform: () => null }))
+mock.module("../AttachSourceSheet", () => ({ AttachSourceSheet: () => null }))
+mock.module("../ContextTracker", () => ({ ContextTracker: () => null }))
+mock.module("../../../lib/visible-models", () => ({
+  resolveShortName: (modelId: string) => modelId,
+  resolveTier: () => "economy",
+}))
+mock.module("../ModelPickerMenu", () => ({ ModelPickerMenu: () => null }))
+mock.module("../FileViewerModal", () => ({ FileViewerModal: () => null }))
+mock.module("../PastedTextChip", () => ({ PastedTextChip: () => null }))
+mock.module("../../voice-mode/ChatBridgeContext", () => ({
+  useChatBridgeOptional: () => null,
+}))
+mock.module("../turns/AskUserQuestionWidget", () => ({ AskUserQuestionWidget: () => null }))
+mock.module("@shogo-ai/sdk/agent", () => ({
+  AgentClient: class {
+    getWorkspaceTree = mock(async () => [])
+    searchFiles = mock(async () => [])
+  },
+}))
+mock.module("../../../lib/agent-fetch", () => ({ agentFetch: fetch }))
+mock.module("../ChatContext", () => ({ useChatContextSafe: () => null }))
+mock.module("../EnvironmentPicker", () => ({ EnvironmentPicker: () => null }))
+
+const { ChatInput } = await import("../ChatInput")
+
+afterEach(() => cleanup())
+
+describe("ChatInput integration — mobile-web TextInput changes", () => {
+  test("repeated same-value TextInput echoes do not cause nested update-depth failures", async () => {
+    const errors: unknown[][] = []
+    const originalError = console.error
+    console.error = (...args: unknown[]) => {
+      errors.push(args)
+      originalError(...args)
+    }
+
+    try {
+      render(
+        <ChatInput
+          onSubmit={mock(() => {})}
+          isPro
+          ideMode
+          ideContext={{ workspaceItems: [] } as any}
+          ideFileSearch={mock(async () => [])}
+          placeholder="Ask Shogo..."
+        />,
+      )
+
+      const input = screen.getByPlaceholderText("Ask Shogo...") as HTMLTextAreaElement
+
+      await act(async () => {
+        fireEvent.change(input, { target: { value: "@" } })
+        for (let i = 0; i < 80; i += 1) {
+          fireEvent.change(input, { target: { value: "@" } })
+        }
+      })
+
+      expect(input.value).toBe("@")
+      expect(
+        errors.some((args) => String(args[0] ?? "").includes("Maximum update depth exceeded")),
+      ).toBe(false)
+    } finally {
+      console.error = originalError
+    }
+  })
+
+  test("repeated identical selection events on an active mention token do not re-render repeatedly", async () => {
+    let commits = 0
+
+    render(
+      <Profiler id="chat-input" onRender={() => { commits += 1 }}>
+        <ChatInput
+          onSubmit={mock(() => {})}
+          isPro
+          ideMode
+          ideContext={{ workspaceItems: [] } as any}
+          ideFileSearch={mock(async () => [])}
+          placeholder="Ask Shogo..."
+        />
+      </Profiler>,
+    )
+
+    const input = screen.getByPlaceholderText("Ask Shogo...") as HTMLTextAreaElement
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "@ali" } })
+    })
+    const commitsAfterTyping = commits
+
+    input.selectionStart = 4
+    input.selectionEnd = 4
+
+    await act(async () => {
+      for (let i = 0; i < 50; i += 1) {
+        fireEvent.select(input)
+      }
+    })
+
+    expect(input.value).toBe("@ali")
+    expect(commits).toBe(commitsAfterTyping)
+  })
+})

--- a/apps/mobile/components/chat/__tests__/ChatInput.update-depth.test.tsx
+++ b/apps/mobile/components/chat/__tests__/ChatInput.update-depth.test.tsx
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+// @ts-ignore Bun resolves this module at test runtime; app tsconfig does not include Bun ambient types.
+import { describe, expect, test } from "bun:test"
+
+import { resolveChatInputTextChange } from "../chat-input-text-change"
+
+describe("ChatInput text-change state transitions", () => {
+  test("ignores same-value mobile-web controlled TextInput echo events", () => {
+    let current = ""
+    let stateWrites = 0
+
+    for (const next of ["@", "@", "@a", "@a", "@al", "@al"]) {
+      const change = resolveChatInputTextChange(current, next, false)
+      if (change.type === "text") {
+        current = change.text
+        stateWrites += 1
+      }
+    }
+
+    expect(current).toBe("@al")
+    expect(stateWrites).toBe(3)
+  })
+
+  test("demonstrates the pre-fix echo loop would write state for every echoed event", () => {
+    const events = ["hello", ...Array.from({ length: 80 }, () => "hello")]
+    let legacyStateWrites = 0
+    let fixedStateWrites = 0
+    let current = ""
+
+    for (const next of events) {
+      legacyStateWrites += 1
+      const change = resolveChatInputTextChange(current, next, false)
+      if (change.type === "text") {
+        current = change.text
+        fixedStateWrites += 1
+      }
+    }
+
+    expect(legacyStateWrites).toBe(81)
+    expect(fixedStateWrites).toBe(1)
+  })
+
+  test("preserves slash command skill-picker transitions", () => {
+    expect(resolveChatInputTextChange("", "/dep", false)).toEqual({
+      type: "text",
+      text: "/dep",
+      resetHeight: false,
+      skillPicker: { open: true, filterText: "dep" },
+      mentionCaret: 4,
+    })
+
+    expect(resolveChatInputTextChange("/dep", "/dep now", false)).toEqual({
+      type: "text",
+      text: "/dep now",
+      resetHeight: false,
+      skillPicker: { open: false },
+      mentionCaret: 8,
+    })
+  })
+
+  test("preserves long-paste extraction", () => {
+    const pasted = "x".repeat(5_100)
+    expect(resolveChatInputTextChange("prefix ", `prefix ${pasted}`, false)).toMatchObject({
+      type: "long-paste",
+      inserted: pasted,
+      restored: "prefix ",
+    })
+  })
+})

--- a/apps/mobile/components/chat/chat-input-text-change.ts
+++ b/apps/mobile/components/chat/chat-input-text-change.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { extractLongPaste } from "./long-text-utils"
+
+export type ChatInputTextChange =
+  | { type: "paste-handled" }
+  | { type: "unchanged" }
+  | { type: "long-paste"; inserted: string; restored: string }
+  | {
+      type: "text"
+      text: string
+      resetHeight: boolean
+      skillPicker: { open: boolean; filterText?: string }
+      mentionCaret: number
+    }
+
+export function resolveChatInputTextChange(
+  previousText: string,
+  nextText: string,
+  pasteAlreadyHandled: boolean,
+): ChatInputTextChange {
+  if (pasteAlreadyHandled) return { type: "paste-handled" }
+
+  if (nextText === previousText) return { type: "unchanged" }
+
+  const paste = extractLongPaste(previousText, nextText)
+  if (paste) {
+    return {
+      type: "long-paste",
+      inserted: paste.inserted,
+      restored: paste.restored,
+    }
+  }
+
+  if (nextText.startsWith("/") && !nextText.includes(" ")) {
+    return {
+      type: "text",
+      text: nextText,
+      resetHeight: nextText.length === 0,
+      skillPicker: { open: true, filterText: nextText.slice(1).toLowerCase() },
+      mentionCaret: nextText.length,
+    }
+  }
+
+  return {
+    type: "text",
+    text: nextText,
+    resetHeight: nextText.length === 0,
+    skillPicker: { open: false },
+    mentionCaret: nextText.length,
+  }
+}


### PR DESCRIPTION
## Summary

Closes #805.

This PR fixes a mobile-web `ChatInput` repeated-update path related to the Sentry `Maximum update depth exceeded` issue seen in production on Android Chrome / React Native Web.

The change is intentionally scoped to the chat composer input state machine:

- extracts text-change transition logic into `chat-input-text-change.ts` so the risky handler behavior can be tested without a full native/web render tree;
- ignores unchanged controlled `TextInput` echo events before scheduling React state updates;
- preserves long-paste extraction behavior;
- preserves slash-command skill picker behavior;
- makes active `@mention` state idempotent by guarding repeated identical `{ start, end, query }` token/caret state;
- resets the active mention guard whenever the mention menu closes or the token disappears;
- adds both pure transition tests and component integration tests for repeated mobile-web text/selection events.

## Production signal / Sentry evidence

Sentry issue `JAVASCRIPT-REACT-3C` reports:

```text
Error: Maximum update depth exceeded
```

Observed stack path:

```text
react-native-web TextInput handleChange
→ apps/mobile/components/chat/ChatInput.tsx handleChangeText
→ React dispatchSetState
→ Maximum update depth exceeded
```

Known affected production context:

- Browser: Chrome Mobile
- OS: Android
- Environment: `production_web`
- Release seen in Sentry: `f54c817781f07a41c86e13bc46948addf7506e01`
- Route seen in the issue: `/projects/82825207-3b59-4055-80d5-43a1adeff8dc`

The crash originates from the React Native Web `TextInput` event path and the first app frame is `ChatInput.handleChangeText`, so the investigation focused on state writes inside and immediately downstream of that input handler.

## RCA

The first hypothesis was that mobile web was repeatedly echoing the same `onChangeText` value from a controlled textarea. That was plausible from the Sentry stack, but it was **not enough** after testing.

A follow-up real-component integration test showed the more concrete repeated-update path is the `@mention` state transition.

`ChatInput.updateMentionState()` was not idempotent. React Native Web can emit repeated text/selection events for the textarea while the active `@mention` token and caret position are unchanged. Before this PR, the active-token branch still scheduled React work on every repeated event:

```ts
setShowMentionMenu(true)
setMentionIndex(0)
setMentionQuery((prev) => (prev === token.query ? prev : token.query))
```

Even though `setMentionQuery` returns the previous value when the query is unchanged, the functional setter still schedules React work. Combined with repeated RNW textarea input/selection events, that path can keep feeding state updates during the same input cycle.

This PR adds an explicit idempotency guard for the active mention token/caret/query before scheduling those state updates.

## Implementation details

### `components/chat/chat-input-text-change.ts`

Adds `resolveChatInputTextChange()`, a deterministic helper for `ChatInput` text transitions.

It returns typed outcomes for:

- unchanged controlled input echoes;
- long-paste extraction;
- normal input changes;
- slash-command picker state.

This lets the risky state-machine behavior be tested directly without mounting the entire native-heavy chat composer tree.

### `components/chat/ChatInput.tsx`

The text-change path now exits early for unchanged values:

```ts
if (change.type === "paste-handled" || change.type === "unchanged") {
  return
}
```

The mention path now tracks the last active mention state:

```ts
const activeMentionStateRef = useRef<{ start: number; end: number; query: string } | null>(null)
```

and returns before any state writes if the active mention token/caret/query is unchanged:

```ts
const nextState = { start: token.start, end: caret, query: token.query }
const currentState = activeMentionStateRef.current
if (
  currentState &&
  currentState.start === nextState.start &&
  currentState.end === nextState.end &&
  currentState.query === nextState.query
) {
  return
}
```

The ref is cleared when:

- `closeMentionMenu()` runs;
- no active mention token is detected anymore.

## Why this should be safe

The guard only skips work when the active mention token state is exactly identical:

```text
same token start
same caret/end
same query
```

Any real user-visible change still flows through normally:

- typing another character changes `query` or `end`;
- moving the caret changes `end`;
- starting a new mention changes `start`;
- leaving the mention token clears the mention state;
- closing/selecting the mention menu resets the guard.

The text-change helper also preserves existing non-error behavior:

- long paste still extracts pasted text;
- regular typing still updates input value;
- slash command detection still opens/filters the skill picker;
- non-slash text still closes the skill picker.

## Tests added

### Pure state-machine regression test

`components/chat/__tests__/ChatInput.update-depth.test.tsx`

Covers:

1. Same-value mobile-web controlled `TextInput` echoes are ignored.
2. The pre-fix equivalent behavior would schedule repeated state writes for echo events.
3. Slash command skill picker behavior still works.
4. Long-paste extraction still works.

### Component integration test

`components/chat/__tests__/ChatInput.integration.test.tsx`

Mounts the actual `ChatInput` with native-heavy dependencies mocked and exercises the web textarea contract.

Covers:

1. Repeated same-value text events do not produce React update-depth failures.
2. Repeated identical selection events on an active `@mention` token do not cause extra commits.

The repeated-selection test exposed the missing `updateMentionState()` idempotency guard before the final fix and passes with this PR.

## Verification performed

Run from `apps/mobile`:

```sh
bun test components/chat/__tests__/ChatInput.integration.test.tsx components/chat/__tests__/ChatInput.update-depth.test.tsx
bun test components/chat/__tests__
git diff --check
```

Results:

```text
Focused tests: 6 pass, 0 fail, 11 expect() calls
Full chat suite: 126 pass, 1 skip, 0 fail, 226 expect() calls
git diff --check: passed
Changed-file lints: no errors
```

Changed files linted clean:

- `components/chat/ChatInput.tsx`
- `components/chat/chat-input-text-change.ts`
- `components/chat/__tests__/ChatInput.integration.test.tsx`
- `components/chat/__tests__/ChatInput.update-depth.test.tsx`

## E2E / production validation caveat

A Chromium Pixel 5 / Android Chrome-style emulation attempt was made against the production URL from the Sentry issue:

```text
https://studio.shogo.ai/projects/82825207-3b59-4055-80d5-43a1adeff8dc
```

The clean browser context was redirected to:

```text
https://studio.shogo.ai/sign-in
```

So the emulated browser did **not** reach the authenticated project `ChatInput`.

What was available:

- Playwright Chromium Pixel 5 emulation launched successfully.
- Production Studio was reachable.
- The unauthenticated session was redirected to sign-in.

What was **not** available in this environment:

- real Android device / ADB;
- Android emulator tooling;
- BrowserStack/Sauce credentials;
- authenticated Playwright `storageState`;
- test Studio credentials.

Therefore, this PR is verified by component/integration tests and full chat regression tests, but final production confirmation should happen by either:

1. running authenticated Android Chrome E2E once credentials/storage state/device access are available; or
2. deploying and monitoring the Sentry issue for recurrence on the same stack.

## Reviewer checklist

- [ ] Confirm the mention-state guard only skips truly identical token/caret/query events.
- [ ] Confirm long paste extraction still behaves as before.
- [ ] Confirm slash command picker behavior is unchanged.
- [ ] Confirm the new integration test is acceptable with mocked native-heavy dependencies.
- [ ] After deploy, monitor Sentry `Maximum update depth exceeded` events from `ChatInput.handleChangeText` on Chrome Mobile / Android.
