### PR TITLE
fix(android): guard native release from desktop and web-only code

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -492,11 +492,12 @@ jobs:
           # AAB. Must match the release we upload sourcemaps for below.
           EXPO_PUBLIC_BUILD_HASH: ${{ github.sha }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_DISABLE_AUTO_UPLOAD: 'true'
 
       - name: Upload JS sourcemaps to Sentry (optional, non-fatal)
-        # The Sentry-injected Gradle bundle task is replaced with a no-op
-        # stub above ("Ensure Sentry CLI binary"), so the AAB ships without
-        # debug-id-stamped JS. We re-run Metro post-build to regenerate the
+        # The Sentry-injected Gradle bundle task is disabled during Build AAB,
+        # so the AAB ships without debug-id-stamped JS. We re-run Metro
+        # post-build to regenerate the
         # bundle + packager map, compose with the Hermes bytecode map (which
         # `bundleRelease` already produced), and upload to Sentry.
         #

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -492,12 +492,11 @@ jobs:
           # AAB. Must match the release we upload sourcemaps for below.
           EXPO_PUBLIC_BUILD_HASH: ${{ github.sha }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_DISABLE_AUTO_UPLOAD: 'true'
 
       - name: Upload JS sourcemaps to Sentry (optional, non-fatal)
-        # The Sentry-injected Gradle bundle task is disabled during Build AAB,
-        # so the AAB ships without debug-id-stamped JS. We re-run Metro
-        # post-build to regenerate the
+        # The Sentry-injected Gradle bundle task is replaced with a no-op
+        # stub above ("Ensure Sentry CLI binary"), so the AAB ships without
+        # debug-id-stamped JS. We re-run Metro post-build to regenerate the
         # bundle + packager map, compose with the Hermes bytecode map (which
         # `bundleRelease` already produced), and upload to Sentry.
         #

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -103,6 +103,7 @@ import { AlwaysOnSection } from '../../../../components/project/AlwaysOnSection'
 import { CheckpointGraphNative } from '../../../../components/project/panels/ide/graph/CheckpointGraphNative'
 import { TrustPrompt, type TrustDecision } from '../../../../components/project/TrustPrompt'
 import { DrawerHost } from '../../../../components/project/panels/ide/DrawerHost'
+import { loadDesktopTerminal } from '../../../../components/project/panels/ide/terminal/desktop-terminal-loader'
 import {
   RefreshCw,
   MessageSquare,
@@ -2506,7 +2507,7 @@ export default observer(function ProjectLayout() {
   const enrichMessage = useCallback(async (text: string): Promise<string> => {
     try {
       if (Platform.OS !== 'web') return text
-      const { terminalContextStore } = await import('@shogo/desktop-terminal')
+      const { terminalContextStore } = await loadDesktopTerminal()
       if (!terminalContextStore.isReady()) return text
 
       const git = {

--- a/apps/mobile/components/project/panels/ide/terminal/XtermView.tsx
+++ b/apps/mobile/components/project/panels/ide/terminal/XtermView.tsx
@@ -24,6 +24,7 @@ import { XtermSession } from './xterm-session'
 import { isDesktopRuntime, type PtyClientLike } from './pty-factory'
 import type { PtyClientState } from './pty-client'
 import { useEditorFont } from '../useEditorFont'
+import { loadDesktopTerminal } from './desktop-terminal-loader'
 
 interface XtermViewProps {
   client: PtyClientLike
@@ -97,7 +98,7 @@ export const XtermView = forwardRef<XtermViewHandle, XtermViewProps>(function Xt
     if (Platform.OS !== 'web') return
     if (!isDesktopRuntime()) return
     let cancelled = false
-    void import('@shogo/desktop-terminal').then((m) => {
+    void loadDesktopTerminal().then((m) => {
       if (!cancelled) setDesktopSurface(() => m.ShogoTerminalSurface as React.ComponentType<any>)
     })
     return () => { cancelled = true }

--- a/apps/mobile/components/project/panels/ide/terminal/desktop-terminal-loader.native.ts
+++ b/apps/mobile/components/project/panels/ide/terminal/desktop-terminal-loader.native.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+export async function loadDesktopTerminal(): Promise<any> {
+  throw new Error('Desktop terminal is unavailable on native')
+}

--- a/apps/mobile/components/project/panels/ide/terminal/desktop-terminal-loader.ts
+++ b/apps/mobile/components/project/panels/ide/terminal/desktop-terminal-loader.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+export async function loadDesktopTerminal(): Promise<any> {
+  throw new Error('Desktop terminal is unavailable outside web')
+}

--- a/apps/mobile/components/project/panels/ide/terminal/desktop-terminal-loader.web.ts
+++ b/apps/mobile/components/project/panels/ide/terminal/desktop-terminal-loader.web.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+export function loadDesktopTerminal(): Promise<any> {
+  return import('@shogo/desktop-terminal')
+}

--- a/apps/mobile/components/project/panels/ide/terminal/pty-factory.ts
+++ b/apps/mobile/components/project/panels/ide/terminal/pty-factory.ts
@@ -19,6 +19,7 @@
  */
 
 import { PtyClient } from './pty-client'
+import { loadDesktopTerminal } from './desktop-terminal-loader'
 
 export type PtyClientStateLike =
   | 'idle' | 'connecting' | 'open' | 'closed' | 'disposed'
@@ -116,15 +117,13 @@ let desktopFactoryPromise: Promise<DesktopFactory> | null = null
 
 function loadDesktopFactory(): Promise<DesktopFactory> {
   if (!desktopFactoryPromise) {
-    desktopFactoryPromise = import('@shogo/desktop-terminal').then(
-      (m) => ({
-        attach: (sessionId: string) => m.createDesktopPtyClient(sessionId) as unknown as PtyClientLike,
-        spawn: async (opts) => {
-          const { client, session } = await m.spawnDesktopPtyClient(opts)
-          return { client: client as unknown as PtyClientLike, session }
-        },
-      }),
-    )
+    desktopFactoryPromise = loadDesktopTerminal().then((m) => ({
+      attach: (sessionId: string) => m.createDesktopPtyClient(sessionId) as unknown as PtyClientLike,
+      spawn: async (opts) => {
+        const { client, session } = await m.spawnDesktopPtyClient(opts)
+        return { client: client as unknown as PtyClientLike, session }
+      },
+    }))
   }
   return desktopFactoryPromise
 }

--- a/apps/mobile/lib/chat-session-events.ts
+++ b/apps/mobile/lib/chat-session-events.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2026 Shogo Technologies, Inc.
 
+import { Platform } from 'react-native'
+
 export type ChatSessionChange = {
   /** Project (context) the change belongs to. */
   projectId: string
@@ -48,7 +50,11 @@ function nextEventId(): string {
 
 function getBroadcastChannel(): BroadcastChannel | null {
   if (broadcastChannel !== undefined) return broadcastChannel
-  if (typeof window === 'undefined' || typeof globalThis.BroadcastChannel !== 'function') {
+  if (
+    Platform.OS !== 'web' ||
+    typeof window === 'undefined' ||
+    typeof globalThis.BroadcastChannel !== 'function'
+  ) {
     broadcastChannel = null
     return broadcastChannel
   }
@@ -97,7 +103,7 @@ function receiveCrossWindowChange(value: unknown): void {
 }
 
 function installCrossWindowListener(): void {
-  if (crossWindowListenerInstalled || typeof window === 'undefined') return
+  if (crossWindowListenerInstalled || Platform.OS !== 'web' || typeof window === 'undefined') return
   crossWindowListenerInstalled = true
 
   const channel = getBroadcastChannel()
@@ -117,6 +123,8 @@ function installCrossWindowListener(): void {
 }
 
 function publishCrossWindowChange(event: ChatSessionChange): void {
+  if (Platform.OS !== 'web') return
+
   const outbound: CrossWindowChatSessionChange = {
     ...event,
     eventId: nextEventId(),


### PR DESCRIPTION
<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/75e483ab-c682-4d21-bb73-1a026aa063d3" />
<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/4a416ab2-35ca-43b3-be0c-c45a047f1eda" />

## Summary

This PR fixes Android/native production safety issues without disabling Sentry.

The main goal is to keep Android release bundles from resolving or executing desktop/browser-only code paths:

1. `@shogo/desktop-terminal` is now loaded through platform-specific loader files so Android/native does not resolve the desktop-only package or its Node-only dependencies.
2. Browser-only chat-session cross-window sync is now guarded to run only on web, preventing a real Android release startup crash found during physical-device testing.
3. Android Sentry remains enabled. The previous `SENTRY_DISABLE_AUTO_UPLOAD` workflow change was removed, and the latest production workflow verified Sentry sourcemap upload successfully.

## What changed

### 1. Platform-specific desktop terminal loading

The mobile terminal code no longer directly imports `@shogo/desktop-terminal` from shared files that Android Metro can see.

New loader files:

```text
apps/mobile/components/project/panels/ide/terminal/desktop-terminal-loader.web.ts
apps/mobile/components/project/panels/ide/terminal/desktop-terminal-loader.native.ts
apps/mobile/components/project/panels/ide/terminal/desktop-terminal-loader.ts
```

On web/desktop, the web loader still imports the desktop terminal package:

```ts
return import('@shogo/desktop-terminal')
```

On native Android/iOS, the native loader does not import that package and instead reports desktop terminal support as unavailable.

This prevents Android production bundles from pulling in desktop/Electron-only terminal code and Node-only dependencies such as:

```ts
node:fs/promises
```

### 2. Terminal call sites now use the safe loader

These files now use `loadDesktopTerminal()` instead of directly importing `@shogo/desktop-terminal`:

```text
apps/mobile/app/(app)/projects/[id]/_layout.tsx
apps/mobile/components/project/panels/ide/terminal/XtermView.tsx
apps/mobile/components/project/panels/ide/terminal/pty-factory.ts
```

The behavior is unchanged for desktop/web, but Android/native no longer resolves the desktop package.

### 3. Guard browser-only chat-session sync on native

Physical Android release testing exposed a real startup crash:

```text
TypeError: undefined is not a function
installCrossWindowListener
```

Root cause: `apps/mobile/lib/chat-session-events.ts` was installing browser-only cross-window listeners on React Native Android. React Native can expose a `window` object, but browser APIs like `BroadcastChannel`, `window.storage`, and `localStorage` cross-window sync are not safe to assume on native.

This PR makes that cross-window sync web-only via `Platform.OS === 'web'` guards.

## What this fixes

- Prevents Android/native builds from resolving `@shogo/desktop-terminal`.
- Prevents Node-only desktop terminal dependencies from leaking into the Android bundle.
- Prevents Android release startup crashes from browser-only chat-session cross-window sync.
- Keeps desktop/web terminal behavior intact.
- Keeps Android Sentry enabled.

## Sentry status

This PR does **not** disable Sentry.

The previous workflow line was removed:

```yaml
SENTRY_DISABLE_AUTO_UPLOAD: 'true'
```

Current Android production workflow verification showed Sentry upload working:

```text
Task :app:createBundleReleaseJsAndAssets_SentryUpload_...
Uploading sourcemaps for release ... distribution 755
> Uploaded files to Sentry
```

The explicit Android sourcemap upload step also succeeded:

```text
Upload JS sourcemaps to Sentry: success
> Uploaded files to Sentry
> Dist: android
```

## Verification

Verified on the PR branch.

### GitHub Actions production release

Latest production Android workflow:

```text
https://github.com/shogo-labs/shogo-ai/actions/runs/28840348242
```

Result:

```text
Status: completed
Conclusion: success
```

Confirmed:

- Required Android signing and release secrets were present.
- `SENTRY_AUTH_TOKEN` and `EXPO_PUBLIC_SENTRY_DSN_ANDROID` were present.
- Android AAB build passed.
- Sentry Gradle sourcemap upload ran successfully.
- Explicit Android sourcemap upload step ran successfully.
- AAB artifact upload passed.
- Google Play production submit succeeded.

Version produced:

```text
version=1.0.9
versionCode=755
```

Play Store submit:

```text
Submitting to production track via profile production
✔ Submitted your app to Google Play Store!
```

### Physical Android device E2E

Validated on physical Android device:

```text
RZGL217B7DT
```

What was tested:

- Built Android release APK from this PR branch.
- Installed it on the connected physical Android device.
- Launched the app.
- Signed in with a real account after rebuilding the local test APK with the correct cloud API URL.
- Confirmed authenticated Home UI loaded on-device.
- Checked device logcat for targeted crash/module-resolution failures.

Device UI reached:

```text
Home
What's on your mind, Ashutosh?
React App
```

Logcat checks after authenticated launch:

```text
FATAL EXCEPTION: 0
Unable to resolve module: 0
Cannot find module: 0
node:fs/promises: 0
@shogo/desktop-terminal: 0
installCrossWindowListener: 0
TypeError: undefined is not a function: 0
ANR: 0
Process ai.shogo.mobile has died: 0
Force finishing activity: 0
```

### Targeted terminal tests

Previously verified targeted terminal coverage for the desktop-terminal loader changes, including:

- `pty-factory.test.ts`
- `pty-client.test.ts`
- `xterm-session-setFont.test.ts`
- `desktop-pty-client.test.ts`
- `terminal-context-store.test.ts`
- `terminal-integration.test.ts`

Result from targeted terminal tests:

```text
95 passing, 0 failing
```