### PR TITLE
studio: serve /_expo assets from shared CDN bucket (kill multi-revision 404s)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -563,6 +563,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.OCI_S3_SECRET_KEY }}
           OCI_S3_ENDPOINT: ${{ vars.OCI_S3_ENDPOINT }}
           OCIR_REGISTRY: ${{ needs.resolve-config.outputs.ocir_registry }}
+          # AWS CLI v2 (>= 2.23) adds default integrity checksums that upload via
+          # `Content-Encoding: aws-chunked` with a trailing checksum. OCI's
+          # S3-compatible endpoint rejects that with `NotImplemented: AWS chunked
+          # encoding not supported`. Force checksums to WHEN_REQUIRED so PutObject
+          # uses a plain, pre-signed payload the OCI endpoint accepts.
+          AWS_REQUEST_CHECKSUM_CALCULATION: WHEN_REQUIRED
+          AWS_RESPONSE_CHECKSUM_VALIDATION: WHEN_REQUIRED
         run: |
           set -euo pipefail
           # Materialize ONLY dist/_expo via the `web-assets` stage (FROM

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -541,6 +541,66 @@ jobs:
           cache-from: type=registry,ref=${{ needs.resolve-config.outputs.ocir_registry }}/shogo/buildcache:${{ matrix.image }}
           cache-to: type=registry,ref=${{ needs.resolve-config.outputs.ocir_registry }}/shogo/buildcache:${{ matrix.image }},mode=max,image-manifest=true,oci-mediatypes=true
 
+      # Upload the studio web app's immutable, content-hashed Expo assets
+      # (dist/_expo) to a shared, append-only object-storage bucket. A
+      # Cloudflare Worker serves studio.<env>.shogo.ai/_expo/* from this
+      # bucket same-origin, so a browser can always fetch a build's hashed
+      # assets no matter which Knative studio revision served the HTML. This
+      # is what makes the multi-revision asset-404 class of bug impossible.
+      #
+      # Runs in build-and-push (before any deploy job patches the ksvc), so
+      # the assets exist in the bucket before the new HTML references them.
+      # Content-hashed filenames make `aws s3 sync` append-only: new builds
+      # add files, older builds' files are preserved (rollback-safe).
+      #
+      # Staging-only for now — the bucket + Worker are wired for staging in
+      # terraform/environments/staging. Production rollout wires the same
+      # module per region and drops this environment gate.
+      - name: Upload web static assets to CDN bucket
+        if: matrix.image == 'web' && needs.resolve-config.outputs.environment == 'staging'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.OCI_S3_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OCI_S3_SECRET_KEY }}
+          OCI_S3_ENDPOINT: ${{ vars.OCI_S3_ENDPOINT }}
+          OCIR_REGISTRY: ${{ needs.resolve-config.outputs.ocir_registry }}
+        run: |
+          set -euo pipefail
+          # Materialize ONLY dist/_expo via the `web-assets` stage (FROM
+          # scratch). Build args + cache ref match the image build above, so
+          # every builder layer is a cache hit and this just exports the
+          # already-produced, byte-identical _expo tree (source maps already
+          # stripped in the builder stage).
+          docker buildx build \
+            --target web-assets \
+            --file apps/mobile/Dockerfile \
+            --platform linux/arm64 \
+            --build-arg WORKSPACE_DEPS="${OCIR_REGISTRY}/shogo/shogo-workspace-deps:${{ github.sha }}" \
+            --build-arg EXPO_PUBLIC_API_URL="${{ vars.EXPO_PUBLIC_API_URL }}" \
+            --build-arg EXPO_PUBLIC_BUILD_HASH="${{ github.sha }}" \
+            --build-arg EXPO_PUBLIC_APP_ENV="${{ needs.resolve-config.outputs.environment }}_web" \
+            --build-arg EXPO_PUBLIC_SENTRY_DSN_WEB="${{ secrets.EXPO_PUBLIC_SENTRY_DSN_WEB }}" \
+            --build-arg SENTRY_AUTH_TOKEN="${{ secrets.SENTRY_AUTH_TOKEN }}" \
+            --build-arg SENTRY_ORG=shogo-ai \
+            --build-arg SENTRY_PROJECT=javascript-react \
+            --cache-from type=registry,ref="${OCIR_REGISTRY}/shogo/buildcache:web" \
+            --output type=local,dest=./web-assets \
+            .
+          test -d ./web-assets/_expo || { echo "ERROR: ./web-assets/_expo missing after export"; exit 1; }
+          # Re-PUT the FULL current asset set every deploy (cp --recursive, not
+          # sync). Content-hashed names mean this is still append-only for new
+          # builds, but re-uploading refreshes the object creation time of every
+          # asset THIS build references. The bucket's 30-day DELETE lifecycle
+          # (terraform/modules/studio-web-assets) then only reaps assets that no
+          # deploy has referenced for 30 days. A plain `sync` would skip an
+          # unchanged-but-still-referenced chunk, let it age out, and reintroduce
+          # the 404 - so this MUST stay `cp --recursive`.
+          aws s3 cp ./web-assets/_expo "s3://shogo-web-assets-staging/_expo/" \
+            --recursive \
+            --endpoint-url "$OCI_S3_ENDPOINT" \
+            --no-progress \
+            --exclude "*.map" \
+            --cache-control "public, max-age=31536000, immutable"
+
   # ===========================================================================
   # Stage 2.5: Replicate Images to Secondary Regions (production only)
   # Uses skopeo to copy images from US OCIR to EU and India OCIR.
@@ -1016,6 +1076,38 @@ jobs:
           patch_ksvc studio "${{ env.NS_SYSTEM }}" shogo-web "$WEB_CHANGED" "$PREV_WEB_IMAGE"
           patch_ksvc api "${{ env.NS_SYSTEM }}" shogo-api "$API_CHANGED" "$PREV_API_IMAGE"
           patch_ksvc docs "${{ env.NS_SYSTEM }}" shogo-docs "$DOCS_CHANGED" "$PREV_DOCS_IMAGE"
+
+      # Retire stale studio revisions. The `studio-direct` Service (see
+      # k8s/overlays/*/studio-ws-ingress.yaml) selects EVERY studio revision by
+      # `serving.knative.dev/service=studio`, and each revision keeps a warm pod
+      # (min-scale + studio-direct feeding its queue-proxy keeps the autoscaler
+      # from scaling it to zero). So without this, old revisions keep serving —
+      # historically 404ing hashed assets ~half the time, and even with the
+      # shared-asset CDN they still serve stale HTML. Once the new revision is
+      # Ready, delete every other studio revision so studio-direct converges to
+      # a single serving build. Guarded so a bad rollout (latest not Ready)
+      # never deletes the only working revision.
+      - name: Retire stale studio revisions
+        if: needs.detect-changes.outputs.web_changed == 'true'
+        run: |
+          set -euo pipefail
+          NS="${{ env.NS_SYSTEM }}"
+          echo "Waiting for studio ksvc to be Ready..."
+          kubectl wait --for=condition=Ready ksvc/studio -n "$NS" --timeout=300s
+          LATEST=$(kubectl get ksvc studio -n "$NS" -o jsonpath='{.status.latestReadyRevisionName}')
+          if [ -z "$LATEST" ]; then
+            echo "ERROR: studio has no latestReadyRevisionName; refusing to GC revisions." >&2
+            exit 1
+          fi
+          echo "Keeping latest-ready studio revision: $LATEST"
+          STALE=$(kubectl get revisions -n "$NS" -l serving.knative.dev/service=studio \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -v "^${LATEST}$" || true)
+          if [ -z "$STALE" ]; then
+            echo "No stale studio revisions to delete."
+          else
+            echo "Deleting stale studio revisions:"; echo "$STALE"
+            echo "$STALE" | xargs -r -n1 kubectl delete revision -n "$NS"
+          fi
 
       - name: Sync API environment variables
         env:

--- a/apps/mobile/Dockerfile
+++ b/apps/mobile/Dockerfile
@@ -125,6 +125,23 @@ RUN if [ -n "$SENTRY_AUTH_TOKEN" ]; then \
     fi
 
 # =============================================================================
+# Asset export stage (CDN upload source)
+# =============================================================================
+# CI builds this stage with `--target web-assets --output type=local` to pull
+# ONLY the immutable, content-hashed Expo output (dist/_expo) out of the build
+# without dragging the whole builder filesystem. These files are uploaded to a
+# shared, append-only object store and served same-origin by a Cloudflare
+# Worker at `/_expo/*`, so a browser can always fetch a given build's hashed
+# assets regardless of which Knative studio revision served the HTML. This is
+# what makes the multi-revision asset-404 class of bug impossible.
+#
+# MUST stay BEFORE the nginx stage so nginx remains the final (default) target
+# and the normal image build is unaffected. Runs after the Sentry `.map` strip
+# above, so no source maps are exported.
+FROM scratch AS web-assets
+COPY --from=builder /app/apps/mobile/dist/_expo /_expo
+
+# =============================================================================
 # Production image with Nginx
 # =============================================================================
 FROM nginx:alpine

--- a/k8s/base/warm-pool-monitor.yaml
+++ b/k8s/base/warm-pool-monitor.yaml
@@ -23,6 +23,13 @@
 #       — node disk exhaustion (the 2026-06-02 EU incident class): boot
 #         volume fills with stacked runtime images, kubelet evicts pods and
 #         GCs images, and the warm pool churns. Earliest clear signal.
+#   * more than one studio revision has Ready pods
+#       — the `studio-direct` Service selects ALL studio revisions, so >1
+#         Ready revision means the WS-capable ingress round-robins across
+#         mismatched web builds. With content-hashed assets served per-pod
+#         this 404s ~half of loads; assets now come from a shared bucket, but
+#         a second live revision still means stale HTML is served, so this is
+#         the hard invariant the deploy-time revision GC must maintain.
 #
 # Modeled after k8s/cnpg/logical-replication/replication-monitor.yaml
 # (deliberately the same structure/operator-experience).
@@ -194,6 +201,34 @@ spec:
                   ')
                   if [ -n "$PRESSURED" ]; then
                     echo "CRITICAL: node(s) under DiskPressure: $PRESSURED"
+                    EXIT_RC=1
+                  fi
+
+                  # 5) Studio single-revision invariant.
+                  # The `studio-direct` Service (see
+                  # k8s/overlays/*/studio-ws-ingress.yaml) selects EVERY studio
+                  # revision by `serving.knative.dev/service=studio`, bypassing
+                  # Knative's route which pins 100% to the latest revision. If
+                  # more than one revision has Ready pods, the ingress
+                  # round-robins across mismatched web builds and serves stale
+                  # HTML (and, before the shared-asset CDN, 404'd hashed assets
+                  # ~half the time). The deploy-time revision GC in
+                  # .github/workflows/deploy.yml is supposed to leave exactly one
+                  # revision; this alerts if that invariant ever breaks (e.g. an
+                  # out-of-band `kubectl patch ksvc studio`).
+                  echo "--- studio single-revision invariant ---"
+                  STUDIO_PODS=$(kubectl get pods -n "$API_NS" -l serving.knative.dev/service=studio -o json)
+                  STUDIO_REVS=$(echo "$STUDIO_PODS" | jq -c '
+                    [.items[]
+                      | select((.status.conditions // [])[]? | select(.type == "Ready" and .status == "True"))
+                      | .metadata.labels["serving.knative.dev/revision"] // empty
+                    ] | unique
+                  ')
+                  STUDIO_REV_COUNT=$(echo "$STUDIO_REVS" | jq 'length')
+                  STUDIO_REV_LIST=$(echo "$STUDIO_REVS" | jq -r 'join(", ")')
+                  echo "  ready studio revisions: count=$STUDIO_REV_COUNT [$STUDIO_REV_LIST]"
+                  if [ "$STUDIO_REV_COUNT" -gt 1 ]; then
+                    echo "CRITICAL: studio-direct spans $STUDIO_REV_COUNT revisions ($STUDIO_REV_LIST) — mixed builds serving; deploy-time revision GC did not converge."
                     EXIT_RC=1
                   fi
 

--- a/terraform/environments/staging/.terraform.lock.hcl
+++ b/terraform/environments/staging/.terraform.lock.hcl
@@ -5,6 +5,8 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
   version     = "4.52.7"
   constraints = "~> 4.0"
   hashes = [
+    "h1:pPItIWii5oymR+geZB219ROSPuSODPLTlM4S/u8xLvM=",
+    "h1:u67GWw8GwD9NDlDzp9Y5VRnSQGcCrE8rSpkGPaBpDl0=",
     "h1:uUUa9dY0XQOycI8pxg16PFFtL0WCTi9uEJz8trTQ7pU=",
     "zh:0c904ce31a4c6c4a5b3bf7ff1560e77c0cc7e2450c8553ded8e8c90398e1418b",
     "zh:36183d310c36373fe4cb936b83c595c6fd3b0a94bc7827f28e5789ccbf59752e",
@@ -28,6 +30,8 @@ provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.17.0"
   constraints = "~> 2.17"
   hashes = [
+    "h1:0LSHBFqJvHTzQesUwagpDLsrzVliY+t2c26nDJizHFM=",
+    "h1:K5FEjxvDnxb1JF1kG1xr8J3pNGxoaR3Z0IBG9Csm/Is=",
     "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
     "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
     "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
@@ -48,6 +52,8 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.38.0"
   constraints = "~> 2.25, ~> 2.35"
   hashes = [
+    "h1:5CkveFo5ynsLdzKk+Kv+r7+U9rMrNjfZPT3a0N/fhgE=",
+    "h1:7nJdsd1RMPBtOjDXidB37+KSDN5VcOWkbkow69qJVGc=",
     "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
     "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
     "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
@@ -65,9 +71,12 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
 }
 
 provider "registry.terraform.io/hashicorp/null" {
-  version = "3.3.0"
+  version     = "3.3.0"
+  constraints = "~> 3.0"
   hashes = [
+    "h1:Gq+xRK4yvwDpBJ2KFJkrmcNZikDiAEuFhAWeDtzanJc=",
     "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
+    "h1:l+dm3lhmu4ys7GbvIldfn544olSPH0DOiYruuFSfQkY=",
     "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
     "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
     "zh:3de4ed47d6d0f4d8edba4a5092c7c9799950eda63989d8d0d2586e6afcb0aa20",
@@ -88,7 +97,9 @@ provider "registry.terraform.io/oracle/oci" {
   version     = "8.14.0"
   constraints = "~> 8.0"
   hashes = [
+    "h1:E9Awn8FmkZ/eMxk2pMXtXx6gmuy9Q60hqYlg6aG/Ft8=",
     "h1:GD9SyetIxuyeGXSuP6NPu3xSAtxyk0LGNg2x1IocpvY=",
+    "h1:smRjcCCFS7AfXx3yVwy4oIZTwQNT1JnOc/P4ybijT3Y=",
     "zh:0f677f7609c10733f5a83d4add15a062b4b213fdcca53869611fc97bbae8e153",
     "zh:277d3376d94dc2dee083f4604d2d27a55beb79c5c81c31008926c255655f1351",
     "zh:30606342d76407d4199d612aa7ecf97e3e2630441dcbe91d54dc5efbf97a53ac",

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -388,6 +388,31 @@ module "publish_hosting" {
 }
 
 # =============================================================================
+# Studio Web Assets (shared immutable /_expo origin)
+# =============================================================================
+# Serves studio.staging.shogo.ai/_expo/* from a shared, append-only bucket via
+# a Cloudflare Worker, so a browser can always fetch a build's content-hashed
+# assets no matter which Knative studio revision served the HTML. This makes the
+# multi-revision asset-404 class of bug impossible. CI uploads dist/_expo to the
+# bucket before patching the ksvc (see .github/workflows/deploy.yml).
+module "studio_web_assets" {
+  source = "../../modules/studio-web-assets"
+
+  compartment_id        = var.compartment_id
+  environment           = local.environment
+  oci_region            = var.region
+  cloudflare_zone_id    = var.cloudflare_zone_id
+  cloudflare_account_id = var.cloudflare_account_id
+  studio_host           = "studio.${local.domain}" # studio.staging.shogo.ai
+  tags                  = local.tags
+
+  # The lifecycle policy on the assets bucket relies on the tenancy-scoped
+  # object-storage service-principal IAM policy created by module.object_storage
+  # (lifecycle_service_policy_*). Order after it so that policy exists first.
+  depends_on = [module.object_storage]
+}
+
+# =============================================================================
 # Preview Router — preview routing without per-preview DNS records
 # =============================================================================
 # Staging mirror of the production-global preview-router so the Worker + KV +

--- a/terraform/modules/studio-web-assets/main.tf
+++ b/terraform/modules/studio-web-assets/main.tf
@@ -1,0 +1,264 @@
+# =============================================================================
+# Studio Web Assets Module - shared immutable asset origin (OCI + Cloudflare)
+# =============================================================================
+# Serves the studio web app's immutable, content-hashed Expo output
+# (`/_expo/*`) from a shared, append-only OCI Object Storage bucket, fronted
+# same-origin by a Cloudflare Worker on `studio.<env>.shogo.ai/_expo/*`.
+#
+# WHY THIS EXISTS
+# ---------------
+# The studio web app is an Expo "single"-output SPA whose hashed assets were
+# previously baked into each nginx pod image. Knative keeps multiple studio
+# revisions alive (min-scale + the `studio-direct` broad selector), so a page
+# load could get `index.html` from build A and then 404 on A's
+# `/_expo/.../index-<hashA>.js` because the asset request was load-balanced to
+# build B's pod, which only has B's hashes.
+#
+# Because the filenames are content-hashed they are globally unique, so
+# uploading every build's `_expo/*` into ONE append-only bucket lets
+# `index-<hashA>.js` and `index-<hashB>.js` coexist forever. This Worker serves
+# `/_expo/*` from that bucket regardless of which revision served the HTML,
+# which makes the multi-revision asset-404 class of bug impossible. It also
+# makes rollbacks and mid-deploy loads safe for free.
+#
+# CI (.github/workflows/deploy.yml, "Upload web static assets to CDN bucket")
+# uploads `dist/_expo` to this bucket BEFORE the ksvc is patched, using
+# `aws s3 cp --recursive` (re-PUTs the full current asset set each deploy) so
+# the age-based lifecycle GC below never reaps a still-referenced asset.
+# =============================================================================
+
+terraform {
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 8.0"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+}
+
+variable "compartment_id" {
+  description = "OCI compartment OCID for the assets bucket."
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (staging, production). Used in the bucket name and Worker name."
+  type        = string
+}
+
+variable "oci_region" {
+  description = "OCI region (e.g. us-ashburn-1). Used to build the PAR base URL."
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone id that hosts `studio_host` (the shogo.ai zone). The Worker route attaches here; the tf token needs Workers Routes:Edit on this zone. No DNS record is created - `studio_host` is managed out-of-band and only needs to be proxied for the route to match."
+  type        = string
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account id (for the Worker script)."
+  type        = string
+}
+
+variable "studio_host" {
+  description = "Fully-qualified studio hostname whose `/_expo/*` requests the Worker serves from the bucket (e.g. studio.staging.shogo.ai). Must be a proxied (orange-cloud) record in `cloudflare_zone_id`."
+  type        = string
+}
+
+variable "asset_max_age_days" {
+  description = "Age (days since object creation) after which an asset is deleted by the bucket lifecycle policy. Because CI re-PUTs the full current asset set each deploy, this reaps only assets no deploy has referenced for this many days. Keep comfortably larger than the longest expected gap between studio web deploys."
+  type        = number
+  default     = 30
+}
+
+variable "tags" {
+  description = "Freeform tags applied to the bucket."
+  type        = map(string)
+  default     = {}
+}
+
+# -----------------------------------------------------------------------------
+# Data sources
+# -----------------------------------------------------------------------------
+data "oci_objectstorage_namespace" "current" {
+  compartment_id = var.compartment_id
+}
+
+locals {
+  namespace   = data.oci_objectstorage_namespace.current.namespace
+  bucket_name = "shogo-web-assets-${var.environment}"
+
+  # PAR access_uri ends in `/o/`; strip trailing slashes in the Worker before
+  # concatenating the object key so we never emit a double slash (a leading `//`
+  # makes OCI parse the object name with a leading slash and 404 every asset).
+  par_base_url = "https://objectstorage.${var.oci_region}.oraclecloud.com${oci_objectstorage_preauthrequest.assets.access_uri}"
+}
+
+# -----------------------------------------------------------------------------
+# OCI Object Storage bucket - append-only, content-hashed studio assets
+# -----------------------------------------------------------------------------
+# Versioning is Disabled on purpose: keys are content-hashed, so a given key is
+# never meaningfully overwritten with different bytes (CI re-PUTs identical
+# bytes to refresh the object timestamp for lifecycle GC). New builds add new
+# keys; the lifecycle rule below bounds growth.
+resource "oci_objectstorage_bucket" "assets" {
+  compartment_id = var.compartment_id
+  namespace      = local.namespace
+  name           = local.bucket_name
+  access_type    = "NoPublicAccess"
+  versioning     = "Disabled"
+
+  freeform_tags = merge(var.tags, {
+    Purpose = "studio-web-immutable-assets"
+  })
+}
+
+# Reap assets no deploy has referenced for `asset_max_age_days`. Relies on the
+# tenancy-scoped `Allow service objectstorage-<region> to manage object-family`
+# IAM policy created by the object-storage module; wire this module with
+# `depends_on = [module.object_storage]` so that policy exists first.
+resource "oci_objectstorage_object_lifecycle_policy" "assets_lifecycle" {
+  namespace = local.namespace
+  bucket    = oci_objectstorage_bucket.assets.name
+
+  rules {
+    name        = "reap-unreferenced-assets"
+    action      = "DELETE"
+    time_amount = var.asset_max_age_days
+    time_unit   = "DAYS"
+    is_enabled  = true
+    target      = "objects"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Pre-authenticated request - read-only, non-listable bucket access for the edge
+# -----------------------------------------------------------------------------
+# Mirrors terraform/modules/publish-hosting-oci: AnyObjectRead + listing Deny is
+# equivalent to the old AnyObjectReadWithoutList. create_before_destroy keeps a
+# valid PAR referenced at all times (the Worker embeds this access_uri), and the
+# ignore_changes pins state against the provider's Read never repopulating
+# bucket_listing_action / the rolling time_expires.
+resource "oci_objectstorage_preauthrequest" "assets" {
+  namespace             = local.namespace
+  bucket                = oci_objectstorage_bucket.assets.name
+  name                  = "cloudflare-cdn-access"
+  access_type           = "AnyObjectRead"
+  bucket_listing_action = "Deny"
+  time_expires          = timeadd(timestamp(), "8760h") # 1 year
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [time_expires, bucket_listing_action]
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Cloudflare Worker - serve /_expo/* from the bucket, fall back to origin
+# -----------------------------------------------------------------------------
+resource "cloudflare_worker_script" "studio_assets" {
+  account_id = var.cloudflare_account_id
+  name       = "shogo-studio-assets-${var.environment}"
+  # ES-modules syntax (export default { fetch }). Without module=true the
+  # runtime rejects `export` with a SyntaxError at deploy time.
+  module = true
+
+  # NOTE: this HEREDOC is processed by Terraform, so the JS uses string
+  # concatenation and avoids JS template literals (which use ${...}).
+  content = <<-JS
+    // Trailing slashes trimmed so ORIGIN_BASE ends at `/o` and we join with a
+    // single `/` (a `//` would make OCI 404 the object).
+    const ORIGIN_BASE = '${local.par_base_url}'.replace(/\/+$/, '');
+
+    // Fall back to the studio origin for anything the bucket can't serve. This
+    // is a same-zone subrequest, so it BYPASSES this Worker (no self-loop) and
+    // hits Kourier -> the current studio pod, which still has this build's
+    // assets baked into its image. Tagged so we can see fallbacks in responses.
+    async function originFallback(request) {
+      const fallback = await fetch(request);
+      const headers = new Headers(fallback.headers);
+      headers.set('X-Shogo-Asset-Origin', 'origin-fallback');
+      return new Response(fallback.body, { status: fallback.status, headers: headers });
+    }
+
+    export default {
+      async fetch(request, env) {
+        // SAFETY: any unexpected error must fall back to the origin rather than
+        // surfacing a Worker 1101 — this Worker sits in the live path for every
+        // studio /_expo asset, so a throw here would blank the whole app.
+        try {
+          // Only GET/HEAD are cacheable static asset reads.
+          if (request.method !== 'GET' && request.method !== 'HEAD') {
+            return await originFallback(request);
+          }
+
+          const url = new URL(request.url);
+          // Object key mirrors the request path without its leading slash:
+          // `/_expo/static/js/web/index-x.js` -> `_expo/static/js/web/index-x.js`.
+          const key = url.pathname.replace(/^\/+/, '');
+          const originUrl = ORIGIN_BASE + '/' + key;
+
+          // Serve from the shared bucket, edge-cached aggressively (assets are
+          // content-hashed / immutable).
+          const fromBucket = await fetch(originUrl, {
+            headers: { 'User-Agent': 'Cloudflare-Worker-StudioAssets' },
+            cf: { cacheEverything: true, cacheTtl: 31536000 },
+          });
+
+          if (fromBucket.ok) {
+            const headers = new Headers(fromBucket.headers);
+            headers.set('Cache-Control', 'public, max-age=31536000, immutable');
+            headers.set('X-Shogo-Asset-Origin', 'bucket');
+            return new Response(fromBucket.body, {
+              status: fromBucket.status,
+              headers: headers,
+            });
+          }
+
+          // Bucket miss (e.g. an upload that lagged the ksvc patch).
+          return await originFallback(request);
+        } catch (e) {
+          // Network error / unexpected throw: never break the asset path.
+          try {
+            return await originFallback(request);
+          } catch (e2) {
+            return new Response('studio asset worker error', { status: 502 });
+          }
+        }
+      },
+    };
+  JS
+}
+
+# Route only `/_expo/*` on the studio host through the Worker. Everything else
+# (`/`, `/api/*`, WebSockets, `/vs/*`, favicon) keeps flowing to Kourier as
+# before. The route attaches to the zone regardless of who manages the DNS
+# record, as long as `studio_host` is proxied.
+resource "cloudflare_worker_route" "studio_assets" {
+  zone_id     = var.cloudflare_zone_id
+  pattern     = "${var.studio_host}/_expo/*"
+  script_name = cloudflare_worker_script.studio_assets.name
+}
+
+# -----------------------------------------------------------------------------
+# Outputs
+# -----------------------------------------------------------------------------
+output "bucket_name" {
+  description = "Name of the studio web assets bucket. Use as the `aws s3 cp` target in CI (s3://<bucket_name>/_expo/)."
+  value       = oci_objectstorage_bucket.assets.name
+}
+
+output "worker_name" {
+  description = "Cloudflare Worker script name serving studio /_expo/*."
+  value       = cloudflare_worker_script.studio_assets.name
+}
+
+output "worker_route_pattern" {
+  description = "Cloudflare Worker route pattern."
+  value       = cloudflare_worker_route.studio_assets.pattern
+}


### PR DESCRIPTION
## Summary
Makes the studio asset-404 bug class structurally impossible. Content-hashed `/_expo/*` assets are uploaded to an append-only OCI bucket and served same-origin by a Cloudflare Worker, so it no longer matters which Knative revision/pod served `index.html`. Deploy-time revision GC + a warm-pool monitor invariant keep `studio-direct` on a single build.

- `apps/mobile/Dockerfile`: add a `scratch` `web-assets` export stage (`dist/_expo`).
- `.github/workflows/deploy.yml`: upload `dist/_expo` to `shogo-web-assets-staging` (immutable cache, `cp --recursive` for lifecycle-safe refresh) before patching the studio ksvc; retire stale studio revisions once the new one is Ready. AWS CLI checksums forced to `WHEN_REQUIRED` (OCI S3 rejects `aws-chunked` PutObject).
- `terraform/modules/studio-web-assets`: OCI bucket + 30d lifecycle GC + read-only PAR + Cloudflare Worker/route for `studio.<env>.shogo.ai/_expo/*`, with origin fallback on bucket miss/error.
- `terraform/environments/staging`: wire the module (staging-first).
- `k8s/base/warm-pool-monitor.yaml`: alert if >1 studio revision has Ready pods.

## Deployed + validated on staging (from this branch)
- `terraform apply -target=module.studio_web_assets` (staging): 5 created, bucket+PAR+Worker+route live.
- Web deploy: 277 `_expo` objects uploaded (0 failures); ksvc patched; GC kept `studio-01296`, deleted `studio-01294/01295`.
- 25/25 loads of the live-referenced bundle return `200` with `x-shogo-asset-origin: bucket` + `Cache-Control: immutable`; CSS likewise. `studio-direct` endpoints resolve to a single revision.

## Merge note (state reconciliation)
Live staging TF state already contains `module.studio_web_assets` (applied from this branch). Merging reconciles `main` with that state; until merged, a staging `terraform apply` from `main` would plan to destroy the bucket/Worker/route.

## Test plan
- [ ] Confirm CI PR terraform plan (staging) shows `module.studio_web_assets` as no-op (state matches).
- [ ] After merge, a normal `main` staging deploy runs the upload + revision-GC steps.
- [ ] Follow-up: after a second bucket-backed build, roll studio back one build and confirm assets still resolve (append-only proof needs two builds in the bucket; only one exists today).

Made with [Cursor](https://cursor.com)