### PR TITLE
Hide Shogo IDE opener outside desktop

### DIFF
--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -2772,7 +2772,10 @@ export default observer(function ProjectLayout() {
             if (base) window.open(`${base}/`, '_blank', 'noopener,noreferrer')
           }
         : undefined,
-    onOpenCodeWorkbench: handleOpenCodeWorkbench,
+    onOpenCodeWorkbench:
+      Platform.OS === 'web' && typeof window !== 'undefined' && !!(window as any).shogoDesktop?.isDesktop
+        ? handleOpenCodeWorkbench
+        : undefined,
     ideEmbed: isIdeChatEmbed,
   }
 

--- a/apps/mobile/components/project/ProjectTopBar.tsx
+++ b/apps/mobile/components/project/ProjectTopBar.tsx
@@ -408,6 +408,11 @@ export function ProjectTopBar({
 
   const isCanvasActive = activeTab === 'canvas'
   const isIdeActive = activeTab === 'ide'
+  const canOpenCodeWorkbench =
+    Platform.OS === 'web' &&
+    typeof window !== 'undefined' &&
+    !!(window as unknown as { shogoDesktop?: { isDesktop?: boolean } }).shogoDesktop?.isDesktop &&
+    !!onOpenCodeWorkbench
 
   // Workspace Trust badge: external (folder-linked) projects only, and
   // only when the parent wired up a toggle handler + a known trust level.
@@ -927,7 +932,7 @@ export function ProjectTopBar({
               busy={trustBusy}
             />
           )}
-          {isIdeActive && onOpenCodeWorkbench && (
+          {isIdeActive && canOpenCodeWorkbench && (
             <Pressable
               onPress={onOpenCodeWorkbench}
               className="h-8 flex-row items-center gap-1.5 rounded-lg border border-orange-500/40 bg-orange-500/10 px-3 active:bg-orange-500/15"


### PR DESCRIPTION

<img width="1512" height="982" alt="Screenshot 2026-07-07 at 12 02 27 PM" src="https://github.com/user-attachments/assets/704ba8a4-f69e-41c7-8f39-9779d26ab6b6" />
<img width="1512" height="982" alt="Screenshot 2026-07-07 at 12 12 33 PM" src="https://github.com/user-attachments/assets/412bea65-f83d-43ca-bfcf-6b7e26dfebd5" />
## Summary

This draft PR fixes the visibility of the `Open in Shogo IDE` action so it is only shown inside the Shogo Desktop application and not in Shogo Web or mobile contexts.

The action is desktop-specific because it depends on the Shogo Desktop shell/bridge to open the local code workbench. Showing it in browser-based Shogo Web creates an incorrect affordance and suggests functionality that should not be available outside desktop.

Closes #809.

## Root cause

The top bar could render the `Open in Shogo IDE` button based primarily on whether an `onOpenCodeWorkbench` handler was provided while the active tab was `ide`. That meant a non-desktop surface could still display the button if the handler was passed through from a parent.

This made the UI contract too dependent on parent-level filtering and allowed a desktop-only action to leak into Shogo Web.

## Implementation details

Updated `apps/mobile/components/project/ProjectTopBar.tsx` to add a defensive render gate close to the button rendering logic.

The button now renders only when all required conditions are true:

- The active project tab is `ide`.
- The current platform is web-rendered UI.
- The runtime is explicitly Shogo Desktop via `window.shogoDesktop?.isDesktop === true`.
- `onOpenCodeWorkbench` is present.

This ensures the component itself enforces the desktop-only contract, even if a parent component accidentally passes the handler in Shogo Web or another non-desktop context.

## User-facing behavior

### Shogo Desktop

- `Open in Shogo IDE` remains available where expected.
- Desktop users can still open the local code workbench from the IDE tab.

### Shogo Web

- `Open in Shogo IDE` is no longer visible.
- Users are not shown a desktop-only action in the browser.

### Mobile/native

- The action remains hidden and unavailable.

## Validation

Local validation performed on the branch:

- `git diff --check` passed.
- Existing mobile RTL smoke test passed:
  - 2 passing tests
  - 0 failing tests

## Notes for reviewers

This PR intentionally keeps the change small and scoped to the rendering guard. It does not alter the desktop bridge, project routing, workspace startup behavior, or any backend APIs.
