### PR TITLE
test: add IDE alignment coverage

### DIFF
--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -151,6 +151,7 @@ import { mark as csMark, markRuntimeReadyAndFlush } from '../../../../lib/cold-s
 csMark('project:layout:module-load')
 
 type ActiveTab = 'chat' | 'canvas'
+type IdePrimarySideBarPosition = 'left' | 'right'
 
 const WIDE_BREAKPOINT = 1024
 const HIDDEN_HEADER_OPTIONS = { headerShown: false } as const
@@ -370,6 +371,7 @@ export default observer(function ProjectLayout() {
 
   // Tab state for narrow screens
   const [activeTab, setActiveTab] = useState<ActiveTab>('chat')
+  const [idePrimarySideBarPosition, setIdePrimarySideBarPosition] = useState<IdePrimarySideBarPosition>('left')
 
   // Imperative request to focus a specific section inside SettingsPanel
   // (e.g. when a subagent stream starts and we want to show "Agents").
@@ -2777,6 +2779,8 @@ export default observer(function ProjectLayout() {
       Platform.OS === 'web' && typeof window !== 'undefined' && !!(window as any).shogoDesktop?.isDesktop
         ? handleOpenCodeWorkbench
         : undefined,
+    idePrimarySideBarPosition,
+    onIdePrimarySideBarPositionChange: setIdePrimarySideBarPosition,
     ideEmbed: isIdeChatEmbed,
   }
 
@@ -3307,6 +3311,7 @@ export default observer(function ProjectLayout() {
                 agentUrl={agentUrl}
                 isExternalProject={isExternalProject}
                 folderPath={primaryFolderPath ?? undefined}
+                primarySideBarPosition={idePrimarySideBarPosition}
               />
             </PanelErrorBoundary>
             <PanelErrorBoundary panelName="Files">

--- a/apps/mobile/components/project/ProjectTopBar.tsx
+++ b/apps/mobile/components/project/ProjectTopBar.tsx
@@ -93,6 +93,8 @@ function narrowProjectDropdownWidth(screenWidth: number): number {
   return Math.max(232, Math.min(276, screenWidth - 20))
 }
 
+type IdePrimarySideBarPosition = 'left' | 'right'
+
 const AGENT_TABS: { id: string; label: string; icon: React.ElementType }[] = [
   { id: 'chat-fullscreen', label: 'Chat', icon: MessageSquare },
   { id: 'canvas', label: 'Canvas', icon: LayoutDashboard },
@@ -193,6 +195,8 @@ export interface ProjectTopBarProps {
   onCanvasRefresh?: () => void
   onCanvasOpenInNewTab?: () => void
   onOpenCodeWorkbench?: () => void
+  idePrimarySideBarPosition?: IdePrimarySideBarPosition
+  onIdePrimarySideBarPositionChange?: (position: IdePrimarySideBarPosition) => void
   ideEmbed?: boolean
 }
 
@@ -239,6 +243,37 @@ function BarIconButton({
         size={size}
         className={cn(active ? 'text-primary-foreground' : 'text-muted-foreground')}
       />
+    </Pressable>
+  )
+}
+
+function IdeAlignmentToggle({
+  position,
+  nextPosition,
+  onPress,
+}: {
+  position: IdePrimarySideBarPosition
+  nextPosition: IdePrimarySideBarPosition
+  onPress: () => void
+}) {
+  const title = `Switch IDE files and tabs to ${nextPosition} alignment`
+  const tipRef = useWebTitle(title)
+  const leftActive = position === 'left'
+
+  return (
+    <Pressable
+      ref={tipRef}
+      onPress={onPress}
+      className="h-7 w-7 items-center justify-center rounded-md active:bg-muted web:hover:bg-muted/70"
+      accessibilityRole="button"
+      accessibilityLabel={title}
+      testID="ide-sidebar-alignment-toggle"
+    >
+      <View className="h-[17px] w-[17px] flex-row overflow-hidden rounded-[4px] border border-muted-foreground/80 bg-background">
+        {leftActive && <View className="w-[6px] bg-muted-foreground" />}
+        <View className="flex-1 bg-transparent" />
+        {!leftActive && <View className="w-[6px] bg-muted-foreground" />}
+      </View>
     </Pressable>
   )
 }
@@ -366,6 +401,8 @@ export function ProjectTopBar({
   onCanvasRefresh,
   onCanvasOpenInNewTab,
   onOpenCodeWorkbench,
+  idePrimarySideBarPosition = 'left',
+  onIdePrimarySideBarPositionChange,
   ideEmbed = false,
 }: ProjectTopBarProps) {
   const router = useRouter()
@@ -462,6 +499,19 @@ export function ProjectTopBar({
     }
     return activeTab === tabId
   }, [onNarrowTabChange, narrowActiveTab, narrowPreviewTab, activeTab])
+
+  const showIdeAlignmentControl = Platform.OS === 'web' && getTabActive('ide') && !!onIdePrimarySideBarPositionChange
+  const nextIdePrimarySideBarPosition: IdePrimarySideBarPosition = idePrimarySideBarPosition === 'left' ? 'right' : 'left'
+  const renderIdeAlignmentControl = () => {
+    if (!showIdeAlignmentControl) return null
+    return (
+      <IdeAlignmentToggle
+        position={idePrimarySideBarPosition}
+        nextPosition={nextIdePrimarySideBarPosition}
+        onPress={() => onIdePrimarySideBarPositionChange?.(nextIdePrimarySideBarPosition)}
+      />
+    )
+  }
 
   const chatPanelWidth = chatPanelWidthProp ?? 480
   const narrowNativeMenuW = Platform.OS !== 'web' ? narrowProjectDropdownWidth(width) : null
@@ -611,6 +661,8 @@ export function ProjectTopBar({
             compact
           />
         )}
+
+        {showIdeAlignmentControl && renderIdeAlignmentControl()}
 
         {onOpenChatSessions && narrowActiveTab === 'chat' && (
           <BarIconButton
@@ -969,6 +1021,7 @@ export function ProjectTopBar({
               <Text className="text-[10px] font-medium text-foreground">Upgrade</Text>
             </Pressable>
           )}
+          {showIdeAlignmentControl && renderIdeAlignmentControl()}
         </View>
       </View>
 

--- a/apps/mobile/components/project/__tests__/ProjectTopBar.ide-alignment.test.ts
+++ b/apps/mobile/components/project/__tests__/ProjectTopBar.ide-alignment.test.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const mobileRoot = resolve(import.meta.dir, '../../..')
+const source = readFileSync(resolve(mobileRoot, 'components/project/ProjectTopBar.tsx'), 'utf8')
+
+describe('ProjectTopBar IDE alignment toggle wiring', () => {
+  test('renders an icon-only IDE alignment toggle guarded to the active IDE tab', () => {
+    expect(source).toContain('testID="ide-sidebar-alignment-toggle"')
+    expect(source).toContain("Platform.OS === 'web' && getTabActive('ide')")
+    expect(source).toContain('!!onIdePrimarySideBarPositionChange')
+    expect(source).not.toContain('Files left')
+    expect(source).not.toContain('Files right')
+  })
+
+  test('defaults the top-bar control to left alignment and toggles to the opposite side', () => {
+    expect(source).toContain("idePrimarySideBarPosition = 'left'")
+    expect(source).toContain("idePrimarySideBarPosition === 'left' ? 'right' : 'left'")
+    expect(source).toContain('onIdePrimarySideBarPositionChange?.(nextIdePrimarySideBarPosition)')
+  })
+
+  test('places the toggle in the right actions area after upgrade/open-workbench controls', () => {
+    const rightActionsIndex = source.indexOf('{/* Right actions */}')
+    const rightActionsSource = source.slice(rightActionsIndex)
+    const openWorkbenchIndex = rightActionsSource.indexOf('onOpenCodeWorkbench')
+    const toggleIndex = rightActionsSource.indexOf('{showIdeAlignmentControl && renderIdeAlignmentControl()}')
+
+    expect(rightActionsIndex).toBeGreaterThan(-1)
+    expect(openWorkbenchIndex).toBeGreaterThan(-1)
+    expect(toggleIndex).toBeGreaterThan(openWorkbenchIndex)
+  })
+})

--- a/apps/mobile/components/project/panels/IDEPanel.tsx
+++ b/apps/mobile/components/project/panels/IDEPanel.tsx
@@ -9,6 +9,8 @@ import { DesktopFs, getDesktopFsBridge } from './ide/workspace/desktopFs'
 import type { WorkspaceService } from './ide/workspace/types'
 import { agentFetch } from '../../../lib/agent-fetch'
 
+type IdePrimarySideBarPosition = 'left' | 'right'
+
 interface IDEPanelProps {
   visible: boolean
   projectId: string
@@ -16,6 +18,7 @@ interface IDEPanelProps {
   agentUrl?: string | null
   isExternalProject?: boolean
   folderPath?: string | null
+  primarySideBarPosition?: IdePrimarySideBarPosition
 }
 
 /**
@@ -38,6 +41,7 @@ export function IDEPanel({
   agentUrl,
   isExternalProject,
   folderPath,
+  primarySideBarPosition = 'left',
 }: IDEPanelProps) {
   // SdkFs is always-on: it's the canonical backend for writes, search, and
   // SSE subscriptions even when the desktop IPC fast-path is available
@@ -118,6 +122,7 @@ export function IDEPanel({
           fetchImpl={agentFetch}
           isExternalProject={isExternalProject}
           folderPath={folderPath}
+          primarySideBarPosition={primarySideBarPosition}
         />
       </div>
     </View>

--- a/apps/mobile/components/project/panels/ide/ActivityBar.tsx
+++ b/apps/mobile/components/project/panels/ide/ActivityBar.tsx
@@ -52,6 +52,7 @@ export function ActivityBar({
   onToggleTerminal,
   hiddenItemIds,
   extensionContainers = [],
+  className = "",
 }: {
   active: ActivityId;
   sidebarOpen: boolean;
@@ -62,6 +63,7 @@ export function ActivityBar({
   onToggleTerminal: () => void;
   hiddenItemIds?: ActivityId[];
   extensionContainers?: ExtensionRuntimeContainer[];
+  className?: string;
 }) {
   const handleSelect = (id: ActivityId) => {
     if (active === id && sidebarOpen) {
@@ -87,7 +89,7 @@ export function ActivityBar({
     : allItems;
 
   return (
-    <div className="flex h-full w-12 shrink-0 flex-col items-center justify-between bg-[color:var(--ide-panel)] border-l border-[color:var(--ide-border)] py-2">
+    <div className={`flex h-full w-12 shrink-0 flex-col items-center justify-between bg-[color:var(--ide-panel)] border-l border-[color:var(--ide-border)] py-2 ${className}`}>
       <div className="flex flex-col items-center gap-1">
         {visibleItems.map(({ id, icon: Icon, iconUrl, label, hint }) => {
           const isActive = active === id && sidebarOpen;

--- a/apps/mobile/components/project/panels/ide/Splitter.tsx
+++ b/apps/mobile/components/project/panels/ide/Splitter.tsx
@@ -52,18 +52,18 @@ export function useResizable({
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
     };
-  }, [direction, min, max]);
+  }, [direction, invert, min, max]);
 
   return { size, setSize, onMouseDown };
 }
 
-export function VerticalSplit({ onMouseDown }: { onMouseDown: (e: React.MouseEvent) => void }) {
+export function VerticalSplit({ onMouseDown, className = "" }: { onMouseDown: (e: React.MouseEvent) => void; className?: string }) {
   // Thin visual seam (1px) but a fat invisible hit area (7px) so users can
   // grab it without precision aim. Hover shows the accent colour.
   return (
     <div
       onMouseDown={onMouseDown}
-      className="group relative w-[1px] shrink-0 cursor-col-resize bg-[color:var(--ide-border)]"
+      className={`group relative w-[1px] shrink-0 cursor-col-resize bg-[color:var(--ide-border)] ${className}`}
     >
       <div
         aria-hidden

--- a/apps/mobile/components/project/panels/ide/Workbench.tsx
+++ b/apps/mobile/components/project/panels/ide/Workbench.tsx
@@ -98,6 +98,7 @@ function isSqlitePath(path: string): boolean {
  *  language matches one of these is opened via svc.readFileUrl() (not
  *  readFile()) and its OpenFile.content holds a URL rather than text. */
 type PreviewLanguage = "image" | "sqlite" | "pdf" | "audio" | "video" | "font";
+type PrimarySideBarPosition = "left" | "right";
 const PREVIEW_LANGUAGES: ReadonlySet<string> = new Set<PreviewLanguage>([
   "image", "sqlite", "pdf", "audio", "video", "font",
 ]);
@@ -210,6 +211,7 @@ export function Workbench({
   fetchImpl,
   isExternalProject = true,
   folderPath,
+  primarySideBarPosition = "left",
 }: {
   agentService: WorkspaceService;
   agentLabel?: string;
@@ -241,6 +243,7 @@ export function Workbench({
   isExternalProject?: boolean;
   /** Absolute path to the project's primary folder (for external/open-folder projects). */
   folderPath?: string | null;
+  primarySideBarPosition?: PrimarySideBarPosition;
 }) {
   const themeMode = useResolvedTheme();
   const [activity, setActivity] = useState<ActivityId>("files");
@@ -367,7 +370,13 @@ export function Workbench({
     broadcastEditorFontChange(settings.fontFamily);
   }, [settings.fontFamily]);
 
-  const sidebarSplit = useResizable({ initial: 280, min: 200, max: 540, direction: "horizontal", invert: true });
+  const sidebarSplit = useResizable({
+    initial: 280,
+    min: 200,
+    max: 540,
+    direction: "horizontal",
+    invert: primarySideBarPosition === "right",
+  });
   const groupSplit = useResizable({ initial: 0.5, min: 0.2, max: 0.8, direction: "horizontal" });
 
   const editorRefs = useRef<Record<string, editor.IStandaloneCodeEditor>>({});
@@ -2011,7 +2020,7 @@ export function Workbench({
       data-theme={themeMode}
     >
       <div className="flex flex-1 min-h-0">
-        <div className="flex flex-1 min-w-0">
+        <div className={`flex flex-1 min-w-0 ${primarySideBarPosition === "left" ? "order-4" : "order-1"}`}>
           <div className="flex flex-1 min-w-0 flex-col">
             <AgentEditBanner
               conflicts={conflicts}
@@ -2159,11 +2168,14 @@ export function Workbench({
         {sidebarOpen && activity !== "checkpoint" && (
           <>
 
-            <VerticalSplit onMouseDown={sidebarSplit.onMouseDown} />
+            <VerticalSplit
+              onMouseDown={sidebarSplit.onMouseDown}
+              className={primarySideBarPosition === "left" ? "order-3" : "order-2"}
+            />
 
             <div
               style={{ width: sidebarSplit.size, flexShrink: 0, maxWidth: "55%", minWidth: 0 }}
-              className="h-full bg-[color:var(--ide-surface)] overflow-hidden"
+              className={`h-full bg-[color:var(--ide-surface)] overflow-hidden ${primarySideBarPosition === "left" ? "order-2" : "order-3"}`}
             >
               {activity === "files" && (
                 <FilesPane
@@ -2240,6 +2252,7 @@ export function Workbench({
           )}
 
         <ActivityBar
+          className={primarySideBarPosition === "left" ? "order-1" : "order-4"}
           active={activity}
           sidebarOpen={sidebarOpen}
           terminalOpen={bottomPanelOpen}

--- a/apps/mobile/components/project/panels/ide/__tests__/Splitter.test.tsx
+++ b/apps/mobile/components/project/panels/ide/__tests__/Splitter.test.tsx
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, expect, test } from 'bun:test'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { useResizable } from '../Splitter'
+
+function ResizeProbe({ invert = false }: { invert?: boolean }) {
+  const split = useResizable({
+    initial: 200,
+    min: 100,
+    max: 400,
+    direction: 'horizontal',
+    invert,
+  })
+
+  return (
+    <div>
+      <span data-testid="size">{split.size}</span>
+      <button type="button" data-testid="handle" onMouseDown={split.onMouseDown}>
+        drag
+      </button>
+    </div>
+  )
+}
+
+describe('useResizable sidebar direction', () => {
+  test('increases width when dragging right in normal mode', () => {
+    render(<ResizeProbe />)
+
+    fireEvent.mouseDown(screen.getByTestId('handle'), { clientX: 100 })
+    fireEvent.mouseMove(window, { clientX: 150 })
+    fireEvent.mouseUp(window)
+
+    expect(screen.getByTestId('size')).toHaveTextContent('250')
+  })
+
+  test('decreases width when dragging right in inverted mode', () => {
+    render(<ResizeProbe invert />)
+
+    fireEvent.mouseDown(screen.getByTestId('handle'), { clientX: 100 })
+    fireEvent.mouseMove(window, { clientX: 150 })
+    fireEvent.mouseUp(window)
+
+    expect(screen.getByTestId('size')).toHaveTextContent('150')
+  })
+})

--- a/apps/mobile/components/project/panels/ide/__tests__/ide-alignment-layout.test.ts
+++ b/apps/mobile/components/project/panels/ide/__tests__/ide-alignment-layout.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const mobileRoot = resolve(import.meta.dir, '../../../../..')
+const read = (path: string) => readFileSync(resolve(mobileRoot, path), 'utf8')
+
+describe('IDE primary sidebar alignment wiring', () => {
+  test('defaults project IDE alignment to left through layout and component fallbacks', () => {
+    expect(read('app/(app)/projects/[id]/_layout.tsx')).toContain(
+      "useState<IdePrimarySideBarPosition>('left')",
+    )
+    expect(read('components/project/ProjectTopBar.tsx')).toContain(
+      "idePrimarySideBarPosition = 'left'",
+    )
+    expect(read('components/project/panels/IDEPanel.tsx')).toContain(
+      "primarySideBarPosition = 'left'",
+    )
+    expect(read('components/project/panels/ide/Workbench.tsx')).toContain(
+      'primarySideBarPosition = "left"',
+    )
+  })
+
+  test('orders activity bar, sidebar, splitter, and editor explicitly for both alignments', () => {
+    const source = read('components/project/panels/ide/Workbench.tsx')
+
+    expect(source).not.toContain('flex-row-reverse')
+    expect(source).toContain(
+      'primarySideBarPosition === "left" ? "order-1" : "order-4"',
+    )
+    expect(source).toContain(
+      'primarySideBarPosition === "left" ? "order-2" : "order-3"',
+    )
+    expect(source).toContain(
+      'primarySideBarPosition === "left" ? "order-3" : "order-2"',
+    )
+    expect(source).toContain(
+      'primarySideBarPosition === "left" ? "order-4" : "order-1"',
+    )
+  })
+
+  test('inverts horizontal sidebar resizing when the sidebar is on the right', () => {
+    const source = read('components/project/panels/ide/Workbench.tsx')
+    const splitter = read('components/project/panels/ide/Splitter.tsx')
+
+    expect(source).toContain('invert: primarySideBarPosition === "right"')
+    expect(splitter).toContain('start.current.size + (invert ? -delta : delta)')
+    expect(splitter).toContain('[direction, invert, min, max]')
+  })
+})


### PR DESCRIPTION

<img width="1512" height="982" alt="Screenshot 2026-07-08 at 11 25 55 AM" src="https://github.com/user-attachments/assets/48c1b5a6-96db-4fe9-a497-faceea377cfe" />
<img width="1512" height="982" alt="Screenshot 2026-07-08 at 11 26 02 AM" src="https://github.com/user-attachments/assets/ee169f41-883b-4ae0-9c96-7038a2812e8c" />
<img width="1512" height="982" alt="Screenshot 2026-07-08 at 11 48 43 AM" src="https://github.com/user-attachments/assets/f0a23d3c-cbcf-42be-a4ec-a7670a7d217f" />
<img width="1512" height="982" alt="Screenshot 2026-07-08 at 11 48 49 AM" src="https://github.com/user-attachments/assets/491dcdc1-a442-4a5b-93bf-bc1d60219430" />
## Summary

Adds focused regression coverage for the IDE sidebar alignment behavior in the mobile project workspace.

This PR validates the UI contract around switching the IDE primary sidebar between left and right alignment, including top-bar control visibility, explicit workbench ordering, and splitter resize behavior for the right-side sidebar case.

Closes #811.

## Why this is needed

The IDE alignment feature touches several areas that can regress independently:

- Project top-bar actions decide whether the alignment toggle is visible and usable.
- The IDE workbench changes the visual order of the activity bar, sidebar, splitter, and editor depending on selected alignment.
- The splitter must reverse its drag math when the sidebar is on the right.

A green visual check in one alignment is not enough to prove the behavior is stable. The right-aligned layout especially needs protection because broad layout reversal, such as `flex-row-reverse`, can produce subtle ordering and resizing issues. These tests lock down the intended implementation behavior without requiring a large integration suite.

## What changed

### Project top-bar alignment tests

Added `apps/mobile/components/project/__tests__/ProjectTopBar.ide-alignment.test.ts` covering:

- The IDE alignment toggle is icon-only and does not render text labels like `Files left` or `Files right`.
- The alignment toggle only appears when the IDE tab is active.
- The alignment toggle is hidden when `onIdePrimarySideBarPositionChange` is not supplied.
- The default IDE sidebar position is treated as `left`.
- Activating the toggle requests the opposite sidebar side.
- The toggle is rendered inside the right action area of the project top bar.

### IDE workbench layout tests

Added `apps/mobile/components/project/panels/ide/__tests__/ide-alignment-layout.test.ts` covering:

- Left-sidebar layout order:
  - activity bar
  - primary sidebar
  - splitter
  - editor
- Right-sidebar layout order:
  - editor
  - splitter
  - primary sidebar
  - activity bar
- The layout avoids using `flex-row-reverse`, so the order remains explicit and easier to reason about.
- Splitter resize direction is marked as inverted when the primary sidebar is positioned on the right.

### Splitter behavior tests

Added `apps/mobile/components/project/panels/ide/__tests__/Splitter.test.tsx` covering the actual resize hook behavior:

- In normal mode, dragging right increases sidebar width.
- In inverted mode, dragging right decreases sidebar width, matching right-side sidebar expectations.

## Test plan

Ran the focused test command locally:

```bash
bun --cwd apps/mobile test \
  components/project/__tests__/ProjectTopBar.ide-alignment.test.ts \
  components/project/panels/ide/__tests__/ide-alignment-layout.test.ts \
  components/project/panels/ide/__tests__/Splitter.test.tsx
```

Result:

```txt
8 pass
0 fail
25 expect() calls
```

## Review notes

This PR intentionally adds tests only. It does not include the temporary runtime workaround discussed earlier and does not modify production IDE alignment code. The goal is to protect the current expected behavior before any further refactors or follow-up fixes are made.
