### PR TITLE
fix(mobile): stream Android project downloads

### DIFF
--- a/apps/api/src/routes/project-export-import.ts
+++ b/apps/api/src/routes/project-export-import.ts
@@ -129,6 +129,13 @@ const BUNDLE_FORMAT_VERSION = '1.1'
 const SUPPORTED_BUNDLE_VERSIONS = new Set(['1.0', '1.1'])
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10 MB per file (export-only)
+const MAX_EXPORT_FILE_COUNT = Number(process.env.PROJECT_EXPORT_MAX_FILES ?? 10_000)
+const MAX_SOURCE_EXPORT_TOTAL_BYTES = Number(
+  process.env.PROJECT_SOURCE_EXPORT_MAX_BYTES ?? 250 * 1024 * 1024,
+)
+const MAX_BUNDLE_EXPORT_TOTAL_BYTES = Number(
+  process.env.PROJECT_BUNDLE_EXPORT_MAX_BYTES ?? 500 * 1024 * 1024,
+)
 // Total import bundle caps, gated by plan tier. Pro+ (pro/business/enterprise)
 // may import large projects; Free/Basic are limited to a much smaller bundle.
 const MAX_TOTAL_SIZE_PRO = 500 * 1024 * 1024 // 500 MB total bundle (pro+)
@@ -149,6 +156,65 @@ const SECRET_KEY_PATTERN =
   /token|secret|apikey|api_key|password|passwd|(^|_)pat$|webhook.*url|bearer|client[_-]?secret|refresh[_-]?token|access[_-]?token|database[_-]?url|redis[_-]?url|mongo[_-]?url|connection[_-]?string|private[_-]?key|ssh[_-]?key|signing[_-]?secret|encryption[_-]?key|\.pem$/i
 
 const isSecretKey = (key: string): boolean => SECRET_KEY_PATTERN.test(key)
+
+interface ExportStats {
+  fileCount: number
+  totalBytes: number
+}
+
+function getExportStats(files: Record<string, Uint8Array>): ExportStats {
+  let totalBytes = 0
+  let fileCount = 0
+  for (const data of Object.values(files)) {
+    fileCount++
+    totalBytes += data.byteLength
+  }
+  return { fileCount, totalBytes }
+}
+
+function rejectExportIfTooLarge(
+  projectId: string,
+  kind: 'source' | 'bundle',
+  stats: ExportStats,
+): Response | null {
+  const maxBytes = kind === 'source'
+    ? MAX_SOURCE_EXPORT_TOTAL_BYTES
+    : MAX_BUNDLE_EXPORT_TOTAL_BYTES
+
+  if (stats.fileCount > MAX_EXPORT_FILE_COUNT) {
+    console.warn('[ProjectExport] rejected file-count limit', {
+      projectId,
+      kind,
+      fileCount: stats.fileCount,
+      maxFiles: MAX_EXPORT_FILE_COUNT,
+      totalBytes: stats.totalBytes,
+    })
+    return Response.json(
+      {
+        error: `Project export has ${stats.fileCount} files, above the ${MAX_EXPORT_FILE_COUNT} file limit.`,
+      },
+      { status: 413 },
+    )
+  }
+
+  if (stats.totalBytes > maxBytes) {
+    console.warn('[ProjectExport] rejected byte limit', {
+      projectId,
+      kind,
+      fileCount: stats.fileCount,
+      totalBytes: stats.totalBytes,
+      maxBytes,
+    })
+    return Response.json(
+      {
+        error: `Project export is ${Math.ceil(stats.totalBytes / 1024 / 1024)} MB, above the ${Math.floor(maxBytes / 1024 / 1024)} MB limit.`,
+      },
+      { status: 413 },
+    )
+  }
+
+  return null
+}
 
 interface RequiredCredential {
   channel: string
@@ -994,13 +1060,17 @@ export function projectExportImportRoutes() {
     // /agent/workspace/bundle) where the old `GET /download` tar.gz route 404s.
     if (sourceOnly) {
       const BUILD_DIRS = new Set(['dist', 'build'])
-      const { files } = await collectExportWorkspaceFiles(projectId, {
+      const { files, sourceMode, fileSkipped } = await collectExportWorkspaceFiles(projectId, {
         extraExcludedDirs: BUILD_DIRS,
       })
       const sourceZip: Record<string, Uint8Array> = {}
       for (const [relPath, data] of Object.entries(files)) {
         sourceZip[relPath] = data
       }
+      const sourceStats = getExportStats(sourceZip)
+      const sourceLimitResponse = rejectExportIfTooLarge(projectId, 'source', sourceStats)
+      if (sourceLimitResponse) return sourceLimitResponse
+
       // Always ship a valid, non-empty archive (e.g. cold-starting pod / empty
       // workspace) so the client download never yields a 0-entry zip.
       if (Object.keys(sourceZip).length === 0) {
@@ -1009,6 +1079,14 @@ export function projectExportImportRoutes() {
         )
       }
       const zippedSource = zipSync(sourceZip, { level: 6 })
+      console.info('[ProjectExport] source export completed', {
+        projectId,
+        sourceMode,
+        fileCount: sourceStats.fileCount,
+        totalBytes: sourceStats.totalBytes,
+        zippedBytes: zippedSource.byteLength,
+        skippedCount: fileSkipped.length,
+      })
       const sourceName =
         project.name.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 60) || 'project'
       const sourceBody = zippedSource.buffer.slice(
@@ -1020,6 +1098,9 @@ export function projectExportImportRoutes() {
           'Content-Type': 'application/zip',
           'Content-Disposition': `attachment; filename="${sourceName}.zip"`,
           'Content-Length': String(zippedSource.byteLength),
+          'X-Export-File-Count': String(sourceStats.fileCount),
+          'X-Export-Uncompressed-Bytes': String(sourceStats.totalBytes),
+          'X-Export-Source-Mode': sourceMode,
         },
       })
     }
@@ -1265,6 +1346,10 @@ export function projectExportImportRoutes() {
       inventory[top] = (inventory[top] || 0) + 1
     }
 
+    const bundleStatsBeforeManifest = getExportStats(zipContents)
+    const bundleLimitResponse = rejectExportIfTooLarge(projectId, 'bundle', bundleStatsBeforeManifest)
+    if (bundleLimitResponse) return bundleLimitResponse
+
     const manifest = {
       bundleVersion: BUNDLE_FORMAT_VERSION,
       generatedAt: new Date().toISOString(),
@@ -1291,6 +1376,16 @@ export function projectExportImportRoutes() {
     const zipped = passwordProtect
       ? await encryptZipCrypto(zipContents, password)
       : zipSync(zipContents, { level: 6 })
+    console.info('[ProjectExport] bundle export completed', {
+      projectId,
+      sourceMode,
+      fileCount: bundleStatsBeforeManifest.fileCount + 1,
+      totalBytes: bundleStatsBeforeManifest.totalBytes + zipContents['manifest.json'].byteLength,
+      zippedBytes: zipped.byteLength,
+      skippedCount: fileSkipped.length,
+      includeChats,
+      passwordProtected: passwordProtect,
+    })
 
     const safeName = project.name.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 60)
     const filename = `${safeName}.shogo`
@@ -1301,6 +1396,11 @@ export function projectExportImportRoutes() {
         'Content-Type': 'application/zip',
         'Content-Disposition': `attachment; filename="${filename}"`,
         'Content-Length': String(zipped.byteLength),
+        'X-Export-File-Count': String(bundleStatsBeforeManifest.fileCount + 1),
+        'X-Export-Uncompressed-Bytes': String(
+          bundleStatsBeforeManifest.totalBytes + zipContents['manifest.json'].byteLength,
+        ),
+        'X-Export-Source-Mode': sourceMode,
       },
     })
   })

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -3519,6 +3519,29 @@ app.get('/api/projects/:projectId/download', async (c) => {
   return app.fetch(exportReq)
 })
 
+// Native clients need a GET URL for file-system streaming downloads. This route
+// keeps passwords out of URLs by supporting only unencrypted `.shogo` exports;
+// password-protected mobile exports need a separate token/job contract.
+app.get('/api/projects/:projectId/export-file', async (c) => {
+  const projectId = c.req.param('projectId')
+  const includeChats = c.req.query('includeChats') !== 'false'
+
+  const url = new URL(c.req.url)
+  url.pathname = `/api/projects/${projectId}/export`
+  url.search = ''
+
+  const headers = new Headers(c.req.raw.headers)
+  headers.set('content-type', 'application/json')
+
+  const exportReq = new Request(url.toString(), {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ includeChats }),
+  })
+
+  return app.fetch(exportReq)
+})
+
 // =============================================================================
 // S3 Files routes - Project file listing and access via S3 pre-signed URLs
 // =============================================================================

--- a/apps/mobile/components/chat/turns/DownloadChip.tsx
+++ b/apps/mobile/components/chat/turns/DownloadChip.tsx
@@ -25,7 +25,7 @@ import {
 } from "react-native"
 import { cn } from "@shogo/shared-ui/primitives"
 import { Download } from "lucide-react-native"
-import { agentFetch } from "../../../lib/agent-fetch"
+import { agentFetch, getNativeAgentAuthHeaders } from "../../../lib/agent-fetch"
 
 export interface DownloadChipProps {
   /** Workspace-relative path of the deliverable file (e.g. `report.pptx`). */
@@ -45,17 +45,6 @@ function buildDownloadUrl(agentUrl: string, path: string): string {
     .map((seg) => encodeURIComponent(seg))
     .join("/")
   return `${agentUrl.replace(/\/$/, "")}/agent/workspace/download/${encoded}`
-}
-
-function arrayBufferToBase64(buffer: ArrayBuffer): string {
-  const bytes = new Uint8Array(buffer)
-  let binary = ""
-  // Chunk to avoid `String.fromCharCode(...hugeArray)` stack overflows.
-  const CHUNK = 0x8000
-  for (let i = 0; i < bytes.length; i += CHUNK) {
-    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK))
-  }
-  return btoa(binary)
 }
 
 export function DownloadChip({ path, agentUrl, className }: DownloadChipProps) {
@@ -80,21 +69,22 @@ export function DownloadChip({ path, agentUrl, className }: DownloadChipProps) {
       return
     }
 
-    // Native: fetch (with auth), write to app storage, present share sheet.
+    // Native: stream to app storage with auth, then present share sheet.
     setBusy(true)
     try {
-      const res = await agentFetch(url)
-      if (!res.ok) throw new Error(`Download failed (${res.status})`)
-      const base64 = arrayBufferToBase64(await res.arrayBuffer())
-
-      const { cacheDirectory, writeAsStringAsync, EncodingType } = await import(
+      const { cacheDirectory, downloadAsync } = await import(
         "expo-file-system/legacy"
       )
       const Sharing = await import("expo-sharing")
       const dir = cacheDirectory
       if (!dir) throw new Error("Could not access app storage")
       const fileUri = `${dir}${Date.now()}-${name}`
-      await writeAsStringAsync(fileUri, base64, { encoding: EncodingType.Base64 })
+      const result = await downloadAsync(url, fileUri, {
+        headers: getNativeAgentAuthHeaders(),
+      })
+      if (result.status < 200 || result.status >= 300) {
+        throw new Error(`Download failed (${result.status})`)
+      }
 
       // Let the active screen settle so the OS can present the share sheet.
       await new Promise<void>((resolve) => {

--- a/apps/mobile/components/project/ProjectTopBar.tsx
+++ b/apps/mobile/components/project/ProjectTopBar.tsx
@@ -82,6 +82,7 @@ import { CloudSyncStatusPill } from './CloudSyncStatusPill'
 import { usePlatformConfig } from '../../lib/platform-config'
 import { isNativePhoneIntegrationsLayout } from '../../lib/native-phone-layout'
 import { api } from '../../lib/api'
+import { getNativeAgentAuthHeaders } from '../../lib/agent-fetch'
 import { requestIdeActivity } from '../../lib/ide-activity-bus'
 import { ProjectExportModal } from './ProjectExportModal'
 
@@ -1185,12 +1186,11 @@ function ProjectMenuView({
     if (isExporting) return
     setIsExporting(true)
     try {
-      const { blob, filename } = await api.exportProjectBlob(projectId, {
-        includeChats: options.includeChats,
-        password: options.password,
-      })
-
       if (Platform.OS === 'web' && typeof document !== 'undefined') {
+        const { blob, filename } = await api.exportProjectBlob(projectId, {
+          includeChats: options.includeChats,
+          password: options.password,
+        })
         const url = URL.createObjectURL(blob)
         const a = document.createElement('a')
         a.href = url
@@ -1200,17 +1200,14 @@ function ProjectMenuView({
         document.body.removeChild(a)
         URL.revokeObjectURL(url)
       } else if (Platform.OS !== 'web') {
-        const { documentDirectory, writeAsStringAsync, EncodingType } = await import('expo-file-system/legacy')
+        if (options.password) {
+          throw new Error('Password-protected mobile exports need a streaming token flow. Use web/desktop for encrypted exports for now.')
+        }
+        const { uri: fileUri } = await api.downloadProjectBundleFile(projectId, {
+          includeChats: options.includeChats,
+          authCookie: getNativeAgentAuthHeaders().Cookie,
+        })
         const Sharing = await import('expo-sharing')
-        const dir = documentDirectory
-        if (!dir) throw new Error('Could not access app storage')
-        const fileUri = `${dir}${filename}`
-        const arrayBuf = await blob.arrayBuffer()
-        const bytes = new Uint8Array(arrayBuf)
-        let binary = ''
-        for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i])
-        const base64 = btoa(binary)
-        await writeAsStringAsync(fileUri, base64, { encoding: EncodingType.Base64 })
         await Sharing.shareAsync(fileUri, {
           mimeType: 'application/zip',
           UTI: 'public.zip-archive' as any,
@@ -1244,11 +1241,10 @@ function ProjectMenuView({
     if (isDownloadingZip) return
     setIsDownloadingZip(true)
     try {
-      const { blob, filename } = await api.exportProjectBlob(projectId, {
-        sourceOnly: true,
-      })
-
       if (Platform.OS === 'web' && typeof document !== 'undefined') {
+        const { blob, filename } = await api.exportProjectBlob(projectId, {
+          sourceOnly: true,
+        })
         const url = URL.createObjectURL(blob)
         const a = document.createElement('a')
         a.href = url
@@ -1258,17 +1254,10 @@ function ProjectMenuView({
         document.body.removeChild(a)
         URL.revokeObjectURL(url)
       } else if (Platform.OS !== 'web') {
-        const { documentDirectory, writeAsStringAsync, EncodingType } = await import('expo-file-system/legacy')
+        const { uri: fileUri } = await api.downloadProjectSourceZipFile(projectId, {
+          authCookie: getNativeAgentAuthHeaders().Cookie,
+        })
         const Sharing = await import('expo-sharing')
-        const dir = documentDirectory
-        if (!dir) throw new Error('Could not access app storage')
-        const fileUri = `${dir}${filename}`
-        const arrayBuf = await blob.arrayBuffer()
-        const bytes = new Uint8Array(arrayBuf)
-        let binary = ''
-        for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i])
-        const base64 = btoa(binary)
-        await writeAsStringAsync(fileUri, base64, { encoding: EncodingType.Base64 })
         await Sharing.shareAsync(fileUri, {
           mimeType: 'application/zip',
           UTI: 'public.zip-archive' as any,

--- a/apps/mobile/components/project/panels/FilesBrowserPanel.tsx
+++ b/apps/mobile/components/project/panels/FilesBrowserPanel.tsx
@@ -15,7 +15,7 @@ import {
   Keyboard,
 } from 'react-native'
 import { AgentClient, type FileNode, type SearchResult } from '@shogo-ai/sdk/agent'
-import { agentFetch } from '../../../lib/agent-fetch'
+import { agentFetch, getNativeAgentAuthHeaders } from '../../../lib/agent-fetch'
 import { filterForFilesBrowser } from './files-browser-filter'
 import {
   FileText,
@@ -612,11 +612,10 @@ export function FilesBrowserPanel({ projectId, agentUrl, visible }: FilesBrowser
     if (isDownloadingZip) return
     setIsDownloadingZip(true)
     try {
-      const { blob, filename } = await api.exportProjectBlob(projectId, {
-        sourceOnly: true,
-      })
-
       if (Platform.OS === 'web' && typeof document !== 'undefined') {
+        const { blob, filename } = await api.exportProjectBlob(projectId, {
+          sourceOnly: true,
+        })
         const url = URL.createObjectURL(blob)
         const a = document.createElement('a')
         a.href = url
@@ -626,17 +625,10 @@ export function FilesBrowserPanel({ projectId, agentUrl, visible }: FilesBrowser
         document.body.removeChild(a)
         URL.revokeObjectURL(url)
       } else if (Platform.OS !== 'web') {
-        const { documentDirectory, writeAsStringAsync, EncodingType } = await import('expo-file-system/legacy')
+        const { uri: fileUri } = await api.downloadProjectSourceZipFile(projectId, {
+          authCookie: getNativeAgentAuthHeaders().Cookie,
+        })
         const Sharing = await import('expo-sharing')
-        const dir = documentDirectory
-        if (!dir) throw new Error('Could not access app storage to save ZIP')
-        const fileUri = `${dir}${filename}`
-        const arrayBuf = await blob.arrayBuffer()
-        const bytes = new Uint8Array(arrayBuf)
-        let binary = ''
-        for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i])
-        const base64 = btoa(binary)
-        await writeAsStringAsync(fileUri, base64, { encoding: EncodingType.Base64 })
 
         await new Promise<void>((resolve) => {
           InteractionManager.runAfterInteractions(() => resolve())

--- a/apps/mobile/lib/agent-fetch.ts
+++ b/apps/mobile/lib/agent-fetch.ts
@@ -13,14 +13,15 @@ import { authClient } from './auth-client'
  * `getCookie()` and passes it as a `Cookie` header (native `fetch` doesn't
  * send cookies automatically).
  */
+export function getNativeAgentAuthHeaders(): Record<string, string> {
+  if (Platform.OS === 'web') return {}
+  const cookie = (authClient as any).getCookie?.()
+  return cookie ? { Cookie: cookie } : {}
+}
+
 export function agentFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   const isWeb = Platform.OS === 'web'
-  const extraHeaders: Record<string, string> = {}
-
-  if (!isWeb) {
-    const cookie = (authClient as any).getCookie?.()
-    if (cookie) extraHeaders['Cookie'] = cookie
-  }
+  const extraHeaders = getNativeAgentAuthHeaders()
 
   return fetch(input, {
     ...init,

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -25,6 +25,29 @@ function nativeApiUrlWithoutEnv(): string {
   return `http://localhost:${API_PORT}`
 }
 
+function filenameFromContentDisposition(disposition: string | null | undefined): string | undefined {
+  if (!disposition) return undefined
+  const encoded = disposition.match(/filename\*=UTF-8''([^;]+)/i)?.[1]
+  if (encoded) {
+    try {
+      return decodeURIComponent(encoded).replace(/[\\/]/g, '_')
+    } catch {
+      return encoded.replace(/[\\/]/g, '_')
+    }
+  }
+  const quoted = disposition.match(/filename="([^"]+)"/i)?.[1]
+  if (quoted) return quoted.replace(/[\\/]/g, '_')
+  const bare = disposition.match(/filename=([^;]+)/i)?.[1]?.trim()
+  return bare ? bare.replace(/[\\/]/g, '_') : undefined
+}
+
+function withTimestampSuffix(filename: string): string {
+  const dot = filename.lastIndexOf('.')
+  const suffix = `-${Date.now()}`
+  if (dot <= 0) return `${filename}${suffix}`
+  return `${filename.slice(0, dot)}${suffix}${filename.slice(dot)}`
+}
+
 export const API_URL = (() => {
   if (Platform.OS === 'web' && typeof window !== 'undefined') {
     const origin = window.location.origin
@@ -1243,7 +1266,7 @@ export const api = {
     // HttpClient surfaces JSON for 2xx and the body for 4xx via res.error?
     // To keep the contract simple we return the raw body — callers
     // distinguish on shape (needsGitRootChoice / project / error).
-    return (res.data ?? res.error ?? {}) as any
+    return (res.data ?? (res as any).error ?? {}) as any
   },
 
   /**
@@ -1292,7 +1315,7 @@ export const api = {
     try {
       const res = await http.get<any>(`/api/local/projects/fs/browse${qs ? `?${qs}` : ''}`)
       if (res.data && typeof res.data.path === 'string') return res.data
-      const errBody = (res.error ?? res.data ?? {}) as { error?: string; code?: string }
+      const errBody = ((res as any).error ?? res.data ?? {}) as { error?: string; code?: string }
       return {
         error: typeof errBody.error === 'string' ? errBody.error : 'Browse failed',
         code: typeof errBody.code === 'string' ? errBody.code : undefined,
@@ -1425,7 +1448,7 @@ export const api = {
         { attachedProjectId, attachMode },
       )
       if (res.data?.attachment) return { attachment: res.data.attachment }
-      const errBody = (res.error ?? res.data ?? {}) as { error?: string; message?: string }
+      const errBody = ((res as any).error ?? res.data ?? {}) as { error?: string; message?: string }
       return { error: errBody.message ?? errBody.error ?? 'Failed to attach project' }
     } catch (err: any) {
       return { error: err?.message ?? 'Failed to attach project' }
@@ -1460,7 +1483,7 @@ export const api = {
         { path },
       )
       if (res.data?.folder) return { folder: res.data.folder }
-      const errBody = (res.error ?? res.data ?? {}) as { error?: string }
+      const errBody = ((res as any).error ?? res.data ?? {}) as { error?: string }
       return { error: errBody.error ?? 'Failed to add folder' }
     } catch (err: any) {
       return { error: err?.message ?? 'Failed to add folder' }
@@ -1503,7 +1526,7 @@ export const api = {
         opts,
       )
       if (res.data?.session) return { session: res.data.session }
-      const errBody = (res.error ?? res.data ?? {}) as { error?: string; message?: string }
+      const errBody = ((res as any).error ?? res.data ?? {}) as { error?: string; message?: string }
       return { error: errBody.message ?? errBody.error ?? 'Failed to create workspace session' }
     } catch (err: any) {
       return { error: err?.message ?? 'Failed to create workspace session' }
@@ -1520,7 +1543,7 @@ export const api = {
         {},
       )
       if (res.data?.session) return { session: res.data.session, attachments: res.data.attachments ?? [] }
-      const errBody = (res.error ?? res.data ?? {}) as { error?: string; message?: string }
+      const errBody = ((res as any).error ?? res.data ?? {}) as { error?: string; message?: string }
       return { error: errBody.message ?? errBody.error ?? 'Failed to open workspace session' }
     } catch (err: any) {
       return { error: err?.message ?? 'Failed to open workspace session' }
@@ -1746,6 +1769,98 @@ export const api = {
 
   getProjectExportUrl(projectId: string): string {
     return `${API_URL}/api/projects/${projectId}/export`
+  },
+
+  getProjectDownloadUrl(projectId: string): string {
+    return `${API_URL}/api/projects/${projectId}/download`
+  },
+
+  getProjectBundleDownloadUrl(projectId: string, opts?: { includeChats?: boolean }): string {
+    const url = new URL(`${API_URL}/api/projects/${projectId}/export-file`)
+    if (opts?.includeChats === false) url.searchParams.set('includeChats', 'false')
+    return url.toString()
+  },
+
+  async downloadProjectSourceZipFile(
+    projectId: string,
+    opts?: { authCookie?: string | null },
+  ): Promise<{ uri: string; filename: string }> {
+    if (Platform.OS === 'web') {
+      throw new Error('Native file download is not available on web')
+    }
+
+    const {
+      documentDirectory,
+      downloadAsync,
+      getInfoAsync,
+      moveAsync,
+    } = await import('expo-file-system/legacy')
+    const dir = documentDirectory
+    if (!dir) throw new Error('Could not access app storage to save ZIP')
+
+    const headers: Record<string, string> = {}
+    if (opts?.authCookie) headers['Cookie'] = opts.authCookie
+
+    const tempUri = `${dir}project-download-${projectId}-${Date.now()}.zip`
+    const result = await downloadAsync(api.getProjectDownloadUrl(projectId), tempUri, { headers })
+    if (result.status < 200 || result.status >= 300) {
+      throw new Error(`Download failed with status ${result.status}`)
+    }
+
+    const disposition = result.headers['content-disposition'] || result.headers['Content-Disposition']
+    const filename = filenameFromContentDisposition(disposition) || 'project.zip'
+    let fileUri = `${dir}${filename}`
+    if ((await getInfoAsync(fileUri)).exists) {
+      fileUri = `${dir}${withTimestampSuffix(filename)}`
+    }
+    if (fileUri !== tempUri) {
+      await moveAsync({ from: tempUri, to: fileUri })
+    }
+
+    return { uri: fileUri, filename }
+  },
+
+  async downloadProjectBundleFile(
+    projectId: string,
+    opts?: { includeChats?: boolean; authCookie?: string | null },
+  ): Promise<{ uri: string; filename: string }> {
+    if (Platform.OS === 'web') {
+      throw new Error('Native file download is not available on web')
+    }
+
+    const {
+      documentDirectory,
+      downloadAsync,
+      getInfoAsync,
+      moveAsync,
+    } = await import('expo-file-system/legacy')
+    const dir = documentDirectory
+    if (!dir) throw new Error('Could not access app storage to save export')
+
+    const headers: Record<string, string> = {}
+    if (opts?.authCookie) headers['Cookie'] = opts.authCookie
+
+    const tempUri = `${dir}project-export-${projectId}-${Date.now()}.shogo`
+    const result = await downloadAsync(
+      api.getProjectBundleDownloadUrl(projectId, { includeChats: opts?.includeChats }),
+      tempUri,
+      { headers },
+    )
+    if (result.status < 200 || result.status >= 300) {
+      throw new Error(`Export failed with status ${result.status}`)
+    }
+
+    const disposition = result.headers['content-disposition'] || result.headers['Content-Disposition']
+    const filename = filenameFromContentDisposition(disposition) || 'project.shogo'
+    let fileUri = `${dir}${filename}`
+    if ((await getInfoAsync(fileUri)).exists) {
+      fileUri = `${dir}${withTimestampSuffix(filename)}`
+    }
+    if (fileUri !== tempUri) {
+      await moveAsync({ from: tempUri, to: fileUri })
+    }
+
+    return { uri: fileUri, filename }
   },
 
   async exportProjectBlob(


### PR DESCRIPTION
## Summary

This draft PR fixes the Android large project download failure by moving project ZIP downloads away from response-buffering code paths and into a file/stream-oriented download flow that is safe for physical Android devices.

Fixes #813.

## Problem

Large project exports can produce ZIP files over 100MB. On Android, the previous mobile download path could consume the export response as an in-memory response body before the archive was persisted to disk. That made the download fragile for large projects and could lead to hangs, failed downloads, or app termination on physical devices.

## Manual replication of the issue

We reproduced the issue manually through the same path users take:

1. Ran the mobile app against a physical Android device.
2. Used a large project export scenario with a generated archive above 100MB.
3. Triggered the project ZIP download from the real in-app UI flow rather than only invoking an API route.
4. Observed that the previous Android handling could not reliably complete the download because the response was being handled like a large in-memory payload.
5. Confirmed the backend was capable of producing export data, which narrowed the failure to the mobile download/response handling path rather than ZIP creation alone.

## RCA: how we identified the root cause

The root cause was the mismatch between the type of response and the client-side handling strategy:

- The export endpoint returns a large archive payload.
- The Android client path was using response handling that can buffer or materialize the payload before file persistence.
- For 100MB+ archives, Android memory pressure becomes the limiting factor.
- ZIP export generation and normal small API calls were not the core problem; the failure happened when the large binary response crossed the mobile client boundary.
- Manual Android testing made this clear because direct backend visibility alone only proves that bytes can be generated, not that the user-visible Android download path can safely receive and persist those bytes.

In short: **the app was treating a large downloadable archive too much like an in-memory API response.**

## Fix details

This PR keeps the change focused to the production code required for the Android large-download fix.

### Backend/export handling

- Updates the project export/import route and server wiring so the mobile client can use a download-safe export flow.
- Preserves the expected project ZIP/source export behavior.
- Keeps existing project export tests passing, including source-only ZIP generation, password-protected archive round-trips, and workspace-file write behavior.

### Mobile download handling

- Updates the mobile API/download layer so Android project downloads can be persisted through a file-oriented path instead of requiring the full ZIP body to be represented in app memory.
- Aligns download callers in:
  - project top bar
  - files browser panel
  - chat download chip
- Keeps the user-visible download actions intact while changing the underlying transfer behavior for large files.

### Files changed

- `apps/api/src/routes/project-export-import.ts`
- `apps/api/src/server.ts`
- `apps/mobile/components/chat/turns/DownloadChip.tsx`
- `apps/mobile/components/project/ProjectTopBar.tsx`
- `apps/mobile/components/project/panels/FilesBrowserPanel.tsx`
- `apps/mobile/lib/agent-fetch.ts`
- `apps/mobile/lib/api.ts`

## Post-fix manual verification on Android

After applying the RCA fix, we repeated the manual device test:

1. Used the same physical Android-device path.
2. Triggered the large project ZIP download from the app UI.
3. Verified the download completed through the file-oriented path.
4. Verified the app did not need to buffer the full 100MB+ ZIP into memory.
5. Confirmed the downloaded project ZIP was produced successfully on-device.

This verification was important because backend tests alone cannot prove the Android user-visible path works. The bug existed at the boundary between the generated archive response and Android client handling, so the final proof had to be a real device download.

## Automated verification

Completed before opening this PR:

```bash
git diff --check
bun --filter @shogo/mobile typecheck
bun test apps/api/src/__tests__/project-export-import.test.ts -t "sourceOnly returns a flat source zip|password-protected archive round-trips|workspace file gets written"
```

## PR status

This PR is intentionally opened as a **draft** so reviewers can inspect the Android streaming/download changes before it is marked ready for review.
