### PR TITLE
fix(metal): upgrade Firecracker to 1.16.1 (enables clock_realtime resume fix)

### DIFF
--- a/scripts/metal-agent/host-bootstrap.sh
+++ b/scripts/metal-agent/host-bootstrap.sh
@@ -13,12 +13,13 @@
 # Usage (on host, as root):  bash host-bootstrap.sh
 # Env:
 #   WORK        artifact dir (default /opt/fc-spike)
-#   FC_VERSION  firecracker version (default 1.10.1)
+#   FC_VERSION  firecracker version (default 1.16.1; >=1.16 supports the
+#               clock_realtime restore flag we rely on to fix resume clock-skew)
 # =============================================================================
 set -euo pipefail
 
 WORK="${WORK:-/opt/fc-spike}"
-FC_VERSION="${FC_VERSION:-1.10.1}"
+FC_VERSION="${FC_VERSION:-1.16.1}"
 log() { echo "[host-bootstrap] $*"; }
 
 [ "$(id -u)" = "0" ] || { echo "must run as root"; exit 1; }
@@ -135,8 +136,22 @@ printf 'vm.swappiness=10\n' > /etc/sysctl.d/99-metal-swap.conf
 sysctl -w vm.swappiness=10 >/dev/null
 
 ARCH="$(uname -m)"  # x86_64 on Latitude s3-large-x86 / c3-large-x86
-if [ ! -x "$WORK/bin/firecracker" ]; then
+# Install OR upgrade firecracker. The binary is host infrastructure (not shipped
+# via the pull-based agent release), so re-running this script must converge an
+# already-provisioned host onto FC_VERSION — the old `[ ! -x ]` guard skipped
+# any host that already had *a* firecracker, which is how the fleet stayed on
+# 1.10.1. We compare the running binary's version and only (re)install on a
+# mismatch. After an upgrade, restart metal-agent so the warm pool re-warms on
+# the new FC.
+#
+# NOTE: Firecracker snapshots are NOT compatible across versions. After an
+# upgrade, existing suspended guests fail to resume and cold-boot instead
+# (pool.open catches the load failure and falls through) — a one-time,
+# self-healing cost, and cold boots come up with a correct wall-clock anyway.
+if ! { [ -x "$WORK/bin/firecracker" ] && "$WORK/bin/firecracker" --version 2>/dev/null | grep -qF "v${FC_VERSION}"; }; then
   log "installing firecracker v${FC_VERSION} ($ARCH)..."
+  # Preserve the current binary so a bad upgrade can be rolled back by hand.
+  [ -x "$WORK/bin/firecracker" ] && cp -a "$WORK/bin/firecracker" "$WORK/bin/firecracker.prev" || true
   curl -fsSL "https://github.com/firecracker-microvm/firecracker/releases/download/v${FC_VERSION}/firecracker-v${FC_VERSION}-${ARCH}.tgz" \
     -o /tmp/fc.tgz
   tar -xzf /tmp/fc.tgz -C /tmp


### PR DESCRIPTION
## Summary
- Bump the metal fleet's Firecracker from **1.10.1 → 1.16.1**. 1.10.1 rejects the `clock_realtime` flag on `/snapshot/load` with `400 unknown field`; FC ≥ 1.16 supports it. That flag advances a restored guest's wall-clock to real time on resume — without it, a resumed guest's `CLOCK_REALTIME` stays frozen at snapshot time and, after enough drift, every outbound TLS handshake fails with *"certificate is not yet valid"* (the 2026-07 "provider connection error" incidents).
- Make `host-bootstrap.sh` **version-aware**: the old `[ ! -x ]` guard skipped the install whenever any firecracker binary already existed, so re-running bootstrap could never upgrade a provisioned host (how the fleet stayed pinned at 1.10.1). Now it (re)installs only on a version mismatch and preserves the prior binary as `firecracker.prev`.

## Rollout status (already applied manually)
The FC binary is host infrastructure, not shipped via the pull-based agent release, so hosts are upgraded by re-running `host-bootstrap.sh` (or an equivalent backup + install + `systemctl restart metal-agent`). All 5 hosts are already on 1.16.1:

| host | role | FC |
|---|---|---|
| shogo-fc-dal-1 | staging | 1.16.1 ✅ |
| latitude-dal-1 | prod | 1.16.1 ✅ |
| latitude-dal-2 | prod | 1.16.1 ✅ |
| latitude-fra-1 | prod | 1.16.1 ✅ |
| latitude-fra-2 | prod | 1.16.1 ✅ |

Each: prior binary backed up to `firecracker-1.10.1.bak`, graceful restart (assigned VMs reparented/re-adopted; warm pool re-warmed on new FC), warm pool healthy afterward.

## Validation
On staging, booted a throwaway microVM on 1.16.1, snapshotted it, and loaded it back with `clock_realtime:true` → **HTTP 204** (the exact call that returned `400 unknown field` on 1.10.1).

## Notes
- FC snapshots are **not** cross-version compatible: after the upgrade, pre-existing 1.10.1 snapshots fail to resume and cold-boot once (`pool.open` already falls back). One-time, self-healing; cold boots come up clock-correct anyway.
- Guest kernel unchanged (6.1.102 — supported by FC 1.16); `clock_realtime` needs only host kernel ≥ 5.16 (hosts run 6.8).

## Test plan
- [ ] CI green
- [ ] Confirm a fresh `host-bootstrap.sh` run on a new host installs 1.16.1
- [ ] Observe resumes on the fleet: no `certificate is not yet valid` / `clock_realtime` 400s; warm-resume (not cold-boot) restored

Made with [Cursor](https://cursor.com)