### PR TITLE
fix(metal): mount devpts in Firecracker runtimes

### DIFF
--- a/apps/metal-agent/src/e2e-real.ts
+++ b/apps/metal-agent/src/e2e-real.ts
@@ -56,6 +56,13 @@ interface Health {
   gateway?: { running?: boolean }
 }
 
+interface TerminalSession {
+  id: string
+  cwd: string
+  cols: number
+  rows: number
+}
+
 async function health(url: string, timeoutMs = 2000): Promise<Health | null> {
   try {
     const res = await fetch(`${url}/health`, { signal: AbortSignal.timeout(timeoutMs) })
@@ -64,6 +71,28 @@ async function health(url: string, timeoutMs = 2000): Promise<Health | null> {
   } catch {
     return null
   }
+}
+
+async function verifyTerminalPty(url: string): Promise<TerminalSession> {
+  const res = await fetch(`${url}/terminal/sessions`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ cols: 80, rows: 24 }),
+    signal: AbortSignal.timeout(5000),
+  })
+  const body = await res.json().catch(() => null) as TerminalSession | { error?: { code?: string; message?: string } } | null
+  if (!res.ok) {
+    const err = body && 'error' in body ? body.error : undefined
+    throw new Error(`terminal PTY create failed (${res.status}): ${err?.code ?? 'unknown'} ${err?.message ?? ''}`.trim())
+  }
+  const session = body as TerminalSession
+  if (!session?.id) throw new Error('terminal PTY create returned no session id')
+  const cleanup = await fetch(`${url}/terminal/sessions/${encodeURIComponent(session.id)}`, {
+    method: 'DELETE',
+    signal: AbortSignal.timeout(3000),
+  })
+  if (!cleanup.ok) throw new Error(`terminal PTY cleanup failed (${cleanup.status}) for ${session.id}`)
+  return session
 }
 
 /**
@@ -119,6 +148,8 @@ async function main() {
     log('boot', `health status=${h.status} poolMode=${h.poolMode} projectId=${h.projectId} gatewayRunning=${h.gateway?.running}`)
     if (h.projectId !== '__POOL__') throw new Error(`expected pool mode, got projectId=${h.projectId}`)
     if (!h.poolMode) throw new Error('runtime did not come up in poolMode')
+    const terminal = await verifyTerminalPty(handle.agentUrl)
+    log('verify', `terminalPty: PASS session=${terminal.id} cwd=${terminal.cwd}`)
     const baseline = h
 
     // Let the boot-time workspace pre-seed warm so the snapshot freezes a
@@ -176,8 +207,9 @@ async function main() {
       // budget; a restore ready in a fraction of that resumed from RAM.
       restoreFasterThanReboot: report.restore.readyMs.p95 < Math.max(2000, report.steps.coldBootReadyMs / 3),
       hostRamFreedOnSuspend: report.steps.vmGoneAfterSuspend === true,
+      terminalPty: terminal.id.length > 0,
     }
-    report.correctness = { baseline, warmed, firstAfter, checks }
+    report.correctness = { baseline, warmed, firstAfter, terminal, checks }
     for (const [k, v] of Object.entries(checks)) log('verify', `${k}: ${v ? 'PASS' : 'FAIL'}`)
 
     const allPass = Object.values(checks).every(Boolean)

--- a/scripts/metal-agent/build-runtime-rootfs.sh
+++ b/scripts/metal-agent/build-runtime-rootfs.sh
@@ -101,6 +101,19 @@ mount -t proc proc /proc 2>/dev/null || true
 mount -t sysfs sys /sys 2>/dev/null || true
 mount -t tmpfs tmpfs /tmp 2>/dev/null || true
 mount -t devtmpfs dev /dev 2>/dev/null || true
+mkdir -p /dev/pts
+if ! grep -Eq ' /dev/pts .* - devpts ' /proc/self/mountinfo 2>/dev/null; then
+  mount -t devpts devpts /dev/pts -o newinstance,ptmxmode=0666,mode=0620,gid=5 2>/dev/null || true
+fi
+if [ -e /dev/pts/ptmx ]; then
+  rm -f /dev/ptmx 2>/dev/null || true
+  ln -s pts/ptmx /dev/ptmx 2>/dev/null || true
+fi
+if ! grep -Eq ' /dev/pts .* - devpts ' /proc/self/mountinfo 2>/dev/null || [ ! -e /dev/pts/ptmx ] || [ ! -e /dev/ptmx ]; then
+  echo "[fc-init] WARNING: PTY device setup incomplete; Bun.spawn({ terminal }) may fail" >&2
+  mount | grep devpts >&2 || true
+  ls -l /dev/ptmx /dev/pts /dev/pts/ptmx >&2 || true
+fi
 
 # eth0 is configured by the kernel ip= cmdline; the host tap is the gateway and
 # NATs us out (net.ts). The container image's /etc/resolv.conf points at the


### PR DESCRIPTION

<img width="1512" height="982" alt="Screenshot 2026-07-21 at 12 26 42 PM" src="https://github.com/user-attachments/assets/6f422c75-5ac9-4bf0-9a69-07b86d02d787" />
## Summary

Fixes #823.

This PR fixes terminal PTY creation in metal/Firecracker runtimes at the guest rootfs level. The issue is not in the terminal WebSocket path or API proxying; the Firecracker guest did not mount `devpts`, so `Bun.spawn({ terminal: ... })` could not allocate a PTY.

## What changed

### `scripts/metal-agent/build-runtime-rootfs.sh`

Updates the generated Firecracker `fc-init` script to set up the PTY subsystem during guest boot:

- creates `/dev/pts`
- mounts `devpts` at `/dev/pts`
- uses PTY-compatible mount options:
  - `newinstance`
  - `ptmxmode=0666`
  - `mode=0620`
  - `gid=5`
- rewires `/dev/ptmx` to `pts/ptmx` when `/dev/pts/ptmx` exists
- logs a clear boot-time warning if PTY setup is incomplete

This restores the device setup that container runtimes usually provide automatically, but that our Firecracker guest init must create explicitly.

### `apps/metal-agent/src/e2e-real.ts`

Adds a real Firecracker runtime e2e assertion for terminal PTY support:

- boots the real metal runtime
- waits for `/health`
- calls `POST /terminal/sessions`
- validates that a session id is returned
- deletes the created terminal session
- fails loudly if PTY creation or cleanup fails

This turns the production failure mode into a substrate-level regression test. If `devpts` is missing again, the e2e should fail with a clear message like:

```txt
terminal PTY create failed (400): spawn_failed Failed to open PTY
```

## RCA

`Bun.spawn({ terminal: ... })` needs a working Linux PTY subsystem inside the guest VM:

```txt
/dev/pts mounted as devpts
/dev/pts/ptmx available
/dev/ptmx usable
```

The Firecracker rootfs init previously mounted only:

```sh
mount -t proc proc /proc
mount -t sysfs sys /sys
mount -t tmpfs tmpfs /tmp
mount -t devtmpfs dev /dev
```

It did not mount `devpts`, so PTY allocation failed in the guest and surfaced through the runtime as:

```json
{"error":{"code":"spawn_failed","message":"Failed to open PTY"}}
```

## Evidence used for the fix

- Production project showed:
  - `GET /terminal/commands -> 200`
  - `POST /terminal/sessions -> 400 64`
- Staging project showed the same pattern.
- Runtime `/health` was reachable, so the runtime was not generally down.
- The 64-byte body matches `{"error":{"code":"spawn_failed","message":"Failed to open PTY"}}`.
- The failing application path is:
  - `runtime-terminal-routes.ts -> manager.create()`
  - `pty-session.ts -> Bun.spawn({ terminal })`
- The generated Firecracker `fc-init` did not mount `devpts`.

## Verification performed locally

```sh
bash -n scripts/metal-agent/build-runtime-rootfs.sh
```

Passed.

```sh
git diff --check -- scripts/metal-agent/build-runtime-rootfs.sh apps/metal-agent/src/e2e-real.ts
```

Passed.

```sh
bun --no-env-file test packages/agent-runtime/src/__tests__/runtime-terminal-routes.test.ts
```

Passed:

```txt
14 pass
0 fail
46 expect() calls
```

```sh
bun --no-env-file build apps/metal-agent/src/e2e-real.ts --target=bun --outfile=/tmp/shogo-metal-e2e-real-check.js
```

Passed as a Bun parser/bundler check.

A script assertion also confirmed that generated `fc-init` contains:

- the `devpts` mount
- `/dev/ptmx` symlink setup
- the PTY diagnostic warning

## Known local check caveat

`bun run --cwd apps/metal-agent typecheck` could not run in the local checkout because the environment could not resolve Bun ambient types:

```txt
TS2688: Cannot find type definition file for 'bun'
```

That failure happens before typechecking this patch and appears to be local dependency/type setup rather than a code issue. The changed e2e file was still validated through Bun's parser/bundler.

## Deployment notes

This PR changes rootfs generation. It will not fix already-running/stale Firecracker guests until the rootfs artifact is rebuilt and old VMs are recycled.

After merge/deploy:

1. Rebuild and publish the metal runtime rootfs artifact.
2. Roll it to the metal fleet.
3. Recycle stale warm/assigned/suspended microVMs.
4. Run the updated real metal e2e on an actual metal host.
5. Verify terminal creation in staging and production:

```txt
POST /api/projects/:projectId/terminal/sessions -> 2xx
```

## Why this is the root fix

This does not hide or special-case `spawn_failed` in the API. It restores the missing guest OS primitive required by PTY allocation and adds an e2e guard to prevent the same substrate regression from reaching production again.
