### PR TITLE
Fix desktop chat stall recovery and path-safe preview generation

### DIFF
--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -72,7 +72,7 @@ import { decideMessagesPropagation } from "./messages-propagation"
 import { useNotifyOnTurnComplete } from "./useNotifyOnTurnComplete"
 import { probeChatTurnStatus, shouldAttachLiveStream, type ChatTurnStatus } from "./probe-turn-status"
 import { decideRetryAction, lastAssistantHasResumableWork } from "./retry-triage"
-import { decideStallRecovery, computeRecoveryBackoff } from "./stall-recovery"
+import { decideStallRecovery, computeRecoveryBackoff, decideStallGiveUpAction } from "./stall-recovery"
 import { cn } from "@shogo/shared-ui/primitives"
 import { API_URL, api, createHttpClient } from "../../lib/api"
 import { workspaceProjectFilter } from "../../lib/project-load"
@@ -4514,8 +4514,19 @@ export const ChatPanel = observer(function ChatPanel({
             return
           }
           if (action === "give-up") {
-            // Terminal or persistently-unknown: leave the manual Retry banner
-            // for the user. `handleRetry` will still triage continue/resend.
+            const giveUpAction = decideStallGiveUpAction({
+              turnStatus,
+              userInitiatedStop: userInitiatedStopRef.current,
+            })
+            if (giveUpAction === "fail-closed") {
+              turnCompletedRef.current = true
+              turnStalledRef.current = false
+              todoStateStore.cancelInProgress()
+              setEmptyResponseError(
+                "The previous response was interrupted before the runtime sent a completion marker. Completed work was preserved, but the turn has been marked failed so it does not stay active forever.",
+              )
+              setErrorDismissed(false)
+            }
             return
           }
           // retry-later: brief backoff, then probe again.
@@ -4533,6 +4544,7 @@ export const ChatPanel = observer(function ChatPanel({
     expoFetch,
     nativeHeaders,
     resumeStream,
+    todoStateStore,
   ])
   stallRecoveryRef.current = attemptStallRecovery
 

--- a/apps/mobile/components/chat/__tests__/stall-recovery.repro.test.ts
+++ b/apps/mobile/components/chat/__tests__/stall-recovery.repro.test.ts
@@ -16,13 +16,14 @@
  * static "tap Retry" banner even though the agent may still be running.
  *
  * This test drives the REAL probe against a 404 and confirms the full chain
- * lands on "give-up".
+ * lands on "give-up". The production fix then converts that give-up into a
+ * local fail-closed UI state so active tasks do not spin forever.
  *
  * Run: bun test apps/mobile/components/chat/__tests__/stall-recovery.repro.test.ts
  */
 import { describe, expect, test } from 'bun:test'
 import { probeChatTurnStatus } from '../probe-turn-status'
-import { decideStallRecovery } from '../stall-recovery'
+import { decideStallGiveUpAction, decideStallRecovery } from '../stall-recovery'
 
 const TURN_URL = 'https://api.example.com/api/projects/d9d1f5a6/chat/98731fc1/turn'
 
@@ -44,10 +45,12 @@ describe('REPRODUCTION: /turn 404 (lost session affinity) → auto-recovery give
     }
 
     // Every intermediate attempt only buys "retry-later"; the final attempt
-    // gives up → falls through to the manual banner. Never "reconnect".
+    // gives up. The follow-up give-up decision must then fail-closed locally
+    // instead of leaving the turn visually active forever.
     expect(actions).not.toContain('reconnect')
     expect(actions[actions.length - 1]).toBe('give-up')
     expect(actions.slice(0, -1).every((a) => a === 'retry-later')).toBe(true)
+    expect(decideStallGiveUpAction({ turnStatus: 'unknown', userInitiatedStop: false })).toBe('fail-closed')
   })
 
   test('a raw network throw on the probe also collapses to unknown → give-up', async () => {
@@ -57,5 +60,6 @@ describe('REPRODUCTION: /turn 404 (lost session affinity) → auto-recovery give
     const turnStatus = await probeChatTurnStatus({ url: TURN_URL, fetch: fetchThrows })
     expect(turnStatus).toBe('unknown')
     expect(decideStallRecovery({ turnStatus, attempt: 5, maxAttempts: 5 })).toBe('give-up')
+    expect(decideStallGiveUpAction({ turnStatus, userInitiatedStop: false })).toBe('fail-closed')
   })
 })

--- a/apps/mobile/components/chat/__tests__/stall-recovery.test.ts
+++ b/apps/mobile/components/chat/__tests__/stall-recovery.test.ts
@@ -15,7 +15,7 @@
  * Run: bun test apps/mobile/components/chat/__tests__/stall-recovery.test.ts
  */
 import { describe, expect, test } from "bun:test"
-import { computeRecoveryBackoff, decideStallRecovery } from "../stall-recovery"
+import { computeRecoveryBackoff, decideStallRecovery, decideStallGiveUpAction } from "../stall-recovery"
 
 describe("decideStallRecovery", () => {
   test("active turn -> reconnect (agent still running, transport drop)", () => {
@@ -51,6 +51,19 @@ describe("decideStallRecovery", () => {
     // never silently restart a turn behind the user's back.
     expect(actions).not.toContain("resend" as never)
     expect(actions).not.toContain("continue" as never)
+  })
+})
+
+describe("decideStallGiveUpAction", () => {
+  test("non-user-initiated unknown/terminal turn -> fail-closed", () => {
+    for (const turnStatus of ["unknown", "completed", "failed", "aborted"] as const) {
+      expect(decideStallGiveUpAction({ turnStatus, userInitiatedStop: false })).toBe("fail-closed")
+    }
+  })
+
+  test("active or user-stopped turn -> ignore", () => {
+    expect(decideStallGiveUpAction({ turnStatus: "active", userInitiatedStop: false })).toBe("ignore")
+    expect(decideStallGiveUpAction({ turnStatus: "unknown", userInitiatedStop: true })).toBe("ignore")
   })
 })
 

--- a/apps/mobile/components/chat/stall-recovery.ts
+++ b/apps/mobile/components/chat/stall-recovery.ts
@@ -24,6 +24,7 @@
 import type { ChatTurnStatus } from "./probe-turn-status"
 
 export type StallRecoveryAction = "reconnect" | "retry-later" | "give-up"
+export type StallGiveUpAction = "fail-closed" | "ignore"
 
 export interface StallRecoveryInput {
   /** Status from the runtime's read-only `/turn` probe. */
@@ -59,6 +60,31 @@ export function decideStallRecovery({
   if (turnStatus === "active") return "reconnect"
   if (turnStatus === "unknown" && attempt < maxAttempts) return "retry-later"
   return "give-up"
+}
+
+export interface StallGiveUpInput {
+  /** The latest status from the final `/turn` probe before giving up. */
+  turnStatus: ChatTurnStatus
+  /** Whether the user explicitly pressed Stop for this turn. */
+  userInitiatedStop: boolean
+}
+
+/**
+ * Decide the local UI terminal action when automatic recovery gives up.
+ *
+ * A stream EOF without `data-turn-complete` is not a normal completed turn. If
+ * the user did not press Stop and the runtime is not actively streamable, close
+ * the UI as a failed/partial turn: clear stale active task state and show a
+ * concrete retry banner. That prevents desktop runtime crashes (for example a
+ * local preview/generate crash) from leaving the turn visually active forever.
+ */
+export function decideStallGiveUpAction({
+  turnStatus,
+  userInitiatedStop,
+}: StallGiveUpInput): StallGiveUpAction {
+  if (userInitiatedStop) return "ignore"
+  if (turnStatus === "active") return "ignore"
+  return "fail-closed"
 }
 
 export interface RecoveryBackoffOptions {

--- a/apps/mobile/lib/__tests__/todo-state-store.test.ts
+++ b/apps/mobile/lib/__tests__/todo-state-store.test.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, expect, test } from "bun:test"
+import { createTodoStateStore } from "../todo-state-store"
+
+describe("createTodoStateStore", () => {
+  test("cancelInProgress marks only active todos as cancelled", () => {
+    const store = createTodoStateStore()
+    store.registerWrite("todo-call-1", [
+      { id: "done", content: "completed work", status: "completed" },
+      { id: "active", content: "active work", status: "in_progress" },
+      { id: "pending", content: "future work", status: "pending" },
+    ])
+
+    store.cancelInProgress()
+
+    expect(store.getLatest()).toEqual([
+      { id: "done", content: "completed work", status: "completed" },
+      { id: "active", content: "active work", status: "cancelled" },
+      { id: "pending", content: "future work", status: "pending" },
+    ])
+    expect(store.getFirstId()).toBe("todo-call-1")
+  })
+
+  test("cancelInProgress is a no-op when no todos are active", () => {
+    const store = createTodoStateStore()
+    let notifications = 0
+    store.subscribe(() => { notifications++ })
+    store.registerWrite("todo-call-1", [
+      { id: "done", content: "completed work", status: "completed" },
+      { id: "pending", content: "future work", status: "pending" },
+    ])
+    notifications = 0
+
+    store.cancelInProgress()
+
+    expect(notifications).toBe(0)
+    expect(store.getLatest()).toEqual([
+      { id: "done", content: "completed work", status: "completed" },
+      { id: "pending", content: "future work", status: "pending" },
+    ])
+  })
+})

--- a/apps/mobile/lib/todo-state-store.ts
+++ b/apps/mobile/lib/todo-state-store.ts
@@ -103,6 +103,7 @@ export interface TodoStateStore {
    *   see the freshest agent state.
    */
   registerWrite(toolId: string, todos: TodoItem[]): void
+  cancelInProgress(): void
   subscribe(fn: () => void): () => void
   clear(): void
 }
@@ -147,6 +148,17 @@ export function createTodoStateStore(): TodoStateStore {
         changed = true
       }
       if (changed) notify()
+    },
+    cancelInProgress() {
+      let changed = false
+      const next = latestTodos.map((todo) => {
+        if (todo.status !== "in_progress") return todo
+        changed = true
+        return { ...todo, status: "cancelled" as const }
+      })
+      if (!changed) return
+      latestTodos = next
+      notify()
     },
     subscribe(fn: () => void): () => void {
       listeners.add(fn)

--- a/packages/agent-runtime/src/__tests__/preview-manager.build-pipeline.test.ts
+++ b/packages/agent-runtime/src/__tests__/preview-manager.build-pipeline.test.ts
@@ -199,6 +199,70 @@ describe('PreviewManager runShogoGenerate (private — invoked indirectly)', () 
       err.mockRestore()
     }
   })
+
+  it('uses the bundled path-safe SDK CLI for legacy generate scripts under paths with spaces', async () => {
+    const workspaceDir = join(dir, 'Application Support')
+    const cwd = join(workspaceDir, 'project')
+    mkdirSync(join(cwd, 'prisma'), { recursive: true })
+    writeFileSync(join(cwd, 'prisma', 'schema.prisma'), 'datasource db {}')
+    writeFileSync(join(cwd, 'package.json'), JSON.stringify({
+      scripts: { generate: 'bunx shogo generate' },
+    }))
+    const bundledCli = join(dir, 'sdk cli.mjs')
+    writeFileSync(bundledCli, '')
+    const previousBundledCli = process.env.SHOGO_BUNDLED_SDK_CLI
+    process.env.SHOGO_BUNDLED_SDK_CLI = bundledCli
+    const m = mk({ workspaceDir }) as any
+    let spawnedArgs: string[] = []
+    const spawnSpy = spyOn(childProc, 'spawn').mockImplementation((_cmd: any, args: any, _opts: any) => {
+      spawnedArgs = args
+      return {
+        stdout: { on: () => {} },
+        stderr: { on: () => {} },
+        on: (event: string, cb: any) => { if (event === 'close') setImmediate(() => cb(0)) },
+        kill: () => {},
+        killed: false,
+      } as any
+    })
+    const log = spyOn(console, 'log').mockImplementation(() => {})
+    try {
+      const ok = await m.runShogoGenerate()
+      expect(ok).toBe(true)
+      expect(spawnedArgs).toEqual([bundledCli, 'generate'])
+    } finally {
+      if (previousBundledCli === undefined) delete process.env.SHOGO_BUNDLED_SDK_CLI
+      else process.env.SHOGO_BUNDLED_SDK_CLI = previousBundledCli
+      spawnSpy.mockRestore()
+      log.mockRestore()
+    }
+  })
+
+  it('fails before spawning unsafe bun x shogo on workspace paths with spaces when no path-safe CLI exists', async () => {
+    const workspaceDir = join(dir, 'Application Support')
+    const cwd = join(workspaceDir, 'project')
+    mkdirSync(join(cwd, 'prisma'), { recursive: true })
+    writeFileSync(join(cwd, 'prisma', 'schema.prisma'), 'datasource db {}')
+    writeFileSync(join(cwd, 'package.json'), JSON.stringify({}))
+    const previousBundledCli = process.env.SHOGO_BUNDLED_SDK_CLI
+    delete process.env.SHOGO_BUNDLED_SDK_CLI
+    const m = mk({ workspaceDir }) as any
+    const spawnSpy = spyOn(childProc, 'spawn').mockImplementation(() => {
+      throw new Error('unsafe spawn should not be called')
+    })
+    const err = spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const ok = await m.runShogoGenerate()
+      expect(ok).toBe(false)
+      expect(spawnSpy).not.toHaveBeenCalled()
+      expect(m.lastGenerateError).toContain('No path-safe shogo generate CLI is available')
+      expect(m.apiPhase).toBe('crashed')
+    } finally {
+      if (previousBundledCli === undefined) delete process.env.SHOGO_BUNDLED_SDK_CLI
+      else process.env.SHOGO_BUNDLED_SDK_CLI = previousBundledCli
+      spawnSpy.mockRestore()
+      err.mockRestore()
+    }
+  })
 })
 
 // --- runExpoExportWeb early bail ------------------------------------------

--- a/packages/agent-runtime/src/preview-manager.ts
+++ b/packages/agent-runtime/src/preview-manager.ts
@@ -1511,6 +1511,13 @@ export class PreviewManager {
       args = [bundledSdkCli!, 'generate']
       cmdLabel = `bun ${bundledSdkCli} generate (bundled fallback)`
     } else {
+      if (/\s/.test(cwd)) {
+        this.lastGenerateError =
+          `No path-safe shogo generate CLI is available for workspace path with spaces: ${cwd}`
+        this.apiPhase = 'crashed'
+        console.error(`[${LOG_PREFIX}] ${this.lastGenerateError}`)
+        return false
+      }
       args = ['x', 'shogo', 'generate']
       cmdLabel = 'bun x shogo generate'
     }


### PR DESCRIPTION
## Summary

This draft PR fixes two related desktop reliability paths:

1. Chat turns that become incomplete/unrecoverable no longer leave the mobile/desktop chat UI stuck with an active task forever.
2. Desktop preview generation now avoids unsafe legacy `bunx shogo generate` fallback behavior under workspace paths containing spaces and prefers the bundled path-safe SDK CLI.

Linked issue: #825

## Problem details

### Chat stall / incomplete stream recovery

A chat turn can lose its live stream or become unrecoverable when the turn-status probe cannot resolve the turn. Reproduction coverage models `/turn` returning 404 and raw network failures. These normalize to `unknown`, and the recovery loop eventually gives up after its bounded retry budget.

Before this branch, the give-up path could still leave user-visible active todos/tasks in progress. That matched the observed stuck state:

```txt
Tasks 1/5 complete • 1 active
```

The result was a UI that looked like the agent was still working even when the recovery path had already exhausted all safe options.

### Desktop path-with-space preview generation

Desktop workspaces often live under macOS paths containing spaces, for example:

```txt
/Users/<user>/Library/Application Support/Shogo/...
```

Legacy generate scripts using shell-interpreted `bunx shogo generate` / `bun x shogo generate` can behave unsafely in these paths. The runtime should prefer a bundled SDK CLI invoked through path-safe execution and should fail before spawning unsafe fallback behavior when no path-safe CLI is available.

## What changed

### Chat recovery

- Added explicit fail-closed behavior when stall recovery gives up on an unrecoverable, non-user-stopped turn.
- Ensured currently active todos are cancelled when the chat turn is no longer recoverable.
- Preserved user-stopped/active-turn behavior so legitimate active work is not cancelled prematurely.
- Added focused todo-state-store coverage for cancelling only active todos.
- Extended stall recovery regression tests for `/turn` 404 and network-error flows.

### Preview generation

- Hardened PreviewManager generation behavior for workspace paths containing spaces.
- Ensured legacy generate scripts use the bundled path-safe SDK CLI when available.
- Added a guard that fails before spawning unsafe `bun x shogo` fallback under path-with-space workspaces if the path-safe CLI is unavailable.
- Added regression tests for both the safe CLI path and the unsafe fallback rejection path.

## Files changed

```txt
apps/mobile/components/chat/ChatPanel.tsx
apps/mobile/components/chat/stall-recovery.ts
apps/mobile/components/chat/__tests__/stall-recovery.test.ts
apps/mobile/components/chat/__tests__/stall-recovery.repro.test.ts
apps/mobile/lib/todo-state-store.ts
apps/mobile/lib/__tests__/todo-state-store.test.ts
packages/agent-runtime/src/preview-manager.ts
packages/agent-runtime/src/__tests__/preview-manager.build-pipeline.test.ts
```

## Verification

### PreviewManager / path-space generation regression

Command:

```sh
bun --no-env-file test packages/agent-runtime/src/__tests__/preview-manager.build-pipeline.test.ts
```

Result:

```txt
37 pass
0 fail
65 expect() calls
```

Key assertions covered:

```txt
uses the bundled path-safe SDK CLI for legacy generate scripts under paths with spaces
fails before spawning unsafe bun x shogo on workspace paths with spaces when no path-safe CLI exists
```

### SDK CLI path safety and bunx rewrite coverage

Command:

```sh
bun --no-env-file test packages/cli/src/__tests__/cli-mjs.test.ts packages/agent-runtime/src/__tests__/bunx-rewrite.test.ts
```

Result:

```txt
10 pass
0 fail
8 expect() calls
```

This confirms:

- `bin/cli.mjs` uses `execFileSync` instead of shell-template `execSync` for the generate script.
- `bin/cli.mjs` converts deploy module paths through `pathToFileURL`.
- Existing Windows `bunx` rewrite coverage still passes.

### Chat stall recovery / incomplete stream regression

Command:

```sh
cd apps/mobile && bun --no-env-file test components/chat/__tests__/stall-recovery.test.ts components/chat/__tests__/stall-recovery.repro.test.ts components/chat/__tests__/chat-panel-wedge.test.ts components/chat/__tests__/probe-turn-status.test.ts lib/__tests__/chat-stop.test.ts lib/__tests__/todo-state-store.test.ts
```

Result:

```txt
68 pass
1 skip
0 fail
143 expect() calls
```

Key scenario covered:

```txt
/turn 404 or network error
→ normalizes to unknown
→ bounded recovery gives up
→ UI fails closed
→ active todos are cancelled instead of spinning forever
```

### Build/static checks

Commands:

```sh
bun run --cwd packages/agent-runtime build
bun run --cwd packages/cli typecheck
bun run --cwd apps/mobile typecheck
git diff --check
```

Results:

```txt
packages/agent-runtime build: passed, bundled 116 modules, server.js 1.37 MB
packages/cli typecheck: passed
apps/mobile typecheck: passed/no-op by design with "Skipping: requires Expo native environment"
git diff --check: passed
```

## Risk and rollout notes

- The chat change is intentionally fail-closed and only cancels active todos after recovery gives up for unrecoverable/non-user-stopped cases.
- The stall recovery retry/reconnect behavior remains intact for statuses that are still active.
- The PreviewManager change is defensive: it prefers the bundled path-safe SDK CLI and avoids spawning unsafe fallback commands under known-risk paths.
- The currently installed packaged desktop app will not reflect this branch until a desktop/dev build includes these changes.

## Known unrelated test debt observed during broader sweep

A broader PreviewManager test run exposed existing/stale tests outside the changed files:

1. `packages/agent-runtime/src/__tests__/integration/preview-manager.expanded.test.ts` imports `../preview-manager` from a nested integration folder, which resolves incorrectly.
2. `packages/agent-runtime/src/__tests__/preview-manager.crash-recovery.test.ts` expects setup failure to leave the phase as `building`, while the newer setup-failure behavior expects terminal `failed`.

These are not introduced by this branch and are intentionally not addressed in this PR.

## PR state

This PR is intentionally opened as a **draft** for packaged desktop/dev-build validation before merge.

Fixes #825
