### PR TITLE
Feat/tooltips homepage

### DIFF
--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -84,6 +84,7 @@ export const DEFAULT_MODEL_PRO = "claude-sonnet-4-6"
 export const DEFAULT_MODEL_FREE = "claude-haiku-4-5-20251001"
 
 import { EnvironmentPicker } from "./EnvironmentPicker"
+import { WebTooltip } from "../ui/web-tooltip"
 
 export type InteractionMode = "agent" | "plan" | "ask"
 
@@ -118,22 +119,6 @@ export const INTERACTION_MODES: InteractionModeConfig[] = [
 const MAX_FILE_SIZE = 10 * 1024 * 1024
 const MAX_FILES = 10
 const INTERACTION_MODE_ORDER: InteractionMode[] = ["agent", "plan", "ask"]
-
-/**
- * Show a native browser tooltip on hover (web only). Wraps children in a
- * `display: contents` div with the `title` attribute so layout is unaffected
- * and the trigger's own ref (e.g. for popover positioning) isn't disturbed.
- * On native this is a transparent passthrough — the icon click opens the
- * popover menu which already shows the full label.
- */
-function WebTooltip({ label, children }: { label: string; children: React.ReactNode }) {
-  if (Platform.OS !== "web") return <>{children}</>
-  return React.createElement(
-    "div",
-    { title: label, style: { display: "contents" } },
-    children,
-  )
-}
 
 const MIN_INPUT_HEIGHT = 60
 const MAX_INPUT_HEIGHT = 200
@@ -1885,7 +1870,7 @@ function ChatInputImpl({
               onOpen={() => setInteractionModeOpen(true)}
               onClose={() => setInteractionModeOpen(false)}
               trigger={(triggerProps) => (
-                <WebTooltip label={`Mode: ${currentInteractionConfig.label}`}>
+                <WebTooltip label={`Mode: ${currentInteractionConfig.label}`} placement="bottom">
                   <Pressable
                     {...triggerProps}
                     disabled={disabled}
@@ -2023,7 +2008,7 @@ function ChatInputImpl({
                 per-device preference: once on, every plan generated in Plan
                 mode also produces a stakeholder summary. */}
             {interactionMode === "plan" && (
-              <WebTooltip label="Also generate a stakeholder summary">
+              <WebTooltip label="Also generate a stakeholder summary" placement="bottom">
                 <Pressable
                   testID="dual-plan-toggle"
                   disabled={disabled}
@@ -2056,7 +2041,7 @@ function ChatInputImpl({
                 onOpen={() => setQuickActionsOpen(true)}
                 onClose={() => setQuickActionsOpen(false)}
                 trigger={(triggerProps) => (
-                  <WebTooltip label="Quick actions">
+                  <WebTooltip label="Quick actions" placement="bottom">
                     <Pressable
                       {...triggerProps}
                       disabled={disabled}

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -84,7 +84,7 @@ export const DEFAULT_MODEL_PRO = "claude-sonnet-4-6"
 export const DEFAULT_MODEL_FREE = "claude-haiku-4-5-20251001"
 
 import { EnvironmentPicker } from "./EnvironmentPicker"
-import { WebTooltip } from "../ui/web-tooltip"
+import { WebTooltip } from "../ui/tooltip"
 
 export type InteractionMode = "agent" | "plan" | "ask"
 

--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -64,7 +64,7 @@ import {
 } from "../../hooks/useTypingPlaceholder"
 
 import { AttachSourceSheet } from "./AttachSourceSheet"
-import { WebTooltip } from "../ui/web-tooltip"
+import { WebTooltip } from "../ui/tooltip"
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024
 const MAX_FILES = 10

--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -64,28 +64,13 @@ import {
 } from "../../hooks/useTypingPlaceholder"
 
 import { AttachSourceSheet } from "./AttachSourceSheet"
+import { WebTooltip } from "../ui/web-tooltip"
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024
 const MAX_FILES = 10
 
 const MIN_INPUT_HEIGHT = 80
 const MAX_INPUT_HEIGHT = 200
-
-/**
- * Show a native browser tooltip on hover (web only). Wraps children in a
- * `display: contents` div with the `title` attribute so layout is unaffected
- * and the trigger's own ref (e.g. for popover positioning) isn't disturbed.
- * On native this is a transparent passthrough — the icon click opens the
- * popover menu which already shows the full label.
- */
-function WebTooltip({ label, children }: { label: string; children: React.ReactNode }) {
-  if (Platform.OS !== "web") return <>{children}</>
-  return React.createElement(
-    "div",
-    { title: label, style: { display: "contents" } },
-    children,
-  )
-}
 
 interface AttachedFile {
   id: string
@@ -655,7 +640,7 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
                 onOpen={() => setInteractionModeOpen(true)}
                 onClose={() => setInteractionModeOpen(false)}
                 trigger={(triggerProps) => (
-                  <WebTooltip label={`Mode: ${currentInteractionConfig.label}`}>
+                  <WebTooltip label={`Mode: ${currentInteractionConfig.label}`} placement="bottom">
                     <Pressable
                       {...triggerProps}
                       disabled={disabled}
@@ -755,7 +740,7 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
                   per-device preference; every subsequent plan auto-generates
                   a stakeholder summary until disabled. */}
               {interactionMode === "plan" && (
-                <WebTooltip label="Also generate a stakeholder summary">
+                <WebTooltip label="Also generate a stakeholder summary" placement="bottom">
                   <Pressable
                     testID="home-dual-plan-toggle"
                     disabled={disabled}
@@ -790,16 +775,18 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
                 onOpen={() => setModelPickerOpen(true)}
                 onClose={() => setModelPickerOpen(false)}
                 trigger={(triggerProps) => (
-                  <Pressable
-                    {...triggerProps}
-                    disabled={disabled}
-                    className="h-[22px] flex-row items-center gap-1 rounded-md px-1.5"
-                  >
-                    <Text className="text-xs text-muted-foreground">
-                      {resolveShortName(currentModelId)}
-                    </Text>
-                    <ChevronDown className="h-2 w-2 text-muted-foreground/60" size={8} />
-                  </Pressable>
+                  <WebTooltip label={`Model: ${resolveShortName(currentModelId)}`} placement="bottom">
+                    <Pressable
+                      {...triggerProps}
+                      disabled={disabled}
+                      className="h-[22px] flex-row items-center gap-1 rounded-md px-1.5"
+                    >
+                      <Text className="text-xs text-muted-foreground">
+                        {resolveShortName(currentModelId)}
+                      </Text>
+                      <ChevronDown className="h-2 w-2 text-muted-foreground/60" size={8} />
+                    </Pressable>
+                  </WebTooltip>
                 )}
               >
                 <PopoverBackdrop />
@@ -831,24 +818,26 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
               </View>
             ) : (
               <View className="flex-row items-center gap-1">
-                <Pressable
-                  onPress={handleAttachClick}
-                  disabled={disabled || isLoading || pendingFiles.length >= MAX_FILES}
-                  role="button"
-                  accessibilityLabel="Attach file"
-                  className="min-h-5 min-w-5 rounded-full items-center justify-center active:opacity-70"
-                  android_ripple={{ color: "rgba(128,128,128,0.25)" }}
-                >
-                  <Plus
-                    className={cn(
-                      "h-4 w-4",
-                      disabled || isLoading || pendingFiles.length >= MAX_FILES
-                        ? "text-muted-foreground/40"
-                        : "text-muted-foreground"
-                    )}
-                    size={12}
-                  />
-                </Pressable>
+                <WebTooltip label="Attach files" placement="bottom">
+                  <Pressable
+                    onPress={handleAttachClick}
+                    disabled={disabled || isLoading || pendingFiles.length >= MAX_FILES}
+                    role="button"
+                    accessibilityLabel="Attach file"
+                    className="min-h-5 min-w-5 rounded-full items-center justify-center active:opacity-70"
+                    android_ripple={{ color: "rgba(128,128,128,0.25)" }}
+                  >
+                    <Plus
+                      className={cn(
+                        "h-4 w-4",
+                        disabled || isLoading || pendingFiles.length >= MAX_FILES
+                          ? "text-muted-foreground/40"
+                          : "text-muted-foreground"
+                      )}
+                      size={12}
+                    />
+                  </Pressable>
+                </WebTooltip>
 
                 {isLoading ? (
                   <View className="h-5 w-5 rounded-full items-center justify-center bg-primary opacity-50">
@@ -868,47 +857,51 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
                     <ArrowUp className="h-3 w-3 text-primary-foreground" size={12} />
                   </Pressable>
                 ) : onStartVoiceProjectCreation ? (
-                  <Pressable
-                    onPress={() => {
-                      voiceInput.clearError()
-                      void Promise.resolve(onStartVoiceProjectCreation()).catch(() => {})
-                    }}
-                    disabled={disabled}
-                    role="button"
-                    accessibilityLabel="Start voice project creation"
-                    className="h-5 w-5 rounded-full items-center justify-center active:opacity-70"
-                  >
-                    <Mic
-                      className={cn(
-                        "h-4 w-4",
-                        disabled
-                          ? "text-muted-foreground/40"
-                          : "text-muted-foreground"
-                      )}
-                      size={14}
-                    />
-                  </Pressable>
+                  <WebTooltip label="Start voice project creation" placement="bottom">
+                    <Pressable
+                      onPress={() => {
+                        voiceInput.clearError()
+                        void Promise.resolve(onStartVoiceProjectCreation()).catch(() => {})
+                      }}
+                      disabled={disabled}
+                      role="button"
+                      accessibilityLabel="Start voice project creation"
+                      className="h-5 w-5 rounded-full items-center justify-center active:opacity-70"
+                    >
+                      <Mic
+                        className={cn(
+                          "h-4 w-4",
+                          disabled
+                            ? "text-muted-foreground/40"
+                            : "text-muted-foreground"
+                        )}
+                        size={14}
+                      />
+                    </Pressable>
+                  </WebTooltip>
                 ) : voiceInput.canRecord ? (
-                  <Pressable
-                    onPress={() => {
-                      voiceInput.clearError()
-                      voiceInput.toggleRecording().catch(() => {})
-                    }}
-                    disabled={disabled}
-                    role="button"
-                    accessibilityLabel="Start voice recording"
-                    className="h-5 w-5 rounded-full items-center justify-center active:opacity-70"
-                  >
-                    <Mic
-                      className={cn(
-                        "h-4 w-4",
-                        disabled
-                          ? "text-muted-foreground/40"
-                          : "text-muted-foreground"
-                      )}
-                      size={14}
-                    />
-                  </Pressable>
+                  <WebTooltip label="Start voice recording" placement="bottom">
+                    <Pressable
+                      onPress={() => {
+                        voiceInput.clearError()
+                        voiceInput.toggleRecording().catch(() => {})
+                      }}
+                      disabled={disabled}
+                      role="button"
+                      accessibilityLabel="Start voice recording"
+                      className="h-5 w-5 rounded-full items-center justify-center active:opacity-70"
+                    >
+                      <Mic
+                        className={cn(
+                          "h-4 w-4",
+                          disabled
+                            ? "text-muted-foreground/40"
+                            : "text-muted-foreground"
+                        )}
+                        size={14}
+                      />
+                    </Pressable>
+                  </WebTooltip>
                 ) : null}
               </View>
             )}

--- a/apps/mobile/components/chat/EnvironmentPicker.tsx
+++ b/apps/mobile/components/chat/EnvironmentPicker.tsx
@@ -28,6 +28,7 @@ import {
   PopoverContent,
 } from "@/components/ui/popover"
 import { cn } from "@shogo/shared-ui/primitives"
+import { WebTooltip } from "../ui/web-tooltip"
 import { useActiveInstance } from "../../contexts/active-instance"
 import { useInstancePicker, type Instance } from "@shogo/shared-app/hooks"
 import { useActiveWorkspace } from "../../hooks/useActiveWorkspace"
@@ -38,21 +39,6 @@ function getAuthHeaders(): Record<string, string> {
   if (Platform.OS === "web") return {}
   const cookie = (authClient as any).getCookie?.()
   return cookie ? { Cookie: cookie } : {}
-}
-
-/**
- * Show a native browser tooltip on hover (web only). Wraps children in a
- * `display: contents` div with the `title` attribute so layout is unaffected
- * and the trigger's own ref isn't disturbed. On native this is a transparent
- * passthrough — the icon click opens the popover menu.
- */
-function WebTooltip({ label, children }: { label: string; children: React.ReactNode }) {
-  if (Platform.OS !== "web") return <>{children}</>
-  return React.createElement(
-    "div",
-    { title: label, style: { display: "contents" } },
-    children,
-  )
 }
 
 function StatusDot({ status }: { status: Instance["status"] }) {
@@ -104,7 +90,7 @@ export function EnvironmentPicker({ disabled }: EnvironmentPickerProps) {
       onOpen={() => { setOpen(true); refresh() }}
       onClose={() => setOpen(false)}
       trigger={(triggerProps) => (
-        <WebTooltip label={`Environment: ${displayLabel}`}>
+        <WebTooltip label={`Environment: ${displayLabel}`} placement="bottom">
           <Pressable
             {...triggerProps}
             disabled={disabled}

--- a/apps/mobile/components/chat/EnvironmentPicker.tsx
+++ b/apps/mobile/components/chat/EnvironmentPicker.tsx
@@ -28,7 +28,7 @@ import {
   PopoverContent,
 } from "@/components/ui/popover"
 import { cn } from "@shogo/shared-ui/primitives"
-import { WebTooltip } from "../ui/web-tooltip"
+import { WebTooltip } from "../ui/tooltip"
 import { useActiveInstance } from "../../contexts/active-instance"
 import { useInstancePicker, type Instance } from "@shogo/shared-app/hooks"
 import { useActiveWorkspace } from "../../hooks/useActiveWorkspace"

--- a/apps/mobile/components/chat/TechStackPicker.tsx
+++ b/apps/mobile/components/chat/TechStackPicker.tsx
@@ -16,7 +16,7 @@
  * reflects what the runtime would seed even before the user touches it.
  */
 import React, { useEffect, useMemo, useRef, useState } from "react"
-import { View, Text, Pressable, ScrollView, Platform } from "react-native"
+import { View, Text, Pressable, ScrollView } from "react-native"
 import { Layers, ChevronDown, Check } from "lucide-react-native"
 import {
   Popover,
@@ -25,21 +25,7 @@ import {
 } from "@/components/ui/popover"
 import { cn } from "@shogo/shared-ui/primitives"
 import { api, createHttpClient, type TechStackSummary } from "../../lib/api"
-
-/**
- * Show a native browser tooltip on hover (web only). Wraps children in a
- * `display: contents` div with the `title` attribute so layout is unaffected
- * and the trigger's own ref (popover positioning) isn't disturbed. On native
- * this is a transparent passthrough — the icon click opens the popover.
- */
-function WebTooltip({ label, children }: { label: string; children: React.ReactNode }) {
-  if (Platform.OS !== "web") return <>{children}</>
-  return React.createElement(
-    "div",
-    { title: label, style: { display: "contents" } },
-    children,
-  )
-}
+import { WebTooltip } from "../ui/web-tooltip"
 
 export interface TechStackPickerProps {
   /** Currently selected stack id (e.g. "react-app"). */
@@ -70,8 +56,8 @@ export function TechStackPicker({ value, onChange, disabled }: TechStackPickerPr
   )
 
   // Until the list loads (or if the id has no match) we don't have a human
-  // label, so fall back to a generic "Stack" rather than flashing the raw id.
-  const displayLabel = selected?.name ?? "Stack"
+  // label, so fall back to a generic "Type" rather than flashing the raw id.
+  const displayLabel = selected?.name ?? "Type"
 
   // Nothing to choose from (tech-stacks dir missing on disk / fetch failed).
   // Hide the chip entirely rather than render a dead control.
@@ -85,11 +71,11 @@ export function TechStackPicker({ value, onChange, disabled }: TechStackPickerPr
       onOpen={() => setOpen(true)}
       onClose={() => setOpen(false)}
       trigger={(triggerProps) => (
-        <WebTooltip label={`Tech stack: ${selected?.name ?? "default"}`}>
+        <WebTooltip label={`Project type: ${selected?.name ?? "default"}`} placement="bottom">
           <Pressable
             {...triggerProps}
             disabled={disabled}
-            accessibilityLabel={`Tech stack: ${selected?.name ?? "default"}`}
+            accessibilityLabel={`Project type: ${selected?.name ?? "default"}`}
             className={cn(
               "h-[22px] flex-row items-center gap-1 rounded-md px-1.5",
               "border border-border/60 bg-muted/40 active:opacity-80",
@@ -109,7 +95,7 @@ export function TechStackPicker({ value, onChange, disabled }: TechStackPickerPr
         <ScrollView>
           <View className="px-3 pt-3 pb-1">
             <Text className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
-              Tech Stack
+              Project Type
             </Text>
           </View>
           {stacks.map((stack) => {

--- a/apps/mobile/components/chat/TechStackPicker.tsx
+++ b/apps/mobile/components/chat/TechStackPicker.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/components/ui/popover"
 import { cn } from "@shogo/shared-ui/primitives"
 import { api, createHttpClient, type TechStackSummary } from "../../lib/api"
-import { WebTooltip } from "../ui/web-tooltip"
+import { WebTooltip } from "../ui/tooltip"
 
 export interface TechStackPickerProps {
   /** Currently selected stack id (e.g. "react-app"). */

--- a/apps/mobile/components/project/ProjectSourceMenu.tsx
+++ b/apps/mobile/components/project/ProjectSourceMenu.tsx
@@ -50,6 +50,7 @@ import { ProjectImportModal } from '../projects/ProjectImportModal'
 import { CloudProjectPickerModal } from '../projects/CloudProjectPickerModal'
 import { useOpenLocalFolder } from './useOpenLocalFolder'
 import { useOpenCloudProject } from './useOpenCloudProject'
+import { WebTooltip } from '../ui/web-tooltip'
 
 export type ProjectSourceVariant = 'chip' | 'button'
 
@@ -143,20 +144,22 @@ export function ProjectSourceMenu({
 
   const trigger = (triggerProps: any) =>
     variant === 'chip' ? (
-      <Pressable
-        {...triggerProps}
-        accessibilityLabel="Project source"
-        className={cn(
-          'h-[22px] flex-row items-center gap-1 rounded-md px-1.5',
-          'border border-border/60 bg-muted/40 active:opacity-80',
-          isPicking && 'opacity-60',
-        )}
-        testID="project-source-menu-trigger"
-      >
-        <Sparkles className="h-3 w-3 text-muted-foreground" size={12} />
-        <Text className="text-[11px] text-muted-foreground">New</Text>
-        <ChevronDown className="h-2 w-2 text-muted-foreground/60" size={8} />
-      </Pressable>
+      <WebTooltip label="Choose how to start the project" placement="bottom">
+        <Pressable
+          {...triggerProps}
+          accessibilityLabel="Project source"
+          className={cn(
+            'h-[22px] flex-row items-center gap-1 rounded-md px-1.5',
+            'border border-border/60 bg-muted/40 active:opacity-80',
+            isPicking && 'opacity-60',
+          )}
+          testID="project-source-menu-trigger"
+        >
+          <Sparkles className="h-3 w-3 text-muted-foreground" size={12} />
+          <Text className="text-[11px] text-muted-foreground">New</Text>
+          <ChevronDown className="h-2 w-2 text-muted-foreground/60" size={8} />
+        </Pressable>
+      </WebTooltip>
     ) : (
       <Pressable
         {...triggerProps}

--- a/apps/mobile/components/project/ProjectSourceMenu.tsx
+++ b/apps/mobile/components/project/ProjectSourceMenu.tsx
@@ -50,7 +50,7 @@ import { ProjectImportModal } from '../projects/ProjectImportModal'
 import { CloudProjectPickerModal } from '../projects/CloudProjectPickerModal'
 import { useOpenLocalFolder } from './useOpenLocalFolder'
 import { useOpenCloudProject } from './useOpenCloudProject'
-import { WebTooltip } from '../ui/web-tooltip'
+import { WebTooltip } from '../ui/tooltip'
 
 export type ProjectSourceVariant = 'chip' | 'button'
 

--- a/apps/mobile/components/project/panels/CapabilitiesPanel.tsx
+++ b/apps/mobile/components/project/panels/CapabilitiesPanel.tsx
@@ -468,16 +468,16 @@ export function CapabilitiesConfigPane({
         </View>
       </View>
 
-      {/* Tech Stack selector */}
+      {/* Project Type selector */}
       {techStacks.length > 0 && (
         <View className="px-4 pt-3 pb-1">
-          <Text className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">Tech Stack</Text>
+          <Text className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">Project Type</Text>
           <View className="border border-border rounded-lg px-3 py-2.5 flex-row items-center gap-3">
             <View className="w-8 h-8 rounded-md items-center justify-center bg-primary/10">
               <Layers size={15} className="text-primary" />
             </View>
             <View className="flex-1">
-              <Text className="text-xs text-muted-foreground">Stack</Text>
+              <Text className="text-xs text-muted-foreground">Type</Text>
               <Popover
                 placement="bottom left"
                 isOpen={stackPickerOpen}

--- a/apps/mobile/components/ui/tooltip/index.tsx
+++ b/apps/mobile/components/ui/tooltip/index.tsx
@@ -33,11 +33,11 @@ const tooltipStyle = tva({
 });
 
 const tooltipContentStyle = tva({
-  base: 'py-1 px-3 rounded-sm bg-foreground web:pointer-events-auto',
+  base: 'py-1 px-3 rounded-sm border border-border bg-popover shadow-md web:pointer-events-auto',
 });
 
 const tooltipTextStyle = tva({
-  base: 'font-normal tracking-normal web:select-none text-xs text-background',
+  base: 'font-normal tracking-normal web:select-none text-xs text-popover-foreground',
 
   variants: {
     isTruncated: {
@@ -132,38 +132,97 @@ interface WebTooltipProps {
   placement?: 'top' | 'bottom';
 }
 
-function WebTooltip({ label, children, placement = 'top' }: WebTooltipProps) {
-  const [isOpen, setIsOpen] = React.useState(false);
+type TooltipTriggerProps = Record<string, any>;
 
-  // Native keeps the previous passthrough behavior because tap targets already open their full popover/menu labels.
+type PossibleRef<T> = React.Ref<T> | undefined;
+
+function assignRef<T>(ref: PossibleRef<T>, value: T) {
+  if (typeof ref === 'function') {
+    ref(value);
+  } else if (ref && typeof ref === 'object') {
+    (ref as React.MutableRefObject<T>).current = value;
+  }
+}
+
+function mergeRefs<T>(...refs: PossibleRef<T>[]) {
+  return (value: T) => refs.forEach((ref) => assignRef(ref, value));
+}
+
+function composeEventHandlers<T extends (...args: any[]) => void>(
+  childHandler?: T,
+  tooltipHandler?: T
+) {
+  return (...args: Parameters<T>) => {
+    childHandler?.(...args);
+    tooltipHandler?.(...args);
+  };
+}
+
+function mergeTriggerProps(
+  child: React.ReactElement,
+  triggerProps: TooltipTriggerProps,
+  label: string
+) {
+  const childProps = child.props as TooltipTriggerProps;
+  const mergedProps: TooltipTriggerProps = {
+    ...triggerProps,
+    ...childProps,
+    ref: mergeRefs((child as any).ref, triggerProps.ref),
+    'aria-label': childProps['aria-label'] ?? label,
+  };
+
+  for (const eventName of [
+    'onBlur',
+    'onFocus',
+    'onMouseEnter',
+    'onMouseLeave',
+    'onPointerEnter',
+    'onPointerLeave',
+  ]) {
+    if (childProps[eventName] || triggerProps[eventName]) {
+      mergedProps[eventName] = composeEventHandlers(
+        childProps[eventName],
+        triggerProps[eventName]
+      );
+    }
+  }
+
+  return mergedProps;
+}
+
+function WebTooltip({ label, children, placement = 'top' }: WebTooltipProps) {
   if (Platform.OS !== 'web') return <>{children}</>;
 
-  // Web composes the existing Gluestack tooltip primitives, but controls hover/focus state here so the desktop Electron embed does not depend on Gluestack's internal hover wiring.
   return (
     <Tooltip
-      isOpen={isOpen}
       placement={placement}
       offset={8}
       shouldFlip
       openDelay={0}
       closeDelay={0}
-      trigger={(triggerProps: any) => (
-        <span
-          ref={triggerProps.ref}
-          onFocus={() => setIsOpen(true)}
-          onBlur={() => setIsOpen(false)}
-          onMouseEnter={() => setIsOpen(true)}
-          onMouseLeave={() => setIsOpen(false)}
-          aria-describedby={triggerProps['aria-describedby']}
-          aria-label={label}
-          style={{ display: 'inline-flex', alignItems: 'center' }}
-        >
-          {children}
-        </span>
-      )}
+      trigger={(triggerProps: TooltipTriggerProps) => {
+        const child = React.Children.only(children);
+
+        if (React.isValidElement(child)) {
+          return React.cloneElement(
+            child,
+            mergeTriggerProps(child, triggerProps, label)
+          );
+        }
+
+        return (
+          <span
+            {...triggerProps}
+            aria-label={label}
+            style={{ display: 'contents' }}
+          >
+            {child}
+          </span>
+        );
+      }}
     >
-      <TooltipContent className="max-w-[260px] rounded-lg border border-border bg-popover px-2 py-1.5 shadow-lg">
-        <TooltipText className="text-xs font-medium leading-4 text-popover-foreground">
+      <TooltipContent className="max-w-[260px] web:pointer-events-none">
+        <TooltipText className="text-xs font-normal leading-4">
           {label}
         </TooltipText>
       </TooltipContent>

--- a/apps/mobile/components/ui/tooltip/index.tsx
+++ b/apps/mobile/components/ui/tooltip/index.tsx
@@ -3,7 +3,7 @@
 'use client';
 import React from 'react';
 import { createTooltip } from '@gluestack-ui/core/tooltip/creator';
-import { View, Text, ViewStyle } from 'react-native';
+import { Platform, View, Text, ViewStyle } from 'react-native';
 import type { VariantProps } from '@gluestack-ui/utils/nativewind-utils';
 import { tva } from '@gluestack-ui/utils/nativewind-utils';
 import { withStyleContext } from '@gluestack-ui/utils/nativewind-utils';
@@ -126,8 +126,49 @@ const TooltipText = React.forwardRef<
   );
 });
 
+interface WebTooltipProps {
+  label: string;
+  children: React.ReactNode;
+  placement?: 'top' | 'bottom';
+}
+
+function WebTooltip({ label, children, placement = 'top' }: WebTooltipProps) {
+  // Native keeps the previous passthrough behavior because tap targets already open their full popover/menu labels.
+  if (Platform.OS !== 'web') return <>{children}</>;
+
+  // Web composes the existing Gluestack tooltip primitives so placement, flipping, and overlay behavior stay centralized.
+  return (
+    <Tooltip
+      placement={placement}
+      offset={8}
+      shouldFlip
+      openDelay={150}
+      closeDelay={0}
+      trigger={(triggerProps: any) => (
+        <span
+          ref={triggerProps.ref}
+          onFocus={triggerProps.onFocus}
+          onBlur={triggerProps.onBlur}
+          onMouseEnter={triggerProps.onMouseEnter}
+          onMouseLeave={triggerProps.onMouseLeave}
+          aria-describedby={triggerProps['aria-describedby']}
+          style={{ display: 'inline-flex', alignItems: 'center' }}
+        >
+          {children}
+        </span>
+      )}
+    >
+      <TooltipContent className="max-w-[260px] rounded-lg border border-border bg-popover px-2 py-1.5 shadow-lg">
+        <TooltipText className="text-xs font-medium leading-4 text-popover-foreground">
+          {label}
+        </TooltipText>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 Tooltip.displayName = 'Tooltip';
 TooltipContent.displayName = 'TooltipContent';
 TooltipText.displayName = 'TooltipText';
 
-export { Tooltip, TooltipContent, TooltipText };
+export { Tooltip, TooltipContent, TooltipText, WebTooltip };

--- a/apps/mobile/components/ui/tooltip/index.tsx
+++ b/apps/mobile/components/ui/tooltip/index.tsx
@@ -133,25 +133,29 @@ interface WebTooltipProps {
 }
 
 function WebTooltip({ label, children, placement = 'top' }: WebTooltipProps) {
+  const [isOpen, setIsOpen] = React.useState(false);
+
   // Native keeps the previous passthrough behavior because tap targets already open their full popover/menu labels.
   if (Platform.OS !== 'web') return <>{children}</>;
 
-  // Web composes the existing Gluestack tooltip primitives so placement, flipping, and overlay behavior stay centralized.
+  // Web composes the existing Gluestack tooltip primitives, but controls hover/focus state here so the desktop Electron embed does not depend on Gluestack's internal hover wiring.
   return (
     <Tooltip
+      isOpen={isOpen}
       placement={placement}
       offset={8}
       shouldFlip
-      openDelay={150}
+      openDelay={0}
       closeDelay={0}
       trigger={(triggerProps: any) => (
         <span
           ref={triggerProps.ref}
-          onFocus={triggerProps.onFocus}
-          onBlur={triggerProps.onBlur}
-          onMouseEnter={triggerProps.onMouseEnter}
-          onMouseLeave={triggerProps.onMouseLeave}
+          onFocus={() => setIsOpen(true)}
+          onBlur={() => setIsOpen(false)}
+          onMouseEnter={() => setIsOpen(true)}
+          onMouseLeave={() => setIsOpen(false)}
           aria-describedby={triggerProps['aria-describedby']}
+          aria-label={label}
           style={{ display: 'inline-flex', alignItems: 'center' }}
         >
           {children}

--- a/apps/mobile/components/ui/web-tooltip.tsx
+++ b/apps/mobile/components/ui/web-tooltip.tsx
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react"
+import { Platform } from "react-native"
+
+interface WebTooltipProps {
+  label: string
+  children: React.ReactNode
+  placement?: "top" | "bottom"
+}
+
+const OFFSET = 8
+
+export function WebTooltip({ label, children, placement = "top" }: WebTooltipProps) {
+  const triggerRef = useRef<HTMLElement | null>(null)
+  const tooltipRef = useRef<HTMLDivElement | null>(null)
+  const [visible, setVisible] = useState(false)
+  const [mounted, setMounted] = useState(false)
+  const [position, setPosition] = useState({ top: 0, left: 0 })
+
+  useEffect(() => {
+    if (Platform.OS !== "web") return
+    setMounted(true)
+  }, [])
+
+  useLayoutEffect(() => {
+    if (!visible || !triggerRef.current || !tooltipRef.current || typeof window === "undefined") return
+
+    const triggerRect = triggerRef.current.getBoundingClientRect()
+    const tooltipRect = tooltipRef.current.getBoundingClientRect()
+    const left = Math.min(
+      Math.max(triggerRect.left + triggerRect.width / 2 - tooltipRect.width / 2, OFFSET),
+      window.innerWidth - tooltipRect.width - OFFSET,
+    )
+    const topPlacement = triggerRect.top - tooltipRect.height - OFFSET
+    const bottomPlacement = triggerRect.bottom + OFFSET
+    const canPlaceAbove = topPlacement >= OFFSET
+    const canPlaceBelow = bottomPlacement + tooltipRect.height <= window.innerHeight - OFFSET
+    const top = placement === "bottom"
+      ? (canPlaceBelow || !canPlaceAbove ? bottomPlacement : topPlacement)
+      : (canPlaceAbove || !canPlaceBelow ? topPlacement : bottomPlacement)
+
+    setPosition({ top, left })
+  }, [visible, label, placement])
+
+  if (Platform.OS !== "web" || !mounted || typeof document === "undefined") {
+    return <>{children}</>
+  }
+
+  const wrapped = React.createElement(
+    "span",
+    {
+      ref: triggerRef,
+      onMouseEnter: () => setVisible(true),
+      onMouseLeave: () => setVisible(false),
+      onFocus: () => setVisible(true),
+      onBlur: () => setVisible(false),
+      style: { display: "inline-flex", alignItems: "center" },
+    },
+    children,
+  )
+
+  if (!visible) return wrapped
+
+  const tooltip = React.createElement(
+    "div",
+    {
+      ref: tooltipRef,
+      role: "tooltip",
+      style: {
+        position: "fixed",
+        top: position.top,
+        left: position.left,
+        zIndex: 2147483647,
+        maxWidth: 260,
+        padding: "6px 8px",
+        borderRadius: 8,
+        border: "1px solid var(--color-border, rgba(148, 163, 184, 0.24))",
+        background: "var(--color-popover, #ffffff)",
+        color: "var(--color-popover-foreground, #0f172a)",
+        boxShadow: "0 10px 30px rgba(15, 23, 42, 0.18)",
+        fontSize: 12,
+        lineHeight: "16px",
+        fontWeight: 500,
+        pointerEvents: "none",
+        whiteSpace: "nowrap",
+      },
+    },
+    label,
+  )
+
+  const { createPortal } = require("react-dom") as typeof import("react-dom")
+  return (
+    <>
+      {wrapped}
+      {createPortal(tooltip, document.body)}
+    </>
+  )
+}

--- a/packages/agent-runtime/tech-stacks/expo-app/stack.json
+++ b/packages/agent-runtime/tech-stacks/expo-app/stack.json
@@ -1,7 +1,7 @@
 {
   "id": "expo-app",
-  "name": "Expo (React Native)",
-  "description": "Build cross-platform mobile apps with Expo + React Native + TypeScript. Metro bundler is supervised by the runtime; web preview is rendered via react-native-web. Real-device preview is exposed via an Expo tunnel + QR.",
+  "name": "Mobile App",
+  "description": "Create an app for iPhone and Android with an easy preview and sharing flow.",
   "tags": ["expo", "react-native", "mobile", "ios", "android", "metro", "typescript"],
   "target": "mobile",
   "seedsOwnTemplate": true,

--- a/packages/agent-runtime/tech-stacks/expo-three/stack.json
+++ b/packages/agent-runtime/tech-stacks/expo-three/stack.json
@@ -1,7 +1,7 @@
 {
   "id": "expo-three",
-  "name": "Expo + Three.js (3D mobile games)",
-  "description": "Build 3D mobile games with Expo + React Native + @react-three/fiber/native + expo-gl. Includes a twin-stick controller scaffold, instanced-mesh patterns for mobs/projectiles, and an FPS overlay. Web preview falls back to @react-three/fiber via react-native-web.",
+  "name": "3D Mobile Game",
+  "description": "Build an interactive 3D game for iPhone and Android devices.",
   "tags": ["expo", "react-native", "threejs", "3d", "games", "gamedev", "expo-gl", "mobile"],
   "target": "mobile",
   "seedsOwnTemplate": true,

--- a/packages/agent-runtime/tech-stacks/none/stack.json
+++ b/packages/agent-runtime/tech-stacks/none/stack.json
@@ -1,7 +1,7 @@
 {
   "id": "none",
-  "name": "None",
-  "description": "No preset tech stack. The agent has full freedom to choose tools, languages, and frameworks.",
+  "name": "Start from Scratch",
+  "description": "Begin with an empty project and build anything you have in mind.",
   "tags": ["blank", "custom"],
   "target": "none",
   "seedsOwnTemplate": true,

--- a/packages/agent-runtime/tech-stacks/phaser-game/stack.json
+++ b/packages/agent-runtime/tech-stacks/phaser-game/stack.json
@@ -1,7 +1,7 @@
 {
   "id": "phaser-game",
-  "name": "Phaser 2D Game Builder",
-  "description": "Build 2D browser games with Phaser 3 and Vite. Includes scene management, arcade physics, sprites, tilemaps, and input handling.",
+  "name": "2D Game",
+  "description": "Create a simple 2D game that runs in a web browser.",
   "tags": ["2d", "games", "phaser", "sprites", "physics", "vite"],
   "target": "web",
   "runtime": {

--- a/packages/agent-runtime/tech-stacks/python-data/stack.json
+++ b/packages/agent-runtime/tech-stacks/python-data/stack.json
@@ -1,7 +1,7 @@
 {
   "id": "python-data",
-  "name": "Python Data Science",
-  "description": "Data analysis and visualization with Python, Jupyter, pandas, matplotlib, and plotly. Write notebooks or scripts to explore, transform, and visualize data.",
+  "name": "Data & Charts",
+  "description": "Explore information, find insights, and create charts or reports.",
   "tags": ["python", "data", "jupyter", "pandas", "matplotlib", "plotly", "analysis"],
   "target": "data",
   "seedsOwnTemplate": true,

--- a/packages/agent-runtime/tech-stacks/react-app/stack.json
+++ b/packages/agent-runtime/tech-stacks/react-app/stack.json
@@ -1,7 +1,7 @@
 {
   "id": "react-app",
-  "name": "React App",
-  "description": "Build apps with Vite + React + TypeScript + Tailwind CSS + shadcn/ui. Includes a Hono backend at server.tsx with Prisma + SQLite for persistent data.",
+  "name": "Website or Web App",
+  "description": "Build a website, dashboard, business tool, or online app.",
   "tags": ["react", "vite", "tailwind", "shadcn", "typescript", "fullstack"],
   "target": "web",
   "runtime": {

--- a/packages/agent-runtime/tech-stacks/react-native/stack.json
+++ b/packages/agent-runtime/tech-stacks/react-native/stack.json
@@ -1,7 +1,7 @@
 {
   "id": "react-native",
-  "name": "React Native (bare)",
-  "description": "Build cross-platform mobile apps with bare React Native + TypeScript (no Expo). Metro bundler is supervised by the runtime. The workspace ships with a Hono + Prisma backend at the root for CRUD APIs that the mobile client can call. Web preview is not produced by bare RN; cloud preview is device-only.",
+  "name": "Custom Mobile App",
+  "description": "Create an iPhone and Android app when you need deeper device-level control.",
   "tags": ["react-native", "mobile", "ios", "android", "metro", "typescript", "bare"],
   "target": "mobile",
   "seedsOwnTemplate": true,

--- a/packages/agent-runtime/tech-stacks/threejs-game/stack.json
+++ b/packages/agent-runtime/tech-stacks/threejs-game/stack.json
@@ -1,7 +1,7 @@
 {
   "id": "threejs-game",
-  "name": "Three.js Game Builder",
-  "description": "Build 3D browser games with Three.js, cannon-es physics, and Vite. Includes scene management, game loop, and physics patterns.",
+  "name": "3D Game",
+  "description": "Build an interactive 3D game that runs in a web browser.",
   "tags": ["3d", "games", "threejs", "webgl", "physics", "vite"],
   "target": "web",
   "runtime": {

--- a/packages/agent-runtime/tech-stacks/unity-game/stack.json
+++ b/packages/agent-runtime/tech-stacks/unity-game/stack.json
@@ -1,7 +1,7 @@
 {
   "id": "unity-game",
-  "name": "Unity Game Builder",
-  "description": "Build games with Unity and C#. Requires .NET SDK (future runtime layer).",
+  "name": "Advanced Game Project",
+  "description": "Build a larger 2D or 3D game for desktop or mobile. Best for full game-engine projects.",
   "tags": ["unity", "csharp", "3d", "2d", "games", "gamedev"],
   "target": "native",
   "seedsOwnTemplate": true,


### PR DESCRIPTION
## Summary
Updated the web/desktop tooltip experience and refreshed tech stack descriptions so users get clearer guidance when choosing modes, actions, environments, models, and project tech stacks.
## Changes
- Added/shared web tooltip support across chat and project controls.
- Added tooltip labels for key compact/full chat input actions, including:
  - Interaction mode
  - Stakeholder summary toggle
  - Quick actions
  - Model picker
  - Attach files
  - Voice project creation
  - Environment picker
  - Project source/menu actions
- Fixed desktop/web tooltip behavior so only one tooltip appears on hover.
  - Removed the native browser `title` tooltip from the custom tooltip wrapper.
  - Preserved accessibility with `aria-label`.
- Updated tech stack descriptions across runtime stack metadata to make stack choices clearer.
- Updated desktop dev startup to sync the web bundle before launching Electron, so desktop fallback loads the latest tooltip changes.
## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [x] Verified no regressions
Tested with:
- Verified tooltip source no longer uses native `title={label}`.
- Verified custom tooltip uses `aria-label`.
- Synced desktop embedded web bundle with `npm --prefix apps/desktop run sync:web`.
- Ran `git diff --check`.
- Ran `npm --prefix apps/desktop run build`.

<img width="1512" height="982" alt="Screenshot 2026-07-22 at 2 24 39 PM" src="https://github.com/user-attachments/assets/25413998-0cfc-4644-9ea1-47d936bb0948" />
<img width="1512" height="982" alt="Screenshot 2026-07-22 at 2 24 42 PM" src="https://github.com/user-attachments/assets/edbc9781-fa8b-4aa6-8b9c-1523c7445fda" />