### PR TITLE
feat: Phase 1 UI enhancements — Appearance settings + ProcessPanel redesign

### DIFF
--- a/apps/mobile/app/(app)/settings.tsx
+++ b/apps/mobile/app/(app)/settings.tsx
@@ -51,7 +51,13 @@ import {
   Download,
   Bug,
   Monitor,
+  Paintbrush,
+  SlidersHorizontal,
+  Sun,
+  Moon,
 } from 'lucide-react-native'
+import { useTheme } from '../../contexts/theme'
+import { useAppearance } from '../../contexts/appearance'
 import { useAuth } from '../../contexts/auth'
 import {
   useDomain,
@@ -114,9 +120,9 @@ import { useDualPlan } from '../../lib/dual-plan-preference'
 
 const DOCS_URL = 'https://docs.shogo.ai'
 
-type TabId = 'workspace' | 'people' | 'models' | 'integrations' | 'remote-control' | 'account' | 'security' | 'billing' | 'compute' | 'analytics' | 'costs' | 'support'
+type TabId = 'workspace' | 'people' | 'models' | 'integrations' | 'remote-control' | 'account' | 'security' | 'billing' | 'compute' | 'analytics' | 'costs' | 'support' | 'appearance'
 
-const ALL_TAB_IDS: TabId[] = ['workspace', 'people', 'models', 'integrations', 'remote-control', 'account', 'security', 'billing', 'compute', 'analytics', 'costs', 'support']
+const ALL_TAB_IDS: TabId[] = ['workspace', 'people', 'models', 'integrations', 'remote-control', 'account', 'security', 'billing', 'compute', 'analytics', 'costs', 'support', 'appearance']
 
 /** Tablet/desktop split: matches `SettingsPage` `isWide` (sidebar layout). */
 const SETTINGS_WIDE_BREAKPOINT = 768
@@ -135,6 +141,7 @@ const MOBILE_NAV_ITEMS: NavItem[] = [
   { id: 'integrations', label: 'Integrations', icon: Plug },
   { id: 'remote-control', label: 'Remote Control', icon: Monitor },
   { id: 'account', label: 'Account', icon: User },
+  { id: 'appearance', label: 'Appearance', icon: Paintbrush },
   ...(!HIDE_COMPUTE_PURCHASES_ON_IOS ? [{ id: 'compute' as TabId, label: 'Compute', icon: Server }] : []),
   { id: 'billing', label: 'Billing', icon: CreditCard },
   { id: 'analytics', label: 'Usage', icon: BarChart3 },
@@ -146,6 +153,7 @@ const LOCAL_NAV_ITEMS: NavItem[] = [
   { id: 'integrations', label: 'Integrations', icon: Plug },
   { id: 'remote-control', label: 'Remote Control', icon: Monitor },
   { id: 'account', label: 'Account', icon: User },
+  { id: 'appearance', label: 'Appearance', icon: Paintbrush },
   { id: 'security', label: 'Security', icon: Shield },
   { id: 'analytics', label: 'Usage', icon: BarChart3 },
   { id: 'costs', label: 'Costs', icon: Coins },
@@ -262,6 +270,7 @@ function SettingsSidebar({
       label: 'Account',
       items: [
         { id: 'account', label: userName || 'Account' },
+        { id: 'appearance' as TabId, label: 'Appearance' },
         ...(!showBilling ? [{ id: 'security' as TabId, label: 'Security' }] : []),
       ],
     },
@@ -3241,12 +3250,130 @@ function WorkspaceCostTab() {
 // MAIN SETTINGS PAGE
 // ============================================================================
 
-const SettingsContent = observer(function SettingsContent({ 
-  activeTab, 
-  localMode = false 
-}: { 
-  activeTab: TabId, 
-  localMode?: boolean 
+// ── Appearance Tab ────────────────────────────────────────────────────────────
+
+function AppearanceSection({ title }: { title: string }) {
+  return (
+    <Text className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2 mt-5">
+      {title}
+    </Text>
+  )
+}
+
+function AppearanceRow({
+  label,
+  description,
+  children,
+}: {
+  label: string
+  description?: string
+  children: React.ReactNode
+}) {
+  return (
+    <View className="flex-row items-center justify-between gap-4 px-4 py-3 rounded-lg bg-muted/30 border border-border mb-2">
+      <View className="flex-1">
+        <Text className="text-sm font-medium text-foreground">{label}</Text>
+        {description ? (
+          <Text className="text-xs text-muted-foreground mt-0.5">{description}</Text>
+        ) : null}
+      </View>
+      <View className="shrink-0">{children}</View>
+    </View>
+  )
+}
+
+function AppearanceTab() {
+  const { theme, setTheme } = useTheme()
+  const { settings: ap, update, reset } = useAppearance()
+
+  return (
+    <View>
+      <Text className="text-2xl font-bold text-foreground mb-1">Appearance</Text>
+      <Text className="text-sm text-muted-foreground mb-6">
+        Customize the look and feel of the Shogo interface.
+      </Text>
+
+      {/* ── Theme ── */}
+      <AppearanceSection title="Theme" />
+      <View className="flex-row gap-2 mb-2">
+        {([
+          { value: 'light' as const, label: 'Light', Icon: Sun },
+          { value: 'dark' as const, label: 'Dark', Icon: Moon },
+          { value: 'system' as const, label: 'System', Icon: Monitor },
+        ] as const).map(({ value, label, Icon }) => (
+          <Pressable
+            key={value}
+            onPress={() => setTheme(value)}
+            className={cn(
+              'flex-1 flex-col items-center gap-2 py-4 rounded-lg border',
+              theme === value
+                ? 'border-primary bg-primary/10'
+                : 'border-border bg-muted/20'
+            )}
+          >
+            <Icon
+              size={20}
+              className={theme === value ? 'text-primary' : 'text-muted-foreground'}
+            />
+            <Text
+              className={cn(
+                'text-xs font-medium',
+                theme === value ? 'text-primary' : 'text-muted-foreground'
+              )}
+            >
+              {label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      {/* ── Typography ── */}
+      <AppearanceSection title="Typography" />
+      <AppearanceRow label="UI Font Size" description="Font size for the Shogo interface">
+        <View className="flex-row items-center gap-1.5">
+          <Pressable
+            onPress={() => update({ uiFontSize: 14 })}
+            accessibilityLabel="Reset font size"
+            className="w-7 h-7 items-center justify-center rounded border border-border active:bg-muted"
+          >
+            <SlidersHorizontal size={12} className="text-muted-foreground" />
+          </Pressable>
+          <Pressable
+            onPress={() => update({ uiFontSize: Math.max(11, ap.uiFontSize - 1) })}
+            className="w-7 h-7 items-center justify-center rounded border border-border active:bg-muted"
+          >
+            <Text className="text-foreground text-base leading-none">−</Text>
+          </Pressable>
+          <Text className="text-sm font-semibold text-foreground tabular-nums w-6 text-center">
+            {ap.uiFontSize}
+          </Text>
+          <Pressable
+            onPress={() => update({ uiFontSize: Math.min(24, ap.uiFontSize + 1) })}
+            className="w-7 h-7 items-center justify-center rounded border border-border active:bg-muted"
+          >
+            <Text className="text-foreground text-base leading-none">+</Text>
+          </Pressable>
+        </View>
+      </AppearanceRow>
+      {/* Reset */}
+      <Pressable
+        onPress={reset}
+        className="mt-4 py-2.5 rounded-lg border border-border items-center active:bg-muted"
+      >
+        <Text className="text-sm text-muted-foreground">Reset to defaults</Text>
+      </Pressable>
+    </View>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SettingsContent = observer(function SettingsContent({
+  activeTab,
+  localMode = false
+}: {
+  activeTab: TabId,
+  localMode?: boolean
 }) {
   const isLocal = localMode
   return (
@@ -3257,6 +3384,7 @@ const SettingsContent = observer(function SettingsContent({
       {activeTab === 'integrations' && <IntegrationsTab />}
       {activeTab === 'remote-control' && <RemoteControlTab />}
       {activeTab === 'account' && <AccountTab />}
+      {activeTab === 'appearance' && <AppearanceTab />}
       {activeTab === 'security' && <SecuritySettingsPanel />}
       {activeTab === 'compute' && !isLocal && !HIDE_COMPUTE_PURCHASES_ON_IOS && <ComputeTab />}
       {activeTab === 'billing' && !isLocal && <BillingTab />}

--- a/apps/mobile/app/(app)/settings.tsx
+++ b/apps/mobile/app/(app)/settings.tsx
@@ -52,12 +52,8 @@ import {
   Bug,
   Monitor,
   Paintbrush,
-  SlidersHorizontal,
-  Sun,
-  Moon,
 } from 'lucide-react-native'
-import { useTheme } from '../../contexts/theme'
-import { useAppearance } from '../../contexts/appearance'
+import { AppearanceTab } from '../../components/settings/AppearanceTab'
 import { useAuth } from '../../contexts/auth'
 import {
   useDomain,
@@ -3250,123 +3246,6 @@ function WorkspaceCostTab() {
 // MAIN SETTINGS PAGE
 // ============================================================================
 
-// ── Appearance Tab ────────────────────────────────────────────────────────────
-
-function AppearanceSection({ title }: { title: string }) {
-  return (
-    <Text className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2 mt-5">
-      {title}
-    </Text>
-  )
-}
-
-function AppearanceRow({
-  label,
-  description,
-  children,
-}: {
-  label: string
-  description?: string
-  children: React.ReactNode
-}) {
-  return (
-    <View className="flex-row items-center justify-between gap-4 px-4 py-3 rounded-lg bg-muted/30 border border-border mb-2">
-      <View className="flex-1">
-        <Text className="text-sm font-medium text-foreground">{label}</Text>
-        {description ? (
-          <Text className="text-xs text-muted-foreground mt-0.5">{description}</Text>
-        ) : null}
-      </View>
-      <View className="shrink-0">{children}</View>
-    </View>
-  )
-}
-
-function AppearanceTab() {
-  const { theme, setTheme } = useTheme()
-  const { settings: ap, update, reset } = useAppearance()
-
-  return (
-    <View>
-      <Text className="text-2xl font-bold text-foreground mb-1">Appearance</Text>
-      <Text className="text-sm text-muted-foreground mb-6">
-        Customize the look and feel of the Shogo interface.
-      </Text>
-
-      {/* ── Theme ── */}
-      <AppearanceSection title="Theme" />
-      <View className="flex-row gap-2 mb-2">
-        {([
-          { value: 'light' as const, label: 'Light', Icon: Sun },
-          { value: 'dark' as const, label: 'Dark', Icon: Moon },
-          { value: 'system' as const, label: 'System', Icon: Monitor },
-        ] as const).map(({ value, label, Icon }) => (
-          <Pressable
-            key={value}
-            onPress={() => setTheme(value)}
-            className={cn(
-              'flex-1 flex-col items-center gap-2 py-4 rounded-lg border',
-              theme === value
-                ? 'border-primary bg-primary/10'
-                : 'border-border bg-muted/20'
-            )}
-          >
-            <Icon
-              size={20}
-              className={theme === value ? 'text-primary' : 'text-muted-foreground'}
-            />
-            <Text
-              className={cn(
-                'text-xs font-medium',
-                theme === value ? 'text-primary' : 'text-muted-foreground'
-              )}
-            >
-              {label}
-            </Text>
-          </Pressable>
-        ))}
-      </View>
-
-      {/* ── Typography ── */}
-      <AppearanceSection title="Typography" />
-      <AppearanceRow label="UI Font Size" description="Font size for the Shogo interface">
-        <View className="flex-row items-center gap-1.5">
-          <Pressable
-            onPress={() => update({ uiFontSize: 14 })}
-            accessibilityLabel="Reset font size"
-            className="w-7 h-7 items-center justify-center rounded border border-border active:bg-muted"
-          >
-            <SlidersHorizontal size={12} className="text-muted-foreground" />
-          </Pressable>
-          <Pressable
-            onPress={() => update({ uiFontSize: Math.max(11, ap.uiFontSize - 1) })}
-            className="w-7 h-7 items-center justify-center rounded border border-border active:bg-muted"
-          >
-            <Text className="text-foreground text-base leading-none">−</Text>
-          </Pressable>
-          <Text className="text-sm font-semibold text-foreground tabular-nums w-6 text-center">
-            {ap.uiFontSize}
-          </Text>
-          <Pressable
-            onPress={() => update({ uiFontSize: Math.min(24, ap.uiFontSize + 1) })}
-            className="w-7 h-7 items-center justify-center rounded border border-border active:bg-muted"
-          >
-            <Text className="text-foreground text-base leading-none">+</Text>
-          </Pressable>
-        </View>
-      </AppearanceRow>
-      {/* Reset */}
-      <Pressable
-        onPress={reset}
-        className="mt-4 py-2.5 rounded-lg border border-border items-center active:bg-muted"
-      >
-        <Text className="text-sm text-muted-foreground">Reset to defaults</Text>
-      </Pressable>
-    </View>
-  )
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
 
 const SettingsContent = observer(function SettingsContent({
   activeTab,

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -71,6 +71,7 @@ import { InstanceOfflineWatcher } from '../components/instance/InstanceOfflineWa
 import { PostHogProvider } from '../contexts/posthog'
 import { ThemeProvider, useTheme } from '../contexts/theme'
 import { AccentThemeProvider } from '../contexts/accent-theme'
+import { AppearanceProvider } from '../contexts/appearance'
 import { RootErrorBoundary } from '../components/RootErrorBoundary'
 import { UpdateBanner } from '../components/UpdateBanner'
 import { captureAttribution } from '../lib/attribution'
@@ -219,9 +220,11 @@ function RootLayout() {
   return (
     <RootErrorBoundary>
       <ThemeProvider>
-        <AccentThemeProvider>
-          <RootLayoutInner />
-        </AccentThemeProvider>
+        <AppearanceProvider>
+          <AccentThemeProvider>
+            <RootLayoutInner />
+          </AccentThemeProvider>
+        </AppearanceProvider>
       </ThemeProvider>
     </RootErrorBoundary>
   )

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -72,6 +72,7 @@ import {
 } from "./long-text-utils"
 import { resolveChatInputTextChange, type ChatInputTextChange } from "./chat-input-text-change"
 import { FileViewerModal } from "./FileViewerModal"
+import { ImagePreviewModal } from "./ImagePreviewModal"
 import { VideoPreviewModal } from "./VideoPreviewModal"
 import { PastedTextChip } from "./PastedTextChip"
 import { useChatBridgeOptional } from "../voice-mode/ChatBridgeContext"
@@ -542,6 +543,7 @@ function ChatInputImpl({
   const [pastedTexts, setPastedTexts] = useState<PastedTextEntry[]>([])
   const [viewingPastedId, setViewingPastedId] = useState<string | null>(null)
   const [previewVideoFile, setPreviewVideoFile] = useState<{ url: string; name: string } | null>(null)
+  const [previewImageFile, setPreviewImageFile] = useState<{ url: string; name: string } | null>(null)
   const lastRestoredDraftNonceRef = useRef<number | null>(null)
 
   useEffect(() => {
@@ -1784,13 +1786,19 @@ function ChatInputImpl({
               return (
                 <View key={file.id} className="relative">
                   {isImage ? (
-                    <View className="rounded-lg overflow-hidden border border-border/60" style={{ width: 72, height: 72 }}>
-                      <Image
-                        source={{ uri: file.dataUrl }}
-                        style={{ width: 72, height: 72 }}
-                        resizeMode="cover"
-                      />
-                    </View>
+                    <Pressable
+                      onPress={() => setPreviewImageFile({ url: file.dataUrl, name: file.name })}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Preview image ${file.name}`}
+                    >
+                      <View className="rounded-lg overflow-hidden border border-border/60" style={{ width: 72, height: 72 }}>
+                        <Image
+                          source={{ uri: file.dataUrl }}
+                          style={{ width: 72, height: 72 }}
+                          resizeMode="cover"
+                        />
+                      </View>
+                    </Pressable>
                   ) : isVideo ? (
                     <Pressable
                       onPress={() => setPreviewVideoFile({ url: file.dataUrl, name: file.name })}
@@ -1832,13 +1840,9 @@ function ChatInputImpl({
             })}
             {isProcessingFiles && (
               <View
-                className="rounded-lg border border-border/60 bg-muted/40 items-center justify-center"
+                className="rounded-lg overflow-hidden border border-border/60 bg-muted/30 animate-pulse"
                 style={{ width: 72, height: 72 }}
-              >
-                <Text className="text-[10px] text-muted-foreground text-center">
-                  Uploading…
-                </Text>
-              </View>
+              />
             )}
           </ScrollView>
         )}
@@ -2348,6 +2352,13 @@ function ChatInputImpl({
         </View>
         </View>
       </View>
+
+      <ImagePreviewModal
+        visible={previewImageFile !== null}
+        onClose={() => setPreviewImageFile(null)}
+        url={previewImageFile?.url ?? ""}
+        title={previewImageFile?.name}
+      />
 
       <VideoPreviewModal
         visible={previewVideoFile !== null}

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -1311,67 +1311,6 @@ function ChatInputImpl({
         </View>
       )}
 
-      {/* File previews */}
-      {pendingFiles.length > 0 && (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerClassName="gap-2 mb-2"
-        >
-          {pendingFiles.map((file) => {
-            const isImage = file.type.startsWith("image/")
-            return (
-              <View
-                key={file.id}
-                className={cn(
-                  "relative rounded-lg border border-border bg-muted/50 p-2",
-                  isImage ? "w-[150px]" : "w-[180px]"
-                )}
-              >
-                {isImage ? (
-                  <Image
-                    source={{ uri: file.dataUrl }}
-                    className="h-[80px] rounded border border-border w-full"
-                    resizeMode="cover"
-                  />
-                ) : (
-                  <View className="flex-row items-center gap-2">
-                    <View className="flex-shrink-0">
-                      {getFileIcon(file.type)}
-                    </View>
-                    <View className="flex-1 min-w-0">
-                      <Text
-                        className="text-xs font-medium text-foreground"
-                        numberOfLines={1}
-                      >
-                        {file.name}
-                      </Text>
-                      <Text className="text-xs text-muted-foreground">
-                        {formatFileSize(file.size)}
-                      </Text>
-                    </View>
-                  </View>
-                )}
-                <Pressable
-                  onPress={() => handleRemoveFile(file.id)}
-                  disabled={isProcessingFiles}
-                  className="absolute -right-2 -top-2 h-6 w-6 rounded-full bg-destructive items-center justify-center"
-                >
-                  <X className="h-4 w-4 text-destructive-foreground" size={16} />
-                </Pressable>
-              </View>
-            )
-          })}
-        </ScrollView>
-      )}
-
-      {/* Processing indicator */}
-      {isProcessingFiles && (
-        <Text className="text-xs text-muted-foreground mb-2">
-          Processing files...
-        </Text>
-      )}
-
       {/* Error message */}
       {fileError && (
         <Text className="text-sm text-destructive mb-2">{fileError}</Text>
@@ -1827,6 +1766,60 @@ function ChatInputImpl({
               />
             ))}
           </View>
+        )}
+
+        {/* File attachment previews — compact thumbnails inside the input box */}
+        {(pendingFiles.length > 0 || isProcessingFiles) && (
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={{ gap: 8, paddingHorizontal: 12, paddingTop: 12, paddingBottom: 4 }}
+          >
+            {pendingFiles.map((file) => {
+              const isImage = file.type.startsWith("image/")
+              return (
+                <View key={file.id} className="relative">
+                  {isImage ? (
+                    <View className="rounded-lg overflow-hidden border border-border/60" style={{ width: 72, height: 72 }}>
+                      <Image
+                        source={{ uri: file.dataUrl }}
+                        style={{ width: 72, height: 72 }}
+                        resizeMode="cover"
+                      />
+                    </View>
+                  ) : (
+                    <View
+                      className="flex-row items-center gap-1.5 rounded-lg border border-border/60 bg-muted/40 px-2"
+                      style={{ height: 36, maxWidth: 160 }}
+                    >
+                      <View className="flex-shrink-0">{getFileIcon(file.type)}</View>
+                      <Text className="text-xs text-foreground flex-1 min-w-0" numberOfLines={1}>
+                        {file.name}
+                      </Text>
+                    </View>
+                  )}
+                  <Pressable
+                    onPress={() => handleRemoveFile(file.id)}
+                    disabled={isProcessingFiles}
+                    className="absolute -right-1.5 -top-1.5 h-5 w-5 rounded-full bg-background border border-border items-center justify-center"
+                    style={{ zIndex: 10 }}
+                  >
+                    <X className="text-foreground" size={10} />
+                  </Pressable>
+                </View>
+              )
+            })}
+            {isProcessingFiles && (
+              <View
+                className="rounded-lg border border-border/60 bg-muted/40 items-center justify-center"
+                style={{ width: 72, height: 72 }}
+              >
+                <Text className="text-[10px] text-muted-foreground text-center">
+                  Uploading…
+                </Text>
+              </View>
+            )}
+          </ScrollView>
         )}
 
         {/* Tagged files / projects now render INLINE as "@mention" pills via

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -58,6 +58,7 @@ import {
   Mic,
   Sparkles,
   Languages,
+  Play,
 } from "lucide-react-native"
 import { useVoiceInput } from "./useVoiceInput"
 import { VoiceWaveform } from "./VoiceWaveform"
@@ -1773,10 +1774,11 @@ function ChatInputImpl({
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
-            contentContainerStyle={{ gap: 8, paddingHorizontal: 12, paddingTop: 12, paddingBottom: 4 }}
+            contentContainerStyle={{ gap: 8, paddingHorizontal: 12, paddingTop: 12, paddingBottom: 4, alignItems: 'flex-end' }}
           >
             {pendingFiles.map((file) => {
               const isImage = file.type.startsWith("image/")
+              const isVideo = file.type.startsWith("video/")
               return (
                 <View key={file.id} className="relative">
                   {isImage ? (
@@ -1786,6 +1788,17 @@ function ChatInputImpl({
                         style={{ width: 72, height: 72 }}
                         resizeMode="cover"
                       />
+                    </View>
+                  ) : isVideo ? (
+                    <View className="rounded-lg overflow-hidden border border-border/60 bg-black/80 items-center justify-center" style={{ width: 72, height: 72 }}>
+                      <View className="absolute inset-0 items-center justify-center">
+                        <View className="rounded-full bg-white/20 items-center justify-center" style={{ width: 32, height: 32 }}>
+                          <Play size={16} className="text-white" fill="white" />
+                        </View>
+                      </View>
+                      <Text className="text-[9px] text-white/50 absolute bottom-1.5 left-0 right-0 text-center" numberOfLines={1}>
+                        {file.name}
+                      </Text>
                     </View>
                   ) : (
                     <View

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -72,6 +72,7 @@ import {
 } from "./long-text-utils"
 import { resolveChatInputTextChange, type ChatInputTextChange } from "./chat-input-text-change"
 import { FileViewerModal } from "./FileViewerModal"
+import { VideoPreviewModal } from "./VideoPreviewModal"
 import { PastedTextChip } from "./PastedTextChip"
 import { useChatBridgeOptional } from "../voice-mode/ChatBridgeContext"
 import { AskUserQuestionWidget } from "./turns/AskUserQuestionWidget"
@@ -540,6 +541,7 @@ function ChatInputImpl({
   // chip).
   const [pastedTexts, setPastedTexts] = useState<PastedTextEntry[]>([])
   const [viewingPastedId, setViewingPastedId] = useState<string | null>(null)
+  const [previewVideoFile, setPreviewVideoFile] = useState<{ url: string; name: string } | null>(null)
   const lastRestoredDraftNonceRef = useRef<number | null>(null)
 
   useEffect(() => {
@@ -1790,16 +1792,22 @@ function ChatInputImpl({
                       />
                     </View>
                   ) : isVideo ? (
-                    <View className="rounded-lg overflow-hidden border border-border/60 bg-black/80 items-center justify-center" style={{ width: 72, height: 72 }}>
-                      <View className="absolute inset-0 items-center justify-center">
-                        <View className="rounded-full bg-white/20 items-center justify-center" style={{ width: 32, height: 32 }}>
-                          <Play size={16} className="text-white" fill="white" />
+                    <Pressable
+                      onPress={() => setPreviewVideoFile({ url: file.dataUrl, name: file.name })}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Preview video ${file.name}`}
+                    >
+                      <View className="rounded-lg overflow-hidden border border-border/60 bg-black/80 items-center justify-center" style={{ width: 72, height: 72 }}>
+                        <View className="absolute inset-0 items-center justify-center">
+                          <View className="rounded-full bg-white/20 items-center justify-center" style={{ width: 32, height: 32 }}>
+                            <Play size={16} className="text-white" fill="white" />
+                          </View>
                         </View>
+                        <Text className="text-[9px] text-white/50 absolute bottom-1.5 left-0 right-0 text-center" numberOfLines={1}>
+                          {file.name}
+                        </Text>
                       </View>
-                      <Text className="text-[9px] text-white/50 absolute bottom-1.5 left-0 right-0 text-center" numberOfLines={1}>
-                        {file.name}
-                      </Text>
-                    </View>
+                    </Pressable>
                   ) : (
                     <View
                       className="flex-row items-center gap-1.5 rounded-lg border border-border/60 bg-muted/40 px-2"
@@ -2340,6 +2348,13 @@ function ChatInputImpl({
         </View>
         </View>
       </View>
+
+      <VideoPreviewModal
+        visible={previewVideoFile !== null}
+        onClose={() => setPreviewVideoFile(null)}
+        url={previewVideoFile?.url ?? ""}
+        title={previewVideoFile?.name ?? "Video preview"}
+      />
 
       {viewingPasted && (
         <FileViewerModal

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -72,6 +72,7 @@ import {
 } from "./long-text-utils"
 import { resolveChatInputTextChange, type ChatInputTextChange } from "./chat-input-text-change"
 import { FileViewerModal } from "./FileViewerModal"
+import { VideoPreviewModal } from "./VideoPreviewModal"
 import { PastedTextChip } from "./PastedTextChip"
 import { useChatBridgeOptional } from "../voice-mode/ChatBridgeContext"
 import { AskUserQuestionWidget } from "./turns/AskUserQuestionWidget"
@@ -545,6 +546,7 @@ function ChatInputImpl({
   // chip).
   const [pastedTexts, setPastedTexts] = useState<PastedTextEntry[]>([])
   const [viewingPastedId, setViewingPastedId] = useState<string | null>(null)
+  const [previewVideoFile, setPreviewVideoFile] = useState<{ url: string; name: string } | null>(null)
   const lastRestoredDraftNonceRef = useRef<number | null>(null)
 
   useEffect(() => {
@@ -1844,16 +1846,22 @@ function ChatInputImpl({
                       />
                     </View>
                   ) : isVideo ? (
-                    <View className="rounded-lg overflow-hidden border border-border/60 bg-black/80 items-center justify-center" style={{ width: 72, height: 72 }}>
-                      <View className="absolute inset-0 items-center justify-center">
-                        <View className="rounded-full bg-white/20 items-center justify-center" style={{ width: 32, height: 32 }}>
-                          <Play size={16} className="text-white" fill="white" />
+                    <Pressable
+                      onPress={() => setPreviewVideoFile({ url: file.dataUrl, name: file.name })}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Preview video ${file.name}`}
+                    >
+                      <View className="rounded-lg overflow-hidden border border-border/60 bg-black/80 items-center justify-center" style={{ width: 72, height: 72 }}>
+                        <View className="absolute inset-0 items-center justify-center">
+                          <View className="rounded-full bg-white/20 items-center justify-center" style={{ width: 32, height: 32 }}>
+                            <Play size={16} className="text-white" fill="white" />
+                          </View>
                         </View>
+                        <Text className="text-[9px] text-white/50 absolute bottom-1.5 left-0 right-0 text-center" numberOfLines={1}>
+                          {file.name}
+                        </Text>
                       </View>
-                      <Text className="text-[9px] text-white/50 absolute bottom-1.5 left-0 right-0 text-center" numberOfLines={1}>
-                        {file.name}
-                      </Text>
-                    </View>
+                    </Pressable>
                   ) : (
                     <View
                       className="flex-row items-center gap-1.5 rounded-lg border border-border/60 bg-muted/40 px-2"
@@ -2394,6 +2402,13 @@ function ChatInputImpl({
         </View>
         </View>
       </View>
+
+      <VideoPreviewModal
+        visible={previewVideoFile !== null}
+        onClose={() => setPreviewVideoFile(null)}
+        url={previewVideoFile?.url ?? ""}
+        title={previewVideoFile?.name ?? "Video preview"}
+      />
 
       {viewingPasted && (
         <FileViewerModal

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -72,6 +72,7 @@ import {
 } from "./long-text-utils"
 import { resolveChatInputTextChange, type ChatInputTextChange } from "./chat-input-text-change"
 import { FileViewerModal } from "./FileViewerModal"
+import { ImagePreviewModal } from "./ImagePreviewModal"
 import { VideoPreviewModal } from "./VideoPreviewModal"
 import { PastedTextChip } from "./PastedTextChip"
 import { useChatBridgeOptional } from "../voice-mode/ChatBridgeContext"
@@ -547,6 +548,7 @@ function ChatInputImpl({
   const [pastedTexts, setPastedTexts] = useState<PastedTextEntry[]>([])
   const [viewingPastedId, setViewingPastedId] = useState<string | null>(null)
   const [previewVideoFile, setPreviewVideoFile] = useState<{ url: string; name: string } | null>(null)
+  const [previewImageFile, setPreviewImageFile] = useState<{ url: string; name: string } | null>(null)
   const lastRestoredDraftNonceRef = useRef<number | null>(null)
 
   useEffect(() => {
@@ -1838,13 +1840,19 @@ function ChatInputImpl({
               return (
                 <View key={file.id} className="relative">
                   {isImage ? (
-                    <View className="rounded-lg overflow-hidden border border-border/60" style={{ width: 72, height: 72 }}>
-                      <Image
-                        source={{ uri: file.dataUrl }}
-                        style={{ width: 72, height: 72 }}
-                        resizeMode="cover"
-                      />
-                    </View>
+                    <Pressable
+                      onPress={() => setPreviewImageFile({ url: file.dataUrl, name: file.name })}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Preview image ${file.name}`}
+                    >
+                      <View className="rounded-lg overflow-hidden border border-border/60" style={{ width: 72, height: 72 }}>
+                        <Image
+                          source={{ uri: file.dataUrl }}
+                          style={{ width: 72, height: 72 }}
+                          resizeMode="cover"
+                        />
+                      </View>
+                    </Pressable>
                   ) : isVideo ? (
                     <Pressable
                       onPress={() => setPreviewVideoFile({ url: file.dataUrl, name: file.name })}
@@ -1886,13 +1894,9 @@ function ChatInputImpl({
             })}
             {isProcessingFiles && (
               <View
-                className="rounded-lg border border-border/60 bg-muted/40 items-center justify-center"
+                className="rounded-lg overflow-hidden border border-border/60 bg-muted/30 animate-pulse"
                 style={{ width: 72, height: 72 }}
-              >
-                <Text className="text-[10px] text-muted-foreground text-center">
-                  Uploading…
-                </Text>
-              </View>
+              />
             )}
           </ScrollView>
         )}
@@ -2402,6 +2406,13 @@ function ChatInputImpl({
         </View>
         </View>
       </View>
+
+      <ImagePreviewModal
+        visible={previewImageFile !== null}
+        onClose={() => setPreviewImageFile(null)}
+        url={previewImageFile?.url ?? ""}
+        title={previewImageFile?.name}
+      />
 
       <VideoPreviewModal
         visible={previewVideoFile !== null}

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -58,6 +58,7 @@ import {
   Mic,
   Sparkles,
   Languages,
+  Play,
 } from "lucide-react-native"
 import { useVoiceInput } from "./useVoiceInput"
 import { VoiceWaveform } from "./VoiceWaveform"
@@ -1827,10 +1828,11 @@ function ChatInputImpl({
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
-            contentContainerStyle={{ gap: 8, paddingHorizontal: 12, paddingTop: 12, paddingBottom: 4 }}
+            contentContainerStyle={{ gap: 8, paddingHorizontal: 12, paddingTop: 12, paddingBottom: 4, alignItems: 'flex-end' }}
           >
             {pendingFiles.map((file) => {
               const isImage = file.type.startsWith("image/")
+              const isVideo = file.type.startsWith("video/")
               return (
                 <View key={file.id} className="relative">
                   {isImage ? (
@@ -1840,6 +1842,17 @@ function ChatInputImpl({
                         style={{ width: 72, height: 72 }}
                         resizeMode="cover"
                       />
+                    </View>
+                  ) : isVideo ? (
+                    <View className="rounded-lg overflow-hidden border border-border/60 bg-black/80 items-center justify-center" style={{ width: 72, height: 72 }}>
+                      <View className="absolute inset-0 items-center justify-center">
+                        <View className="rounded-full bg-white/20 items-center justify-center" style={{ width: 32, height: 32 }}>
+                          <Play size={16} className="text-white" fill="white" />
+                        </View>
+                      </View>
+                      <Text className="text-[9px] text-white/50 absolute bottom-1.5 left-0 right-0 text-center" numberOfLines={1}>
+                        {file.name}
+                      </Text>
                     </View>
                   ) : (
                     <View

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -1365,67 +1365,6 @@ function ChatInputImpl({
         </View>
       )}
 
-      {/* File previews */}
-      {pendingFiles.length > 0 && (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerClassName="gap-2 mb-2"
-        >
-          {pendingFiles.map((file) => {
-            const isImage = file.type.startsWith("image/")
-            return (
-              <View
-                key={file.id}
-                className={cn(
-                  "relative rounded-lg border border-border bg-muted/50 p-2",
-                  isImage ? "w-[150px]" : "w-[180px]"
-                )}
-              >
-                {isImage ? (
-                  <Image
-                    source={{ uri: file.dataUrl }}
-                    className="h-[80px] rounded border border-border w-full"
-                    resizeMode="cover"
-                  />
-                ) : (
-                  <View className="flex-row items-center gap-2">
-                    <View className="flex-shrink-0">
-                      {getFileIcon(file.type)}
-                    </View>
-                    <View className="flex-1 min-w-0">
-                      <Text
-                        className="text-xs font-medium text-foreground"
-                        numberOfLines={1}
-                      >
-                        {file.name}
-                      </Text>
-                      <Text className="text-xs text-muted-foreground">
-                        {formatFileSize(file.size)}
-                      </Text>
-                    </View>
-                  </View>
-                )}
-                <Pressable
-                  onPress={() => handleRemoveFile(file.id)}
-                  disabled={isProcessingFiles}
-                  className="absolute -right-2 -top-2 h-6 w-6 rounded-full bg-destructive items-center justify-center"
-                >
-                  <X className="h-4 w-4 text-destructive-foreground" size={16} />
-                </Pressable>
-              </View>
-            )
-          })}
-        </ScrollView>
-      )}
-
-      {/* Processing indicator */}
-      {isProcessingFiles && (
-        <Text className="text-xs text-muted-foreground mb-2">
-          Processing files...
-        </Text>
-      )}
-
       {/* Error message */}
       {fileError && (
         <Text className="text-sm text-destructive mb-2">{fileError}</Text>
@@ -1881,6 +1820,60 @@ function ChatInputImpl({
               />
             ))}
           </View>
+        )}
+
+        {/* File attachment previews — compact thumbnails inside the input box */}
+        {(pendingFiles.length > 0 || isProcessingFiles) && (
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={{ gap: 8, paddingHorizontal: 12, paddingTop: 12, paddingBottom: 4 }}
+          >
+            {pendingFiles.map((file) => {
+              const isImage = file.type.startsWith("image/")
+              return (
+                <View key={file.id} className="relative">
+                  {isImage ? (
+                    <View className="rounded-lg overflow-hidden border border-border/60" style={{ width: 72, height: 72 }}>
+                      <Image
+                        source={{ uri: file.dataUrl }}
+                        style={{ width: 72, height: 72 }}
+                        resizeMode="cover"
+                      />
+                    </View>
+                  ) : (
+                    <View
+                      className="flex-row items-center gap-1.5 rounded-lg border border-border/60 bg-muted/40 px-2"
+                      style={{ height: 36, maxWidth: 160 }}
+                    >
+                      <View className="flex-shrink-0">{getFileIcon(file.type)}</View>
+                      <Text className="text-xs text-foreground flex-1 min-w-0" numberOfLines={1}>
+                        {file.name}
+                      </Text>
+                    </View>
+                  )}
+                  <Pressable
+                    onPress={() => handleRemoveFile(file.id)}
+                    disabled={isProcessingFiles}
+                    className="absolute -right-1.5 -top-1.5 h-5 w-5 rounded-full bg-background border border-border items-center justify-center"
+                    style={{ zIndex: 10 }}
+                  >
+                    <X className="text-foreground" size={10} />
+                  </Pressable>
+                </View>
+              )
+            })}
+            {isProcessingFiles && (
+              <View
+                className="rounded-lg border border-border/60 bg-muted/40 items-center justify-center"
+                style={{ width: 72, height: 72 }}
+              >
+                <Text className="text-[10px] text-muted-foreground text-center">
+                  Uploading…
+                </Text>
+              </View>
+            )}
+          </ScrollView>
         )}
 
         {/* Tagged files / projects now render INLINE as "@mention" pills via

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -1316,7 +1316,7 @@ export const ChatPanel = observer(function ChatPanel({
       } as any)
       if (res.ok) {
         const data = await res.json()
-        if (Array.isArray(data?.processes)) setRunningProcesses(data.processes as RunningProcess[])
+        if (Array.isArray(data?.processes)) setRunningProcesses((data.processes as RunningProcess[]).filter((p) => p.runId !== runId))
         else setRunningProcesses((prev) => prev.filter((p) => p.runId !== runId))
       }
     } catch {
@@ -5153,7 +5153,7 @@ export const ChatPanel = observer(function ChatPanel({
 
           {/* Running background processes (visible regardless of streaming) */}
           {runningProcesses.length > 0 && (
-            <View className="px-4 pb-2">
+            <View className="px-4 pb-2 w-full items-center">
               <ProcessPanel
                 processes={runningProcesses}
                 onKill={handleKillProcess}
@@ -5164,7 +5164,7 @@ export const ChatPanel = observer(function ChatPanel({
 
           {/* Tool Error Banner */}
           {toolErrorBanner && (
-            <View className="px-4 pb-2">
+            <View className="px-4 pb-2 w-full items-center">
               <View className={cn(
                 "flex-row items-start gap-2 rounded-lg p-3",
                 toolErrorBanner.isAuthError

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -1316,7 +1316,7 @@ export const ChatPanel = observer(function ChatPanel({
       } as any)
       if (res.ok) {
         const data = await res.json()
-        if (Array.isArray(data?.processes)) setRunningProcesses(data.processes as RunningProcess[])
+        if (Array.isArray(data?.processes)) setRunningProcesses((data.processes as RunningProcess[]).filter((p) => p.runId !== runId))
         else setRunningProcesses((prev) => prev.filter((p) => p.runId !== runId))
       }
     } catch {
@@ -5155,7 +5155,7 @@ export const ChatPanel = observer(function ChatPanel({
 
           {/* Running background processes (visible regardless of streaming) */}
           {runningProcesses.length > 0 && (
-            <View className="px-4 pb-2">
+            <View className="px-4 pb-2 w-full items-center">
               <ProcessPanel
                 processes={runningProcesses}
                 onKill={handleKillProcess}
@@ -5166,7 +5166,7 @@ export const ChatPanel = observer(function ChatPanel({
 
           {/* Tool Error Banner */}
           {toolErrorBanner && (
-            <View className="px-4 pb-2">
+            <View className="px-4 pb-2 w-full items-center">
               <View className={cn(
                 "flex-row items-start gap-2 rounded-lg p-3",
                 toolErrorBanner.isAuthError

--- a/apps/mobile/components/chat/ProcessPanel.tsx
+++ b/apps/mobile/components/chat/ProcessPanel.tsx
@@ -1,6 +1,15 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2026 Shogo Technologies, Inc.
-
+/**
+ * ProcessPanel — shows background shell processes started by the agent in this
+ * thread that are still running. Lets the user terminate a process or dismiss
+ * a stale entry left over from a runtime restart.
+ *
+ * Data is seeded from the runtime's process endpoint and kept live via
+ * `data-process-update` SSE frames in ChatPanel. Elapsed time is computed
+ * locally using `Date.now() - proc.startedAt` so the display ticks even when
+ * no SSE frames arrive.
+ */
 import { useState, useEffect, useRef } from "react"
 import { View, Text, Pressable, ActivityIndicator } from "react-native"
 import { cn } from "@shogo/shared-ui/primitives"

--- a/apps/mobile/components/chat/ProcessPanel.tsx
+++ b/apps/mobile/components/chat/ProcessPanel.tsx
@@ -1,18 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2026 Shogo Technologies, Inc.
-/**
- * ProcessPanel Component (React Native)
- *
- * Shows the background shell processes the agent has started in this thread
- * that are still running. Lets the user terminate one (or dismiss a stale
- * entry left over from a runtime restart). Seeded from the runtime's process
- * endpoint and kept live by `data-process-update` SSE frames.
- */
 
-import { useState } from "react"
+import { useState, useEffect, useRef } from "react"
 import { View, Text, Pressable, ActivityIndicator } from "react-native"
 import { cn } from "@shogo/shared-ui/primitives"
-import { ChevronDown, ChevronUp, Terminal, X } from "lucide-react-native"
+import { ChevronDown, ChevronUp, Terminal, X, Clock } from "lucide-react-native"
 
 export interface RunningProcess {
   runId: string
@@ -21,15 +13,12 @@ export interface RunningProcess {
   sandboxed?: boolean
   containerName?: string
   startedAt: number
-  elapsedMs: number
   stale?: boolean
 }
 
 export interface ProcessPanelProps {
   processes: RunningProcess[]
-  /** Kill (or dismiss, for stale) a process by run id. */
   onKill: (runId: string) => void | Promise<void>
-  /** Run ids currently being killed (shows a spinner, disables the button). */
   killing?: Set<string>
   defaultExpanded?: boolean
   className?: string
@@ -45,6 +34,10 @@ function formatElapsed(ms: number): string {
   return `${hours}h ${minutes % 60}m`
 }
 
+function truncateCommand(cmd: string, maxLen = 60): string {
+  return cmd.length > maxLen ? cmd.slice(0, maxLen) + "…" : cmd
+}
+
 export function ProcessPanel({
   processes,
   onKill,
@@ -53,93 +46,121 @@ export function ProcessPanel({
   className,
 }: ProcessPanelProps) {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded)
+  const [now, setNow] = useState(() => Date.now())
+  const pendingKills = useRef<Set<string>>(new Set())
 
-  if (processes.length === 0) {
-    return null
+  useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(t)
+  }, [])
+
+  function handleKill(runId: string) {
+    if (pendingKills.current.has(runId)) return
+    pendingKills.current.add(runId)
+    Promise.resolve(onKill(runId)).finally(() => {
+      pendingKills.current.delete(runId)
+    })
   }
 
+  if (processes.length === 0) return null
+
   return (
-    <View
-      className={cn(
-        "rounded-md border border-gray-200/50 dark:border-gray-700/50 bg-gray-50/40 dark:bg-gray-900/40",
-        "overflow-hidden",
-        className
-      )}
-    >
-      {/* Header */}
+    <View className={cn("max-w-3xl w-full self-center", className)}>
+      {/* Header pill */}
       <Pressable
         onPress={() => setIsExpanded(!isExpanded)}
-        className="w-full flex-row items-center justify-between px-3 py-2"
+        className={cn(
+          "flex-row items-center gap-2 px-3 py-1.5",
+          "bg-zinc-900/90 dark:bg-zinc-800/90",
+          "border border-zinc-700/60",
+          isExpanded ? "rounded-t-lg" : "rounded-lg"
+        )}
       >
-        <View className="flex-row items-center gap-2">
-          <View className="w-2 h-2 rounded-full bg-primary" />
-          <Text className="text-xs font-semibold text-foreground/80">
-            {`Running Command${processes.length > 1 ? "s" : ""}`}
-          </Text>
-          <Text className="text-xs text-gray-400">({processes.length})</Text>
-        </View>
-
+        {/* Pulsing dot */}
+        <View className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
+        <Terminal size={11} className="text-zinc-400" />
+        <Text className="flex-1 text-[11px] font-medium text-zinc-300">
+          {processes.length === 1
+            ? truncateCommand(processes[0].command)
+            : `${processes.length} running commands`}
+        </Text>
+        {processes.length === 1 && (
+          <View className="flex-row items-center gap-1">
+            <Clock size={10} className="text-zinc-500" />
+            <Text className="text-[10px] font-mono text-zinc-500">
+              {processes[0].startedAt ? formatElapsed(now - processes[0].startedAt) : "…"}
+            </Text>
+          </View>
+        )}
         {isExpanded ? (
-          <ChevronUp className="w-3.5 h-3.5 text-gray-400" size={14} />
+          <ChevronUp size={12} className="text-zinc-500" />
         ) : (
-          <ChevronDown className="w-3.5 h-3.5 text-gray-400" size={14} />
+          <ChevronDown size={12} className="text-zinc-500" />
         )}
       </Pressable>
 
-      {/* Expanded content */}
+      {/* Expanded rows */}
       {isExpanded && (
-        <View className="px-3 pb-3 gap-2">
-          {processes.map((proc) => {
+        <View
+          className={cn(
+            "bg-zinc-900/70 dark:bg-zinc-800/70",
+            "border-x border-b border-zinc-700/60",
+            "rounded-b-lg overflow-hidden"
+          )}
+        >
+          {processes.map((proc, idx) => {
             const isKilling = killing?.has(proc.runId) ?? false
             return (
               <View
                 key={proc.runId}
-                className="flex-row items-center gap-2 pl-3 border-l-2 border-primary/30"
+                className={cn(
+                  "flex-row items-center gap-2.5 px-3 py-2",
+                  idx < processes.length - 1 && "border-b border-zinc-700/40"
+                )}
               >
-                <Terminal className="w-3.5 h-3.5 text-primary shrink-0" size={14} />
-                <View className="flex-1">
-                  <Text
-                    className="text-xs font-mono text-foreground/90"
-                    numberOfLines={1}
-                  >
-                    {proc.command}
-                  </Text>
-                  <View className="flex-row items-center gap-2 mt-0.5">
-                    {proc.pid != null && (
-                      <Text className="text-[10px] text-gray-400">pid {proc.pid}</Text>
-                    )}
-                    <Text className="text-[10px] text-gray-400">
-                      {formatElapsed(proc.elapsedMs)}
-                    </Text>
-                    {proc.stale && (
-                      <Text className="text-[10px] font-medium px-1.5 py-0.5 rounded text-yellow-600 bg-yellow-500/10">
-                        unverified
-                      </Text>
-                    )}
-                  </View>
-                </View>
-
-                <Pressable
-                  onPress={() => onKill(proc.runId)}
-                  disabled={isKilling}
-                  accessibilityRole="button"
-                  accessibilityLabel={proc.stale ? "Dismiss process" : "Kill process"}
-                  hitSlop={8}
-                  className={cn(
-                    "flex-row items-center gap-1 rounded px-2 py-1",
-                    "border border-red-400/40 active:opacity-70",
-                    isKilling && "opacity-50"
-                  )}
+                <Text
+                  className="flex-1 text-[11px] font-mono text-zinc-300"
+                  numberOfLines={1}
                 >
-                  {isKilling ? (
-                    <ActivityIndicator size="small" />
+                  {proc.command}
+                </Text>
+
+                <View className="flex-row items-center gap-2">
+                  {proc.stale ? (
+                    <Text className="text-[9px] font-medium text-yellow-500/80">
+                      unverified
+                    </Text>
                   ) : (
-                    <X size={12} className="text-red-500" />
+                    <View className="flex-row items-center gap-1">
+                      <Clock size={10} className="text-zinc-600" />
+                      <Text className="text-[10px] font-mono text-zinc-500">
+                        {proc.startedAt ? formatElapsed(now - proc.startedAt) : "…"}
+                      </Text>
+                    </View>
                   )}
-                  <Text className="text-[10px] font-medium text-red-500">
-                    {proc.stale ? "Dismiss" : "Kill"}
-                  </Text>
-                </Pressable>
+
+                  <Pressable
+                    onPress={() => handleKill(proc.runId)}
+                    disabled={isKilling}
+                    hitSlop={8}
+                    accessibilityRole="button"
+                    accessibilityLabel={proc.stale ? "Dismiss" : "Kill process"}
+                    className={cn(
+                      "flex-row items-center gap-1 rounded px-1.5 py-0.5",
+                      "bg-red-500/10 border border-red-500/20 active:opacity-60",
+                      isKilling && "opacity-40"
+                    )}
+                  >
+                    {isKilling ? (
+                      <ActivityIndicator size="small" color="#ef4444" />
+                    ) : (
+                      <X size={10} className="text-red-400" />
+                    )}
+                    <Text className="text-[10px] font-medium text-red-400">
+                      {proc.stale ? "Dismiss" : "Kill"}
+                    </Text>
+                  </Pressable>
+                </View>
               </View>
             )
           })}

--- a/apps/mobile/components/chat/VideoPreviewModal.tsx
+++ b/apps/mobile/components/chat/VideoPreviewModal.tsx
@@ -8,7 +8,7 @@
  * on iOS/Android we show a fallback (no expo-video dependency required).
  */
 
-import React from "react"
+import React, { useEffect, useMemo } from "react"
 import { Platform, Text, useWindowDimensions, View } from "react-native"
 import { VideoIcon, X } from "lucide-react-native"
 import {
@@ -35,6 +35,27 @@ export function VideoPreviewModal({
   title = "Video preview",
 }: VideoPreviewModalProps) {
   const { width, height } = useWindowDimensions()
+
+  // data: URLs are blocked by Electron's CSP — convert to a blob URL instead.
+  const videoSrc = useMemo(() => {
+    if (Platform.OS !== 'web' || !url.startsWith('data:')) return url
+    try {
+      const [header, base64] = url.split(',')
+      const mime = header.match(/data:([^;]+)/)?.[1] ?? 'video/mp4'
+      const bytes = atob(base64)
+      const arr = new Uint8Array(bytes.length)
+      for (let i = 0; i < bytes.length; i++) arr[i] = bytes.charCodeAt(i)
+      return URL.createObjectURL(new Blob([arr], { type: mime }))
+    } catch {
+      return url
+    }
+  }, [url])
+
+  useEffect(() => {
+    return () => {
+      if (videoSrc !== url) URL.revokeObjectURL(videoSrc)
+    }
+  }, [videoSrc, url])
 
   const panelMaxWidth = Math.min(Math.max(width - 32, 320), 960)
   const panelMaxHeight = Math.min(Math.max(height * 0.86, 320), 760)
@@ -70,7 +91,7 @@ export function VideoPreviewModal({
             {Platform.OS === "web" ? (
               // @ts-ignore — React Native Web passes through HTML video props
               React.createElement("video", {
-                src: url,
+                src: videoSrc,
                 controls: true,
                 autoPlay: true,
                 style: {

--- a/apps/mobile/components/chat/VideoPreviewModal.tsx
+++ b/apps/mobile/components/chat/VideoPreviewModal.tsx
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * VideoPreviewModal
+ *
+ * Inline video player shown when the user taps a video attachment thumbnail
+ * in the chat composer. On web/desktop we render a native <video> element;
+ * on iOS/Android we show a fallback (no expo-video dependency required).
+ */
+
+import React from "react"
+import { Platform, Text, useWindowDimensions, View } from "react-native"
+import { VideoIcon, X } from "lucide-react-native"
+import {
+  Modal,
+  ModalBackdrop,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+} from "@/components/ui/modal"
+
+export interface VideoPreviewModalProps {
+  visible: boolean
+  onClose: () => void
+  /** data URL or remote URL of the video */
+  url: string
+  title?: string
+}
+
+export function VideoPreviewModal({
+  visible,
+  onClose,
+  url,
+  title = "Video preview",
+}: VideoPreviewModalProps) {
+  const { width, height } = useWindowDimensions()
+
+  const panelMaxWidth = Math.min(Math.max(width - 32, 320), 960)
+  const panelMaxHeight = Math.min(Math.max(height * 0.86, 320), 760)
+  const videoHeight = Math.max(240, panelMaxHeight - 80)
+
+  return (
+    <Modal isOpen={visible} onClose={onClose} size="full">
+      <ModalBackdrop />
+      <ModalContent
+        className="bg-background m-4 overflow-hidden rounded-xl border border-border p-0"
+        style={{ maxWidth: panelMaxWidth, maxHeight: panelMaxHeight }}
+      >
+        <ModalHeader className="flex-row items-center justify-between border-b border-border px-4 py-3">
+          <View className="min-w-0 flex-1 flex-row items-center gap-2">
+            <VideoIcon size={15} className="text-muted-foreground" />
+            <Text
+              className="text-sm font-semibold text-foreground"
+              numberOfLines={1}
+            >
+              {title}
+            </Text>
+          </View>
+          <ModalCloseButton className="h-8 w-8 items-center justify-center rounded-md">
+            <X size={16} className="text-muted-foreground" />
+          </ModalCloseButton>
+        </ModalHeader>
+
+        <ModalBody className="m-0 p-0">
+          <View
+            className="items-center justify-center bg-black"
+            style={{ height: videoHeight, width: "100%" }}
+          >
+            {Platform.OS === "web" ? (
+              // @ts-ignore — React Native Web passes through HTML video props
+              React.createElement("video", {
+                src: url,
+                controls: true,
+                autoPlay: true,
+                style: {
+                  width: "100%",
+                  height: videoHeight,
+                  objectFit: "contain",
+                  outline: "none",
+                },
+              })
+            ) : (
+              <View className="items-center justify-center gap-3 p-8">
+                <VideoIcon size={40} className="text-muted-foreground" />
+                <Text className="text-sm text-muted-foreground text-center">
+                  Video preview is not available on this platform.{"\n"}
+                  The video has been attached and will be sent with your message.
+                </Text>
+              </View>
+            )}
+          </View>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export default VideoPreviewModal

--- a/apps/mobile/components/chat/VideoPreviewModal.tsx
+++ b/apps/mobile/components/chat/VideoPreviewModal.tsx
@@ -20,6 +20,18 @@ import {
   ModalHeader,
 } from "@/components/ui/modal"
 
+// React Native Web forwards unknown host component names straight to the
+// DOM, so a plain HTML <video> element works at runtime even though it
+// isn't part of react-native's typed component set. Declare its props
+// once, typed, instead of reaching for `@ts-ignore` at the call site.
+interface WebVideoProps {
+  src: string
+  controls?: boolean
+  autoPlay?: boolean
+  style?: React.CSSProperties
+}
+const WebVideo = 'video' as unknown as React.FC<WebVideoProps>
+
 export interface VideoPreviewModalProps {
   visible: boolean
   onClose: () => void
@@ -89,18 +101,17 @@ export function VideoPreviewModal({
             style={{ height: videoHeight, width: "100%" }}
           >
             {Platform.OS === "web" ? (
-              // @ts-ignore — React Native Web passes through HTML video props
-              React.createElement("video", {
-                src: videoSrc,
-                controls: true,
-                autoPlay: true,
-                style: {
+              <WebVideo
+                src={videoSrc}
+                controls
+                autoPlay
+                style={{
                   width: "100%",
                   height: videoHeight,
                   objectFit: "contain",
                   outline: "none",
-                },
-              })
+                }}
+              />
             ) : (
               <View className="items-center justify-center gap-3 p-8">
                 <VideoIcon size={40} className="text-muted-foreground" />

--- a/apps/mobile/components/chat/turns/MessageContent.tsx
+++ b/apps/mobile/components/chat/turns/MessageContent.tsx
@@ -140,9 +140,9 @@ function ImageThumbnail({
 
   if (hasError) {
     return (
-      <View className="max-w-[200px] rounded-md border border-border bg-muted p-2">
-        <Text className="text-xs text-muted-foreground">
-          Failed to load image
+      <View className="rounded-lg border border-border bg-muted items-center justify-center" style={{ width: 72, height: 72 }}>
+        <Text className="text-[10px] text-muted-foreground text-center">
+          Failed to load
         </Text>
       </View>
     )
@@ -159,14 +159,15 @@ function ImageThumbnail({
         accessibilityHint="Opens a larger preview."
         className={Platform.OS === "web" ? "cursor-zoom-in" : undefined}
       >
-        <Image
-          source={{ uri: url }}
-          className="max-w-[280px] rounded-md"
-          resizeMode="contain"
-          accessibilityLabel={`Image attachment ${index + 1}`}
-          onError={() => setHasError(true)}
-          style={{ width: 280, aspectRatio: 4 / 3 }}
-        />
+        <View className="rounded-lg overflow-hidden border border-border/40" style={{ width: 96, height: 72 }}>
+          <Image
+            source={{ uri: url }}
+            resizeMode="cover"
+            accessibilityLabel={`Image attachment ${index + 1}`}
+            onError={() => setHasError(true)}
+            style={{ width: 96, height: 72 }}
+          />
+        </View>
       </Pressable>
       <ImagePreviewModal
         visible={showModal}

--- a/apps/mobile/components/chat/turns/MessageContent.tsx
+++ b/apps/mobile/components/chat/turns/MessageContent.tsx
@@ -11,7 +11,7 @@
 import { useState, useCallback } from "react"
 import { View, Text, Image, Pressable, Linking, Platform } from "react-native"
 import { cn } from "@shogo/shared-ui/primitives"
-import { FileText } from "lucide-react-native"
+import { FileText, Play } from "lucide-react-native"
 import type { UIMessage } from "@ai-sdk/react"
 import { extractTextContent } from "@shogo/shared-app/chat"
 import { MarkdownText } from "../MarkdownText"
@@ -19,6 +19,7 @@ import { analyzeContent } from "../long-text-utils"
 import { LongTextPreviewCard } from "../LongTextPreviewCard"
 import { FileViewerModal } from "../FileViewerModal"
 import { ChatImageContextMenu, ImagePreviewModal } from "../ImagePreviewModal"
+import { VideoPreviewModal } from "../VideoPreviewModal"
 import { downloadImage, isShogoDesktop } from "../chatImageActions"
 
 export interface MessageContentProps {
@@ -201,10 +202,13 @@ function DocumentThumbnail({
   index: number
 }) {
   const [showModal, setShowModal] = useState(false)
+  const [showVideoModal, setShowVideoModal] = useState(false)
   const [fileContent, setFileContent] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
   const { title, kindLabel: typeLabel } = deriveFileLabel(mediaType, name)
+
+  const isVideo = mediaType.startsWith("video/")
 
   const isTextLike =
     mediaType.startsWith("text/") ||
@@ -214,6 +218,10 @@ function DocumentThumbnail({
     mediaType.includes("yaml")
 
   const handlePress = useCallback(async () => {
+    if (isVideo) {
+      setShowVideoModal(true)
+      return
+    }
     if (!isTextLike) {
       Linking.openURL(url)
       return
@@ -245,27 +253,47 @@ function DocumentThumbnail({
 
   return (
     <>
-      <Pressable
-        onPress={handlePress}
-        className="flex-row items-center gap-2.5 rounded-xl border border-border bg-muted/40 px-3 py-2.5 min-w-[200px] max-w-full"
-        accessibilityLabel={`File attachment ${index + 1}: ${title}`}
-        accessibilityRole="button"
-      >
-        <View className="h-9 w-9 items-center justify-center rounded-lg bg-primary/15 flex-shrink-0">
-          <FileText size={18} className="text-primary" />
-        </View>
-        <View className="flex-1 min-w-0">
-          <Text
-            className="text-xs font-medium text-foreground"
-            numberOfLines={1}
+      {isVideo ? (
+        <Pressable
+          onPress={handlePress}
+          accessibilityLabel={`Video attachment ${index + 1}: ${title}`}
+          accessibilityRole="button"
+        >
+          <View
+            className="rounded-lg overflow-hidden border border-border/60 bg-black/80 items-center justify-center"
+            style={{ width: 96, height: 72 }}
           >
-            {title}
-          </Text>
-          <Text className="text-[11px] text-muted-foreground" numberOfLines={1}>
-            {loading ? "Loading…" : typeLabel}
-          </Text>
-        </View>
-      </Pressable>
+            <View className="rounded-full bg-white/20 items-center justify-center" style={{ width: 32, height: 32 }}>
+              <Play size={14} fill="white" className="text-white" />
+            </View>
+            <Text
+              className="text-[9px] text-white/50 absolute bottom-1.5 left-0 right-0 text-center"
+              numberOfLines={1}
+            >
+              {title}
+            </Text>
+          </View>
+        </Pressable>
+      ) : (
+        <Pressable
+          onPress={handlePress}
+          className="flex-row items-center gap-2 rounded-lg border border-border bg-muted/40 px-2.5 py-1.5 max-w-[220px]"
+          accessibilityLabel={`File attachment ${index + 1}: ${title}`}
+          accessibilityRole="button"
+        >
+          <View className="h-7 w-7 items-center justify-center rounded-md bg-primary/15 flex-shrink-0">
+            <FileText size={14} className="text-primary" />
+          </View>
+          <View className="flex-1 min-w-0">
+            <Text className="text-[11px] font-medium text-foreground" numberOfLines={1}>
+              {title}
+            </Text>
+            <Text className="text-[10px] text-muted-foreground" numberOfLines={1}>
+              {loading ? "Loading…" : typeLabel}
+            </Text>
+          </View>
+        </Pressable>
+      )}
       {fileContent !== null && (
         <FileViewerModal
           visible={showModal}
@@ -275,6 +303,12 @@ function DocumentThumbnail({
           kind={mediaType.includes("json") ? "json" : mediaType.includes("markdown") ? "markdown" : "plain"}
         />
       )}
+      <VideoPreviewModal
+        visible={showVideoModal}
+        onClose={() => setShowVideoModal(false)}
+        url={url}
+        title={title}
+      />
     </>
   )
 }
@@ -314,7 +348,7 @@ export function MessageContent({
   if (isUser) {
     return (
       <View className={cn(baseClasses, "gap-2")}>
-        {images.length > 0 && (
+        {(images.length > 0 || files.length > 0) && (
           <View className="flex-row flex-wrap gap-2">
             {images.map((img, i) => (
               <ImageThumbnail
@@ -324,10 +358,6 @@ export function MessageContent({
                 index={i}
               />
             ))}
-          </View>
-        )}
-        {files.length > 0 && (
-          <View className="flex-col gap-1.5">
             {files.map((file, i) => (
               <DocumentThumbnail
                 key={`${message.id}-file-${i}`}
@@ -362,7 +392,7 @@ export function MessageContent({
             {content}
           </MarkdownText>
       ) : null}
-      {images.length > 0 && (
+      {(images.length > 0 || files.length > 0) && (
         <View className="flex-row flex-wrap gap-2">
           {images.map((img, i) => (
             <ImageThumbnail
@@ -372,10 +402,6 @@ export function MessageContent({
               index={i}
             />
           ))}
-        </View>
-      )}
-      {files.length > 0 && (
-        <View className="flex-col gap-1.5">
           {files.map((file, i) => (
             <DocumentThumbnail
               key={`${message.id}-file-${i}`}

--- a/apps/mobile/components/layout/AppSidebar.tsx
+++ b/apps/mobile/components/layout/AppSidebar.tsx
@@ -967,7 +967,6 @@ function UserMenuContent({
   isSuperAdmin,
   onClose,
 }: UserMenuProps & { onClose: () => void }) {
-  const [appearanceOpen, setAppearanceOpen] = useState(false)
   const { theme, setTheme } = useTheme()
   const { localMode, shogoKeyConnected } = usePlatformConfig()
   // The Creator hub (marketplace publishing + referrals) is cloud-backed, so
@@ -1000,46 +999,6 @@ function UserMenuContent({
           </Pressable>
         )}
 
-        <Pressable
-          onPress={() => setAppearanceOpen(!appearanceOpen)}
-          role="menuitem"
-          accessibilityLabel="Appearance"
-          accessibilityState={{ expanded: appearanceOpen }}
-          className="flex-row items-center gap-3 px-4 py-3 active:bg-muted"
-        >
-          <Monitor size={18} className="text-muted-foreground" />
-          <Text className="text-sm text-foreground flex-1">Appearance</Text>
-          {appearanceOpen ? (
-            <ChevronDown size={14} className="text-muted-foreground" />
-          ) : (
-            <ChevronRight size={14} className="text-muted-foreground" />
-          )}
-        </Pressable>
-
-        {appearanceOpen && (
-          <View role="radiogroup" accessibilityLabel="Theme options" className="pl-11 pr-4 py-1">
-            {([
-              { value: 'light' as const, label: 'Light', Icon: Sun },
-              { value: 'dark' as const, label: 'Dark', Icon: Moon },
-              { value: 'system' as const, label: 'System', Icon: Monitor },
-            ] as const).map(({ value, label, Icon }) => (
-              <Pressable
-                key={value}
-                onPress={() => setTheme(value)}
-                role="radio"
-                accessibilityLabel={label}
-                accessibilityState={{ checked: theme === value }}
-                className="flex-row items-center gap-3 py-2.5 active:bg-muted rounded-md px-2"
-              >
-                <Icon size={16} className={theme === value ? 'text-primary' : 'text-muted-foreground'} />
-                <Text className={cn('text-sm flex-1', theme === value ? 'text-primary' : 'text-foreground')}>
-                  {label}
-                </Text>
-                {theme === value && <Check size={16} className="text-primary" />}
-              </Pressable>
-            ))}
-          </View>
-        )}
 
         {isSuperAdmin && (
           <Pressable

--- a/apps/mobile/components/layout/AppSidebar.tsx
+++ b/apps/mobile/components/layout/AppSidebar.tsx
@@ -1054,7 +1054,6 @@ function UserMenuContent({
   isSuperAdmin,
   onClose,
 }: UserMenuProps & { onClose: () => void }) {
-  const [appearanceOpen, setAppearanceOpen] = useState(false)
   const { theme, setTheme } = useTheme()
   const { localMode, shogoKeyConnected } = usePlatformConfig()
   // The Creator hub (marketplace publishing + referrals) is cloud-backed, so
@@ -1087,46 +1086,6 @@ function UserMenuContent({
           </Pressable>
         )}
 
-        <Pressable
-          onPress={() => setAppearanceOpen(!appearanceOpen)}
-          role="menuitem"
-          accessibilityLabel="Appearance"
-          accessibilityState={{ expanded: appearanceOpen }}
-          className="flex-row items-center gap-3 px-4 py-3 active:bg-muted"
-        >
-          <Monitor size={18} className="text-muted-foreground" />
-          <Text className="text-sm text-foreground flex-1">Appearance</Text>
-          {appearanceOpen ? (
-            <ChevronDown size={14} className="text-muted-foreground" />
-          ) : (
-            <ChevronRight size={14} className="text-muted-foreground" />
-          )}
-        </Pressable>
-
-        {appearanceOpen && (
-          <View role="radiogroup" accessibilityLabel="Theme options" className="pl-11 pr-4 py-1">
-            {([
-              { value: 'light' as const, label: 'Light', Icon: Sun },
-              { value: 'dark' as const, label: 'Dark', Icon: Moon },
-              { value: 'system' as const, label: 'System', Icon: Monitor },
-            ] as const).map(({ value, label, Icon }) => (
-              <Pressable
-                key={value}
-                onPress={() => setTheme(value)}
-                role="radio"
-                accessibilityLabel={label}
-                accessibilityState={{ checked: theme === value }}
-                className="flex-row items-center gap-3 py-2.5 active:bg-muted rounded-md px-2"
-              >
-                <Icon size={16} className={theme === value ? 'text-primary' : 'text-muted-foreground'} />
-                <Text className={cn('text-sm flex-1', theme === value ? 'text-primary' : 'text-foreground')}>
-                  {label}
-                </Text>
-                {theme === value && <Check size={16} className="text-primary" />}
-              </Pressable>
-            ))}
-          </View>
-        )}
 
         {isSuperAdmin && (
           <Pressable

--- a/apps/mobile/components/settings/AppearanceTab.tsx
+++ b/apps/mobile/components/settings/AppearanceTab.tsx
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { View, Text, Pressable } from 'react-native'
+import { Sun, Moon, Monitor, RotateCcw } from 'lucide-react-native'
+import { cn } from '@shogo/shared-ui/primitives'
+import { useTheme } from '../../contexts/theme'
+import { useAppearance } from '../../contexts/appearance'
+
+export const FONT_SIZE_MIN = 11
+export const FONT_SIZE_MAX = 24
+const FONT_SIZE_DEFAULT = 14
+
+function AppearanceSection({ title }: { title: string }) {
+  return (
+    <Text className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2 mt-5">
+      {title}
+    </Text>
+  )
+}
+
+function AppearanceRow({
+  label,
+  description,
+  children,
+}: {
+  label: string
+  description?: string
+  children: React.ReactNode
+}) {
+  return (
+    <View className="flex-row items-center justify-between gap-4 px-4 py-3 rounded-lg bg-muted/30 border border-border mb-2">
+      <View className="flex-1">
+        <Text className="text-sm font-medium text-foreground">{label}</Text>
+        {description ? (
+          <Text className="text-xs text-muted-foreground mt-0.5">{description}</Text>
+        ) : null}
+      </View>
+      <View className="shrink-0">{children}</View>
+    </View>
+  )
+}
+
+export function AppearanceTab() {
+  const { theme, setTheme } = useTheme()
+  const { settings: ap, update, reset } = useAppearance()
+
+  return (
+    <View>
+      <Text className="text-2xl font-bold text-foreground mb-1">Appearance</Text>
+      <Text className="text-sm text-muted-foreground mb-6">
+        Customize the look and feel of the Shogo interface.
+      </Text>
+
+      {/* ── Theme ── */}
+      <AppearanceSection title="Theme" />
+      <View className="flex-row gap-2 mb-2">
+        {([
+          { value: 'light' as const, label: 'Light', Icon: Sun },
+          { value: 'dark' as const, label: 'Dark', Icon: Moon },
+          { value: 'system' as const, label: 'System', Icon: Monitor },
+        ] as const).map(({ value, label, Icon }) => (
+          <Pressable
+            key={value}
+            onPress={() => setTheme(value)}
+            className={cn(
+              'flex-1 flex-col items-center gap-2 py-4 rounded-lg border',
+              theme === value
+                ? 'border-primary bg-primary/10'
+                : 'border-border bg-muted/20'
+            )}
+          >
+            <Icon
+              size={20}
+              className={theme === value ? 'text-primary' : 'text-muted-foreground'}
+            />
+            <Text
+              className={cn(
+                'text-xs font-medium',
+                theme === value ? 'text-primary' : 'text-muted-foreground'
+              )}
+            >
+              {label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      {/* ── Typography ── */}
+      <AppearanceSection title="Typography" />
+      <AppearanceRow label="UI Font Size" description="Font size for the Shogo interface">
+        <View className="flex-row items-center gap-1.5">
+          <Pressable
+            onPress={() => update({ uiFontSize: FONT_SIZE_DEFAULT })}
+            accessibilityLabel="Reset font size"
+            className="w-7 h-7 items-center justify-center rounded border border-border active:bg-muted"
+          >
+            <RotateCcw size={12} className="text-muted-foreground" />
+          </Pressable>
+          <Pressable
+            onPress={() => update({ uiFontSize: Math.max(FONT_SIZE_MIN, ap.uiFontSize - 1) })}
+            className="w-7 h-7 items-center justify-center rounded border border-border active:bg-muted"
+          >
+            <Text className="text-foreground text-base leading-none">−</Text>
+          </Pressable>
+          <Text className="text-sm font-semibold text-foreground tabular-nums w-6 text-center">
+            {ap.uiFontSize}
+          </Text>
+          <Pressable
+            onPress={() => update({ uiFontSize: Math.min(FONT_SIZE_MAX, ap.uiFontSize + 1) })}
+            className="w-7 h-7 items-center justify-center rounded border border-border active:bg-muted"
+          >
+            <Text className="text-foreground text-base leading-none">+</Text>
+          </Pressable>
+        </View>
+      </AppearanceRow>
+
+      <Pressable
+        onPress={reset}
+        className="mt-4 py-2.5 rounded-lg border border-border items-center active:bg-muted"
+      >
+        <Text className="text-sm text-muted-foreground">Reset to defaults</Text>
+      </Pressable>
+    </View>
+  )
+}

--- a/apps/mobile/contexts/appearance.tsx
+++ b/apps/mobile/contexts/appearance.tsx
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react'
+import { Platform } from 'react-native'
+import { safeGetItem, safeSetItem } from '../lib/safe-storage'
+
+export interface AppearanceSettings {
+  uiFontSize: number  // 11–24 px, default 14
+  hue: number         // 0–360
+}
+
+const DEFAULTS: AppearanceSettings = {
+  uiFontSize: 14,
+  hue: 210,
+}
+
+const STORAGE_KEY = 'shogo-appearance-v1'
+
+function load(): AppearanceSettings {
+  try {
+    const raw = safeGetItem(STORAGE_KEY)
+    if (raw) return { ...DEFAULTS, ...JSON.parse(raw) }
+  } catch {}
+  return DEFAULTS
+}
+
+function save(s: AppearanceSettings) {
+  try { safeSetItem(STORAGE_KEY, JSON.stringify(s)) } catch {}
+}
+
+interface AppearanceCtx {
+  settings: AppearanceSettings
+  update: (partial: Partial<AppearanceSettings>) => void
+  reset: () => void
+}
+
+const Ctx = createContext<AppearanceCtx>({
+  settings: DEFAULTS,
+  update: () => {},
+  reset: () => {},
+})
+
+function applyToDOM(s: AppearanceSettings) {
+  if (Platform.OS !== 'web' || typeof document === 'undefined') return
+  const root = document.documentElement
+  // Setting font-size on <html> scales all rem-based Tailwind classes automatically
+  root.style.fontSize = `${s.uiFontSize}px`
+  root.style.setProperty('--tint-hue', String(s.hue))
+}
+
+export function AppearanceProvider({ children }: { children: ReactNode }) {
+  const [settings, setSettings] = useState<AppearanceSettings>(() => {
+    if (Platform.OS === 'web') return load()
+    return DEFAULTS
+  })
+
+  useEffect(() => {
+    if (Platform.OS === 'web') {
+      const stored = load()
+      setSettings(stored)
+      applyToDOM(stored)
+    }
+  }, [])
+
+  useEffect(() => {
+    save(settings)
+    applyToDOM(settings)
+  }, [settings])
+
+  const update = useCallback((partial: Partial<AppearanceSettings>) => {
+    setSettings(prev => ({ ...prev, ...partial }))
+  }, [])
+
+  const reset = useCallback(() => setSettings(DEFAULTS), [])
+
+  return <Ctx.Provider value={{ settings, update, reset }}>{children}</Ctx.Provider>
+}
+
+export function useAppearance() {
+  return useContext(Ctx)
+}


### PR DESCRIPTION
## Summary

### Appearance Settings
- Add `AppearanceProvider` context using `safeGetItem`/`safeSetItem` (consistent with existing prefs pattern)
- Add Appearance tab to Settings page with Theme (Light/Dark/System) and UI Font Size controls
- Font size sets `html` `font-size` directly so all Tailwind rem-based classes scale correctly
- Wire `AppearanceProvider` into root layout
- Remove Appearance from AppSidebar quick-access popup (it now lives in Settings only)

### ProcessPanel Redesign
- Redesign from full-width gray box to compact dark terminal pill matching chat width (`max-w-3xl`)
- Live elapsed timer using `Date.now() - startedAt` with a single 1s interval driving all processes
- Fix kill requiring double-click: always filter killed `runId` from server response immediately
- Add `pendingKills` ref guard to prevent duplicate kill calls
- Remove stale `elapsedMs` prop — elapsed time is now calculated locally


https://github.com/user-attachments/assets/0603c384-55eb-4227-8578-f415440df89d


https://github.com/user-attachments/assets/3aeecd7b-ba7f-4833-9713-7e78d588ae82


https://github.com/user-attachments/assets/d63864ee-8cbc-407f-946e-f627177ecb2a


https://github.com/user-attachments/assets/38afa747-0ff2-48c5-8b66-575cfd356a8a