### PR TITLE
fix(android): update Play Billing dependency

### DIFF
--- a/patches/react-native-iap@12.16.4.patch
+++ b/patches/react-native-iap@12.16.4.patch
@@ -16,3 +16,16 @@ index 0000000000000000000000000000000000000000..11111111111111111111111111111111
          if (activity == null) {
              promise.safeReject(PromiseUtils.E_UNKNOWN, "getCurrentActivity returned null")
              return
+diff --git a/android/gradle.properties b/android/gradle.properties
+index 0000000000000000000000000000000000000000..1111111111111111111111111111111111111111 100644
+--- a/android/gradle.properties
++++ b/android/gradle.properties
+@@ -6,7 +6,7 @@ RNIap_buildToolsVersion=33.0.0
+ RNIap_ndkversion=23.1.7779620
+ RNIap_playServicesVersion=18.1.0
+ RNIap_amazonSdkVersion=3.0.7
+-RNIap_playBillingSdkVersion=7.0.0
++RNIap_playBillingSdkVersion=8.0.0
+ RNIap_isAmazonDrmEnabled=true
+ 
+ android.useAndroidX=true


### PR DESCRIPTION
## Summary

Fixes #832.

This PR addresses the Google Play Console warning that the Android app may contain an outdated Google Play Billing Library version. Google requires Android app submissions after the August 31, 2026 policy deadline to use Google Play Billing Library `8.0.0` or later.

The investigation found that prior generated Android artifacts included Billing Library `7.0.0` through `react-native-iap@12.16.4`:

```text
com.android.billingclient:billing-ktx:7.0.0
com.android.billingclient:billing:7.0.0
```

`react-native-iap` controls that Android dependency with `RNIap_playBillingSdkVersion` in its internal `android/gradle.properties`. This repo already uses a Bun patch for `react-native-iap@12.16.4`, so this PR extends that existing patch to make the dependency compliant when Android IAP is included.

## What Changed

Only one tracked file changes in this PR:

```text
patches/react-native-iap@12.16.4.patch
```

Inside that patch file, this PR adds a patch hunk for the third-party dependency file:

```text
react-native-iap/android/gradle.properties
```

The actual semantic change is one version bump:

```diff
-RNIap_playBillingSdkVersion=7.0.0
+RNIap_playBillingSdkVersion=8.0.0
```

GitHub shows about 13 added lines because this is a patch file. Most of those lines are patch metadata/context, such as:

```text
diff --git ...
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -6,7 +6,7 @@
```

Those lines are required so Bun/patch can identify the dependency file and apply the one-line version change reliably. They are not extra app behavior changes.

## Why This Fix Is Scoped This Way

The Play Console warning is about the Billing SDK packaged into the Android app bundle. It is not caused by Stripe billing code, Apple IAP server verification, product IDs, purchase receipt handling, or application UI code.

`react-native-iap` is the dependency that owns the Android Billing declaration:

```gradle
playImplementation "com.android.billingclient:billing-ktx:$playBillingSdkVersion"
```

The safest narrow fix is therefore to update `react-native-iap`'s own `playBillingSdkVersion` source through the existing Bun patch. This avoids broader Gradle resolution overrides that could hide future dependency issues or affect unrelated Android dependencies.

## What Did Not Change

This PR does not change:

- app-level purchase flow code
- subscription product IDs
- receipt verification code
- Stripe or Apple IAP server-side logic
- Android package ID, version code, signing, or release metadata
- Gradle plugin versions
- React Native / Expo versions
- lockfile contents

## Testing Performed

### 1. Verified the old source of the warning

Local generated Android artifacts from an earlier build showed the old Billing dependency:

```text
com.android.billingclient:billing-ktx:7.0.0
com.android.billingclient:billing:7.0.0
```

That matched the Play Console warning and pointed to `react-native-iap` as the source.

### 2. Verified the patched dependency now uses Billing 8

After applying the patch, the installed/patched `react-native-iap` package source showed:

```text
RNIap_playBillingSdkVersion=8.0.0
```

This confirms that if Android includes `react-native-iap`, it will resolve Google Play Billing from `8.0.0` instead of `7.0.0`.

### 3. Verified only the intended repository file changed

Ran:

```bash
git status --short
git diff -- patches/react-native-iap@12.16.4.patch
```

Result:

- only `patches/react-native-iap@12.16.4.patch` was modified before commit
- the diff only adds the patch hunk that changes `RNIap_playBillingSdkVersion` from `7.0.0` to `8.0.0`

### 4. Verified the current Android release dependency graph

Ran:

```bash
cd apps/mobile/android
PATH="/opt/homebrew/bin:$PATH" ./gradlew --no-daemon clean :app:dependencies --configuration releaseRuntimeClasspath
```

Then checked for:

```text
billingclient
billing-ktx
com.android.billingclient
react-native-iap
```

Result:

- the current clean local release dependency graph did not print `com.android.billingclient` entries
- `react-native-iap` also did not appear as an Android Gradle project in the current local project list

This means the current local Android release path does not appear to bundle Play Billing directly. From a Google Play policy standpoint, that is acceptable because the Billing Library requirement applies when Billing is present. The patch still matters because it prevents the old `7.0.0` version from being bundled if Android IAP is included by the release pipeline.

### 5. Verified Android release bundle build

A normal release bundle build reached the Sentry source map upload step, then failed because the local environment did not have a Sentry auth token. That failure was unrelated to this Billing change.

Then reran the release bundle build with Sentry upload disabled:

```bash
cd apps/mobile/android
PATH="/opt/homebrew/bin:$PATH" SENTRY_DISABLE_AUTO_UPLOAD=true ./gradlew --no-daemon :app:bundleRelease
```

Result:

```text
BUILD SUCCESSFUL
```

### 6. Inspected the generated AAB

After the successful release bundle build, inspected the generated AAB:

```bash
unzip -l apps/mobile/android/app/build/outputs/bundle/release/app-release.aab \
  | awk '/billingclient|billing-ktx|react-native-iap|RNIap|dooboolab/ { print }'
```

Result:

- no `billingclient` entries found
- no `billing-ktx` entries found
- no `react-native-iap`, `RNIap`, or `dooboolab` entries found

This confirms the current generated local AAB does not include the old Billing Library.

## Why This Is Safe To Merge

This is safe to merge because:

- the repository change is limited to the existing `react-native-iap@12.16.4` patch file
- the semantic change is a single dependency version bump from Billing `7.0.0` to `8.0.0`
- no app runtime code or billing business logic is changed
- no lockfile or package version churn is introduced
- Android release bundle generation succeeded locally when unrelated Sentry upload was disabled
- the generated local AAB did not contain the old Billing Library
- if Android IAP is included by CI/EAS/release builds, the patched dependency now satisfies Google Play's `8.0.0+` requirement
- if Android IAP is not included, the artifact remains compliant because no Play Billing Library is bundled

## Known Notes / Follow-Up

- Local `bun install --frozen-lockfile` could not be used as a validation step in the VS Code terminal sandbox because Bun failed before dependency work with a temp directory permission error. This was an environment/sandbox limitation, not a patch failure.
- A normal local release build without `SENTRY_DISABLE_AUTO_UPLOAD=true` failed at Sentry upload because no Sentry auth token was available. The build succeeded with upload disabled, and that failure is unrelated to the Billing dependency change.
- Google Play compliance should ultimately be confirmed by uploading the next production/internal app bundle to Play Console after CI/EAS builds it, since Play Console scans the final uploaded artifact.

## Related Issues

Fixes #832
