### PR TITLE
Fix native mobile project workspace layout

### DIFF
--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -237,6 +237,7 @@ const HomeScreen = observer(function HomeScreen() {
   const isDark = useDarkMode()
   const { width: screenWidth } = useWindowDimensions()
   const isMobile = screenWidth < 640
+  const isNativePhone = Platform.OS !== 'web' && isMobile
 
   const [prompt, setPrompt] = useState('')
   const [interactionMode, setInteractionMode] = useState<InteractionMode>('agent')
@@ -856,7 +857,13 @@ const HomeScreen = observer(function HomeScreen() {
               // their flows immediately and route into the resulting
               // project.
               leadingControls={
-                <View className="flex-row items-center gap-1">
+                <View
+                  className={
+                    isNativePhone
+                      ? "min-w-0 flex-row flex-wrap items-center gap-1"
+                      : "flex-row items-center gap-1"
+                  }
+                >
                   <ProjectSourceMenu
                     workspaceId={currentWorkspace?.id}
                     variant="chip"

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -6,11 +6,13 @@ import {
   Text,
   Platform,
   Alert,
+  StyleSheet,
   useWindowDimensions,
 } from 'react-native'
 import { useRouter } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { observer } from 'mobx-react-lite'
+import { LinearGradient } from 'expo-linear-gradient'
 import Svg, { Defs, RadialGradient, Stop, Ellipse } from 'react-native-svg'
 import { Button } from '@shogo/shared-ui/primitives'
 import { usePostHogSafe } from '../../contexts/posthog'
@@ -118,32 +120,38 @@ function generateProjectNameFromPrompt(prompt: string): string {
 
 const LovableGradient = memo(function LovableGradient({ isDark }: { isDark: boolean }) {
   if (Platform.OS !== 'web') {
-    const o = isDark ? 0.35 : 1
     return (
-      <View className="absolute inset-0 overflow-hidden" style={{ pointerEvents: 'none' }}>
-        <Svg width="100%" height="100%" style={{ position: 'absolute' }}>
+      <View style={styles.gradientLayer} pointerEvents="none">
+        <LinearGradient
+          colors={['#101820', '#1e2027', '#3a2229', '#4a241f']}
+          locations={[0, 0.36, 0.68, 1]}
+          start={{ x: 0, y: 0.05 }}
+          end={{ x: 1, y: 1 }}
+          style={StyleSheet.absoluteFill}
+        />
+        <Svg width="100%" height="100%" style={StyleSheet.absoluteFill}>
           <Defs>
             <RadialGradient id="orb1" cx="50%" cy="50%" rx="50%" ry="50%">
-              <Stop offset="0%" stopColor="rgb(96,165,250)" stopOpacity={0.55 * o} />
-              <Stop offset="40%" stopColor="rgb(147,197,253)" stopOpacity={0.35 * o} />
+              <Stop offset="0%" stopColor="rgb(96,165,250)" stopOpacity={0.34} />
+              <Stop offset="45%" stopColor="rgb(147,197,253)" stopOpacity={0.16} />
               <Stop offset="100%" stopColor="rgb(96,165,250)" stopOpacity={0} />
             </RadialGradient>
             <RadialGradient id="orb2" cx="50%" cy="50%" rx="50%" ry="50%">
-              <Stop offset="0%" stopColor="rgb(244,114,182)" stopOpacity={0.55 * o} />
-              <Stop offset="30%" stopColor="rgb(251,113,133)" stopOpacity={0.4 * o} />
-              <Stop offset="60%" stopColor="rgb(249,115,22)" stopOpacity={0.2 * o} />
+              <Stop offset="0%" stopColor="rgb(244,114,182)" stopOpacity={0.38} />
+              <Stop offset="34%" stopColor="rgb(251,113,133)" stopOpacity={0.26} />
+              <Stop offset="65%" stopColor="rgb(249,115,22)" stopOpacity={0.16} />
               <Stop offset="100%" stopColor="rgb(244,114,182)" stopOpacity={0} />
             </RadialGradient>
             <RadialGradient id="orb3" cx="50%" cy="50%" rx="50%" ry="50%">
-              <Stop offset="0%" stopColor="rgb(251,113,133)" stopOpacity={0.45 * o} />
-              <Stop offset="25%" stopColor="rgb(236,72,153)" stopOpacity={0.35 * o} />
-              <Stop offset="50%" stopColor="rgb(249,115,22)" stopOpacity={0.2 * o} />
+              <Stop offset="0%" stopColor="rgb(251,113,133)" stopOpacity={0.28} />
+              <Stop offset="35%" stopColor="rgb(236,72,153)" stopOpacity={0.18} />
+              <Stop offset="65%" stopColor="rgb(249,115,22)" stopOpacity={0.12} />
               <Stop offset="100%" stopColor="rgb(251,113,133)" stopOpacity={0} />
             </RadialGradient>
           </Defs>
-          <Ellipse cx="30%" cy="15%" rx="55%" ry="45%" fill="url(#orb1)" />
-          <Ellipse cx="80%" cy="35%" rx="50%" ry="55%" fill="url(#orb2)" />
-          <Ellipse cx="50%" cy="90%" rx="55%" ry="40%" fill="url(#orb3)" />
+          <Ellipse cx="10%" cy="8%" rx="78%" ry="55%" fill="url(#orb1)" />
+          <Ellipse cx="94%" cy="26%" rx="82%" ry="68%" fill="url(#orb2)" />
+          <Ellipse cx="62%" cy="92%" rx="76%" ry="45%" fill="url(#orb3)" />
         </Svg>
       </View>
     )
@@ -223,6 +231,13 @@ const COMPOSER_WRAPPER_WEB_DARK = {
   boxShadow:
     '0 4px 24px rgba(0,0,0,0.4), 0 1px 4px rgba(0,0,0,0.3)',
 } as const
+
+const styles = StyleSheet.create({
+  gradientLayer: {
+    ...StyleSheet.absoluteFillObject,
+    overflow: 'hidden',
+  },
+})
 
 const HomeScreen = observer(function HomeScreen() {
   const router = useRouter()

--- a/apps/mobile/app/(app)/notifications.tsx
+++ b/apps/mobile/app/(app)/notifications.tsx
@@ -10,7 +10,6 @@
  */
 import { useCallback, useEffect, useState } from 'react'
 import { View, Text, Pressable, ScrollView, RefreshControl, ActivityIndicator } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
 import { observer } from 'mobx-react-lite'
 import {
@@ -128,7 +127,7 @@ export default observer(function NotificationsScreen() {
   }, [items, actions])
 
   return (
-    <SafeAreaView className="flex-1 bg-background" edges={['top']}>
+    <View className="flex-1 bg-background">
       {/* Header */}
       <View className="flex-row items-center gap-2 px-4 py-3 border-b border-border">
         <Pressable
@@ -203,6 +202,6 @@ export default observer(function NotificationsScreen() {
           })}
         </ScrollView>
       )}
-    </SafeAreaView>
+    </View>
   )
 })

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -1510,7 +1510,10 @@ export default observer(function ProjectLayout() {
       (requested !== 'canvas' &&
         requested !== 'chat-fullscreen' &&
         requested !== 'external-preview' &&
-        requested !== 'ide')
+        requested !== 'ide' &&
+        requested !== 'files' &&
+        requested !== 'plans' &&
+        requested !== 'settings')
     ) {
       return
     }
@@ -1519,7 +1522,10 @@ export default observer(function ProjectLayout() {
     appliedTabIntentRef.current = token
     previewTabInitForRef.current = projectId
     setPreviewTab(requested)
-  }, [projectId, params.tab, params.tabNonce])
+    if (Platform.OS !== 'web' && nativePhone && !isWide) {
+      setActiveTab(requested === 'chat-fullscreen' ? 'chat' : 'canvas')
+    }
+  }, [projectId, params.tab, params.tabNonce, nativePhone, isWide])
 
   useEffect(() => {
     if (!projectId || !project) return
@@ -2717,6 +2723,9 @@ export default observer(function ProjectLayout() {
 
   const chatHidden = isWide ? (isChatFullscreen || chatCollapsed) : activeTab !== 'chat'
   const canvasAreaHidden = (!isWide && activeTab === 'chat') || isChatFullscreen
+  const nativePhoneCanvasFrame = Platform.OS !== 'web' && nativePhone && !isWide && activeTab === 'canvas'
+  const nativePhoneStandalonePanel = nativePhoneCanvasFrame && STANDALONE_PANELS.includes(effectiveTab)
+  const nativePhonePlansOverlay = nativePhoneCanvasFrame && effectiveTab === 'plans'
 
   // Defined after `chatHidden` so it can drive the canvas's `fullBleed`
   // prop — see comment on `fullBleed` for why the iframe's left margin
@@ -3116,7 +3125,9 @@ export default observer(function ProjectLayout() {
                           transitionDuration: '220ms',
                           transitionTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)',
                         } as any
-                      : undefined
+                      : !isChatFullscreen && !isWide && chatHidden
+                        ? { display: 'none' }
+                        : undefined
                   }
                 >
                   {/* Chat content column. The recessed-under-canvas styling
@@ -3252,9 +3263,15 @@ export default observer(function ProjectLayout() {
         <View
           className={cn(
             'relative flex-1 overflow-hidden',
+            nativePhoneCanvasFrame && 'bg-background',
             canvasAreaHidden && 'hidden',
             Platform.OS === 'web' && !canvasAreaHidden && 'min-h-0',
           )}
+          style={
+            nativePhoneCanvasFrame
+              ? { position: 'absolute', top: 0, right: 0, bottom: 0, left: 0 }
+              : undefined
+          }
         >
           <DrawerHost
             projectId={projectId ?? null}
@@ -3265,33 +3282,6 @@ export default observer(function ProjectLayout() {
             isChatFullscreen={isChatFullscreen}
             folderPath={primaryFolderPath ?? undefined}
           >
-          {/* Floating chat button on native narrow canvas — above every canvas sub-tab (z-20 panels) */}
-          {showNativeNarrowChatFab && (
-            <SafeAreaView
-              edges={['bottom']}
-              className="absolute bottom-0 right-0 z-30 pr-4 pb-4"
-              pointerEvents="box-none"
-              style={
-                narrowCanvasKeyboardInset > 0
-                  ? { marginBottom: narrowCanvasKeyboardInset }
-                  : undefined
-              }
-            >
-              <Pressable
-                onPress={() => {
-                  // Explicit user navigation — drop any in-flight attention override.
-                  setAttentionTab(null)
-                  setActiveTab('chat')
-                  setPreviewTab('chat-fullscreen')
-                }}
-                className="flex-row items-center gap-1.5 rounded-full bg-primary px-4 py-2.5 shadow-lg"
-              >
-                <MessageSquare size={16} className="text-primary-foreground" />
-                <Text className="text-sm font-semibold text-primary-foreground">Chat</Text>
-              </Pressable>
-            </SafeAreaView>
-          )}
-
           {canvasEnabled && effectiveTab === 'canvas' && (
             <View className="absolute inset-0">
               <PanelErrorBoundary panelName="Canvas">
@@ -3316,6 +3306,11 @@ export default observer(function ProjectLayout() {
                 ? 'z-20 bg-background'
                 : 'pointer-events-none',
             )}
+            style={
+              nativePhoneStandalonePanel
+                ? { position: 'absolute', top: 0, right: 0, bottom: 0, left: 0, width: '100%', height: '100%', alignSelf: 'stretch' }
+                : undefined
+            }
             pointerEvents={
               STANDALONE_PANELS.includes(effectiveTab)
                 ? 'auto'
@@ -3336,7 +3331,7 @@ export default observer(function ProjectLayout() {
               <FilesBrowserPanel visible={effectiveTab === 'files'} projectId={projectId!} agentUrl={agentUrl} />
             </PanelErrorBoundary>
             <PanelErrorBoundary panelName="Plans">
-              <PlansPanel visible={effectiveTab === 'plans'} projectId={projectId!} agentUrl={agentUrl} selectedModel={selectedModel} requestedPlanPath={requestedPlanPath} onBuildPlan={handleBuildPlan} />
+              <PlansPanel visible={effectiveTab === 'plans' && !nativePhonePlansOverlay} projectId={projectId!} agentUrl={agentUrl} selectedModel={selectedModel} requestedPlanPath={requestedPlanPath} onBuildPlan={handleBuildPlan} />
             </PanelErrorBoundary>
             <PanelErrorBoundary panelName="Settings">
               {(() => {
@@ -3606,6 +3601,53 @@ export default observer(function ProjectLayout() {
           </View>
           </DrawerHost>
         </View>
+
+        {nativePhonePlansOverlay && (
+          <View
+            className="absolute inset-0 z-40 bg-background"
+            pointerEvents="auto"
+            style={{ position: 'absolute', top: 0, right: 0, bottom: 0, left: 0, width: '100%', height: '100%' }}
+          >
+            <PanelErrorBoundary panelName="Plans">
+              <PlansPanel
+                visible
+                projectId={projectId!}
+                agentUrl={agentUrl}
+                selectedModel={selectedModel}
+                requestedPlanPath={requestedPlanPath}
+                onBuildPlan={handleBuildPlan}
+              />
+            </PanelErrorBoundary>
+          </View>
+        )}
+
+        {/* Floating chat button on native narrow canvas — render after overlays so canvas/panels cannot cover it. */}
+        {showNativeNarrowChatFab && (
+          <SafeAreaView
+            edges={['bottom']}
+            className="absolute bottom-0 right-0 z-50 pr-4 pb-4"
+            pointerEvents="box-none"
+            style={[
+              { zIndex: 50, elevation: 50 },
+              narrowCanvasKeyboardInset > 0
+                ? { marginBottom: narrowCanvasKeyboardInset }
+                : null,
+            ]}
+          >
+            <Pressable
+              onPress={() => {
+                // Explicit user navigation — drop any in-flight attention override.
+                setAttentionTab(null)
+                setActiveTab('chat')
+                setPreviewTab('chat-fullscreen')
+              }}
+              className="flex-row items-center gap-1.5 rounded-full bg-primary px-4 py-2.5 shadow-lg"
+            >
+              <MessageSquare size={16} className="text-primary-foreground" />
+              <Text className="text-sm font-semibold text-primary-foreground">Chat</Text>
+            </Pressable>
+          </SafeAreaView>
+        )}
 
         {/* Workspace trust prompt — first-mount only, dismissible. */}
         {isExternalProject ? (
@@ -4040,6 +4082,7 @@ function CanvasPanel({
   // or a sidecar that never reports healthy (crash loop, template without
   // `/health`) still shows the app within ~20s instead of hanging forever.
   const showCanvas = shouldShowCanvas({ baseReady, apiLatched, timedOut: apiWaitElapsed })
+  const nativeFullFrame = Platform.OS !== 'web' && fullBleed
 
   if (!showCanvas) {
     // `!baseReady` → runtime / dev server not up yet (show its phase, and the
@@ -4114,14 +4157,10 @@ function CanvasPanel({
   return (
     <View
       className={cn(
-        // The chat panel column on the left has a `rounded-tr-2xl` cut-out
-        // and inset shadow so the canvas reads as elevated against it; in
-        // that layout the iframe flushes flush against the chat panel's
-        // right edge (no left gutter). When the canvas is solo (`fullBleed`
-        // — chat fullscreen, chat collapsed, or narrow canvas tab) there's
-        // no chat seam to align with, so we restore the symmetric 8px gap.
-        'flex-1 overflow-hidden rounded-2xl mr-2 mb-2',
-        fullBleed && 'ml-2',
+        nativeFullFrame
+          ? 'flex-1 overflow-hidden bg-background'
+          : 'flex-1 overflow-hidden rounded-2xl mr-2 mb-2',
+        !nativeFullFrame && fullBleed && 'ml-2',
       )}
     >
       <CanvasWebView

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -3269,7 +3269,7 @@ export default observer(function ProjectLayout() {
           )}
           style={
             nativePhoneCanvasFrame
-              ? { position: 'absolute', top: 0, right: 0, bottom: 0, left: 0 }
+              ? { position: 'absolute', top: 0, right: 0, bottom: 0, left: 0, width: '100%', height: '100%', alignSelf: 'stretch' }
               : undefined
           }
         >
@@ -3283,7 +3283,14 @@ export default observer(function ProjectLayout() {
             folderPath={primaryFolderPath ?? undefined}
           >
           {canvasEnabled && effectiveTab === 'canvas' && (
-            <View className="absolute inset-0">
+            <View
+              className="absolute inset-0"
+              style={
+                nativePhoneCanvasFrame
+                  ? { position: 'absolute', top: 0, right: 0, bottom: 0, left: 0, width: '100%', height: '100%' }
+                  : undefined
+              }
+            >
               <PanelErrorBoundary panelName="Canvas">
                 {canvasPanel}
               </PanelErrorBoundary>

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -1144,7 +1144,7 @@ export default observer(function ProjectLayout() {
             return
           }
           openTabsRestoredRef.current = true
-          setTabsHydration('restored-empty')
+          setTabsHydration(Platform.OS !== 'web' && nativePhone ? 'fresh' : 'restored-empty')
           return
         }
       } catch { /* ignore malformed data */ }
@@ -1155,7 +1155,7 @@ export default observer(function ProjectLayout() {
       openTabsRestoredRef.current = true
       setTabsHydration('fresh')
     })
-  }, [projectId])
+  }, [projectId, nativePhone])
 
   // Persist open tabs to AsyncStorage on every change, including `[]`.
   // Storing the explicit empty array is what lets the next mount distinguish
@@ -1417,6 +1417,13 @@ export default observer(function ProjectLayout() {
   const [attentionTab, setAttentionTab] = useState<string | null>(null)
   const effectiveTab = attentionTab ?? previewTab
 
+  useEffect(() => {
+    if (Platform.OS !== 'web' && nativePhone && !isWide) {
+      setActiveTab('chat')
+      setNarrowChatPickerOpen(false)
+    }
+  }, [projectId, nativePhone, isWide])
+
   // Close the narrow picker as soon as the layout shifts off the chat tab
   // (e.g. user switched to canvas, or the viewport widened into split mode).
   useEffect(() => {
@@ -1518,6 +1525,11 @@ export default observer(function ProjectLayout() {
     if (!projectId || !project) return
     if (previewTabInitForRef.current === projectId) return
     previewTabInitForRef.current = projectId
+    if (Platform.OS !== 'web' && nativePhone && !isWide) {
+      setPreviewTab('chat-fullscreen')
+      AsyncStorage.removeItem(`shogo:lastPreviewTab:${projectId}`).catch(() => {})
+      return
+    }
     AsyncStorage.getItem(`${PREVIEW_TAB_STORAGE_PREFIX}${projectId}`).then((saved) => {
       // Legacy values written before the v1 dynamic-app -> canvas tab rename
       // (chore/remove-canvas-v1) get normalized on read so existing users don't
@@ -1537,7 +1549,7 @@ export default observer(function ProjectLayout() {
     }).catch(() => {})
     // Best-effort cleanup of the pre-fix v1 key so it doesn't linger.
     AsyncStorage.removeItem(`shogo:lastPreviewTab:${projectId}`).catch(() => {})
-  }, [projectId, project, isExternalProject])
+  }, [projectId, project, isExternalProject, nativePhone, isWide])
 
   useEffect(() => {
     if (projectId && previewTab && PERSISTABLE_PREVIEW_TABS.has(previewTab)) {
@@ -2618,6 +2630,11 @@ export default observer(function ProjectLayout() {
     />
   )
 
+  const nativePhoneChatViewportHeight =
+    Platform.OS !== 'web' && nativePhone && !isWide
+      ? Math.max(0, height - insets.top - insets.bottom - 24)
+      : undefined
+
   const chatPanels = (
     <>
       {openChatTabIds.map((tabId) => {
@@ -2628,7 +2645,13 @@ export default observer(function ProjectLayout() {
           <View
             key={tabId}
             className="flex-1"
-            style={!isActive ? { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, opacity: 0 } : undefined}
+            style={
+              !isActive
+                ? { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, opacity: 0 }
+                : nativePhoneChatViewportHeight
+                  ? { height: nativePhoneChatViewportHeight }
+                  : undefined
+            }
             pointerEvents={isActive ? 'auto' : 'none'}
           >
             <PanelErrorBoundary panelName="Chat">

--- a/apps/mobile/components/canvas/CanvasWebView.tsx
+++ b/apps/mobile/components/canvas/CanvasWebView.tsx
@@ -12,6 +12,7 @@
 import { useCallback, useEffect, useRef, useMemo, useState } from 'react'
 import { Platform, View, StyleSheet, ActivityIndicator, Text, TouchableOpacity } from 'react-native'
 import { useCanvasThemeOptional } from './CanvasThemeContext'
+import type { CanvasThemeVariant } from './canvas-themes'
 
 interface CanvasCapabilities {
   supportsTheme: boolean
@@ -97,7 +98,7 @@ export function CanvasWebView({ agentUrl, canvasBaseUrl, onCanvasError, onCanvas
     return <CanvasIframe key={refreshKey} url={canvasUrl} agentUrl={agentUrl} themeMessage={themeMessage} onCanvasError={onCanvasError} onCanvasCapabilities={onCanvasCapabilities} />
   }
 
-  return <CanvasNativeWebView url={canvasUrl} agentUrl={agentUrl} themeMessage={themeMessage} onCanvasError={onCanvasError} onCanvasCapabilities={onCanvasCapabilities} />
+  return <CanvasNativeWebView key={refreshKey} url={canvasUrl} agentUrl={agentUrl} themeMessage={themeMessage} onCanvasError={onCanvasError} onCanvasCapabilities={onCanvasCapabilities} />
 }
 
 // ---------------------------------------------------------------------------
@@ -106,7 +107,7 @@ export function CanvasWebView({ agentUrl, canvasBaseUrl, onCanvasError, onCanvas
 
 interface ThemeMessage {
   type: 'canvas-theme'
-  variables: Record<string, string>
+  variables: CanvasThemeVariant
   isDark: boolean
 }
 
@@ -129,7 +130,7 @@ function CanvasIframe({ url, agentUrl, themeMessage, onCanvasError, onCanvasCapa
   const [error, setError] = useState<{ phase: string; message: string } | null>(null)
   const [refreshCount, setRefreshCount] = useState(0)
 
-  const sendToIframe = useCallback((msg: Record<string, unknown>) => {
+  const sendToIframe = useCallback((msg: unknown) => {
     iframeRef.current?.contentWindow?.postMessage(msg, '*')
   }, [])
 
@@ -239,15 +240,30 @@ function CanvasNativeWebView({ url, agentUrl, themeMessage, onCanvasError, onCan
   const WebView = require('react-native-webview').default
   const webViewRef = useRef<any>(null)
   const readyRef = useRef(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<{ phase: string; message: string } | null>(null)
 
-  const sendToWebView = useCallback((msg: Record<string, unknown>) => {
+  const sendToWebView = useCallback((msg: unknown) => {
     webViewRef.current?.postMessage(JSON.stringify(msg))
   }, [])
+
+  useEffect(() => {
+    readyRef.current = false
+    setLoading(true)
+    setError(null)
+  }, [url])
 
   // Send theme when it changes
   useEffect(() => {
     if (themeMessage && readyRef.current) sendToWebView(themeMessage)
   }, [themeMessage, sendToWebView])
+
+  const handleRetry = useCallback(() => {
+    readyRef.current = false
+    setError(null)
+    setLoading(true)
+    webViewRef.current?.reload?.()
+  }, [])
 
   const onMessage = useCallback((e: any) => {
     try {
@@ -255,6 +271,8 @@ function CanvasNativeWebView({ url, agentUrl, themeMessage, onCanvasError, onCan
 
       if (msg.type === 'canvas-ready') {
         readyRef.current = true
+        setLoading(false)
+        setError(null)
         if (themeMessage) sendToWebView(themeMessage)
       } else if (msg.type === 'canvas-capabilities') {
         onCanvasCapabilities?.({ supportsTheme: !!msg.supportsTheme })
@@ -263,20 +281,34 @@ function CanvasNativeWebView({ url, agentUrl, themeMessage, onCanvasError, onCan
         const recentActions = Array.isArray(msg.recentActions)
           ? (msg.recentActions as CanvasErrorAction[])
           : undefined
+        const message = msg.error as string
         postCanvasError(agentUrl, {
           phase: msg.phase as string,
-          error: msg.error as string,
+          error: message,
           route,
           recentActions,
         })
+        setLoading(false)
+        setError({ phase: msg.phase as string, message })
         onCanvasError?.(
           msg.phase as 'compile' | 'runtime',
-          msg.error as string,
+          message,
           { route, recentActions },
         )
       }
     } catch {}
   }, [agentUrl, sendToWebView, themeMessage, onCanvasError, onCanvasCapabilities])
+
+  const onNativeLoadEnd = useCallback(() => {
+    // The canvas runtime normally sends `canvas-ready`. If that bridge message
+    // is delayed, keep the centered loading state instead of showing a blank WebView.
+  }, [])
+
+  const onNativeError = useCallback((e: any) => {
+    const message = e?.nativeEvent?.description || e?.nativeEvent?.domain || 'Unable to load preview'
+    setLoading(false)
+    setError({ phase: 'runtime', message })
+  }, [])
 
   return (
     <View style={styles.container}>
@@ -287,10 +319,32 @@ function CanvasNativeWebView({ url, agentUrl, themeMessage, onCanvasError, onCan
         javaScriptEnabled={true}
         domStorageEnabled={true}
         onMessage={onMessage}
+        onLoadEnd={onNativeLoadEnd}
+        onError={onNativeError}
         originWhitelist={['*']}
         allowsInlineMediaPlayback={true}
         mediaPlaybackRequiresUserAction={false}
       />
+      {loading && !error && (
+        <View style={styles.loadingOverlay}>
+          <ActivityIndicator size="large" color="#888" />
+          <Text style={styles.loadingText}>Loading preview…</Text>
+        </View>
+      )}
+      {error && (
+        <View style={styles.errorOverlay}>
+          <Text style={styles.errorIcon}>⚠️</Text>
+          <Text style={styles.errorTitle}>
+            {error.phase === 'compile' ? 'Build Error' : 'Runtime Error'}
+          </Text>
+          <Text style={styles.errorMessage} numberOfLines={4}>
+            {error.message}
+          </Text>
+          <TouchableOpacity style={styles.retryButton} onPress={handleRetry}>
+            <Text style={styles.retryButtonText}>Retry</Text>
+          </TouchableOpacity>
+        </View>
+      )}
     </View>
   )
 }

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -2294,7 +2294,10 @@ function ChatInputImpl({
               )}
             >
               <PopoverBackdrop />
-              <PopoverContent className="p-0 max-h-[360px] web:outline-none web:overflow-visible web:max-w-none">
+              <PopoverContent
+                className="p-0 max-h-[360px] web:outline-none web:overflow-visible web:max-w-none"
+                style={isNativePhone ? { width: 136 } : undefined}
+              >
                 <ModelPickerMenu
                   currentModelId={currentModelId}
                   effectiveIsPro={effectiveIsPro}

--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -23,6 +23,7 @@ import {
   Image,
   ScrollView,
   Platform,
+  useWindowDimensions,
 } from "react-native"
 import { cn } from "@shogo/shared-ui/primitives"
 import {
@@ -137,6 +138,17 @@ function WebTooltip({ label, children }: { label: string; children: React.ReactN
 
 const MIN_INPUT_HEIGHT = 60
 const MAX_INPUT_HEIGHT = 200
+
+function compactNativeModelLabel(modelId: string): string {
+  const label = resolveShortName(modelId)
+  const lower = label.toLowerCase()
+  if (lower.includes("haiku")) return "Haiku"
+  if (lower.includes("sonnet")) return "Sonnet"
+  if (lower.includes("opus")) return "Opus"
+  if (lower.includes("gemini")) return "Gemini"
+  if (lower.includes("gpt")) return "GPT"
+  return label.length > 12 ? `${label.slice(0, 9)}…` : label
+}
 
 interface AttachedFile {
   id: string
@@ -430,7 +442,10 @@ function ChatInputImpl({
   flush = false,
 }: ChatInputProps) {
   const { features } = usePlatformConfig()
+  const { width: windowWidth } = useWindowDimensions()
   const effectiveIsPro = features.billing ? isPro : true
+  const isNativePhone = Platform.OS !== "web" && windowWidth < 600
+  const modelTriggerMaxWidth = Math.max(64, Math.min(96, Math.floor(windowWidth * 0.22)))
 
   const bridge = useChatBridgeOptional()
   const ezAvailable = Platform.OS === "web" && features.ezMode && !!bridge
@@ -2003,9 +2018,19 @@ function ChatInputImpl({
         </View>
 
         {/* Bottom toolbar */}
-        <View className="flex-row items-center justify-between p-1.5">
+        <View
+          className={cn(
+            "flex-row items-center justify-between p-1.5",
+            isNativePhone && "items-end gap-y-1"
+          )}
+        >
           {/* Left side buttons */}
-          <View className="flex-row items-center gap-1">
+          <View
+            className={cn(
+              "flex-row items-center gap-1",
+              isNativePhone && "min-w-0 flex-1 flex-wrap"
+            )}
+          >
             {/* Interaction mode selector (Agent / Plan / Ask) */}
             <Popover
               placement="top"
@@ -2252,12 +2277,19 @@ function ChatInputImpl({
                 <Pressable
                   {...triggerProps}
                   disabled={disabled}
-                  className="h-[22px] flex-row items-center gap-1 rounded-md px-1.5"
+                  className={cn(
+                    "h-[22px] flex-row items-center gap-1 rounded-md px-1.5",
+                    isNativePhone && "min-w-0"
+                  )}
+                  style={isNativePhone ? { maxWidth: modelTriggerMaxWidth } : undefined}
                 >
-                  <Text className="text-xs text-muted-foreground">
-                    {resolveShortName(currentModelId)}
+                  <Text
+                    className="text-xs text-muted-foreground"
+                    numberOfLines={1}
+                  >
+                    {isNativePhone ? compactNativeModelLabel(currentModelId) : resolveShortName(currentModelId)}
                   </Text>
-                  <ChevronDown className="h-2 w-2 text-muted-foreground/60" size={8} />
+                  <ChevronDown className="h-2 w-2 flex-shrink-0 text-muted-foreground/60" size={8} />
                 </Pressable>
               )}
             >
@@ -2278,7 +2310,7 @@ function ChatInputImpl({
 
           {/* Right side buttons */}
           {voiceInput.isRecording ? (
-            <View className="flex-row items-center gap-2">
+            <View className="flex-row flex-shrink-0 items-center gap-2">
               <VoiceWaveform />
               <Pressable
                 onPress={() => voiceInput.toggleRecording().catch(() => {})}
@@ -2290,7 +2322,7 @@ function ChatInputImpl({
               </Pressable>
             </View>
           ) : (
-          <View className="flex-row items-center gap-1">
+          <View className="flex-row flex-shrink-0 items-center gap-1">
             {contextUsage && (
               <ContextTracker
                 inputTokens={contextUsage.inputTokens}

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -4896,6 +4896,8 @@ export const ChatPanel = observer(function ChatPanel({
   )
 
   const errorMessage = error?.message ?? null
+  const nativePhonePanelWidth = isNativePhoneLayout ? Math.max(0, windowWidth) : undefined
+  const nativePhoneComposerWidth = isNativePhoneLayout ? Math.max(0, windowWidth - 24) : undefined
 
   // Memoizing the context value is the single biggest win for streaming
   // re-renders. Previously this was a fresh object literal on every
@@ -5019,6 +5021,7 @@ export const ChatPanel = observer(function ChatPanel({
               isNativePhoneLayout ? "px-2 pt-2 pb-36" : "p-2 pb-[40px]",
               "max-w-3xl w-full self-center",
             )}
+            contentContainerStyle={nativePhonePanelWidth ? { width: nativePhonePanelWidth } : undefined}
             keyboardShouldPersistTaps="handled"
             onScroll={isNative ? undefined : handleMessagesScrollWeb}
             onScrollBeginDrag={() => {
@@ -5403,7 +5406,10 @@ export const ChatPanel = observer(function ChatPanel({
           )}
 
           {/* Input */}
-          <View className="bg-transparent max-w-3xl w-full self-center mt-1">
+          <View
+            className="bg-transparent max-w-3xl w-full self-center mt-1"
+            style={nativePhoneComposerWidth ? { width: nativePhoneComposerWidth } : undefined}
+          >
             <WorktreeBar
               agentUrl={resolvedAgentUrl}
               chatSessionId={currentSessionId}

--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -834,7 +834,10 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
                 )}
               >
                 <PopoverBackdrop />
-                <PopoverContent className="p-0 max-h-[360px] web:outline-none web:overflow-visible web:max-w-none">
+                <PopoverContent
+                  className="p-0 max-h-[360px] web:outline-none web:overflow-visible web:max-w-none"
+                  style={isNativePhone ? { width: 136 } : undefined}
+                >
                   <ModelPickerMenu
                     currentModelId={currentModelId}
                     effectiveIsPro={effectiveIsPro}

--- a/apps/mobile/components/chat/CompactChatInput.tsx
+++ b/apps/mobile/components/chat/CompactChatInput.tsx
@@ -14,7 +14,7 @@
  */
 
 import React, { useState, useRef, useCallback, forwardRef, useEffect, useMemo } from "react"
-import { View, Text, TextInput, Pressable, Image, ScrollView, Platform } from "react-native"
+import { View, Text, TextInput, Pressable, Image, ScrollView, Platform, useWindowDimensions } from "react-native"
 import { cn } from "@shogo/shared-ui/primitives"
 import {
   Popover,
@@ -70,6 +70,17 @@ const MAX_FILES = 10
 
 const MIN_INPUT_HEIGHT = 80
 const MAX_INPUT_HEIGHT = 200
+
+function compactNativeModelLabel(modelId: string): string {
+  const label = resolveShortName(modelId)
+  const lower = label.toLowerCase()
+  if (lower.includes("haiku")) return "Haiku"
+  if (lower.includes("sonnet")) return "Sonnet"
+  if (lower.includes("opus")) return "Opus"
+  if (lower.includes("gemini")) return "Gemini"
+  if (lower.includes("gpt")) return "GPT"
+  return label.length > 12 ? `${label.slice(0, 9)}…` : label
+}
 
 /**
  * Show a native browser tooltip on hover (web only). Wraps children in a
@@ -166,7 +177,10 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
     ref
   ) {
     const { features } = usePlatformConfig()
+    const { width: windowWidth } = useWindowDimensions()
     const effectiveIsPro = features.billing ? isPro : true
+    const isNativePhone = Platform.OS !== "web" && windowWidth < 600
+    const modelTriggerMaxWidth = Math.max(64, Math.min(96, Math.floor(windowWidth * 0.22)))
 
     const [internalValue, setInternalValue] = useState("")
     const [inputHeight, setInputHeight] = useState(MIN_INPUT_HEIGHT)
@@ -639,9 +653,19 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
           />
 
           {/* Bottom toolbar */}
-          <View className="flex-row items-center justify-between p-1.5">
+          <View
+            className={cn(
+              "flex-row items-center justify-between p-1.5",
+              isNativePhone && "items-end gap-y-1"
+            )}
+          >
             {/* Left side buttons */}
-            <View className="flex-row items-center gap-1">
+            <View
+              className={cn(
+                "flex-row items-center gap-1",
+                isNativePhone && "min-w-0 flex-1 flex-wrap"
+              )}
+            >
               {/* Caller-supplied leading slot (e.g. project-source menu
                   on the home composer). Rendered before built-in
                   controls so it reads as "what am I creating?" prior to
@@ -793,12 +817,19 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
                   <Pressable
                     {...triggerProps}
                     disabled={disabled}
-                    className="h-[22px] flex-row items-center gap-1 rounded-md px-1.5"
+                    className={cn(
+                      "h-[22px] flex-row items-center gap-1 rounded-md px-1.5",
+                      isNativePhone && "min-w-0"
+                    )}
+                    style={isNativePhone ? { maxWidth: modelTriggerMaxWidth } : undefined}
                   >
-                    <Text className="text-xs text-muted-foreground">
-                      {resolveShortName(currentModelId)}
+                    <Text
+                      className="text-xs text-muted-foreground"
+                      numberOfLines={1}
+                    >
+                      {isNativePhone ? compactNativeModelLabel(currentModelId) : resolveShortName(currentModelId)}
                     </Text>
-                    <ChevronDown className="h-2 w-2 text-muted-foreground/60" size={8} />
+                    <ChevronDown className="h-2 w-2 flex-shrink-0 text-muted-foreground/60" size={8} />
                   </Pressable>
                 )}
               >
@@ -818,7 +849,7 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
 
             {/* Right side buttons */}
             {voiceInput.isRecording ? (
-              <View className="flex-row items-center gap-2">
+              <View className="flex-row flex-shrink-0 items-center gap-2">
                 <VoiceWaveform />
                 <Pressable
                   onPress={() => voiceInput.toggleRecording().catch(() => {})}
@@ -830,7 +861,7 @@ export const CompactChatInput = forwardRef<View, CompactChatInputProps>(
                 </Pressable>
               </View>
             ) : (
-              <View className="flex-row items-center gap-1">
+              <View className="flex-row flex-shrink-0 items-center gap-1">
                 <Pressable
                   onPress={handleAttachClick}
                   disabled={disabled || isLoading || pendingFiles.length >= MAX_FILES}

--- a/apps/mobile/components/chat/ModelPickerMenu.tsx
+++ b/apps/mobile/components/chat/ModelPickerMenu.tsx
@@ -55,6 +55,8 @@ function formatContextWindow(tokens?: number): string | null {
 
 /** Width of the detached web info card that floats beside the list on hover. */
 const INFO_PANEL_WIDTH = 232
+const NATIVE_MENU_WIDTH = 136
+const WEB_MENU_WIDTH = 280
 
 function ModelInfoPanel({ model }: { model: PickerModel }) {
   const context = formatContextWindow(model.contextWindow)
@@ -175,7 +177,7 @@ export function ModelPickerMenu({
   }
 
   const list = (
-    <View style={isWeb ? { width: 280 } : undefined}>
+    <View style={{ width: isWeb ? WEB_MENU_WIDTH : NATIVE_MENU_WIDTH }}>
       <ScrollView style={{ maxHeight: 340 }}>
         <AutoModelOption
           currentModelId={currentModelId}

--- a/apps/mobile/components/chat/TechStackPicker.tsx
+++ b/apps/mobile/components/chat/TechStackPicker.tsx
@@ -16,7 +16,7 @@
  * reflects what the runtime would seed even before the user touches it.
  */
 import React, { useEffect, useMemo, useRef, useState } from "react"
-import { View, Text, Pressable, ScrollView, Platform } from "react-native"
+import { View, Text, Pressable, ScrollView, Platform, useWindowDimensions } from "react-native"
 import { Layers, ChevronDown, Check } from "lucide-react-native"
 import {
   Popover,
@@ -50,6 +50,9 @@ export interface TechStackPickerProps {
 }
 
 export function TechStackPicker({ value, onChange, disabled }: TechStackPickerProps) {
+  const { width: windowWidth } = useWindowDimensions()
+  const isNativePhone = Platform.OS !== "web" && windowWidth < 600
+  const triggerMaxWidth = Math.max(84, Math.min(128, Math.floor(windowWidth * 0.32)))
   const [open, setOpen] = useState(false)
   const [stacks, setStacks] = useState<TechStackSummary[]>([])
   const fetchedRef = useRef(false)
@@ -93,13 +96,15 @@ export function TechStackPicker({ value, onChange, disabled }: TechStackPickerPr
             className={cn(
               "h-[22px] flex-row items-center gap-1 rounded-md px-1.5",
               "border border-border/60 bg-muted/40 active:opacity-80",
+              isNativePhone && "min-w-0",
               disabled && "opacity-60",
             )}
+            style={isNativePhone ? { maxWidth: triggerMaxWidth } : undefined}
             testID="tech-stack-picker-trigger"
           >
-            <Layers className="h-3 w-3 text-muted-foreground" size={12} />
-            <Text className="text-[11px] text-muted-foreground">{displayLabel}</Text>
-            <ChevronDown className="h-2 w-2 text-muted-foreground/60" size={8} />
+            <Layers className="h-3 w-3 flex-shrink-0 text-muted-foreground" size={12} />
+            <Text className="text-[11px] text-muted-foreground" numberOfLines={1}>{displayLabel}</Text>
+            <ChevronDown className="h-2 w-2 flex-shrink-0 text-muted-foreground/60" size={8} />
           </Pressable>
         </WebTooltip>
       )}

--- a/apps/mobile/components/layout/AppSidebar.tsx
+++ b/apps/mobile/components/layout/AppSidebar.tsx
@@ -1569,10 +1569,10 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
   const insets = useSafeAreaInsets()
   const isWide = width >= 768
   const isPhoneDrawer = Platform.OS !== 'web' && !isWide
-  const drawerTopInset = isPhoneDrawer ? Math.max(insets.top + 56, 112) : insets.top
-  const drawerBottomInset = isPhoneDrawer ? Math.max(insets.bottom + 24, 56) : insets.bottom
-  const drawerSideInset = isPhoneDrawer ? Math.max(insets.left, 22) : 0
-  const drawerPanelWidth = isPhoneDrawer ? Math.min(264, Math.max(240, width - 84)) : undefined
+  const drawerTopInset = isPhoneDrawer ? Math.max(insets.top, 56) : insets.top
+  const drawerBottomInset = isPhoneDrawer ? Math.max(insets.bottom, 18) : insets.bottom
+  const drawerSideInset = isPhoneDrawer ? Math.max(insets.left, 4) : 0
+  const drawerPanelWidth = isPhoneDrawer ? Math.min(288, Math.max(264, width - 48)) : undefined
   const { features, localMode } = usePlatformConfig()
 
   const { user, signOut } = useAuth()
@@ -1777,7 +1777,13 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
   const workspacePlan = currentWorkspace?.id ? (allPlans[currentWorkspace.id] ?? null) : null
   const isPaidPlan = billingData.hasActiveSubscription || (workspacePlan?.planId !== 'free' && workspacePlan?.status === 'active')
 
-  const toggleCollapse = useCallback(() => setCollapsed((c) => !c), [])
+  const toggleCollapse = useCallback(() => {
+    if (isPhoneDrawer) {
+      onClose?.()
+      return
+    }
+    setCollapsed((c) => !c)
+  }, [isPhoneDrawer, onClose])
 
   const handleSwitchWorkspace = useCallback(
     (workspaceId: string) => {
@@ -1851,7 +1857,7 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
       role="navigation"
       accessibilityLabel="App sidebar"
       className={cn('flex-1 bg-card border-r border-border', collapsed ? 'w-16' : 'w-64')}
-      style={isPhoneDrawer ? { paddingLeft: drawerSideInset, paddingRight: 8 } : undefined}
+      style={isPhoneDrawer ? { paddingLeft: drawerSideInset, paddingRight: 4 } : undefined}
     >
       {isPhoneDrawer && <View style={{ height: drawerTopInset }} />}
       {/* ── Logo Row ── */}
@@ -2293,14 +2299,42 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
 
   if (!isOpen) return null
 
+  if (isPhoneDrawer) {
+    return (
+      <Modal
+        visible={isOpen}
+        transparent
+        animationType="none"
+        statusBarTranslucent
+        onRequestClose={onClose}
+      >
+        <View
+          onStartShouldSetResponder={() => true}
+          onResponderRelease={onClose}
+          style={{ flex: 1, backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
+        >
+          <View
+            style={{ position: 'absolute', left: 0, right: 0, top: 0, bottom: 0, flexDirection: 'row' }}
+          >
+            <View
+              onStartShouldSetResponder={() => true}
+              style={[
+                { height: '100%', zIndex: 10 },
+                drawerPanelWidth ? { width: drawerPanelWidth } : null,
+              ]}
+            >
+              {sidebarContent}
+            </View>
+          </View>
+        </View>
+      </Modal>
+    )
+  }
+
   return (
     <View
       className="absolute left-0 right-0 z-50 flex-row"
-      style={
-        isPhoneDrawer
-          ? { top: -insets.top, bottom: -insets.bottom }
-          : { top: 0, bottom: 0, paddingTop: insets.top }
-      }
+      style={{ top: 0, bottom: 0, paddingTop: insets.top }}
     >
       <Pressable onPress={onClose} className="absolute inset-0 bg-black/50" />
       <View

--- a/apps/mobile/components/layout/AppSidebar.tsx
+++ b/apps/mobile/components/layout/AppSidebar.tsx
@@ -1568,6 +1568,11 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
   const router = useRouter()
   const insets = useSafeAreaInsets()
   const isWide = width >= 768
+  const isPhoneDrawer = Platform.OS !== 'web' && !isWide
+  const drawerTopInset = isPhoneDrawer ? Math.max(insets.top + 56, 112) : insets.top
+  const drawerBottomInset = isPhoneDrawer ? Math.max(insets.bottom + 24, 56) : insets.bottom
+  const drawerSideInset = isPhoneDrawer ? Math.max(insets.left, 22) : 0
+  const drawerPanelWidth = isPhoneDrawer ? Math.min(264, Math.max(240, width - 84)) : undefined
   const { features, localMode } = usePlatformConfig()
 
   const { user, signOut } = useAuth()
@@ -1842,7 +1847,13 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
   const isMarketplacePage = pathname.startsWith('/marketplace') || pathname.startsWith('/(app)/marketplace')
 
   const sidebarContent = (
-    <View role="navigation" accessibilityLabel="App sidebar" className={cn('flex-1 bg-card border-r border-border', collapsed ? 'w-16' : 'w-64')}>
+    <View
+      role="navigation"
+      accessibilityLabel="App sidebar"
+      className={cn('flex-1 bg-card border-r border-border', collapsed ? 'w-16' : 'w-64')}
+      style={isPhoneDrawer ? { paddingLeft: drawerSideInset, paddingRight: 8 } : undefined}
+    >
+      {isPhoneDrawer && <View style={{ height: drawerTopInset }} />}
       {/* ── Logo Row ── */}
       <View
         className={cn(
@@ -1967,7 +1978,7 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
                         <Pressable
                           key={opt.value}
                           onPress={() => updateProjectFilter({ sort: opt.value })}
-                          role="menuitemradio"
+                          accessibilityRole="radio"
                           accessibilityState={{ checked: projectFilter.sort === opt.value }}
                           className="flex-row items-center gap-2 px-3 py-2 active:bg-muted"
                         >
@@ -1993,7 +2004,7 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
                         <Pressable
                           key={opt.value}
                           onPress={() => updateProjectFilter({ scope: opt.value })}
-                          role="menuitemradio"
+                          accessibilityRole="radio"
                           accessibilityState={{ checked: projectFilter.scope === opt.value }}
                           className="flex-row items-center gap-2 px-3 py-2 active:bg-muted"
                         >
@@ -2056,7 +2067,7 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
       </ScrollView>
 
       {/* ── Bottom Section ── */}
-      <View className="border-t border-border" style={{ paddingBottom: insets.bottom }}>
+      <View className="border-t border-border" style={{ paddingBottom: drawerBottomInset }}>
         {/* Upgrade to Pro CTA */}
         {features.billing && !collapsed && !isPaidPlan && (
           <View className="px-2 pt-2">
@@ -2092,7 +2103,7 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
               onNavigate={(href) => { if (!isWide) onClose?.(); router.push(href as any); onNavPress() }}
               isSuperAdmin={hasAdminAccess}
               isWide={isWide}
-              bottomInset={insets.bottom}
+              bottomInset={drawerBottomInset}
               collapsed={collapsed}
               workspaces={allWorkspaces}
               currentWorkspace={currentWorkspace}
@@ -2283,9 +2294,19 @@ export const AppSidebar = observer(function AppSidebar({ isOpen, onClose }: AppS
   if (!isOpen) return null
 
   return (
-    <View className="absolute inset-0 z-50 flex-row" style={{ paddingTop: insets.top }}>
+    <View
+      className="absolute left-0 right-0 z-50 flex-row"
+      style={
+        isPhoneDrawer
+          ? { top: -insets.top, bottom: -insets.bottom }
+          : { top: 0, bottom: 0, paddingTop: insets.top }
+      }
+    >
       <Pressable onPress={onClose} className="absolute inset-0 bg-black/50" />
-      <View className="w-72 h-full z-10">
+      <View
+        className="w-72 h-full z-10"
+        style={drawerPanelWidth ? { width: drawerPanelWidth } : undefined}
+      >
         {sidebarContent}
       </View>
     </View>

--- a/apps/mobile/components/project/ProjectTopBar.tsx
+++ b/apps/mobile/components/project/ProjectTopBar.tsx
@@ -51,7 +51,6 @@ import {
   MessageSquare,
   LayoutDashboard,
   Code2,
-  FolderOpen,
   Sliders,
   Radio,
   Activity,
@@ -104,7 +103,7 @@ const AGENT_TABS: { id: string; label: string; icon: React.ElementType }[] = [
   // APP_MODE_DISABLED: { id: 'app-preview', label: 'App', icon: AppWindow },
   ...(Platform.OS === 'web'
     ? [{ id: 'ide', label: 'IDE', icon: Code2 }]
-    : [{ id: 'files', label: 'Files', icon: FolderOpen }]),
+    : [{ id: 'files', label: 'Files', icon: Code2 }]),
   { id: 'plans', label: 'Plans', icon: ClipboardList },
   // Folders, Capabilities, Channels, Agents, Monitor, Checkpoints all
   // live behind this Settings tab now (rendered by SettingsPanel with a
@@ -439,7 +438,7 @@ export function ProjectTopBar({
   const narrowOverflowTabs = visibleTabs.filter(t => !narrowPrimaryIds.has(t.id))
   const narrowMoreItems = [
     ...narrowOverflowTabs.map(t => ({ id: t.id, label: t.label })),
-    ...(!hasActiveSubscription ? [{ id: '_upgrade', label: 'Upgrade' }] : []),
+    ...(!hasActiveSubscription && !(Platform.OS !== 'web' && isNativePhone) ? [{ id: '_upgrade', label: 'Upgrade' }] : []),
   ]
 
   const handleTabPress = useCallback((tabId: string) => {
@@ -528,14 +527,14 @@ export function ProjectTopBar({
                   )}
                   style={[
                     (triggerProps as { style?: StyleProp<ViewStyle> }).style,
-                    isNativePhone ? { maxWidth: nativeNarrowTitleMaxWidth } : undefined,
+                    isNativePhone ? { maxWidth: nativeNarrowTitleMaxWidth, alignSelf: 'flex-start' } : undefined,
                   ]}
                   accessibilityLabel="Switch project"
                   testID="project-switcher-trigger"
                 >
                   <Text
                     className="text-xs font-semibold text-foreground"
-                    style={isNativePhone ? { flex: 1, minWidth: 0 } : undefined}
+                    style={isNativePhone ? { maxWidth: nativeNarrowTitleMaxWidth - 18 } : undefined}
                     numberOfLines={1}
                     ellipsizeMode="tail"
                   >

--- a/apps/mobile/components/project/ProjectTopBar.tsx
+++ b/apps/mobile/components/project/ProjectTopBar.tsx
@@ -87,9 +87,9 @@ import { ProjectExportModal } from './ProjectExportModal'
 /** Native narrow bar: Popover trigger often ignores Tailwind `max-w`; cap width in dp (slightly above 120). */
 const nativeNarrowTitleMaxWidth = 132
 
-/** Native narrow top bar only (not web): slimmer than 320px desktop popover, capped to screen width. */
+/** Native narrow top bar only (not web): keep the project menu wide enough for the account row and usage card. */
 function narrowProjectDropdownWidth(screenWidth: number): number {
-  return Math.max(232, Math.min(276, screenWidth - 20))
+  return Math.max(300, Math.min(320, screenWidth - 96))
 }
 
 const AGENT_TABS: { id: string; label: string; icon: React.ElementType }[] = [
@@ -553,7 +553,7 @@ export function ProjectTopBar({
                 }
                 style={
                   narrowNativeMenuW != null
-                    ? { width: narrowNativeMenuW, maxWidth: narrowNativeMenuW }
+                    ? { width: narrowNativeMenuW, maxWidth: narrowNativeMenuW, left: 16 }
                     : undefined
                 }
               >

--- a/apps/mobile/components/project/panels/PlansPanel.tsx
+++ b/apps/mobile/components/project/panels/PlansPanel.tsx
@@ -137,6 +137,7 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
   const planStream = usePlanStreamSafe()
   const [plans, setPlans] = useState<AgentPlanSummary[]>([])
   const [loading, setLoading] = useState(false)
+  const [plansError, setPlansError] = useState<string | null>(null)
   const [selectedPlan, setSelectedPlan] = useState<string | null>(null)
   const [planContent, setPlanContent] = useState<string | null>(null)
   const [detailLoading, setDetailLoading] = useState(false)
@@ -192,11 +193,14 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
 
   const fetchPlans = useCallback(async () => {
     setLoading(true)
+    setPlansError(null)
     try {
       const list = await agentClient.listPlans()
       setPlans(list)
-    } catch (err) {
-      console.error("[PlansPanel] Failed to fetch plans:", err)
+    } catch (err: any) {
+      const message = err?.message || "Unable to load plans right now"
+      setPlansError(message)
+      console.log("[PlansPanel] Failed to fetch plans:", err)
     } finally {
       setLoading(false)
     }
@@ -209,7 +213,7 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
         const data = await agentClient.getPlan(filename)
         setPlanContent(data.content)
       } catch (err) {
-        console.error("[PlansPanel] Failed to fetch plan detail:", err)
+        console.log("[PlansPanel] Failed to fetch plan detail:", err)
         setPlanContent(null)
       } finally {
         setDetailLoading(false)
@@ -228,7 +232,7 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
           setPlanContent(null)
         }
       } catch (err) {
-        console.error("[PlansPanel] Failed to delete plan:", err)
+        console.log("[PlansPanel] Failed to delete plan:", err)
       }
     },
     [agentClient, selectedPlan]
@@ -277,7 +281,7 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
       setActiveTab("summary")
     } catch (err: any) {
       const message = err?.message || "Failed to generate summary"
-      console.error("[PlansPanel] Summary generation failed:", err)
+      console.log("[PlansPanel] Summary generation failed:", err)
       setTranslateError(message)
     } finally {
       setTranslateLoading((cur) => (cur === selectedPlan ? null : cur))
@@ -369,7 +373,7 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
       !isSummarizingThisPlan
 
     return (
-      <View className="flex-1 bg-background">
+      <View className="flex-1 bg-background" style={{ alignSelf: "stretch", width: "100%", height: "100%" }}>
         {/* Detail header */}
         <View className="flex-row items-center gap-2 px-4 py-3 border-b border-border" style={{ zIndex: 10, overflow: "visible" as any }}>
           <Pressable
@@ -612,7 +616,7 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
 
   // List view
   return (
-    <View className="flex-1 bg-background">
+    <View className="flex-1 bg-background" style={{ alignSelf: "stretch", width: "100%", height: "100%" }}>
       {/* Header */}
       <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
         <View className="flex-row items-center gap-2">
@@ -674,7 +678,17 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
       </View>
 
       {/* List */}
-      <ScrollView className="flex-1">
+      <ScrollView
+        className="flex-1"
+        style={{ flex: 1, alignSelf: "stretch", width: "100%" }}
+        contentContainerStyle={{
+          flexGrow: 1,
+          justifyContent:
+            filteredPlans.length === 0 && !planStream?.streamingPlan
+              ? "center"
+              : "flex-start",
+        }}
+      >
         {/* Streaming plan — clickable list entry that opens the detail view */}
         {planStream?.streamingPlan ? (
           <Pressable
@@ -695,7 +709,7 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
             </View>
           </Pressable>
         ) : planStream?.isPlanStreaming && filteredPlans.length === 0 && !loading ? (
-          <View className="items-center justify-center py-12 px-4">
+          <View className="items-center justify-center px-4">
             <ActivityIndicator className="mb-3" />
             <Text className="text-sm text-muted-foreground text-center">
               Shogo is researching...
@@ -716,8 +730,21 @@ export function PlansPanel({ visible, projectId, agentUrl, selectedModel, reques
 
         {loading && !planStream?.isPlanStreaming ? (
           <ActivityIndicator className="mt-8" />
+        ) : plansError && filteredPlans.length === 0 && !planStream?.isPlanStreaming && !planStream?.streamingPlan ? (
+          <View className="items-center justify-center px-4">
+            <ClipboardList className="h-8 w-8 text-muted-foreground/40 mb-3" size={32} />
+            <Text className="text-sm text-muted-foreground text-center">
+              Plans are unavailable
+            </Text>
+            <Text className="text-xs text-muted-foreground/70 text-center mt-1">
+              {plansError}
+            </Text>
+            <Pressable onPress={fetchPlans} className="mt-4 rounded-lg border border-border px-3 py-2 active:bg-accent">
+              <Text className="text-xs font-medium text-foreground">Try again</Text>
+            </Pressable>
+          </View>
         ) : filteredPlans.length === 0 && !planStream?.isPlanStreaming && !planStream?.streamingPlan ? (
-          <View className="items-center justify-center py-12 px-4">
+          <View className="items-center justify-center px-4">
             <ClipboardList className="h-8 w-8 text-muted-foreground/40 mb-3" size={32} />
             <Text className="text-sm text-muted-foreground text-center">
               {searchQuery ? "No plans match your search" : "No plans yet"}

--- a/apps/mobile/components/ui/popover/index.tsx
+++ b/apps/mobile/components/ui/popover/index.tsx
@@ -173,7 +173,7 @@ const Popover = React.forwardRef<
 const PopoverContent = React.forwardRef<
   React.ComponentRef<typeof UIPopover.Content>,
   IPopoverContentProps
->(function PopoverContent({ className, size, children, ...props }, ref) {
+>(function PopoverContent({ className, size, children, style, ...props }, ref) {
   const { size: parentSize } = useStyleContext(SCOPE);
 
   return (
@@ -191,7 +191,7 @@ const PopoverContent = React.forwardRef<
         },
       }}
       {...props}
-      style={{ pointerEvents: 'auto' }}
+      style={[style, { pointerEvents: 'auto' }]}
     >
       <View
         className={popoverContentStyle({


### PR DESCRIPTION

<img width="1512" height="982" alt="Screenshot 2026-07-29 at 3 24 43 PM" src="https://github.com/user-attachments/assets/961b890e-2f2a-4303-bad5-83511d868ee2" />
<img width="1512" height="982" alt="Screenshot 2026-07-29 at 3 24 50 PM" src="https://github.com/user-attachments/assets/cfc77140-1708-4c00-8e42-3cae6d36cbd0" />
<img width="1512" height="982" alt="Screenshot 2026-07-29 at 3 24 59 PM" src="https://github.com/user-attachments/assets/5c96bfbb-12bb-4fdf-a3f7-d54d11801d53" />
<img width="573" height="800" alt="Screenshot 2026-07-29 at 6 09 11 PM" src="https://github.com/user-attachments/assets/cadf33f1-8da1-45a0-ac72-f4d6a49861be" />
<img width="596" height="823" alt="Screenshot 2026-07-29 at 6 09 22 PM" src="https://github.com/user-attachments/assets/03c7f7e5-a3b2-4783-94c3-1fe66bec4527" />

## Summary

This draft PR stabilizes the native mobile project workspace layout and interactions. It focuses on phone-sized UI regressions around the project canvas, chat composer model picker, sidebars, safe-area spacing, and adjacent project workspace controls.

Closes #846.

## Detailed changes

### Canvas / preview sizing

- Updates the native canvas slot sizing so the canvas tab can fill the available mobile workspace width and height.
- Keeps the fill behavior on the outer native canvas area rather than forcing absolute positioning inside the inner canvas panel.
- Preserves normal flex behavior for the canvas loading and WebView content so the preview does not become offset, blank, or detached from the intended parent container.
- Ensures the canvas route is handled as a mobile full-screen workspace surface under the project toolbar.

### Model picker popover

- Fixes the mobile model picker popover width so it no longer collapses into a tiny checkmark-only box.
- Keeps the native width compact to avoid overflowing the chatbox/screen edge.
- Preserves the wider web/desktop menu width separately.
- Avoids changing mic, voice, or unrelated chat behavior.

### Mobile project workspace polish

This branch also includes earlier mobile UI fixes that improve the same project workspace experience:

- Improves chat input responsiveness on mobile.
- Adds safer phone sidebar padding.
- Allows the sidebar to close when tapping outside it.
- Aligns project chat UI behavior more closely with the intended mobile design.
- Prevents project menu clipping.
- Removes extra notifications top padding.
- Matches the mobile home gradient background.
- Fixes mobile plans canvas layout handling.

## Why this is needed

The native mobile workspace relies on a tightly constrained layout: toolbar at the top, tab-specific content below, and floating controls such as chat/model picker overlays. Small mistakes in wrapper sizing or popover width can make the UI unusable on phone screens.

The canvas in particular needs its outer slot to own full-screen sizing. Applying full-screen positioning too deep inside the component tree can cause the preview to detach from the expected parent bounds or render as a blank/offset area. This PR keeps sizing responsibility at the appropriate wrapper level.

## Testing / verification

Verified locally on the branch:

- `git diff --check`
- `bun run typecheck`

The repo's typecheck command currently prints the existing Expo-native skip message:

```bash
Skipping: requires Expo native environment
```

Additional manual QA recommended before marking ready for review:

1. Launch the native mobile app on an iPhone simulator.
2. Open a project.
3. Switch to the canvas tab.
4. Confirm the loading state fills the available mobile workspace area.
5. Wait for the preview to load and confirm the loaded canvas also fills the available area.
6. Open the chat composer model picker and confirm it is compact, readable, and does not overflow.
7. Check chat, code, tasks, and settings tab controls remain accessible.
8. Check sidebar open/close behavior and safe-area spacing.
9. Verify desktop/web project workspace layout remains unchanged.

## Risk notes

- Most changes are mobile-layout scoped, but project workspace layout is shared across several tabs, so manual QA should cover tab switching.
- Canvas sizing is sensitive to wrapper hierarchy; this PR intentionally avoids moving the full-screen behavior into inner canvas content.
- The PR is opened as draft so the visual behavior can be validated on simulator/device before final review.
