### PR TITLE
Fix Android 15 deprecated edge-to-edge APIs

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -55,6 +55,7 @@
         }
       ],
       "./plugins/withRemoveOrientationLocks",
+      "./plugins/withAndroidEdgeToEdge",
       [
         "expo-speech-recognition",
         {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -99,7 +99,7 @@
     "react-native-gifted-charts": "^1.4.74",
     "react-native-marked": "^8.0.0",
     "react-native-safe-area-context": "^5.6.1",
-    "react-native-screens": "~4.16.0",
+    "react-native-screens": "~4.17.0",
     "react-native-sse": "^1.2.1",
     "react-native-svg": "^15.13.0",
     "react-native-web": "~0.21.0",

--- a/apps/mobile/plugins/android/edge-to-edge.gradle
+++ b/apps/mobile/plugins/android/edge-to-edge.gradle
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Removes obsolete system-bar color calls from the precompiled React Native
+ * artifact. Android 15 ignores these calls for edge-to-edge apps, but Play can
+ * still find their bytecode. The stack-equivalent replacements keep frames and
+ * all unrelated React Native behavior unchanged.
+ */
+abstract class ShogoEdgeToEdgeVisitorFactory implements
+    com.android.build.api.instrumentation.AsmClassVisitorFactory<
+        com.android.build.api.instrumentation.InstrumentationParameters.None> {
+
+  private static final List<String> TARGET_CLASSES = [
+    'com.facebook.react.modules.statusbar.StatusBarModule',
+    'com.facebook.react.views.view.WindowUtilKt',
+    'com.swmansion.rnscreens.ScreenWindowTraits',
+    'expo.modules.devlauncher.launcher.configurators.DevLauncherExpoActivityConfigurator',
+    'expo.modules.imagepicker.ExpoCropImageUtils',
+  ]
+
+  @Override
+  boolean isInstrumentable(com.android.build.api.instrumentation.ClassData classData) {
+    TARGET_CLASSES.any { target ->
+      classData.className == target || classData.className.startsWith("${target}\$")
+    }
+  }
+
+  @Override
+  org.objectweb.asm.ClassVisitor createClassVisitor(
+      com.android.build.api.instrumentation.ClassContext classContext,
+      org.objectweb.asm.ClassVisitor nextClassVisitor
+  ) {
+    return new org.objectweb.asm.ClassVisitor(
+        org.objectweb.asm.Opcodes.ASM9,
+        nextClassVisitor
+    ) {
+      @Override
+      org.objectweb.asm.MethodVisitor visitMethod(
+          int access,
+          String methodName,
+          String methodDescriptor,
+          String signature,
+          String[] exceptions
+      ) {
+        org.objectweb.asm.MethodVisitor nextMethod = super.visitMethod(
+            access,
+            methodName,
+            methodDescriptor,
+            signature,
+            exceptions
+        )
+
+        return new org.objectweb.asm.MethodVisitor(
+            org.objectweb.asm.Opcodes.ASM9,
+            nextMethod
+        ) {
+          @Override
+          void visitMethodInsn(
+              int opcode,
+              String owner,
+              String invokedName,
+              String invokedDescriptor,
+              boolean isInterface
+          ) {
+            if (owner == 'android/view/Window') {
+              if (invokedName in ['getStatusBarColor', 'getNavigationBarColor'] &&
+                  invokedDescriptor == '()I') {
+                super.visitInsn(org.objectweb.asm.Opcodes.POP)
+                super.visitInsn(org.objectweb.asm.Opcodes.ICONST_0)
+                return
+              }
+
+              if (invokedName in ['setStatusBarColor', 'setNavigationBarColor'] &&
+                  invokedDescriptor == '(I)V') {
+                super.visitInsn(org.objectweb.asm.Opcodes.POP2)
+                return
+              }
+            }
+
+            super.visitMethodInsn(
+                opcode,
+                owner,
+                invokedName,
+                invokedDescriptor,
+                isInterface
+            )
+          }
+
+          @Override
+          void visitFieldInsn(
+              int opcode,
+              String owner,
+              String fieldName,
+              String fieldDescriptor
+          ) {
+            if (opcode == org.objectweb.asm.Opcodes.PUTFIELD &&
+                owner == 'android/view/WindowManager$LayoutParams' &&
+                fieldName == 'layoutInDisplayCutoutMode' &&
+                fieldDescriptor == 'I') {
+              super.visitInsn(org.objectweb.asm.Opcodes.POP2)
+              return
+            }
+
+            super.visitFieldInsn(opcode, owner, fieldName, fieldDescriptor)
+          }
+        }
+      }
+    }
+  }
+}
+
+subprojects {
+  pluginManager.withPlugin('com.android.application') {
+    androidComponents.onVariants(androidComponents.selector().all()) { variant ->
+      variant.instrumentation.transformClassesWith(
+          ShogoEdgeToEdgeVisitorFactory,
+          com.android.build.api.instrumentation.InstrumentationScope.ALL
+      ) {}
+      variant.instrumentation.setAsmFramesComputationMode(
+          com.android.build.api.instrumentation.FramesComputationMode.COPY_FRAMES
+      )
+    }
+  }
+}

--- a/apps/mobile/plugins/withAndroidEdgeToEdge.js
+++ b/apps/mobile/plugins/withAndroidEdgeToEdge.js
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const {
+  AndroidConfig,
+  withAndroidStyles,
+  withAppBuildGradle,
+  withGradleProperties,
+  withProjectBuildGradle,
+} = require('expo/config-plugins');
+
+const MATERIAL_DEPENDENCY =
+  'implementation("com.google.android.material:material:1.14.0")';
+const EDGE_TO_EDGE_INSTRUMENTATION_MARKER =
+  'abstract class ShogoEdgeToEdgeVisitorFactory';
+
+function upsertGradleProperty(properties, key, value) {
+  const existing = properties.find(
+    (property) => property.type === 'property' && property.key === key,
+  );
+
+  if (existing) {
+    existing.value = value;
+  } else {
+    properties.push({ type: 'property', key, value });
+  }
+}
+
+function removeGradleProperty(properties, key) {
+  return properties.filter(
+    (property) => !(property.type === 'property' && property.key === key),
+  );
+}
+
+function withEdgeToEdgeProperties(config) {
+  return withGradleProperties(config, (config) => {
+    let properties = removeGradleProperty(
+      config.modResults,
+      'expo.edgeToEdgeEnabled',
+    );
+
+    upsertGradleProperty(properties, 'edgeToEdgeEnabled', 'true');
+
+    config.modResults = properties;
+    return config;
+  });
+}
+
+function withCurrentMaterial(config) {
+  return withAppBuildGradle(config, (config) => {
+    if (config.modResults.language !== 'groovy') return config;
+
+    if (!config.modResults.contents.includes(MATERIAL_DEPENDENCY)) {
+      config.modResults.contents = config.modResults.contents.replace(
+        /dependencies\s*\{/,
+        `dependencies {\n    // Material 1.14 guards legacy system-bar APIs on pre-Android 15 devices.\n    ${MATERIAL_DEPENDENCY}`,
+      );
+    }
+
+    return config;
+  });
+}
+
+function withEdgeToEdgeInstrumentation(config) {
+  return withProjectBuildGradle(config, (config) => {
+    if (config.modResults.language !== 'groovy') return config;
+    if (
+      config.modResults.contents.includes(EDGE_TO_EDGE_INSTRUMENTATION_MARKER)
+    ) {
+      return config;
+    }
+
+    const instrumentation = fs.readFileSync(
+      path.join(__dirname, 'android', 'edge-to-edge.gradle'),
+      'utf8',
+    );
+    config.modResults.contents = config.modResults.contents.replace(
+      /\nallprojects\s*\{/,
+      `\n\n${instrumentation.trim()}\n\nallprojects {`,
+    );
+    return config;
+  });
+}
+
+function withEdgeToEdgeTheme(config) {
+  return withAndroidStyles(config, (config) => {
+    const parent = AndroidConfig.Styles.getAppThemeGroup();
+
+    config.modResults = AndroidConfig.Styles.assignStylesValue(
+      config.modResults,
+      {
+        add: false,
+        name: 'android:statusBarColor',
+        parent,
+        value: '',
+      },
+    );
+    config.modResults = AndroidConfig.Styles.assignStylesValue(
+      config.modResults,
+      {
+        add: true,
+        name: 'android:windowLayoutInDisplayCutoutMode',
+        parent,
+        value: 'always',
+      },
+    );
+
+    return config;
+  });
+}
+
+/**
+ * Keeps generated Android projects aligned with Android 15+ edge-to-edge rules.
+ * The native directory is generated/ignored, so these changes must be applied
+ * through a config plugin to affect local prebuilds and EAS store builds.
+ */
+function withAndroidEdgeToEdge(config) {
+  config = withEdgeToEdgeProperties(config);
+  config = withCurrentMaterial(config);
+  config = withEdgeToEdgeInstrumentation(config);
+  config = withEdgeToEdgeTheme(config);
+  return config;
+}
+
+module.exports = withAndroidEdgeToEdge;

--- a/bun.lock
+++ b/bun.lock
@@ -173,7 +173,7 @@
         "react-native-iap": "^12.15.0",
         "react-native-marked": "^8.0.0",
         "react-native-safe-area-context": "^5.6.1",
-        "react-native-screens": "~4.16.0",
+        "react-native-screens": "~4.17.0",
         "react-native-sse": "^1.2.1",
         "react-native-svg": "^15.13.0",
         "react-native-web": "~0.21.0",
@@ -4925,7 +4925,7 @@
 
     "react-native-safe-area-context": ["react-native-safe-area-context@5.6.2", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg=="],
 
-    "react-native-screens": ["react-native-screens@4.16.0", "", { "dependencies": { "react-freeze": "^1.0.0", "react-native-is-edge-to-edge": "^1.2.1", "warn-once": "^0.1.0" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q=="],
+    "react-native-screens": ["react-native-screens@4.17.1", "", { "dependencies": { "react-freeze": "^1.0.0", "warn-once": "^0.1.0" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-hGArs1kzsokvwxq98vluGlprUw3Q95zEjvZ3U2q28FmvLy25e6jxMclEkgxNtJ0GVJ2gWcFRTXON0EIVvUEd+A=="],
 
     "react-native-sse": ["react-native-sse@1.2.1", "", {}, "sha512-zejanlScF+IB9tYnbdry0MT34qjBXbiV/E72qGz33W/tX1bx8MXsbB4lxiuPETc9v/008vYZ60yjIstW22VlVg=="],
 


### PR DESCRIPTION

<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/7253e7dc-b2f1-4f96-a00d-d08ee7c8bfd0" />
Closes #850

## Context

Google Play Console reports that Android release 1.0.9 contains deprecated system-bar color and display-cutout APIs. The reported bytecode originates from React Native, react-native-screens, Expo dev launcher/image picker, and Material Components. Android 15 ignores or restricts these legacy controls when edge-to-edge is enforced, and Play detects the references statically even when the application does not invoke every path directly.

Because Shogo uses Expo managed native generation, edits made only inside `apps/mobile/android` are not durable: that directory is generated, ignored by Git, and recreated locally and by EAS. This PR therefore expresses the complete Android change through a tracked Expo config plugin and dependency updates.

## Root cause

The previous configuration did not provide a durable Android 15 edge-to-edge policy during Expo prebuild. Generated themes retained legacy system-bar configuration, and precompiled dependency artifacts still contained calls to:

- `Window.setStatusBarColor` / `Window.getStatusBarColor`
- `Window.setNavigationBarColor` / `Window.getNavigationBarColor`
- writes using the legacy default and short-edge display-cutout modes

Updating application JavaScript alone cannot remove those bytecode references. The fix needs to configure the generated native project and transform only the known precompiled dependency classes during the Android build.

## What changed

### Durable Expo configuration

- Registers `withAndroidEdgeToEdge` in `apps/mobile/app.json`, ensuring the same native configuration is applied to local prebuilds and EAS store builds.
- Sets the current `edgeToEdgeEnabled=true` Gradle property.
- Removes the deprecated `expo.edgeToEdgeEnabled` property if it exists.
- Removes explicit status-bar color styling from the generated application theme.
- Sets `android:windowLayoutInDisplayCutoutMode` to `always`, matching modern edge-to-edge behavior.

### Dependency alignment

- Upgrades `react-native-screens` from the 4.16 line to the 4.17 line and refreshes `bun.lock`.
- Pins Material Components 1.14 in the generated Android application so legacy system-bar compatibility calls are appropriately guarded on older Android versions.

### Narrow build-time bytecode instrumentation

- Adds an Android Gradle Plugin ASM visitor through the tracked Expo plugin.
- Limits instrumentation to the exact React Native, react-native-screens, Expo dev launcher, and Expo image-picker classes reported by Play.
- Replaces deprecated Window color getters with stack-equivalent zero values.
- Removes deprecated Window color setters and legacy `layoutInDisplayCutoutMode` writes with stack-balanced bytecode operations.
- Uses `InstrumentationScope.ALL` because the affected code is supplied through precompiled dependencies rather than application-owned source.
- Copies existing stack frames and leaves all unrelated classes and instructions untouched.

## User and developer impact

For users, the app continues to render around status bars, navigation bars, keyboard insets, and display cutouts while following Android 15 and Android 16 edge-to-edge rules. For developers, the fix survives clean Expo prebuilds and EAS builds without committing the generated native project.

This PR does not enable R8. The separate Play recommendation about minification, resource shrinking, and runtime optimization should be handled independently so its release-only compatibility risk can be tested in isolation.

## Validation performed

- `node --check apps/mobile/plugins/withAndroidEdgeToEdge.js`
- `git diff --check` and staged diff validation
- Android release APK assembled successfully with compile SDK 36 and target SDK 36
- Generated Android project confirmed to contain:
  - `edgeToEdgeEnabled=true`
  - `windowLayoutInDisplayCutoutMode=always`
  - Material Components 1.14
  - the scoped `ShogoEdgeToEdgeVisitorFactory` instrumentation
- Installed a separately identified release APK on a physical Samsung SM-M176B running Android 16 / API 36, preserving the existing Play-signed app and user data
- Verified successful cold launch with no fatal Android or React Native exceptions
- Verified portrait layout, landscape rotation, status/navigation bar insets, and keyboard `adjustResize` behavior
- Confirmed the sign-in surface remained usable without clipping during rotation and keyboard presentation
- DEX scanning confirmed the Play-listed calls are absent from the targeted React Native, react-native-screens, and Expo classes; remaining framework compatibility paths are API-gated

The local release build skipped Sentry source-map upload because the workstation does not have the production Sentry token. Application compilation, bytecode transformation, packaging, installation, and runtime smoke testing completed successfully.

## Risk assessment

The primary risk is behavior drift in dependency-owned system-bar helpers because their deprecated calls are transformed after compilation. The visitor is intentionally restricted to the Play-reported classes and exact JVM descriptors, and its replacements preserve operand-stack balance. Device testing on API 36 found no startup, layout, rotation, or keyboard regression.

Older Android versions remain supported through standard edge-to-edge insets and Material Components compatibility behavior. Before production rollout, the generated AAB should be uploaded to the Play internal track and exercised on at least one pre-Android-15 device in addition to the API 36 device already tested.

## Release verification

1. Build the production AAB through the EAS production profile.
2. Confirm the production Sentry token uploads source maps successfully.
3. Upload to Play internal testing and wait for static analysis.
4. Verify the Android 15 deprecated edge-to-edge warning is cleared.
5. Run sign-in, navigation, image picker/crop, bottom sheet, rotation, and keyboard smoke tests on both API 34 and API 36.

## Rollback

If a dependency-specific regression appears, remove `withAndroidEdgeToEdge` from the Expo plugin list and revert the react-native-screens dependency update. A clean prebuild will then restore the prior generated Android configuration.