### PR TITLE
feat(android): enable R8 release optimization

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -68,7 +68,8 @@
           "icon": "./assets/adaptive-icon.png",
           "color": "#E27927"
         }
-      ]
+      ],
+      "./plugins/withAndroidR8"
     ],
     "extra": {
       "router": {},

--- a/apps/mobile/plugins/withAndroidR8.js
+++ b/apps/mobile/plugins/withAndroidR8.js
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+const {
+  AndroidConfig,
+  withAppBuildGradle,
+  withDangerousMod,
+  withGradleProperties,
+} = require("expo/config-plugins");
+const fs = require("node:fs/promises");
+const path = require("node:path");
+
+const R8_PROPERTIES = {
+  "android.enableMinifyInReleaseBuilds": "true",
+  "android.enableShrinkResourcesInReleaseBuilds": "true",
+};
+
+const EXPO_RECORDS_KEEP_RULE =
+  "-keep class expo.modules.kotlin.records.** { *; }";
+const EXPO_RECORDS_KEEP_BLOCK = [
+  "# Expo Modules converts native bridge argument records through Kotlin",
+  "# reflection. Optimizing these converter classes breaks SecureStore options.",
+  EXPO_RECORDS_KEEP_RULE,
+].join("\n");
+
+function withR8GradleProperties(config) {
+  return withGradleProperties(config, (config) => {
+    for (const [name, value] of Object.entries(R8_PROPERTIES)) {
+      AndroidConfig.BuildProperties.updateAndroidBuildProperty(
+        config.modResults,
+        name,
+        value,
+      );
+    }
+
+    return config;
+  });
+}
+
+function withOptimizedProguardDefaults(config) {
+  return withAppBuildGradle(config, (config) => {
+    if (config.modResults.language !== "groovy") {
+      throw new Error("withAndroidR8 only supports a Groovy app build.gradle");
+    }
+
+    const optimizedDefaults =
+      'getDefaultProguardFile("proguard-android-optimize.txt")';
+
+    if (!config.modResults.contents.includes(optimizedDefaults)) {
+      const defaultRules = 'getDefaultProguardFile("proguard-android.txt")';
+
+      if (!config.modResults.contents.includes(defaultRules)) {
+        throw new Error(
+          "Unable to enable optimized R8 defaults: Expo app build.gradle template changed",
+        );
+      }
+
+      config.modResults.contents = config.modResults.contents.replace(
+        defaultRules,
+        optimizedDefaults,
+      );
+    }
+
+    return config;
+  });
+}
+
+function withR8CompatibilityRules(config) {
+  return withDangerousMod(config, [
+    "android",
+    async (config) => {
+      const rulesPath = path.join(
+        config.modRequest.platformProjectRoot,
+        "app",
+        "proguard-rules.pro",
+      );
+      const rules = await fs.readFile(rulesPath, "utf8");
+
+      if (!rules.includes(EXPO_RECORDS_KEEP_RULE)) {
+        await fs.writeFile(
+          rulesPath,
+          `${rules.trimEnd()}\n\n${EXPO_RECORDS_KEEP_BLOCK}\n`,
+        );
+      }
+
+      return config;
+    },
+  ]);
+}
+
+function withAndroidR8(config) {
+  config = withR8GradleProperties(config);
+  config = withOptimizedProguardDefaults(config);
+  config = withR8CompatibilityRules(config);
+  return config;
+}
+
+module.exports = withAndroidR8;


### PR DESCRIPTION

<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/870f14b5-4602-4fcd-9af0-faef5f64f37a" />
## Summary

Closes #852 and implements [SHOG-740](https://odin-ai.atlassian.net/browse/SHOG-740).

This PR enables R8 code optimization and resource shrinking for Android release builds. It also adds the minimum compatibility rule needed to keep Expo SecureStore working after optimization.

## Changes

### Expo configuration

- Registered `./plugins/withAndroidR8` in `apps/mobile/app.json`.
- Added `apps/mobile/plugins/withAndroidR8.js` as an idempotent Expo config plugin.

### Release optimization

The plugin generates the following release properties:

```properties
android.enableMinifyInReleaseBuilds=true
android.enableShrinkResourcesInReleaseBuilds=true
```

It also replaces the standard Android defaults with:

```groovy
getDefaultProguardFile("proguard-android-optimize.txt")
```

### Expo SecureStore compatibility

The first optimized release APK failed during cold start in `ExpoSecureStore.getValueWithKeySync`. Expo Modules converts SecureStore option objects through Kotlin record converters and reflection; R8 optimization broke that conversion and sent the app to the root error boundary.

The plugin therefore appends this focused compatibility rule to the generated `proguard-rules.pro`:

```proguard
# Expo Modules converts native bridge argument records through Kotlin
# reflection. Optimizing these converter classes breaks SecureStore options.
-keep class expo.modules.kotlin.records.** { *; }
```

A rule targeting only `expo.modules.securestore.**` did not fix the crash because the converter belongs to the shared Expo Kotlin bridge. The final rule deliberately avoids keeping all Expo Modules classes, and R8 mapping output confirms that the SecureStore module itself remains obfuscated.

## Generated configuration behavior

- Repeated Expo prebuilds retain one copy of each Gradle property.
- The compatibility rule is appended only when absent.
- The generated `android/` directory is not committed; EAS/local prebuild generates the native changes from the source plugin.
- If Expo stops generating the expected Groovy `app/build.gradle` structure, the plugin fails with an explicit error instead of silently leaving releases unoptimized.

## Verification

### Release build

- Ran a fresh `./gradlew :app:bundleRelease`.
- Build completed successfully: `934` tasks, including `minifyReleaseWithR8`.
- Generated a valid signed AAB of approximately `47 MiB`.
- Verified AAB ZIP integrity and signing.
- Confirmed generation of R8 mapping, seeds, usage, configuration, and resource-usage files.
- Ran repeated prebuild checks and confirmed properties/rules remain idempotent.
- `git diff --check` passed.

### Physical-device testing

Device: Samsung SM-M176B, Android 16 / API 36.

- Installed and launched the optimized release APK.
- Signed in successfully with the provided test account.
- Verified session persistence after force-stop and cold restart.
- Verified Home and Marketplace.
- Verified Settings, Billing, and Remote Control screens.
- Launched document picker and Android photo picker.
- Granted camera permission and launched the Samsung camera.
- Granted microphone permission and received real partial/final speech transcripts.
- Opened external documentation in Chrome.
- Exercised the Remote Control clipboard action without an app error.
- Granted notification permission and tested notification preference handling.
- Final package-scoped logs contained no fatal exception, fatal signal, SecureStore failure, root error boundary, or JavaScript type error.

Final cold-start measurements:

| Run | Total time |
| --- | ---: |
| 1 | `988 ms` |
| 2 | `1001 ms` |
| 3 | `979 ms` |

Idle process PSS on the test device was approximately `168 MiB`.

### Automated tests

```shell
bun --no-env-file test \
  components/chat/__tests__/useNotifyOnTurnComplete.test.ts \
  lib/notifications/__tests__/preferences.test.ts \
  test/helpers/mockAgentFetch.ts
```

Result: `19 passed, 0 failed`.

## Risk assessment

| Area | Risk | Mitigation / result |
| --- | --- | --- |
| SecureStore and authentication | Reflection converters can be optimized incorrectly. | Added the narrow Expo Kotlin record keep rule and verified sign-in plus cold-start session restoration. |
| Native modules | R8 can expose hidden reflection assumptions. | Exercised camera, pickers, speech recognition, permissions, browser handoff, and clipboard on a physical device. |
| Resource shrinking | Referenced-at-runtime resources could be removed. | Smoke-tested core screens and native flows using the optimized APK. |
| Expo upgrades | Generated Gradle structure can change. | Plugin validates the expected Groovy template and fails loudly when it cannot apply the configuration. |
| Diagnostic visibility | Obfuscated crashes are harder to interpret. | Release builds generate mapping/seeds/usage artifacts; mappings should be retained/uploaded with releases. |

## Known limitations

- Completed-turn notification delivery was not observed end to end because the backend returned an empty response for the new test chat. Notification logic tests passed.
- Expo Updates reported a remote-update request failure in the local channel/runtime context, but embedded assets loaded and the application reached Home.
- Actual Sentry event delivery was not tested because the local environment did not expose the Android DSN; CI/EAS configuration remains unchanged.
- Android IAP is intentionally disabled and was not modified by this PR.

## Files changed

- `apps/mobile/app.json`
- `apps/mobile/plugins/withAndroidR8.js`
