### PR TITLE
Fix proxy body poisoning, the mobile badge flake, and multi-GB cold boots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,11 +85,19 @@ jobs:
         # the latest published `^X.Y.Z` first (GitHub runners have npm + net).
         # Plain `bun install` (not --frozen-lockfile): the rewrite makes the
         # template's checked-in bun.lock drift from its package.json.
+        #
+        # The rewrite is a BUILD-TIME transform, so undo it once dist/ exists.
+        # Leaving it applied edits tracked files under the tests' feet: the
+        # manifest no longer carries the `workspace:*` sentinel that
+        # materialize-runtime-template.test.ts exists to guard, and every test
+        # that copies the template (workspace-seeding, binary-ships-…) would
+        # silently assert against a manifest that is not the one we ship.
+        # node_modules/ and dist/ survive, so the later template-dist build is
+        # unaffected.
         run: |
           bun run scripts/materialize-runtime-template.ts templates/runtime-template/package.json
-          cd templates/runtime-template
-          bun install
-          bun run build
+          (cd templates/runtime-template && bun install && bun run build)
+          git checkout -- templates/runtime-template/package.json templates/runtime-template/bun.lock
 
       - name: Build one agent template (sales-bdr-pipeline) for overlay tests
         # `packages/agent-runtime/templates/<id>/dist/` is also gitignored.

--- a/apps/api/src/__tests__/chat-region-pin.integration.test.ts
+++ b/apps/api/src/__tests__/chat-region-pin.integration.test.ts
@@ -339,3 +339,38 @@ describe('client auto-resume + server region-pin, end to end (P0 + P1)', () => {
     }
   })
 })
+
+describe('a proxied request body never corrupts the NEXT proxied request', () => {
+  test('a peer that answers without reading the POST body leaves the connection usable', async () => {
+    // Regression for oven-sh/bun#32847. `proxyToPeer` forwards the request body
+    // as a stream; when the peer answers before reading it (here the SSE reply,
+    // in production any early reject — 401/404/413/validation), Bun stopped the
+    // upload but returned the socket to the keep-alive pool mid-request. The
+    // next proxied request to that peer was written INTO the abandoned body, so
+    // the peer's parser never saw a request line and answered a bare 400.
+    //
+    // The victim is the FOLLOWING request, so the assertion that matters is not
+    // that the POST worked — it always did — but that the GET after it reaches
+    // a route handler at all.
+    //
+    // Reproduces on Linux (and so on CI); on macOS it passes either way, so
+    // treat a local pass as no evidence.
+    homeSeen.length = 0
+    const big = JSON.stringify({ messages: [{ role: 'user', content: 'x'.repeat(512 * 1024) }] })
+
+    const post = await fetch(`${EDGE_URL}/api/projects/p_home/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: big,
+    })
+    expect(post.status).toBe(200)
+    await readAll(post.body)
+
+    const get = await fetch(`${EDGE_URL}/api/projects/p_home/chat/${SESSION_ID}/stream?fromSeq=5`)
+    expect(get.status).toBe(200)
+    expect(await readAll(get.body)).toContain('RESUMED_FROM_HOME')
+
+    // The decisive one: before the fix the peer's handler never ran for the GET.
+    expect(homeSeen.filter((s) => s.method === 'GET')).toHaveLength(1)
+  })
+})

--- a/apps/api/src/lib/region-peer-proxy.ts
+++ b/apps/api/src/lib/region-peer-proxy.ts
@@ -113,7 +113,20 @@ export async function proxyToPeer(
       method,
       headers,
       // Stream the request body straight through (duplex required for streams).
-      ...(hasBody ? { body: c.req.raw.body, duplex: 'half' } : {}),
+      //
+      // `keepalive: false` is load-bearing, not a tuning knob. When a peer
+      // answers before it has read the streamed body — any early reject: 401,
+      // 404, 413, a validation error — Bun stops the upload but still returns
+      // the socket to the keep-alive pool MID-REQUEST-MESSAGE. The next proxied
+      // request to that peer is then written INTO the abandoned request's
+      // chunked body, so the peer's HTTP parser never sees a request line and
+      // answers a bare 400 that never reaches a route handler. The victim is
+      // the FOLLOWING request, which is what makes it so confusing: a chat POST
+      // rejected upstream makes the unrelated resume GET after it fail.
+      // See oven-sh/bun#32847; unfixed as of Bun 1.3.14. Costs one connection
+      // setup per body-carrying proxy hop, which is cheap next to the SSE turn
+      // it precedes. Revisit once the runtime carries the upstream fix.
+      ...(hasBody ? { body: c.req.raw.body, duplex: 'half', keepalive: false } : {}),
       // Peers terminate TLS behind the same cert; tolerate self-signed in-mesh.
       ...(typeof Bun !== 'undefined' ? { tls: { rejectUnauthorized: false } } : {}),
     } as any)

--- a/apps/metal-agent/src/config.ts
+++ b/apps/metal-agent/src/config.ts
@@ -165,6 +165,20 @@ export const config = {
    * (the subsequent rebuild is async and not covered by this timeout).
    */
   hydrateTimeoutMs: parseInt(env('METAL_HYDRATE_TIMEOUT_MS', '60000'), 10),
+  /**
+   * Extra hydrate budget per MiB of archive, on top of `hydrateTimeoutMs`.
+   *
+   * A single flat timeout has to be either too tight for a large archive or
+   * uselessly slack for the p50 (0.7 MB). Measured on staging, a cold boot runs
+   * 12 s at 25 MB and 34 s at 900 MB — roughly 25 MB/s once the fixed costs are
+   * paid — so 120 ms/MiB is ~3x the observed marginal cost and absorbs a
+   * contended host. That headroom is the point: the one hydrate failure seen in
+   * testing was a 900 MB archive on a host still flushing a freshly written
+   * file, and a rootfs rebuild creates exactly that contention across the whole
+   * fleet at once. Since hydrate is fail-closed, an expired timeout is not a
+   * slow boot — it is a project that cannot open.
+   */
+  hydrateTimeoutPerMiBMs: parseInt(env('METAL_HYDRATE_TIMEOUT_PER_MIB_MS', '120'), 10),
 
   /**
    * Balloon-reclaim before snapshot. Firecracker's CreateSnapshot writes the

--- a/apps/metal-agent/src/pool-hydrate.test.ts
+++ b/apps/metal-agent/src/pool-hydrate.test.ts
@@ -40,15 +40,19 @@ class TestPool extends MetalWarmPool {
     // hydrateFromBackup is private; reach it through the instance.
     return (this as any).hydrateFromBackup(projectId, HANDLE, env) as Promise<{ hydrated: boolean; parentEtag?: string }>
   }
+  budget(bytes: number) {
+    return this.hydrateBudgetMs(bytes)
+  }
 }
 
-function makePool(dir: string): TestPool {
+function makePool(dir: string, over: Partial<typeof config> = {}): TestPool {
   const cfg = {
     ...config,
     work: dir,
     snapDir: join(dir, 'snap'),
     runDir: join(dir, 'run'),
     hydrateTimeoutMs: 5000,
+    ...over,
   } as typeof config
   mkdirSync(cfg.snapDir, { recursive: true })
   mkdirSync(cfg.runDir, { recursive: true })
@@ -126,5 +130,49 @@ describe('pool.hydrateFromBackup (cold-start hydration)', () => {
 
     await pool.hydrate('p3', {})
     expect(calls[0].headers.Authorization).toBeUndefined()
+  })
+})
+
+describe('pool.hydrateBudgetMs (the deadline scales with the archive)', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'metal-budget-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  test('a small archive gets the flat allowance and nothing more', () => {
+    const pool = makePool(dir, { hydrateTimeoutPerMiBMs: 120 })
+    // The median project is well under a MiB; it should not be paying for a
+    // budget sized for the tail.
+    expect(pool.budget(0)).toBe(5000)
+    expect(pool.budget(700 * 1000)).toBe(5000 + 120)
+  })
+
+  test('the budget grows with size, so the tail is not judged by the median', () => {
+    const pool = makePool(dir, { hydrateTimeoutPerMiBMs: 120 })
+    const mib = 1024 * 1024
+    expect(pool.budget(100 * mib)).toBe(5000 + 100 * 120)
+    expect(pool.budget(900 * mib)).toBe(5000 + 900 * 120)
+    expect(pool.budget(900 * mib)).toBeGreaterThan(pool.budget(100 * mib))
+  })
+
+  test('the largest archive in production gets minutes, not the flat 60s', () => {
+    // 1.85 GB is a real project. Under the old flat timeout its hydrate had
+    // exactly the same deadline as a 0.7 MB one, and hydrate is fail-closed —
+    // so falling short means the project cannot open at all.
+    const pool = makePool(dir, { hydrateTimeoutMs: 60_000, hydrateTimeoutPerMiBMs: 120 })
+    const budget = pool.budget(1847 * 1024 * 1024)
+    expect(budget).toBeGreaterThan(4 * 60_000)
+    // Still bounded: a hung guest must not pin the assign indefinitely.
+    expect(budget).toBeLessThan(15 * 60_000)
+  })
+
+  test('setting the per-MiB term to zero restores the old flat behaviour', () => {
+    // The escape hatch has to actually work: an operator who sets
+    // METAL_HYDRATE_TIMEOUT_PER_MIB_MS=0 gets exactly the previous semantics.
+    const pool = makePool(dir, { hydrateTimeoutPerMiBMs: 0 })
+    expect(pool.budget(900 * 1024 * 1024)).toBe(5000)
   })
 })

--- a/apps/metal-agent/src/pool.ts
+++ b/apps/metal-agent/src/pool.ts
@@ -870,11 +870,27 @@ export class MetalWarmPool {
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
       body: archive.bytes,
-      signal: AbortSignal.timeout(this.cfg.hydrateTimeoutMs),
+      signal: AbortSignal.timeout(this.hydrateBudgetMs(archive.bytes.byteLength)),
     })
     if (!res.ok) throw new Error(`/pool/hydrate failed (${res.status}): ${await res.text()}`)
     console.log(`[pool] hydrated ${projectId} from durable backup (${archive.bytes.byteLength} bytes, etag=${archive.etag ?? 'none'})`)
     return { hydrated: true, parentEtag: archive.etag ?? undefined }
+  }
+
+  /**
+   * Hydrate deadline for an archive of `bytes`: a fixed allowance for the
+   * round trip plus a per-MiB term for actually moving and extracting it.
+   *
+   * A single flat timeout cannot serve both ends of this distribution — the
+   * median project is 0.7 MB and the largest is 1.8 GB. The flat 60 s was
+   * comfortable for the former and, on a busy host, not always enough for the
+   * latter; because hydrate is fail-closed, falling short does not produce a
+   * slow boot but a project that will not open.
+   */
+  protected hydrateBudgetMs(bytes: number): number {
+    const perMiB = this.cfg.hydrateTimeoutPerMiBMs
+    if (!perMiB || bytes <= 0) return this.cfg.hydrateTimeoutMs
+    return this.cfg.hydrateTimeoutMs + Math.ceil(bytes / (1024 * 1024)) * perMiB
   }
 
   /**
@@ -1062,7 +1078,7 @@ export class MetalWarmPool {
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
       body: archive.bytes,
-      signal: AbortSignal.timeout(this.cfg.hydrateTimeoutMs),
+      signal: AbortSignal.timeout(this.hydrateBudgetMs(archive.bytes.byteLength)),
     })
     if (!res.ok) {
       throw new Error(`/pool/hydrate (project data) failed (${res.status}): ${await res.text()}`)
@@ -1257,7 +1273,7 @@ export class MetalWarmPool {
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
       body: archive,
-      signal: AbortSignal.timeout(this.cfg.hydrateTimeoutMs),
+      signal: AbortSignal.timeout(this.hydrateBudgetMs(archive.byteLength)),
     })
     if (!res.ok) throw new Error(`/pool/hydrate (data) failed (${res.status}): ${await res.text()}`)
     console.log(`[pool] hydrated published-data for ${subdomain} (${archive.byteLength} bytes)`)

--- a/apps/metal-agent/src/project-data-archive.test.ts
+++ b/apps/metal-agent/src/project-data-archive.test.ts
@@ -128,6 +128,11 @@ describe('DATA_MAX_BYTES', () => {
   test('matches the guest hydrate body cap, so a stored archive is restorable', () => {
     // An archive larger than the guest will accept would consume storage while
     // still cold-booting empty — durability that is not.
-    expect(DATA_MAX_BYTES).toBe(1024 * 1024 * 1024)
+    //
+    // Keep this in lockstep with `maxRequestBodySize` in
+    // packages/agent-runtime/src/server.ts. This assertion is the tripwire for
+    // the two drifting apart; if it fails because the guest cap moved, move
+    // this constant rather than relaxing the test.
+    expect(DATA_MAX_BYTES).toBe(4 * 1024 * 1024 * 1024)
   })
 })

--- a/apps/metal-agent/src/project-data-archive.ts
+++ b/apps/metal-agent/src/project-data-archive.ts
@@ -124,13 +124,16 @@ export function dataQuarantineKey(projectId: string): string {
 }
 
 /**
- * Hard ceiling on a writable-state archive (1 GiB). Matches the guest's
- * `/pool/hydrate` request-body cap — an archive we cannot hydrate is worse than
- * useless, since it would consume storage while still cold-booting empty.
+ * Hard ceiling on a writable-state archive (4 GiB). Deliberately the same
+ * number as the guest's `/pool/hydrate` request-body cap: storing an archive
+ * larger than we can hand back is worse than not storing it, because the
+ * project still cold-boots empty and now pays for the storage too. If that cap
+ * moves, move this with it.
+ *
  * Exceeding it is a loud, metered error rather than a silent skip: it means a
  * project has outgrown this durability mechanism and needs attention.
  */
-export const DATA_MAX_BYTES = 1024 * 1024 * 1024
+export const DATA_MAX_BYTES = 4 * 1024 * 1024 * 1024
 
 /** A current archive at or above this size holds enough state to be worth noting. */
 export const DATA_REAL_MIN_BYTES = 1024 * 1024

--- a/apps/mobile/components/project/panels/ide/badges/__tests__/useProblemsBadgeCount.test.tsx
+++ b/apps/mobile/components/project/panels/ide/badges/__tests__/useProblemsBadgeCount.test.tsx
@@ -74,9 +74,21 @@ afterEach(() => {
   globalThis.clearTimeout = origClearTimeout
 })
 
-function flushPromises() {
-  // Drain the microtask queue so awaited fetches resolve.
-  return new Promise((r) => origSetTimeout(r as any, 0))
+async function flushPromises() {
+  // Every assertion here waits on the same chain: the injected fetch resolves,
+  // the hook sets state, React re-renders. A bare `setTimeout(0)` only yields
+  // one macrotask, which is enough for the first two steps but not reliably for
+  // the render — so on a loaded machine a single test out of the file would
+  // fail, a different one each run. (Seen on CI four times across two runs and
+  // their serial retries; never locally.)
+  //
+  // `act` is the supported way to wait for that: it flushes effects and pending
+  // state updates and does not return until React is quiescent. The real
+  // `setTimeout` is used deliberately — `globalThis.setTimeout` is the fake this
+  // file installs to control the poller, and yielding through it would deadlock.
+  await act(async () => {
+    await new Promise((r) => origSetTimeout(r as any, 0))
+  })
 }
 
 function fireOneTimer() {

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -2597,13 +2597,31 @@ function scheduleHydrateRebuild(): void {
 }
 
 app.post('/pool/hydrate', async (c) => {
-  const body = await c.req.arrayBuffer()
-  if (!body || body.byteLength === 0) {
-    return c.json({ error: 'empty archive' }, 400)
-  }
   const tmp = join('/tmp', `pool-hydrate-${Date.now()}.tar.gz`)
+  let bytes = 0
   try {
-    writeFileSync(tmp, Buffer.from(body))
+    // Spool to disk as it arrives rather than buffering the whole archive.
+    // The largest production source archive is ~1.8 GB against a 4 GiB guest,
+    // so `arrayBuffer()` put the request body and the runtime's own heap into
+    // the same budget and made the ceiling a memory limit rather than a policy
+    // one. Streaming makes the cost O(chunk), so the only real bound left is
+    // guest disk — which is why the body cap above can be raised at all.
+    const stream = c.req.raw.body
+    if (!stream) return c.json({ error: 'empty archive' }, 400)
+    const sink = Bun.file(tmp).writer()
+    try {
+      for await (const chunk of stream as any as AsyncIterable<Uint8Array>) {
+        bytes += chunk.byteLength
+        sink.write(chunk)
+        // Bound the writer's own buffer; without this the spool is just a
+        // slower way of holding the whole archive in memory.
+        await sink.flush()
+      }
+    } finally {
+      await sink.end()
+    }
+    if (bytes === 0) return c.json({ error: 'empty archive' }, 400)
+
     const entries: string[] = []
     const tarMod = await import('tar')
     await tarMod.list({ file: tmp, onReadEntry: (e: { path: string }) => entries.push(e.path) })
@@ -2624,8 +2642,8 @@ app.post('/pool/hydrate', async (c) => {
     // Rebuild so the served dist reflects everything that was hydrated —
     // debounced, because more overlays are usually still arriving.
     scheduleHydrateRebuild()
-    console.log(`[pool/hydrate] hydrated workspace from durable backup (${body.byteLength} bytes)`)
-    return c.json({ ok: true, bytes: body.byteLength })
+    console.log(`[pool/hydrate] hydrated workspace from durable backup (${bytes} bytes)`)
+    return c.json({ ok: true, bytes })
   } catch (err: any) {
     console.error('[pool/hydrate] failed:', err?.message ?? err)
     return c.json({ error: err?.message ?? 'hydrate failed' }, 500)
@@ -6149,8 +6167,17 @@ export default {
   idleTimeout: 0,
   // Durable-backup hydration (`POST /pool/hydrate`) streams a full project
   // tarball — source + uploaded assets + built `dist/` — into the guest. Bun's
-  // default 128 MB request-body cap rejected large restored workspaces with a
-  // 413, leaving those projects unable to load. Raise the cap so realistic
-  // asset-heavy workspaces hydrate; 1 GiB stays well under the guest's 4 GB RAM.
-  maxRequestBodySize: 1024 * 1024 * 1024,
+  // default 128 MB cap rejected large restored workspaces with a 413, and
+  // hydrate failure is FAIL-CLOSED: the host destroys the VM and the project
+  // cannot open at all, so the cap is not a throttle but a hard eligibility
+  // line for being able to open your project.
+  //
+  // 1 GiB was chosen when the handler buffered the body in the guest's 4 GB of
+  // RAM. Two production projects are already past it (1.85 GB and 1.77 GB of
+  // generated video frames and downloaded stock footage) and survive only
+  // because a snapshot exists — a rootfs rebuild invalidates every snapshot and
+  // would strand them. The handler now spools to disk, so the constraint moved
+  // from guest RAM to guest disk (a 13.6 GB rootfs). 4 GiB clears today's
+  // largest archive with room to grow and still refuses something absurd.
+  maxRequestBodySize: 4 * 1024 * 1024 * 1024,
 }


### PR DESCRIPTION
Three fixes that came out of chasing the two red checks on the writable-state work. Two are production bugs; one is the CI flake that was hiding them.

## Summary

**Region proxy corrupts the request after any early reply** (`region-peer-proxy.ts`). `proxyToPeer` forwards the request body as a stream. When the peer answers before reading it — an SSE reply, or in production any early reject: 401, 404, 413, a validation error — Bun stops the upload but returns the socket to the keep-alive pool mid-request-message. The *next* proxied request is written into the abandoned body, so the peer's parser never sees a request line and answers a bare 400 that never reaches a route handler. The victim being the following request is what made this so confusing: a chat POST rejected upstream makes an unrelated resume GET fail. Fixed with `keepalive: false` on body-carrying hops. Upstream is oven-sh/bun#32847, unfixed as of Bun 1.3.14; the comment says to revisit when the runtime carries the fix. Reproduces on Linux and therefore CI, but passes on macOS either way — a local pass is no evidence.

**Multi-GB projects cannot cold-boot** (`server.ts`, `pool.ts`, `config.ts`). Four production projects are at or past the guest's 1 GiB hydrate body cap (1.85 GB, 1.77 GB, 0.98 GB, 0.94 GB). They open today only because a snapshot exists — a rootfs rebuild invalidates every snapshot at once, and each would then cold-boot into a 413 and be unopenable. All four are media-generation projects whose bulk is generated output, so the archives are legitimate. Hydrate is fail-closed, so falling short is not a slow boot, it is a project that will not open. Two changes: the guest spools the body to disk instead of buffering it (the old cap was a memory limit dressed as policy — `arrayBuffer()` put the archive and the runtime heap in the same 4 GiB; streaming moves the bound to the 13.6 GB rootfs, so the cap goes to 4 GiB), and the host deadline now scales at 120 ms/MiB, roughly 3x the marginal cost measured on staging.

**`useProblemsBadgeCount` flake** (test only). `flushPromises` yielded a single macrotask, enough for the fetch to resolve and the hook to set state but not reliably for the render. Under CI load one test out of the file would fail, a different one each run — four times across two runs and their serial retries, never locally. Now waits via `async act()`, which is the supported way to wait for React to go quiescent.

Also restores `templates/runtime-template/package.json` after the CI build step, which was editing a tracked file out from under `materialize-runtime-template.test.ts`.

## Test plan

- [x] Regression test for the proxy bug asserts the *following* GET reaches a handler, not that the POST worked — the POST always worked. Verified on CI Linux.
- [x] 2.00 GiB body streamed end to end: accepted, spooled to disk intact, peak RSS +50 MB.
- [x] Hydrate budget unit tests cover the p50, the 1.8 GB tail, and `METAL_HYDRATE_TIMEOUT_PER_MIB_MS=0` restoring the old flat behaviour.
- [x] `DATA_MAX_BYTES` tripwire test updated to pin 4 GiB against the guest cap.
- [x] Flake fix stressed locally under CPU load: 0/65 failures with, 2/25 without.
- [x] metal-agent 228 pass, agent-runtime 3722 pass, typecheck unchanged (same 4 allowlisted).
- [ ] Guest-side cap needs a rootfs build to reach staging; the 2 GB staging run happens after this lands and the runtime image ships.

Made with [Cursor](https://cursor.com)