### PR TITLE
Stop spooling multi-GB archives into the guest's RAM

### DIFF
--- a/packages/agent-runtime/src/__tests__/spool.test.ts
+++ b/packages/agent-runtime/src/__tests__/spool.test.ts
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * The bug this file exists for: `/pool/hydrate` was changed to spool its body
+ * to a file "instead of holding it in memory", and the file went to
+ * `os.tmpdir()`. In the guest that is a tmpfs sized at half of RAM, so the
+ * spool was memory with extra steps — a 1.9 GB hydrate killed the microVM
+ * outright while every unit test and a 2 GiB local run passed, because on a
+ * developer machine `/tmp` is a real disk.
+ *
+ * So the tests that matter here are the ones that distinguish those two
+ * environments, which means simulating a RAM-backed temp dir rather than
+ * trusting whatever the test host happens to mount.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { isRamBacked, resetSpoolDir, resolveSpoolDir, spoolPath, spooledFileResponse, sweepSpool, type SpoolProbe } from '../spool'
+
+let dir: string
+let realTmpdir: string | undefined
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'spool-test-'))
+  // The tests that go through the real probe would otherwise resolve to the
+  // machine's shared temp dir and sweep it — deleting other runs' files, and
+  // failing whenever a previous run left one behind. `os.tmpdir()` reads TMPDIR
+  // on each call, so redirecting it gives each test its own spool.
+  realTmpdir = process.env.TMPDIR
+  process.env.TMPDIR = join(dir, 'systmp')
+  mkdirSync(process.env.TMPDIR, { recursive: true })
+  resetSpoolDir()
+})
+afterEach(() => {
+  if (realTmpdir === undefined) delete process.env.TMPDIR
+  else process.env.TMPDIR = realTmpdir
+  rmSync(dir, { recursive: true, force: true })
+  resetSpoolDir()
+})
+
+/** A probe with a real filesystem underneath but a scripted view of what is RAM. */
+function probe(opts: { tmp: string; ram?: string[]; unwritable?: string[] }): SpoolProbe {
+  const ram = opts.ram ?? []
+  const unwritable = opts.unwritable ?? []
+  return {
+    tmpdir: () => opts.tmp,
+    isRamBacked: (p) => ram.some((r) => p === r || p.startsWith(r + '/')),
+    ensureWritable: (p) => {
+      if (unwritable.some((u) => p === u || p.startsWith(u + '/'))) return false
+      mkdirSync(p, { recursive: true })
+      return true
+    },
+  }
+}
+
+describe('resolveSpoolDir', () => {
+  test('uses the temp dir when it is real disk, so normal environments are unchanged', () => {
+    const tmp = join(dir, 'tmp')
+    const chosen = resolveSpoolDir(join(dir, 'app/workspace'), probe({ tmp }))
+    expect(chosen).toBe(join(tmp, 'shogo-spool'))
+  })
+
+  test('THE GUEST CASE: a RAM-backed temp dir is refused in favour of disk', () => {
+    // This is the regression. `/tmp` exists, is writable, and passes every
+    // check a spool implementation would normally make — it just happens to be
+    // memory, which is the one property that matters at 2 GB.
+    const tmp = join(dir, 'tmp')
+    const workspace = join(dir, 'app/workspace')
+    const chosen = resolveSpoolDir(workspace, probe({ tmp, ram: [tmp] }))
+    expect(chosen).toBe(join(dir, 'app/.shogo-spool'))
+    expect(chosen).not.toContain(tmp)
+  })
+
+  test('the fallback is a sibling of the workspace, never inside it', () => {
+    // Anything under the workspace is swept into `packProjectArchive` and
+    // shipped to durable storage, so a spool file there would be uploaded as
+    // if the user had written it — and would land back in the workspace on the
+    // next hydrate.
+    const workspace = join(dir, 'app/workspace')
+    const chosen = resolveSpoolDir(workspace, probe({ tmp: join(dir, 'tmp'), ram: [join(dir, 'tmp')] }))
+    expect(chosen.startsWith(workspace)).toBe(false)
+    expect(dirname(chosen)).toBe(dirname(workspace))
+  })
+
+  test('skips a candidate it cannot actually write to', () => {
+    // mkdir succeeding does not mean writable: read-only mount, full disk,
+    // wrong owner. Discovering that at 2 GB is too late.
+    const tmp = join(dir, 'tmp')
+    const workspace = join(dir, 'app/workspace')
+    const chosen = resolveSpoolDir(workspace, probe({ tmp, unwritable: [tmp] }))
+    expect(chosen).toBe(join(dir, 'app/.shogo-spool'))
+  })
+
+  test('falls back to temp and warns when everything reachable is RAM', () => {
+    const tmp = join(dir, 'tmp')
+    const workspace = join(dir, 'app/workspace')
+    const warnings: string[] = []
+    const orig = console.warn
+    console.warn = (m: any) => warnings.push(String(m))
+    try {
+      const chosen = resolveSpoolDir(workspace, probe({ tmp, ram: [tmp, join(dir, 'app')] }))
+      expect(chosen).toBe(join(tmp, 'shogo-spool'))
+    } finally {
+      console.warn = orig
+    }
+    // Silently doing the dangerous thing is how this bug shipped the first time.
+    expect(warnings.join(' ')).toContain('RAM-backed')
+  })
+})
+
+describe('isRamBacked', () => {
+  const linux = process.platform === 'linux'
+  const onLinux = linux ? test : test.skip
+
+  onLinux('recognises a real tmpfs and a real disk', () => {
+    // /dev/shm is tmpfs on every Linux worth running this on; the repo root is
+    // not. Pinned against the actual kernel rather than a mock, because the
+    // magic number is the whole load-bearing detail.
+    expect(isRamBacked('/dev/shm')).toBe(true)
+    expect(isRamBacked(process.cwd())).toBe(false)
+  })
+
+  test('answers false for a path it cannot stat rather than throwing', () => {
+    // Callers use this to choose a directory; an exception here would take out
+    // hydrate entirely, which is fail-closed.
+    expect(isRamBacked(join(dir, 'does/not/exist'))).toBe(false)
+  })
+})
+
+describe('sweepSpool', () => {
+  test('removes files left by a killed request but keeps live ones', () => {
+    const ws = join(dir, 'app/workspace')
+    mkdirSync(ws, { recursive: true })
+    const spool = spoolPath('x.tar.gz', ws)
+    mkdirSync(dirname(spool), { recursive: true })
+
+    const stale = join(dirname(spool), 'stale.tar.gz')
+    const fresh = join(dirname(spool), 'fresh.tar.gz')
+    writeFileSync(stale, 'old')
+    writeFileSync(fresh, 'new')
+    const longAgo = new Date(Date.now() - 3 * 60 * 60 * 1000)
+    utimesSync(stale, longAgo, longAgo)
+
+    expect(sweepSpool(60 * 60 * 1000, ws)).toBe(1)
+    expect(existsSync(stale)).toBe(false)
+    expect(existsSync(fresh)).toBe(true)
+  })
+
+  test('is silent about a spool directory that does not exist yet', () => {
+    expect(() => sweepSpool(1000, join(dir, 'nope/workspace'))).not.toThrow()
+  })
+})
+
+describe('spooledFileResponse', () => {
+  async function drain(res: Response): Promise<{ bytes: number; chunks: number }> {
+    const reader = res.body!.getReader()
+    let bytes = 0
+    let chunks = 0
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      bytes += value!.byteLength
+      chunks++
+    }
+    return { bytes, chunks }
+  }
+
+  test('serves the exact bytes and reports the length', async () => {
+    const p = join(dir, 'a.tar.gz')
+    const payload = Buffer.from('hello archive'.repeat(1000))
+    writeFileSync(p, payload)
+
+    const res = await spooledFileResponse(p, { 'Content-Type': 'application/gzip' })
+    expect(res.headers.get('Content-Length')).toBe(String(payload.length))
+    expect(res.headers.get('Content-Type')).toBe('application/gzip')
+    expect(Buffer.from(await res.arrayBuffer()).equals(payload)).toBe(true)
+  })
+
+  test('unlinks before sending, yet still serves the whole file', async () => {
+    // The unlink is deliberately up front so a client that hangs up mid-download
+    // cannot leave a multi-gigabyte file on a guest disk that has no room for
+    // it. POSIX keeps the inode alive for our descriptor, which is what makes
+    // that safe — this test is the proof.
+    const p = join(dir, 'b.tar.gz')
+    const payload = Buffer.alloc(3 * 1024 * 1024, 7)
+    writeFileSync(p, payload)
+
+    const res = await spooledFileResponse(p, {})
+    expect(existsSync(p)).toBe(false)
+
+    const got = Buffer.from(await res.arrayBuffer())
+    expect(got.length).toBe(payload.length)
+    expect(got.equals(payload)).toBe(true)
+  })
+
+  test('streams in chunks instead of materialising the archive', async () => {
+    // The structural version of "does not hold 1.8 GB in RAM": a file several
+    // times the chunk size must arrive as several chunks. Deterministic, unlike
+    // watching RSS.
+    const p = join(dir, 'c.tar.gz')
+    writeFileSync(p, Buffer.alloc(5 * 1024 * 1024, 3))
+
+    const { bytes, chunks } = await drain(await spooledFileResponse(p, {}))
+    expect(bytes).toBe(5 * 1024 * 1024)
+    expect(chunks).toBeGreaterThan(1)
+  })
+
+  test('releases the file when the caller abandons the download', async () => {
+    const p = join(dir, 'd.tar.gz')
+    writeFileSync(p, Buffer.alloc(4 * 1024 * 1024, 1))
+
+    const res = await spooledFileResponse(p, {})
+    const reader = res.body!.getReader()
+    await reader.read()
+    await reader.cancel()
+
+    // Already unlinked, so the space is reclaimed once the descriptor closes.
+    expect(existsSync(p)).toBe(false)
+  })
+
+  test('closes the descriptor and rethrows when the spool file vanishes', async () => {
+    // The caller's `finally` decides whether to unlink based on whether this
+    // returned, so it has to actually throw rather than hand back a Response
+    // with a zero Content-Length and a stream that disagrees.
+    await expect(spooledFileResponse(join(dir, 'missing.tar.gz'), {})).rejects.toThrow()
+  })
+
+  test('survives the stage directory being removed out from under it', async () => {
+    // `/pool/export-data` deletes its whole staging directory in a `finally`
+    // that runs before the response is consumed.
+    const stage = join(dir, 'stage')
+    mkdirSync(stage, { recursive: true })
+    const p = join(stage, 'data.tar.gz')
+    const payload = Buffer.alloc(2 * 1024 * 1024, 9)
+    writeFileSync(p, payload)
+
+    const res = await spooledFileResponse(p, {})
+    rmSync(stage, { recursive: true, force: true })
+
+    expect(Buffer.from(await res.arrayBuffer()).equals(payload)).toBe(true)
+  })
+})
+
+describe('spoolPath', () => {
+  test('does not collide when called twice in the same millisecond', () => {
+    const ws = join(dir, 'app/workspace')
+    const a = spoolPath('x.tar.gz', ws)
+    const b = spoolPath('x.tar.gz', ws)
+    expect(a).not.toBe(b)
+  })
+
+  test('keeps the caller-supplied suffix so a spool file is identifiable', () => {
+    expect(spoolPath('pool-hydrate.tar.gz', join(dir, 'app/workspace'))).toEndWith('pool-hydrate.tar.gz')
+  })
+})

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -87,6 +87,7 @@ import {
   writableStateTag,
   WRITABLE_STATE_PATHS,
 } from './writable-state'
+import { spoolDir, spoolPath, spooledFileResponse, sweepSpool } from './spool'
 import { runtimeDiagnosticsRoutes } from './runtime-diagnostics-routes'
 import { runtimeLspRoutes } from './runtime-lsp-routes'
 import { computePublishedReadiness } from './published-readiness'
@@ -2597,7 +2598,8 @@ function scheduleHydrateRebuild(): void {
 }
 
 app.post('/pool/hydrate', async (c) => {
-  const tmp = join('/tmp', `pool-hydrate-${Date.now()}.tar.gz`)
+  sweepSpool()
+  const tmp = spoolPath('pool-hydrate.tar.gz')
   let bytes = 0
   try {
     // Spool to disk as it arrives rather than buffering the whole archive.
@@ -2606,6 +2608,9 @@ app.post('/pool/hydrate', async (c) => {
     // the same budget and made the ceiling a memory limit rather than a policy
     // one. Streaming makes the cost O(chunk), so the only real bound left is
     // guest disk — which is why the body cap above can be raised at all.
+    //
+    // `spoolPath`, not `/tmp`: the guest's `/tmp` is tmpfs, so spooling there
+    // is still spending RAM, just without it showing up as heap. See spool.ts.
     const stream = c.req.raw.body
     if (!stream) return c.json({ error: 'empty archive' }, 400)
     const sink = Bun.file(tmp).writer()
@@ -2664,7 +2669,9 @@ app.post('/pool/hydrate', async (c) => {
 // Auth: under the `/pool` prefix, so it requires the runtime token — the agent
 // presents the same RUNTIME_AUTH_SECRET it injected via `/pool/assign`.
 app.post('/pool/export', async (c) => {
-  const tmp = join('/tmp', `pool-export-${Date.now()}.tar.gz`)
+  sweepSpool()
+  const tmp = spoolPath('pool-export.tar.gz')
+  let handedOff = false
   try {
     const sync =
       s3SyncInstance ??
@@ -2676,19 +2683,26 @@ app.post('/pool/export', async (c) => {
     if (!sync) return c.json({ error: 's3 sync unavailable' }, 500)
     const packed = await sync.packProjectArchive(tmp)
     if (!packed) return c.body(null, 204) // empty/new workspace — nothing to back up
-    const bytes = readFileSync(tmp)
-    console.log(`[pool/export] packed workspace source for durable backup (${bytes.length} bytes)`)
-    return new Response(new Uint8Array(bytes), {
-      status: 200,
-      headers: { 'Content-Type': 'application/gzip' },
-    })
+    const size = statSync(tmp).size
+    console.log(`[pool/export] packed workspace source for durable backup (${size} bytes)`)
+    // Streamed, not read into a Buffer: the largest source archive in
+    // production is ~1.8 GB and the guest has 4 GiB, so materialising it to
+    // respond is most of the VM's memory for the length of the upload.
+    const res = await spooledFileResponse(tmp, { 'Content-Type': 'application/gzip' })
+    // Only now: if the call above threw before taking ownership, the `finally`
+    // still needs to clean up.
+    handedOff = true
+    return res
   } catch (err: any) {
     console.error('[pool/export] failed:', err?.message ?? err)
     return c.json({ error: err?.message ?? 'export failed' }, 500)
   } finally {
-    try {
-      unlinkSync(tmp)
-    } catch {}
+    // The streaming response already unlinked it and owns the descriptor.
+    if (!handedOff) {
+      try {
+        unlinkSync(tmp)
+      } catch {}
+    }
   }
 })
 
@@ -2735,8 +2749,11 @@ app.post('/pool/export-data', async (c) => {
   }
 
   const fsp = await import('node:fs/promises')
-  const os = await import('node:os')
-  const stage = await fsp.mkdtemp(join(os.tmpdir(), 'shogo-data-export-'))
+  sweepSpool()
+  // Under the spool, not os.tmpdir(): this stages a VACUUM INTO copy of the
+  // database AND the tar built from it, so in the guest it would be paying for
+  // the writable state twice over in RAM. See spool.ts.
+  const stage = await fsp.mkdtemp(join(spoolDir(), 'shogo-data-export-'))
   const out = join(stage, 'data.tar.gz')
   try {
     const pack = await packWritableState({
@@ -2749,18 +2766,18 @@ app.post('/pool/export-data', async (c) => {
     })
     if (!pack) return c.body(null, 204)
 
-    const bytes = readFileSync(out)
+    const size = statSync(out).size
     console.log(
       `[pool/export-data] packed writable state for durable backup ` +
-        `(${bytes.length} bytes, paths: ${pack.paths.join(', ')}, tag: ${pack.tag ?? 'none'})`,
+        `(${size} bytes, paths: ${pack.paths.join(', ')}, tag: ${pack.tag ?? 'none'})`,
     )
-    return new Response(new Uint8Array(bytes), {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/gzip',
-        'X-Shogo-Data-Paths': pack.paths.join(','),
-        ...(pack.tag ? { ETag: pack.tag } : {}),
-      },
+    // Streams from an already-unlinked descriptor, so the `finally` below can
+    // remove the stage directory out from under it without truncating the
+    // response.
+    return await spooledFileResponse(out, {
+      'Content-Type': 'application/gzip',
+      'X-Shogo-Data-Paths': pack.paths.join(','),
+      ...(pack.tag ? { ETag: pack.tag } : {}),
     })
   } catch (err: any) {
     // Deliberately NOT falling back to copying the database files: a torn copy

--- a/packages/agent-runtime/src/spool.ts
+++ b/packages/agent-runtime/src/spool.ts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * A scratch directory for multi-gigabyte archives that is guaranteed not to be
+ * RAM.
+ *
+ * The guest mounts `/tmp` as tmpfs with no `size=` (scripts/metal-agent/
+ * build-runtime-rootfs.sh), which Linux defaults to half of RAM — about 2 GiB
+ * in a 4 GiB microVM. So `os.tmpdir()` in the guest is memory wearing a
+ * filesystem's clothes, and "spool it to a file instead of buffering it" buys
+ * nothing there: a 1.9 GB hydrate spooled to `/tmp` killed the VM outright
+ * (`fc process gone`) while the same code passed every test on a laptop, where
+ * `/tmp` is a real disk. Nothing in the type system or a unit test distinguishes
+ * those two directories, so this module asks the filesystem.
+ *
+ * The rule is "prefer tmpdir, but never if it is RAM", which keeps normal
+ * environments on the path they already use and only diverges where it matters.
+ */
+
+import { mkdirSync, readdirSync, rmSync, statSync, statfsSync, writeFileSync, unlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+/** `man 2 statfs` f_type values for the in-memory filesystems. */
+const TMPFS_MAGIC = 0x01021994
+const RAMFS_MAGIC = 0x858458f6
+
+/** Files older than this are assumed orphaned by a crashed request. */
+const SWEEP_AGE_MS = 60 * 60 * 1000
+
+export interface SpoolProbe {
+  tmpdir: () => string
+  isRamBacked: (path: string) => boolean
+  ensureWritable: (path: string) => boolean
+}
+
+/**
+ * Whether `path` lives on a memory-backed filesystem.
+ *
+ * Fails to `false`: on a platform where statfs reports something we don't
+ * recognise (macOS returns its own values), the honest answer is "no evidence
+ * this is RAM", and the caller's existing behaviour is the safer default.
+ */
+export function isRamBacked(path: string): boolean {
+  try {
+    const type = Number((statfsSync(path) as unknown as { type: number | bigint }).type)
+    return type === TMPFS_MAGIC || type === RAMFS_MAGIC
+  } catch {
+    return false
+  }
+}
+
+function ensureWritable(path: string): boolean {
+  try {
+    mkdirSync(path, { recursive: true })
+    // mkdir succeeding does not prove we can write into it (read-only mount,
+    // full filesystem, wrong owner), and we only find out at 2 GB otherwise.
+    const probe = join(path, `.write-probe-${process.pid}`)
+    writeFileSync(probe, 'x')
+    unlinkSync(probe)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const defaultProbe: SpoolProbe = { tmpdir, isRamBacked, ensureWritable }
+
+/**
+ * Pick a scratch directory for `workspaceDir`, preferring the platform temp dir
+ * and falling back to a sibling of the workspace when temp is RAM.
+ *
+ * The fallback is a SIBLING, never a child: anything inside the workspace gets
+ * swept up by `packProjectArchive` and shipped to durable storage as if the
+ * user had written it.
+ */
+export function resolveSpoolDir(workspaceDir: string, probe: SpoolProbe = defaultProbe): string {
+  const tmp = join(probe.tmpdir(), 'shogo-spool')
+  if (!probe.isRamBacked(probe.tmpdir()) && probe.ensureWritable(tmp)) return tmp
+
+  const adjacent = join(dirname(workspaceDir), '.shogo-spool')
+  if (!probe.isRamBacked(dirname(workspaceDir)) && probe.ensureWritable(adjacent)) return adjacent
+
+  // Everything we can reach is RAM. Use temp anyway — the caller has to put the
+  // bytes somewhere, and a loud log beats a silent OOM two gigabytes later.
+  console.warn(
+    `[spool] no disk-backed scratch directory found (tried ${tmp}, ${adjacent}); ` +
+      `falling back to RAM-backed ${tmp}. Large archives may exhaust memory.`,
+  )
+  probe.ensureWritable(tmp)
+  return tmp
+}
+
+let cached: string | null = null
+
+/** Memoized spool directory for the running agent. */
+export function spoolDir(workspaceDir?: string): string {
+  if (cached) return cached
+  const ws = workspaceDir ?? process.env.WORKSPACE_DIR ?? process.env.AGENT_DIR ?? process.env.PROJECT_DIR ?? '/app/workspace'
+  cached = resolveSpoolDir(ws)
+  return cached
+}
+
+/** Test seam: forget the memoized directory. */
+export function resetSpoolDir(): void {
+  cached = null
+}
+
+/** A unique path inside the spool directory. `name` should include an extension. */
+export function spoolPath(name: string, workspaceDir?: string): string {
+  return join(spoolDir(workspaceDir), `${Date.now()}-${Math.random().toString(36).slice(2, 8)}-${name}`)
+}
+
+/**
+ * Delete spool entries older than `maxAgeMs`.
+ *
+ * A request killed between writing the spool and its `finally` leaves a
+ * multi-gigabyte file behind, and the guest's disk is not large enough to
+ * absorb many of those. Cheap enough to call on the way into each spooling
+ * request.
+ */
+export function sweepSpool(maxAgeMs: number = SWEEP_AGE_MS, workspaceDir?: string): number {
+  const dir = spoolDir(workspaceDir)
+  let removed = 0
+  try {
+    const cutoff = Date.now() - maxAgeMs
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry)
+      try {
+        if (statSync(full).mtimeMs >= cutoff) continue
+        rmSync(full, { recursive: true, force: true })
+        removed++
+      } catch {}
+    }
+  } catch {}
+  if (removed) console.log(`[spool] swept ${removed} stale file(s) from ${dir}`)
+  return removed
+}
+
+const STREAM_CHUNK = 1024 * 1024
+
+/**
+ * Serve a spooled archive as a streaming response and delete it, without ever
+ * holding it whole.
+ *
+ * `readFileSync(path)` costs the archive's full size in RAM at the moment of
+ * responding, which for a 1.8 GB export is most of the guest. Streaming from
+ * an open descriptor costs one chunk.
+ *
+ * The unlink happens up front, before a single byte is sent. POSIX keeps the
+ * inode alive as long as we hold the descriptor, so the bytes remain readable
+ * while the name is already gone — which means the disk is reclaimed even if
+ * the caller hangs up mid-download or the process is killed, the two cases a
+ * `finally` block does not cover.
+ */
+export async function spooledFileResponse(path: string, headers: Record<string, string>): Promise<Response> {
+  const fsp = await import('node:fs/promises')
+  const fh = await fsp.open(path, 'r')
+  let size: number
+  try {
+    // Not best-effort: a wrong Content-Length against a correct stream is a
+    // truncated or hung download, so fail here where the caller still has a
+    // 500 to return.
+    size = (await fh.stat()).size
+  } catch (err) {
+    await fh.close().catch(() => {})
+    throw err
+  }
+  // Best-effort by contrast — if the name cannot be removed the bytes are
+  // still correct, and `sweepSpool` reclaims it later.
+  await fsp.unlink(path).catch(() => {})
+
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const buf = Buffer.allocUnsafe(STREAM_CHUNK)
+      const { bytesRead } = await fh.read(buf, 0, STREAM_CHUNK, null)
+      if (bytesRead === 0) {
+        await fh.close().catch(() => {})
+        controller.close()
+        return
+      }
+      controller.enqueue(new Uint8Array(buf.buffer, buf.byteOffset, bytesRead))
+    },
+    async cancel() {
+      await fh.close().catch(() => {})
+    },
+  })
+
+  return new Response(stream, {
+    status: 200,
+    headers: { ...headers, 'Content-Length': String(size) },
+  })
+}


### PR DESCRIPTION
Follow-up to #856, found by actually running the 2 GB staging test it promised.

## Summary

The guest mounts `/tmp` as tmpfs with no `size=`, which Linux defaults to half of RAM — about 2 GiB in a 4 GiB microVM. So #856's "spool the hydrate body to disk instead of buffering it" moved the archive out of the heap and into a RAM disk. Same memory, different accounting.

Staging, on the freshly rebuilt rootfs: a 1.07 GiB archive hydrated fine (that size returned a 413 before, so the raised body cap does work), and a 1.91 GiB archive killed the VM outright — `fc process gone`, not a timeout. Every unit test and a local 2 GiB run passed, because on a developer machine `/tmp` is a real disk. Nothing short of running it in the guest tells those two directories apart, which is why the new code asks `statfs` rather than trusting a path.

`/pool/export` and `/pool/export-data` had the same flaw and predate this work: both stage into `/tmp` *and* `readFileSync` the result into a Buffer, so a 1.8 GB source export wanted roughly 3.6 GB of a 4 GiB guest on the suspend path too.

- `spool.ts` picks a scratch directory by filesystem type, preferring `tmpdir()` and refusing it when it is tmpfs/ramfs. Anywhere `/tmp` is real disk behaves exactly as before; only the guest diverges, onto a sibling of the workspace — never a child, since anything inside gets packed into `project-src.tar.gz` and shipped as if the user wrote it.
- Export responses stream from an already-unlinked descriptor. Unlinking before the first byte means the disk is reclaimed even when the client hangs up mid-download, which a `finally` does not cover.
- Stale spool files are swept on the way into each spooling request.

## Test plan

- [x] 17 tests in `spool.test.ts`, including the guest case (a writable, existing temp dir that simply happens to be RAM) and the unlink-then-stream guarantees.
- [x] tmpfs detection pinned against a real kernel on Linux (`/dev/shm` vs the repo root), skipped on macOS where the magic numbers don't apply.
- [x] agent-runtime 3737 pass, 0 fail. Typecheck unchanged (116 pre-existing, none in the new code).
- [ ] Re-run the 2 GB staging cold boot once this ships a new runtime image — the only check that would have caught the original bug.

Made with [Cursor](https://cursor.com)