### PR TITLE
Extract hydrate straight from the stream, never storing the archive

### DIFF
--- a/packages/agent-runtime/src/__tests__/tar-stream.test.ts
+++ b/packages/agent-runtime/src/__tests__/tar-stream.test.ts
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Streaming hydrate: pipe the request body into tar so the archive is never
+ * held whole.
+ *
+ * Two earlier versions of this path each moved the cost instead of removing
+ * it — `arrayBuffer()` charged the guest's RAM, a spool file charged its disk
+ * twice — and both were caught only by running a multi-gigabyte archive in a
+ * real microVM. The cases below are the ones that would have caught them
+ * earlier: that a listing large enough to fill a pipe does not deadlock, that a
+ * huge archive does not produce a proportional allocation, and that tar's exit
+ * status is not swallowed.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { extractTarStream, scanTarOutput } from '../tar-stream'
+import { archiveNeedsSidecarClear, SQLITE_SIDECAR_ENTRY } from '../writable-state'
+
+let dir: string
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'tar-stream-'))
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+async function sh(cmd: string[]): Promise<void> {
+  const p = Bun.spawn(cmd, { stdout: 'pipe', stderr: 'pipe' })
+  const [code, err] = await Promise.all([p.exited, new Response(p.stderr).text()])
+  if (code !== 0) throw new Error(`${cmd.join(' ')} exited ${code}: ${err}`)
+}
+
+/** Build a .tar.gz from a described tree and return a body stream over it. */
+async function archiveOf(files: Record<string, string | Uint8Array>): Promise<ReadableStream<Uint8Array>> {
+  const src = join(dir, `src-${Math.random().toString(36).slice(2)}`)
+  for (const [rel, content] of Object.entries(files)) {
+    const full = join(src, rel)
+    mkdirSync(join(full, '..'), { recursive: true })
+    writeFileSync(full, content as any)
+  }
+  const tgz = join(dir, `a-${Math.random().toString(36).slice(2)}.tar.gz`)
+  await sh(['tar', '-czf', tgz, '-C', src, '.'])
+  return Bun.file(tgz).stream() as unknown as ReadableStream<Uint8Array>
+}
+
+function outDir(): string {
+  const out = join(dir, `out-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(out, { recursive: true })
+  return out
+}
+
+describe('extractTarStream', () => {
+  test('extracts a tree from the stream and reports the bytes it read', async () => {
+    const out = outDir()
+    const body = await archiveOf({ 'a.txt': 'hello', 'src/b.ts': 'export const b = 1\n' })
+
+    const res = await extractTarStream(body, out, SQLITE_SIDECAR_ENTRY)
+
+    expect(readFileSync(join(out, 'a.txt'), 'utf8')).toBe('hello')
+    expect(readFileSync(join(out, 'src/b.ts'), 'utf8')).toBe('export const b = 1\n')
+    expect(res.bytes).toBeGreaterThan(0)
+  })
+
+  test('returns only the paths the caller asked for', async () => {
+    // The filter is what keeps a 200k-file project from allocating a 200k-entry
+    // array on the path whose entire purpose is to avoid size-proportional
+    // allocation.
+    const out = outDir()
+    const body = await archiveOf({
+      'prisma/dev.db': 'sqlite',
+      'src/one.ts': '1',
+      'src/two.ts': '2',
+      'assets/big.bin': 'x'.repeat(1000),
+    })
+
+    const res = await extractTarStream(body, out, SQLITE_SIDECAR_ENTRY)
+
+    expect(res.matched.map((m) => m.replace(/^\.\//, ''))).toEqual(['prisma/dev.db'])
+    // Everything still lands on disk; only the LISTING is filtered.
+    expect(existsSync(join(out, 'src/two.ts'))).toBe(true)
+    expect(existsSync(join(out, 'assets/big.bin'))).toBe(true)
+  })
+
+  test('feeds archiveNeedsSidecarClear correctly for a db-without-wal archive', async () => {
+    // The filtered listing has to be a faithful substitute for the full one, or
+    // a restored database gets silently reverted by a stale WAL.
+    const out = outDir()
+    const withoutWal = await extractTarStream(await archiveOf({ 'prisma/dev.db': 'db' }), out, SQLITE_SIDECAR_ENTRY)
+    expect(archiveNeedsSidecarClear(withoutWal.matched)).toBe(true)
+
+    const out2 = outDir()
+    const withWal = await extractTarStream(
+      await archiveOf({ 'prisma/dev.db': 'db', 'prisma/dev.db-wal': 'wal' }),
+      out2,
+      SQLITE_SIDECAR_ENTRY,
+    )
+    expect(archiveNeedsSidecarClear(withWal.matched)).toBe(false)
+  })
+
+  test('does not deadlock when the listing is far larger than a pipe buffer', async () => {
+    // THE DEADLOCK CASE. `tar -v` prints a line per file; a pipe holds ~64 KB.
+    // If the caller writes the whole body before reading stdout, tar blocks on
+    // its listing, stops reading the archive, and both sides wait forever. Only
+    // reproduces above a few thousand files, which is every real project and no
+    // toy fixture.
+    const files: Record<string, string> = {}
+    for (let i = 0; i < 6000; i++) files[`deep/dir-${i % 50}/file-${i}-with-a-long-enough-name.ts`] = `${i}`
+    const out = outDir()
+
+    const res = await Promise.race([
+      extractTarStream(await archiveOf(files), out, /file-42-/),
+      new Promise<never>((_, rej) => setTimeout(() => rej(new Error('deadlocked')), 60_000)),
+    ])
+
+    expect(res.matched.length).toBe(1)
+    expect(existsSync(join(out, 'deep/dir-49/file-5999-with-a-long-enough-name.ts'))).toBe(true)
+  }, 70_000)
+
+  test('surfaces tar’s exit code and its diagnostics', async () => {
+    // Hydrate is fail-closed: the host destroys the VM on failure. Swallowing a
+    // non-zero exit would instead hand back a half-extracted workspace that
+    // looks fine, which is how a project silently opens as a template.
+    const out = outDir()
+    const notATarball = new Blob([new Uint8Array(2048).fill(7)]).stream() as unknown as ReadableStream<Uint8Array>
+
+    await expect(extractTarStream(notATarball, out, /x/)).rejects.toThrow(/tar exited [1-9]/)
+  })
+
+  test('reports ENOSPC-style failures rather than reporting success', async () => {
+    const out = join(dir, 'does-not-exist')
+    await expect(extractTarStream(await archiveOf({ 'a.txt': 'x' }), out, /x/)).rejects.toThrow(/tar exited/)
+  })
+
+  test('settles on an empty body instead of hanging', async () => {
+    // GNU tar treats a zero-length archive as an error and bsdtar does not, so
+    // the portable guarantee is only that this RETURNS — the caller rejects
+    // `bytes === 0` itself rather than relying on tar to.
+    const out = outDir()
+    const empty = new Blob([]).stream() as unknown as ReadableStream<Uint8Array>
+
+    const settled = await Promise.race([
+      extractTarStream(empty, out, /x/).then(
+        (r) => ({ ok: true as const, bytes: r.bytes }),
+        () => ({ ok: false as const, bytes: 0 }),
+      ),
+      new Promise<never>((_, rej) => setTimeout(() => rej(new Error('hung on empty body')), 15_000)),
+    ])
+
+    expect(settled.bytes).toBe(0)
+  }, 20_000)
+
+  test('memory stays flat across an archive far larger than any buffer', async () => {
+    // The regression in one number. A 256 MB incompressible archive through a
+    // handler that holds it whole shows up as a matching jump in RSS; through
+    // this one it does not.
+    const out = outDir()
+    const big = join(dir, 'big.bin')
+    await sh(['dd', 'if=/dev/urandom', `of=${big}`, 'bs=1048576', 'count=256', 'status=none'])
+    const srcDir = join(dir, 'bigsrc')
+    mkdirSync(srcDir, { recursive: true })
+    await sh(['mv', big, join(srcDir, 'big.bin')])
+    const tgz = join(dir, 'big.tar.gz')
+    await sh(['tar', '-czf', tgz, '-C', srcDir, '.'])
+
+    Bun.gc(true)
+    const before = process.memoryUsage.rss()
+    const res = await extractTarStream(
+      Bun.file(tgz).stream() as unknown as ReadableStream<Uint8Array>,
+      out,
+      /nothing/,
+    )
+    Bun.gc(true)
+    const grewMb = (process.memoryUsage.rss() - before) / 1024 / 1024
+
+    expect(res.bytes).toBeGreaterThan(200 * 1024 * 1024)
+    // Deliberately loose. The failure being guarded is growth PROPORTIONAL to
+    // the archive — an earlier version of this that handed the stream to Bun
+    // peaked at +2.4 GB on a 1 GB archive — so the bound only has to sit well
+    // below 256 MB, not track GC timing.
+    expect(grewMb).toBeLessThan(128)
+  }, 120_000)
+})
+
+describe('scanTarOutput', () => {
+  function streamOf(...chunks: string[]): ReadableStream<Uint8Array> {
+    const enc = new TextEncoder()
+    return new ReadableStream({
+      start(c) {
+        for (const s of chunks) c.enqueue(enc.encode(s))
+        c.close()
+      },
+    })
+  }
+  const matched = async (...chunks: string[]) =>
+    (await scanTarOutput(streamOf(...chunks), SQLITE_SIDECAR_ENTRY)).matched
+
+  test('reassembles lines split across chunk boundaries', async () => {
+    // tar's output arrives in pipe-sized reads with no regard for line ends, so
+    // a path can straddle two chunks.
+    expect(await matched('./prisma/de', 'v.db\n./src/a.ts\n')).toEqual(['./prisma/dev.db'])
+  })
+
+  test('keeps a final line with no trailing newline', async () => {
+    expect(await matched('./src/a.ts\n./prisma/dev.db')).toEqual(['./prisma/dev.db'])
+  })
+
+  test('strips the bsdtar "x " prefix so both tars agree', async () => {
+    // GNU tar prints the bare path, bsdtar prefixes it. Left unnormalized, the
+    // sidecar comparison downstream succeeds on Linux and fails on macOS — and
+    // the consequence of failing is a restored database silently reverted by a
+    // stale WAL, not a visible error.
+    expect(await matched('x ./prisma/dev.db\n')).toEqual(['./prisma/dev.db'])
+  })
+
+  test('does not mistake a multi-byte character split across chunks', async () => {
+    const bytes = new TextEncoder().encode('./caf\u00e9/prisma/dev.db\n')
+    const cut = 7 // lands inside the two-byte é
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(bytes.slice(0, cut))
+        c.enqueue(bytes.slice(cut))
+        c.close()
+      },
+    })
+    expect((await scanTarOutput(stream, SQLITE_SIDECAR_ENTRY)).matched).toEqual(['./café/prisma/dev.db'])
+  })
+
+  test('ignores blank lines and returns nothing when there is no match', async () => {
+    expect(await matched('\n\n./src/a.ts\n\n')).toEqual([])
+  })
+
+  test('does not treat a diagnostic mentioning the database as an entry', async () => {
+    // stderr carries both the listing (bsdtar) and error text, so the filter
+    // has to tell "extracted this" from "failed on this".
+    expect(await matched('tar: ./prisma/dev.db: Cannot write: No space left on device\n')).toEqual([])
+  })
+
+  test('caps the diagnostic tail instead of buffering the stream', async () => {
+    const noise = 'x'.repeat(100_000)
+    const { tail } = await scanTarOutput(streamOf(noise + '\nlast line\n'), /nothing/, 1024)
+    expect(tail.length).toBeLessThanOrEqual(1024)
+    expect(tail).toContain('last line')
+  })
+})

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -86,8 +86,10 @@ import {
   packWritableState,
   writableStateTag,
   WRITABLE_STATE_PATHS,
+  SQLITE_SIDECAR_ENTRY,
 } from './writable-state'
 import { spoolDir, spoolPath, spooledFileResponse, sweepSpool } from './spool'
+import { extractTarStream } from './tar-stream'
 import { runtimeDiagnosticsRoutes } from './runtime-diagnostics-routes'
 import { runtimeLspRoutes } from './runtime-lsp-routes'
 import { computePublishedReadiness } from './published-readiness'
@@ -2598,39 +2600,26 @@ function scheduleHydrateRebuild(): void {
 }
 
 app.post('/pool/hydrate', async (c) => {
+  const stream = c.req.raw.body
+  if (!stream) return c.json({ error: 'empty archive' }, 400)
   sweepSpool()
-  const tmp = spoolPath('pool-hydrate.tar.gz')
   let bytes = 0
   try {
-    // Spool to disk as it arrives rather than buffering the whole archive.
-    // The largest production source archive is ~1.8 GB against a 4 GiB guest,
-    // so `arrayBuffer()` put the request body and the runtime's own heap into
-    // the same budget and made the ceiling a memory limit rather than a policy
-    // one. Streaming makes the cost O(chunk), so the only real bound left is
-    // guest disk — which is why the body cap above can be raised at all.
+    // Extract straight from the request body — the archive is never written
+    // down as a whole, in memory or on disk.
     //
-    // `spoolPath`, not `/tmp`: the guest's `/tmp` is tmpfs, so spooling there
-    // is still spending RAM, just without it showing up as heap. See spool.ts.
-    const stream = c.req.raw.body
-    if (!stream) return c.json({ error: 'empty archive' }, 400)
-    const sink = Bun.file(tmp).writer()
-    try {
-      for await (const chunk of stream as any as AsyncIterable<Uint8Array>) {
-        bytes += chunk.byteLength
-        sink.write(chunk)
-        // Bound the writer's own buffer; without this the spool is just a
-        // slower way of holding the whole archive in memory.
-        await sink.flush()
-      }
-    } finally {
-      await sink.end()
-    }
+    // The two previous attempts each moved the cost rather than removing it:
+    // `arrayBuffer()` charged it to the guest's 4 GiB of RAM, and spooling to a
+    // file charged it to disk TWICE (the archive plus what comes out of it),
+    // against the ~3.8 GiB actually free on the rootfs. Piping into tar makes
+    // the peak the extracted tree alone, which is the irreducible cost of
+    // having the project on the machine.
+    // Only the database and its WAL affect the decision below, so the listing
+    // is filtered as it streams instead of being accumulated.
+    const result = await extractTarStream(stream, WORKSPACE_DIR, SQLITE_SIDECAR_ENTRY)
+    bytes = result.bytes
+    const entries = result.matched
     if (bytes === 0) return c.json({ error: 'empty archive' }, 400)
-
-    const entries: string[] = []
-    const tarMod = await import('tar')
-    await tarMod.list({ file: tmp, onReadEntry: (e: { path: string }) => entries.push(e.path) })
-    await extractTarFastNonBlocking(tmp, WORKSPACE_DIR)
 
     // A database restored WITHOUT its WAL must not be opened next to someone
     // else's. A `-wal` left over from the rootfs template still holds live
@@ -2652,10 +2641,6 @@ app.post('/pool/hydrate', async (c) => {
   } catch (err: any) {
     console.error('[pool/hydrate] failed:', err?.message ?? err)
     return c.json({ error: err?.message ?? 'hydrate failed' }, 500)
-  } finally {
-    try {
-      unlinkSync(tmp)
-    } catch {}
   }
 })
 
@@ -6193,8 +6178,14 @@ export default {
   // RAM. Two production projects are already past it (1.85 GB and 1.77 GB of
   // generated video frames and downloaded stock footage) and survive only
   // because a snapshot exists — a rootfs rebuild invalidates every snapshot and
-  // would strand them. The handler now spools to disk, so the constraint moved
-  // from guest RAM to guest disk (a 13.6 GB rootfs). 4 GiB clears today's
-  // largest archive with room to grow and still refuses something absurd.
+  // would strand them.
+  //
+  // The handler no longer holds the archive at all: it pipes the body into tar,
+  // so the cost is the extracted tree rather than the tree plus a copy of the
+  // archive. What that has to fit in is the rootfs free space — about 3.8 GiB,
+  // NOT the 13.6 GB image size, most of which is the runtime itself. This cap
+  // is therefore the looser of the two limits and exists to refuse something
+  // absurd; a project that genuinely cannot fit fails at extraction with a
+  // legible ENOSPC instead.
   maxRequestBodySize: 4 * 1024 * 1024 * 1024,
 }

--- a/packages/agent-runtime/src/tar-stream.ts
+++ b/packages/agent-runtime/src/tar-stream.ts
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Extract a gzipped tar directly from a request body, without ever writing the
+ * archive down.
+ *
+ * Hydrating a project used to cost the archive twice: once to hold it (RAM, and
+ * then a tmpfs spool that was RAM wearing a filesystem's clothes) and once for
+ * what came out of it. A 4 GiB guest with ~3.8 GiB free on its rootfs cannot
+ * pay that for the multi-gigabyte projects this exists to restore. Piping the
+ * body straight into `tar` makes the peak the extracted tree alone.
+ */
+
+import { closeSync, openSync, unlinkSync } from 'node:fs'
+import { spoolPath } from './spool'
+
+/** GNU tar cannot sniff compression on a pipe: `-z` is required, not optional. */
+const TAR_ARGS = ['-xzv', '--no-same-owner', '--no-same-permissions']
+
+/** How much of tar's diagnostics to keep for an error message. */
+const STDERR_TAIL_BYTES = 8192
+
+export interface TarStreamResult {
+  /** Bytes read from the body — the compressed size. */
+  bytes: number
+  /** Extracted paths matching the caller's filter, in archive order. */
+  matched: string[]
+}
+
+export interface ScanResult {
+  matched: string[]
+  /** Trailing output, capped, for diagnostics. */
+  tail: string
+}
+
+/**
+ * Read `body` into `tar`, extracting into `cwd`.
+ *
+ * `keep` selects which extracted paths are returned. It exists so callers don't
+ * accumulate the full listing: `-v` names every file, and a large project has
+ * hundreds of thousands of them, which would reintroduce a size-proportional
+ * allocation on the exact path that is trying to avoid one.
+ *
+ * Throws on a non-zero tar exit, with tar's own diagnostics attached. Callers
+ * treat hydrate as fail-closed, so a partially extracted workspace is safe: the
+ * host destroys the VM rather than serving it.
+ */
+export async function extractTarStream(
+  body: ReadableStream<Uint8Array>,
+  cwd: string,
+  keep: RegExp,
+  spawn: typeof Bun.spawn = Bun.spawn,
+): Promise<TarStreamResult> {
+  // tar's output goes to a FILE rather than a pipe, for two independent
+  // reasons that happen to have the same fix:
+  //
+  //  - Deadlock. `tar -v` prints a line per extracted file. A pipe holds ~64 KB,
+  //    so on a real project tar blocks writing its listing, stops reading the
+  //    archive, and we block feeding it.
+  //  - Truncation. Draining that pipe concurrently avoids the deadlock, but
+  //    when stdin is hand-pumped Bun delivers only the FIRST chunk of the
+  //    child's output and then closes the stream — while the exit status still
+  //    says success. Downstream that reads as "the archive held one file",
+  //    which for the SQLite check means a restored database quietly left beside
+  //    a stale WAL. A silent wrong answer, not an error.
+  //
+  // The file is proportional to the FILE COUNT, not to the archive size: a
+  // 200k-file project writes a few MB, against an archive of gigabytes.
+  const listingPath = spoolPath('tar-listing.txt')
+  const fd = openSync(listingPath, 'w')
+  let fdOpen = true
+
+  try {
+    // stdin stays hand-pumped. Handing Bun the ReadableStream instead makes it
+    // accumulate: measured at +2.4 GB of RSS for a 1 GB archive, which is the
+    // exact failure being engineered out here. write()+flush() holds one chunk.
+    const proc = spawn(['tar', ...TAR_ARGS, '-C', cwd], { stdin: 'pipe', stdout: fd, stderr: fd })
+
+    let bytes = 0
+    try {
+      for await (const chunk of body as unknown as AsyncIterable<Uint8Array>) {
+        bytes += chunk.byteLength
+        proc.stdin.write(chunk)
+        // Bound the writer's buffer. Without this the pipe is just a slower way
+        // of holding the whole archive in memory.
+        await proc.stdin.flush()
+      }
+    } finally {
+      proc.stdin.end()
+    }
+
+    const code = await proc.exited
+    closeSync(fd)
+    fdOpen = false
+
+    // Read back with the same line scanner, so a huge listing still costs one
+    // buffer rather than its full size.
+    const { matched, tail } = await scanTarOutput(
+      Bun.file(listingPath).stream() as unknown as ReadableStream<Uint8Array>,
+      keep,
+      STDERR_TAIL_BYTES,
+    )
+    if (code !== 0) {
+      throw new Error(`tar exited ${code}: ${tail.trim().slice(-400) || 'no output'}`)
+    }
+    return { bytes, matched }
+  } finally {
+    if (fdOpen) {
+      try {
+        closeSync(fd)
+      } catch {}
+    }
+    try {
+      unlinkSync(listingPath)
+    } catch {}
+  }
+}
+
+/**
+ * Scan a tar output stream line by line, keeping only what the caller asked
+ * for plus (optionally) a bounded tail for error reporting.
+ *
+ * Deliberately never accumulates the stream: on a large project the listing is
+ * tens of megabytes, and buffering it would put back the allocation this whole
+ * path exists to avoid.
+ */
+export async function scanTarOutput(
+  stream: ReadableStream<Uint8Array>,
+  keep: RegExp,
+  tailBytes = 0,
+): Promise<ScanResult> {
+  const matched: string[] = []
+  const decoder = new TextDecoder()
+  let buf = ''
+  let tail = ''
+
+  const take = (raw: string) => {
+    const line = normalizeListingLine(raw)
+    if (line && keep.test(line)) matched.push(line)
+  }
+
+  for await (const chunk of stream as unknown as AsyncIterable<Uint8Array>) {
+    const text = decoder.decode(chunk, { stream: true })
+    if (tailBytes > 0) tail = (tail + text).slice(-tailBytes)
+    buf += text
+    let nl: number
+    while ((nl = buf.indexOf('\n')) >= 0) {
+      take(buf.slice(0, nl))
+      buf = buf.slice(nl + 1)
+    }
+  }
+  take(buf)
+  return { matched, tail }
+}
+
+/**
+ * Normalize one line of tar verbose output to a bare path.
+ *
+ * bsdtar prefixes each extracted entry with `x `; GNU tar prints the path
+ * alone. Without this the same archive yields paths that compare equal on Linux
+ * and not on macOS, which downstream turns into a database restored next to a
+ * stale WAL.
+ */
+function normalizeListingLine(raw: string): string {
+  const line = raw.trim()
+  return line.startsWith('x ') ? line.slice(2).trim() : line
+}

--- a/packages/agent-runtime/src/writable-state.ts
+++ b/packages/agent-runtime/src/writable-state.ts
@@ -370,3 +370,13 @@ export function archiveNeedsSidecarClear(entries: Iterable<string>): boolean {
   }
   return hasDb && !hasWal
 }
+
+/**
+ * The archive entries {@link archiveNeedsSidecarClear} can act on.
+ *
+ * A caller reading a tar listing as it streams uses this to keep the handful of
+ * relevant paths and discard the rest — a large project lists hundreds of
+ * thousands of files, and holding all of them would defeat the point of
+ * streaming. Kept next to the decision it feeds so the two cannot drift.
+ */
+export const SQLITE_SIDECAR_ENTRY = /(^|\/)prisma\/dev\.db(-wal)?$/


### PR DESCRIPTION
Third and last place this cost was hiding. Follow-up to #856 and #857.

## Summary

Spooling to a disk-backed file fixed the RAM exhaustion, but hydrate still charged the guest **twice** — the archive plus what comes out of it — against the ~3.8 GiB actually free on the rootfs. (The rootfs is 13.6 GB in total; the runtime image is most of it. A comment I wrote on #856 cited the total as if it were headroom, and is corrected here.)

Measured on staging against the rebuilt rootfs: 1.1 GB cold boots in 44.6 s, and 2 GB dies with `tar: Cannot write: No space left on device` — no longer an OOM kill, but still a project that cannot open. Piping the body into `tar` makes the peak the extracted tree alone, so the 1.85 GB project needs ~1.9 GiB rather than ~3.7 GiB.

Two non-obvious things this had to work around, both of which produce a *wrong answer* rather than an error:

- Handing Bun the `ReadableStream` as stdin makes it accumulate — **+2.4 GB of RSS for a 1 GB archive**, reintroducing the exact bug being fixed. stdin stays hand-pumped with `write()`+`flush()`, which measures flat (1.5 GB archive, +2 MB).
- With a hand-pumped stdin, Bun delivers only the **first chunk** of the child's piped output and then closes it, while the exit status still reports success. tar's listing therefore arrived truncated to one line, which downstream reads as "the archive held one file" — and for the SQLite sidecar check that means a restored database left beside a stale WAL, silently reverted. tar's output now goes to a file, which also removes the pipe-capacity deadlock outright. That file scales with file count, not archive size, and is filtered as it is read.

## Test plan

- [x] 15 tests in `tar-stream.test.ts`: extraction, the filtered listing feeding `archiveNeedsSidecarClear`, a 6000-file archive that would deadlock a pipe, tar exit codes surfaced, and memory flat across a 256 MB archive.
- [x] Both tars covered: GNU writes the listing to stdout, bsdtar to stderr with an `x ` prefix. Reading one and not the other is invisible on whichever platform you happen to use.
- [x] Memory measured directly: 256 MB → +59 MB, 1 GB → +22 MB, 1.5 GB → +2 MB. The rejected variant was +2.4 GB at 1 GB.
- [x] agent-runtime 3753 pass, 0 fail. Typecheck back to the 116 pre-existing errors.
- [ ] 2 GB staging cold boot, once this ships a runtime image.

Made with [Cursor](https://cursor.com)