### PR TITLE
Send hydrate archives chunked, or Bun buffers them into the guest

### DIFF
--- a/apps/metal-agent/src/pool-hydrate.test.ts
+++ b/apps/metal-agent/src/pool-hydrate.test.ts
@@ -43,6 +43,9 @@ class TestPool extends MetalWarmPool {
   budget(bytes: number) {
     return this.hydrateBudgetMs(bytes)
   }
+  bodyFor(bytes: Uint8Array) {
+    return this.archiveBody(bytes)
+  }
 }
 
 function makePool(dir: string, over: Partial<typeof config> = {}): TestPool {
@@ -76,9 +79,12 @@ describe('pool.hydrateFromBackup (cold-start hydration)', () => {
     pool.archive = new Uint8Array([1, 2, 3, 4])
     pool.etag = '"abc123"'
 
-    const calls: Array<{ url: string; init: any }> = []
+    const calls: Array<{ url: string; init: any; sent: Uint8Array }> = []
     globalThis.fetch = mock(async (url: any, init: any) => {
-      calls.push({ url: String(url), init })
+      // The body is a stream now (see the chunked-body suite below), so read it
+      // back to assert the guest receives the archive byte for byte.
+      const sent = new Uint8Array(await new Response(init.body).arrayBuffer())
+      calls.push({ url: String(url), init, sent })
       return new Response(JSON.stringify({ ok: true, bytes: 4 }), { status: 200 })
     }) as any
 
@@ -88,7 +94,7 @@ describe('pool.hydrateFromBackup (cold-start hydration)', () => {
     expect(calls[0].url).toBe('http://10.0.0.9:8080/pool/hydrate')
     expect(calls[0].init.method).toBe('POST')
     expect(calls[0].init.headers.Authorization).toBe('Bearer secret-token')
-    expect(calls[0].init.body).toEqual(pool.archive)
+    expect(calls[0].sent).toEqual(pool.archive!)
     // The returned lineage anchors the workspace to the backup we applied, so a
     // later suspend can safely overwrite exactly that object.
     expect(result).toEqual({ hydrated: true, parentEtag: '"abc123"' })
@@ -130,6 +136,82 @@ describe('pool.hydrateFromBackup (cold-start hydration)', () => {
 
     await pool.hydrate('p3', {})
     expect(calls[0].headers.Authorization).toBeUndefined()
+  })
+})
+
+describe('the archive is sent chunked, never as a sized body', () => {
+  let dir: string
+  const realFetch = globalThis.fetch
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'metal-body-'))
+  })
+  afterEach(() => {
+    globalThis.fetch = realFetch
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  test('hydrate sends a stream with duplex:half and no Content-Length', async () => {
+    // THE GUEST-OOM REGRESSION. Bun.serve buffers a request body whole when
+    // Content-Length is set, whatever the handler does with it: measured at
+    // +1978 MB of RSS for a 1 GB body versus +91 MB chunked. Passing a
+    // Uint8Array sets that header, and a 2 GB hydrate then panicked the guest
+    // kernel ("Out of memory and no killable processes") before its streaming
+    // handler saw a byte. Passing a Uint8Array here again would look perfectly
+    // reasonable in review, so it is pinned.
+    const pool = makePool(dir)
+    pool.archive = new Uint8Array(4 * 1024 * 1024)
+
+    let init: any
+    globalThis.fetch = mock(async (_url: any, i: any) => {
+      init = i
+      // Drain, or the producing stream never runs.
+      await new Response(i.body).arrayBuffer()
+      return new Response('{}', { status: 200 })
+    }) as any
+
+    await pool.hydrate('p-chunked', { RUNTIME_AUTH_SECRET: 'tok' })
+
+    expect(init.body).toBeInstanceOf(ReadableStream)
+    expect(init.duplex).toBe('half')
+    expect(ArrayBuffer.isView(init.body)).toBe(false)
+    expect(init.headers['Content-Length']).toBeUndefined()
+  })
+
+  test('the stream reproduces the archive exactly, in bounded pieces', async () => {
+    // Chunking is only safe if it is lossless and actually chunked — one
+    // enqueue of the whole buffer would pass the type check above while
+    // changing nothing about the memory behaviour.
+    const pool = makePool(dir)
+    const bytes = new Uint8Array(5 * 1024 * 1024 + 123)
+    for (let i = 0; i < bytes.length; i++) bytes[i] = i % 251
+
+    const { body } = pool.bodyFor(bytes)
+    const reader = body.getReader()
+    const chunks: Uint8Array[] = []
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      chunks.push(value!)
+    }
+
+    expect(chunks.length).toBeGreaterThan(1)
+    expect(Math.max(...chunks.map((c) => c.byteLength))).toBeLessThanOrEqual(1024 * 1024)
+    const joined = new Uint8Array(chunks.reduce((n, c) => n + c.byteLength, 0))
+    let at = 0
+    for (const c of chunks) {
+      joined.set(c, at)
+      at += c.byteLength
+    }
+    expect(joined).toEqual(bytes)
+  })
+
+  test('an empty archive produces an immediately-closed stream', () => {
+    const pool = makePool(dir)
+    expect(async () => {
+      const { body } = pool.bodyFor(new Uint8Array(0))
+      const { done } = await body.getReader().read()
+      expect(done).toBe(true)
+    }).not.toThrow()
   })
 })
 

--- a/apps/metal-agent/src/pool.ts
+++ b/apps/metal-agent/src/pool.ts
@@ -869,12 +869,40 @@ export class MetalWarmPool {
         'Content-Type': 'application/gzip',
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
-      body: archive.bytes,
+      ...this.archiveBody(archive.bytes),
       signal: AbortSignal.timeout(this.hydrateBudgetMs(archive.bytes.byteLength)),
-    })
+    } as any)
     if (!res.ok) throw new Error(`/pool/hydrate failed (${res.status}): ${await res.text()}`)
     console.log(`[pool] hydrated ${projectId} from durable backup (${archive.bytes.byteLength} bytes, etag=${archive.etag ?? 'none'})`)
     return { hydrated: true, parentEtag: archive.etag ?? undefined }
+  }
+
+  /**
+   * Send an archive to the guest as a CHUNKED body rather than a sized one.
+   *
+   * This is not a style choice. Bun.serve buffers a request body whole when
+   * Content-Length is set, no matter what the handler does with it — measured
+   * at +1978 MB of RSS for a 1 GB body against +91 MB for the same bytes sent
+   * chunked. Passing a Uint8Array sets that header, so a 2 GB hydrate filled
+   * the guest's 4 GiB and the kernel panicked ("Out of memory and no killable
+   * processes", with 3.7 GiB of anon in `bun`) before the guest's own streaming
+   * handler ever saw a byte. Sending the same archive without a Content-Length
+   * is what lets the guest stream it.
+   */
+  protected archiveBody(bytes: Uint8Array): { body: ReadableStream<Uint8Array>; duplex: 'half' } {
+    const CHUNK = 1024 * 1024
+    let offset = 0
+    return {
+      body: new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (offset >= bytes.byteLength) return controller.close()
+          const end = Math.min(offset + CHUNK, bytes.byteLength)
+          controller.enqueue(bytes.subarray(offset, end))
+          offset = end
+        },
+      }),
+      duplex: 'half',
+    }
   }
 
   /**
@@ -1077,9 +1105,9 @@ export class MetalWarmPool {
         'Content-Type': 'application/gzip',
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
-      body: archive.bytes,
+      ...this.archiveBody(archive.bytes),
       signal: AbortSignal.timeout(this.hydrateBudgetMs(archive.bytes.byteLength)),
-    })
+    } as any)
     if (!res.ok) {
       throw new Error(`/pool/hydrate (project data) failed (${res.status}): ${await res.text()}`)
     }
@@ -1272,9 +1300,9 @@ export class MetalWarmPool {
         'Content-Type': 'application/gzip',
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
-      body: archive,
+      ...this.archiveBody(archive),
       signal: AbortSignal.timeout(this.hydrateBudgetMs(archive.byteLength)),
-    })
+    } as any)
     if (!res.ok) throw new Error(`/pool/hydrate (data) failed (${res.status}): ${await res.text()}`)
     console.log(`[pool] hydrated published-data for ${subdomain} (${archive.byteLength} bytes)`)
   }


### PR DESCRIPTION
The actual cause of the 2 GB cold-boot failure. Follow-up to #856, #857, #858.

## Summary

`Bun.serve` buffers a request body **whole** whenever `Content-Length` is set, regardless of what the handler does with it. One server, two clients, measured on the staging host:

| client | peak RSS for a 1 GB body |
| --- | --- |
| chunked `ReadableStream` (no Content-Length) | +91 MB |
| `Uint8Array` (Content-Length set) | +1978 MB |

The host passed `archive.bytes`, which sets that header. So the guest's streaming handler never saw a byte: a 2 GB hydrate filled the 4 GiB microVM and the kernel panicked — `Out of memory and no killable processes`, 3.7 GiB of anon in `bun`, PID 1 — which the host reported five minutes later as a hydrate timeout.

This is why the two previous fixes did not move the 2 GB case. Making the guest handler stream (#857) and then removing its spool entirely (#858) were both real fixes to real problems, and 1.1 GB now cold-boots in 44.6 s where it previously returned a 413. But neither could help while the body was already resident before the handler ran.

Sending the same archive without a `Content-Length` is what lets the guest stream it. Applies to all three body-carrying hydrate calls (source, project data, published data).

## Test plan

- [x] Pinned by test: the hydrate body must be a `ReadableStream` with `duplex: 'half'` and no `Content-Length`. Passing a `Uint8Array` here would read as perfectly ordinary in review, which is exactly why it needs an assertion.
- [x] The chunking is lossless and actually chunked — a single enqueue of the whole buffer would satisfy a type check while changing nothing about memory.
- [x] metal-agent 231 pass, 0 fail. Typecheck unchanged (11 pass, 4 allowlisted).
- [ ] 2 GB staging cold boot. Agent-bundle only, so staging converges in minutes rather than needing a rootfs rebuild.

Made with [Cursor](https://cursor.com)