### PR TITLE
Have the guest pull its archive, since Bun won't push back

### DIFF
--- a/apps/metal-agent/src/archive-ref.test.ts
+++ b/apps/metal-agent/src/archive-ref.test.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * describeObject — the "look, don't download" step that makes a multi-gigabyte
+ * cold boot possible.
+ *
+ * The properties worth pinning are all about what it DOESN'T do: it must not
+ * read the object, it must not turn an S3 outage into "this project has no
+ * backup" (that is how a template gets served over real source and then written
+ * back over it), and it must not fail a hydrate just because presigning is
+ * unavailable.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { describeObject } from './archive-ref'
+
+interface FakeOpts {
+  exists?: boolean
+  etag?: string | null
+  size?: number | null
+  statThrows?: boolean
+  existsThrows?: boolean
+  presignThrows?: boolean
+}
+
+function fakeClient(opts: FakeOpts) {
+  const calls = { exists: 0, stat: 0, presign: 0, download: 0 }
+  const client = {
+    file(key: string) {
+      return {
+        key,
+        async exists() {
+          calls.exists++
+          if (opts.existsThrows) throw new Error('connection reset')
+          return opts.exists ?? true
+        },
+        async stat() {
+          calls.stat++
+          if (opts.statThrows) throw new Error('stat blew up')
+          return { etag: opts.etag ?? null, size: opts.size ?? null }
+        },
+        presign() {
+          calls.presign++
+          if (opts.presignThrows) throw new Error('cannot presign')
+          return `https://s3.example/${key}?X-Amz-Signature=sig`
+        },
+        async arrayBuffer() {
+          calls.download++
+          return new Uint8Array([1, 2, 3]).buffer
+        },
+      }
+    },
+  }
+  return { client: client as any, calls }
+}
+
+describe('describeObject', () => {
+  test('reports lineage, size and a presigned URL without reading the object', async () => {
+    const { client, calls } = fakeClient({ etag: '"abc"', size: 1234 })
+
+    const ref = await describeObject(client, 'p1/project-src.tar.gz', 900)
+
+    expect(ref).not.toBeNull()
+    expect(ref!.etag).toBe('"abc"')
+    expect(ref!.bytes).toBe(1234)
+    expect(ref!.url).toContain('p1/project-src.tar.gz')
+    // The entire point: a 2 GB archive must not pass through the host.
+    expect(calls.download).toBe(0)
+  })
+
+  test('downloads only when the caller asks, for the push fallback', async () => {
+    const { client, calls } = fakeClient({ etag: '"abc"', size: 3 })
+    const ref = await describeObject(client, 'k', 900)
+
+    expect(calls.download).toBe(0)
+    expect(await ref!.load()).toEqual(new Uint8Array([1, 2, 3]))
+    expect(calls.download).toBe(1)
+  })
+
+  test('returns null when the object does not exist', async () => {
+    const { client, calls } = fakeClient({ exists: false })
+    expect(await describeObject(client, 'missing', 900)).toBeNull()
+    expect(calls.stat).toBe(0)
+  })
+
+  test('propagates a transport error instead of reporting the object absent', async () => {
+    // "No backup" and "cannot reach S3" must never collapse into one answer.
+    // Hydrate is fail-closed precisely so an outage cannot be mistaken for a
+    // new project, which would serve the template over real source.
+    const { client } = fakeClient({ existsThrows: true })
+    await expect(describeObject(client, 'k', 900)).rejects.toThrow(/connection reset/)
+  })
+
+  test('still describes the object when stat fails', async () => {
+    // Losing the ETag costs lineage (a later export quarantines rather than
+    // overwrites) and losing the size costs deadline precision. Both are better
+    // than failing a hydrate that would otherwise work.
+    const { client } = fakeClient({ statThrows: true })
+    const ref = await describeObject(client, 'k', 900)
+    expect(ref).not.toBeNull()
+    expect(ref!.etag).toBeNull()
+    expect(ref!.bytes).toBe(0)
+    expect(ref!.url).toBeTruthy()
+  })
+
+  test('falls back to no URL when the store cannot presign', async () => {
+    // The caller reads a null URL as "push the bytes", so a store without
+    // presigning degrades to the old behaviour rather than to an outage.
+    const { client } = fakeClient({ presignThrows: true, etag: '"e"', size: 10 })
+    const ref = await describeObject(client, 'k', 900)
+    expect(ref!.url).toBeNull()
+    expect(ref!.etag).toBe('"e"')
+  })
+})

--- a/apps/metal-agent/src/archive-ref.ts
+++ b/apps/metal-agent/src/archive-ref.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * A durable archive described rather than downloaded.
+ *
+ * Hydrate used to begin by pulling the whole object into the host's memory so
+ * it could be POSTed to the guest. That is what put a multi-gigabyte archive on
+ * the wire in a shape the guest could not survive: Bun.serve holds a request
+ * body in memory whenever the handler reads slower than it arrives, and `tar`
+ * extracting gigabytes is far slower than the virtio link, so the archive
+ * landed in the guest's 4 GiB and the kernel panicked. No framing on the
+ * sending side fixes that, because the accumulation happens below the handler.
+ *
+ * What does fix it is not sending the bytes at all. The host HEADs the object
+ * for the lineage ETag and size it actually needs, mints a short-lived
+ * presigned GET, and hands the guest a URL. The guest pulls it through `curl`
+ * into `tar`, where the kernel pipe provides the backpressure Bun's streams do
+ * not. Neither process ever holds the archive.
+ *
+ * `load` remains for the fallback: a guest running an older runtime has no pull
+ * endpoint, so the host downloads and pushes as before. That path is bounded by
+ * the rollout, not by project size.
+ */
+
+import type { S3Client } from 'bun'
+
+/** A durable archive addressed by URL, with its bytes available on demand. */
+export interface ArchiveRef {
+  /** ETag of the object — the lineage anchor a later write must match. */
+  etag: string | null
+  /** Compressed size, for the hydrate deadline and for logging. 0 if unreported. */
+  bytes: number
+  /**
+   * Short-lived presigned GET the guest can pull from directly, or null when
+   * the store cannot mint one. Null forces the push fallback; it is never a
+   * reason to skip hydrating.
+   */
+  url: string | null
+  /** Download the archive. Only the push fallback pays this. */
+  load: () => Promise<Uint8Array>
+}
+
+/**
+ * Describe `key` without downloading it: existence, lineage ETag, size, and a
+ * presigned GET valid for `expiresInSec`.
+ *
+ * Returns null when the object does not exist — the caller's "nothing durable
+ * to apply" case. A transport error PROPAGATES instead of reading as absent,
+ * because hydrate is fail-closed: mistaking an S3 outage for "this project has
+ * no backup" is how a template gets served over real source and then written
+ * back over it.
+ */
+export async function describeObject(
+  client: S3Client,
+  key: string,
+  expiresInSec: number,
+): Promise<ArchiveRef | null> {
+  const file = client.file(key)
+  if (!(await file.exists())) return null
+
+  let etag: string | null = null
+  let bytes = 0
+  try {
+    const st = await file.stat()
+    etag = st.etag ?? null
+    if (typeof st.size === 'number') bytes = st.size
+  } catch {
+    // Size and ETag are best-effort: a missing size only costs a less precise
+    // deadline, and a missing ETag costs lineage (the writer will not be able
+    // to prove descent and its export quarantines) — both preferable to
+    // failing a hydrate that can otherwise succeed.
+  }
+
+  return { etag, bytes, url: presign(client, key, expiresInSec), load: () => download(file) }
+}
+
+/**
+ * Mint a presigned GET, or null if the client cannot.
+ *
+ * Never throws: presigning is an optimisation over pushing the bytes, so a
+ * store that does not support it degrades to the fallback rather than failing
+ * the hydrate.
+ */
+function presign(client: S3Client, key: string, expiresInSec: number): string | null {
+  try {
+    return client.file(key).presign({ expiresIn: expiresInSec, method: 'GET' })
+  } catch {
+    return null
+  }
+}
+
+async function download(file: ReturnType<S3Client['file']>): Promise<Uint8Array> {
+  return new Uint8Array(await file.arrayBuffer())
+}

--- a/apps/metal-agent/src/pool-hydrate.test.ts
+++ b/apps/metal-agent/src/pool-hydrate.test.ts
@@ -12,8 +12,8 @@
  * shipped because nothing asserted the cold-open path hydrates.
  *
  * We drive the private `hydrateFromBackup` directly with an injected archive
- * (via the `fetchArchive` seam) and a stubbed global `fetch`, so no real S3 /
- * Firecracker host is needed. The resume path is covered by construction:
+ * reference (via the `sourceRef` seam) and a stubbed global `fetch`, so no real
+ * S3 / Firecracker host is needed. The resume path is covered by construction:
  * `hydrateFromBackup` is only called from the cold `assign()` branch, never from
  * `resume()`.
  */
@@ -22,6 +22,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { mkdtempSync, mkdirSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
+import type { ArchiveRef } from './archive-ref'
 import { config } from './config'
 import { MetalWarmPool } from './pool'
 import type { FirecrackerVMManager } from './firecracker-vm-manager'
@@ -33,8 +34,21 @@ const HANDLE = { id: 'vm-1', agentUrl: 'http://10.0.0.9:8080', guestIp: '10.0.0.
 class TestPool extends MetalWarmPool {
   archive: Uint8Array | null = null
   etag: string | null = null
-  override fetchArchive(_projectId: string): Promise<import('./workspace-archive').WorkspaceArchive | null> {
-    return Promise.resolve(this.archive ? { bytes: this.archive, etag: this.etag } : null)
+  /** null → the store could not presign, so the host must push the bytes. */
+  url: string | null = 'https://s3.example/p1/project-src.tar.gz?X-Amz-Signature=deadbeef'
+  loads = 0
+  override sourceRef(_projectId: string): Promise<ArchiveRef | null> {
+    if (!this.archive) return Promise.resolve(null)
+    const bytes = this.archive
+    return Promise.resolve({
+      etag: this.etag,
+      bytes: bytes.byteLength,
+      url: this.url,
+      load: async () => {
+        this.loads++
+        return bytes
+      },
+    })
   }
   hydrate(projectId: string, env: Record<string, string>) {
     // hydrateFromBackup is private; reach it through the instance.
@@ -74,30 +88,53 @@ describe('pool.hydrateFromBackup (cold-start hydration)', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
-  test('streams the durable archive to the guest /pool/hydrate with the runtime token and returns its lineage etag', async () => {
+  test('hands the guest a URL to pull, and never downloads the archive itself', async () => {
+    // THE GUEST-OOM FIX. Pushing bytes cannot work at multi-gigabyte sizes:
+    // Bun.serve accumulates a request body in memory whenever the handler reads
+    // slower than the wire delivers it (+2423 MB of RSS for a 1 GB body against
+    // +94 MB when the reader keeps up), and tar never keeps up. Pulling puts a
+    // kernel pipe between download and extraction, which is the only part of
+    // this path that has ever applied backpressure.
     const pool = makePool(dir)
     pool.archive = new Uint8Array([1, 2, 3, 4])
     pool.etag = '"abc123"'
 
-    const calls: Array<{ url: string; init: any; sent: Uint8Array }> = []
+    const calls: Array<{ url: string; init: any }> = []
     globalThis.fetch = mock(async (url: any, init: any) => {
-      // The body is a stream now (see the chunked-body suite below), so read it
-      // back to assert the guest receives the archive byte for byte.
-      const sent = new Uint8Array(await new Response(init.body).arrayBuffer())
-      calls.push({ url: String(url), init, sent })
+      calls.push({ url: String(url), init })
       return new Response(JSON.stringify({ ok: true, bytes: 4 }), { status: 200 })
     }) as any
 
     const result = await pool.hydrate('p1', { RUNTIME_AUTH_SECRET: 'secret-token' })
 
     expect(calls).toHaveLength(1)
-    expect(calls[0].url).toBe('http://10.0.0.9:8080/pool/hydrate')
+    expect(calls[0].url).toBe('http://10.0.0.9:8080/pool/hydrate-url')
     expect(calls[0].init.method).toBe('POST')
     expect(calls[0].init.headers.Authorization).toBe('Bearer secret-token')
-    expect(calls[0].sent).toEqual(pool.archive!)
+    expect(JSON.parse(calls[0].init.body)).toMatchObject({ url: pool.url, bytes: 4 })
+    // The host downloading it anyway would defeat the entire point — it is the
+    // reason a 2 GB archive used to be resident on both sides at once.
+    expect(pool.loads).toBe(0)
     // The returned lineage anchors the workspace to the backup we applied, so a
     // later suspend can safely overwrite exactly that object.
     expect(result).toEqual({ hydrated: true, parentEtag: '"abc123"' })
+  })
+
+  test('gives the guest a deadline to pull within, and waits longer than it', async () => {
+    // The guest holds the transfer open for the whole pull, so the host must
+    // outlast the deadline it just handed out — otherwise the host aborts a
+    // hydrate that was about to succeed and the project fails to open.
+    const pool = makePool(dir, { hydrateTimeoutMs: 60_000, hydrateTimeoutPerMiBMs: 120 })
+    pool.archive = new Uint8Array(8 * 1024 * 1024)
+
+    let sent: any
+    globalThis.fetch = mock(async (_url: any, init: any) => {
+      sent = JSON.parse(init.body)
+      return new Response('{}', { status: 200 })
+    }) as any
+
+    await pool.hydrate('p-deadline', { RUNTIME_AUTH_SECRET: 'tok' })
+    expect(sent.timeoutMs).toBe(pool.budget(8 * 1024 * 1024))
   })
 
   test('is a no-op returning hydrated:false when the project has no durable backup (new project)', async () => {
@@ -121,7 +158,9 @@ describe('pool.hydrateFromBackup (cold-start hydration)', () => {
 
     globalThis.fetch = mock(async () => new Response('boom', { status: 500 })) as any
 
-    await expect(pool.hydrate('p2', { RUNTIME_AUTH_SECRET: 'tok' })).rejects.toThrow(/\/pool\/hydrate failed \(500\)/)
+    await expect(pool.hydrate('p2', { RUNTIME_AUTH_SECRET: 'tok' })).rejects.toThrow(
+      /\/pool\/hydrate-url .* failed \(500\)/,
+    )
   })
 
   test('omits the Authorization header when no runtime token is present', async () => {
@@ -139,6 +178,82 @@ describe('pool.hydrateFromBackup (cold-start hydration)', () => {
   })
 })
 
+describe('falling back to a push when the guest cannot pull', () => {
+  let dir: string
+  const realFetch = globalThis.fetch
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'metal-fallback-'))
+  })
+  afterEach(() => {
+    globalThis.fetch = realFetch
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  test('a 404 from /pool/hydrate-url means an older guest, so the bytes are pushed', async () => {
+    // The two sides deploy independently — the guest runtime ships in a rootfs
+    // image, the host in an agent bundle — so for a window the host is new and
+    // the guest is not. Without this the entire fleet fails to cold-boot during
+    // that window, and hydrate is fail-closed: projects simply do not open.
+    const pool = makePool(dir)
+    pool.archive = new Uint8Array([5, 6, 7])
+    pool.etag = '"e"'
+
+    const seen: Array<{ url: string; sent?: Uint8Array }> = []
+    globalThis.fetch = mock(async (url: any, init: any) => {
+      const u = String(url)
+      if (u.endsWith('/pool/hydrate-url')) {
+        seen.push({ url: u })
+        return new Response('not found', { status: 404 })
+      }
+      seen.push({ url: u, sent: new Uint8Array(await new Response(init.body).arrayBuffer()) })
+      return new Response('{}', { status: 200 })
+    }) as any
+
+    const result = await pool.hydrate('p-old-guest', { RUNTIME_AUTH_SECRET: 'tok' })
+
+    expect(seen.map((s) => s.url)).toEqual([
+      'http://10.0.0.9:8080/pool/hydrate-url',
+      'http://10.0.0.9:8080/pool/hydrate',
+    ])
+    expect(seen[1].sent).toEqual(pool.archive!)
+    expect(pool.loads).toBe(1)
+    expect(result).toEqual({ hydrated: true, parentEtag: '"e"' })
+  })
+
+  test('a store that cannot presign pushes without trying to pull first', async () => {
+    const pool = makePool(dir)
+    pool.archive = new Uint8Array([1])
+    pool.url = null
+
+    const urls: string[] = []
+    globalThis.fetch = mock(async (url: any, init: any) => {
+      urls.push(String(url))
+      await new Response(init.body).arrayBuffer()
+      return new Response('{}', { status: 200 })
+    }) as any
+
+    await pool.hydrate('p-nopresign', { RUNTIME_AUTH_SECRET: 'tok' })
+    expect(urls).toEqual(['http://10.0.0.9:8080/pool/hydrate'])
+  })
+
+  test('any other failure from the pull endpoint is an error, not a reason to push', async () => {
+    // A 500 means the guest TRIED and failed — pushing after it would turn a
+    // clean failure into the multi-gigabyte push this design exists to avoid.
+    const pool = makePool(dir)
+    pool.archive = new Uint8Array([1])
+
+    const urls: string[] = []
+    globalThis.fetch = mock(async (url: any) => {
+      urls.push(String(url))
+      return new Response('curl exited 22', { status: 500 })
+    }) as any
+
+    await expect(pool.hydrate('p-pull-broke', { RUNTIME_AUTH_SECRET: 'tok' })).rejects.toThrow(/500/)
+    expect(urls).toEqual(['http://10.0.0.9:8080/pool/hydrate-url'])
+    expect(pool.loads).toBe(0)
+  })
+})
+
 describe('the archive is sent chunked, never as a sized body', () => {
   let dir: string
   const realFetch = globalThis.fetch
@@ -150,16 +265,14 @@ describe('the archive is sent chunked, never as a sized body', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
-  test('hydrate sends a stream with duplex:half and no Content-Length', async () => {
-    // THE GUEST-OOM REGRESSION. Bun.serve buffers a request body whole when
-    // Content-Length is set, whatever the handler does with it: measured at
-    // +1978 MB of RSS for a 1 GB body versus +91 MB chunked. Passing a
-    // Uint8Array sets that header, and a 2 GB hydrate then panicked the guest
-    // kernel ("Out of memory and no killable processes") before its streaming
-    // handler saw a byte. Passing a Uint8Array here again would look perfectly
-    // reasonable in review, so it is pinned.
+  test('the push fallback sends a stream with duplex:half and no Content-Length', async () => {
+    // Bun.serve buffers a request body whole when Content-Length is set,
+    // whatever the handler does with it: +1978 MB of RSS for a 1 GB body versus
+    // +91 MB chunked. Passing a Uint8Array here would look perfectly reasonable
+    // in review while making the fallback strictly worse, so it is pinned.
     const pool = makePool(dir)
     pool.archive = new Uint8Array(4 * 1024 * 1024)
+    pool.url = null // force the push path
 
     let init: any
     globalThis.fetch = mock(async (_url: any, i: any) => {

--- a/apps/metal-agent/src/pool.ts
+++ b/apps/metal-agent/src/pool.ts
@@ -40,18 +40,30 @@ import {
   type SnapshotStore,
 } from './snapshot-store'
 import {
-  fetchWorkspaceArchive,
+  describeWorkspaceArchive,
   uploadWorkspaceArchiveGuarded,
   type BackupWriteOutcome,
-  type WorkspaceArchive,
 } from './workspace-archive'
-import { fetchPublishedDataArchive, uploadPublishedDataArchive } from './published-data-archive'
 import {
-  fetchProjectDataArchive,
+  describePublishedDataArchive,
+  uploadPublishedDataArchive,
+} from './published-data-archive'
+import {
+  describeProjectDataArchive,
   uploadProjectDataGuarded,
   type DataLineage,
   type DataWriteOutcome,
 } from './project-data-archive'
+import type { ArchiveRef } from './archive-ref'
+
+/**
+ * How long a presigned hydrate URL stays valid.
+ *
+ * Matches the guest's own ceiling on a pull, so a URL never outlives the
+ * transfer it was minted for. It is a bearer capability for one object handed
+ * to guest code, so the bound matters more than the convenience.
+ */
+const PRESIGN_TTL_SEC = 30 * 60
 
 export interface PooledVm {
   handle: FcVmHandle
@@ -824,23 +836,6 @@ export class MetalWarmPool {
   }
 
   /**
-   * Cold-start hydration: pull the project's durable source backup from S3
-   * (host-side — the guest has no S3 creds) and stream it to the guest's
-   * `/pool/hydrate` control endpoint, which extracts it over the template and
-   * rebuilds. Authenticated with the same RUNTIME_AUTH_SECRET the API injected
-   * into the guest via `/pool/assign`. No durable backup (a brand-new project)
-   * is a no-op — the template is the correct initial state.
-   */
-  /**
-   * Fetch the durable source backup (bytes + lineage ETag) for a project. A
-   * `protected` seam so tests can inject a canned archive (or `null`) without
-   * touching S3 or module mocks.
-   */
-  protected fetchArchive(projectId: string): Promise<WorkspaceArchive | null> {
-    return fetchWorkspaceArchive(projectId, this.cfg)
-  }
-
-  /**
    * Cold-start hydration. Returns whether a durable backup was applied and, if
    * so, the ETag the resulting workspace descends from (its lineage anchor).
    *   - no durable backup (new project) → `{ hydrated: false }`; the template
@@ -857,37 +852,91 @@ export class MetalWarmPool {
     handle: FcVmHandle,
     env: Record<string, string>,
   ): Promise<{ hydrated: boolean; parentEtag?: string }> {
-    const archive = await this.fetchArchive(projectId)
-    if (!archive) {
+    const ref = await this.sourceRef(projectId)
+    if (!ref) {
       console.log(`[pool] no durable backup for ${projectId} — cold start keeps template`)
       return { hydrated: false }
     }
+    await this.applyArchive(handle, env, ref, `${projectId} source`)
+    console.log(
+      `[pool] hydrated ${projectId} from durable backup (${ref.bytes} bytes, etag=${ref.etag ?? 'none'})`,
+    )
+    return { hydrated: true, parentEtag: ref.etag ?? undefined }
+  }
+
+  /**
+   * Describe the durable source backup without downloading it. A `protected`
+   * seam so tests can supply a canned reference without touching S3.
+   */
+  protected sourceRef(projectId: string): Promise<ArchiveRef | null> {
+    return describeWorkspaceArchive(projectId, this.cfg, PRESIGN_TTL_SEC)
+  }
+
+
+  /**
+   * Get an archive into the guest's workspace, preferring the guest to PULL it.
+   *
+   * Pushing bytes cannot work at multi-gigabyte sizes: Bun.serve accumulates a
+   * request body in memory whenever the handler reads slower than the wire
+   * delivers it (+2423 MB of RSS for a 1 GB body against +94 MB when the reader
+   * keeps up), and `tar` never keeps up. That is what panicked the guest kernel
+   * on a 2 GB cold boot — "Out of memory and no killable processes" — with the
+   * host's careful chunking making no difference, because the accumulation
+   * happens below the guest's handler.
+   *
+   * So the host hands over a short-lived presigned URL and the guest pulls it
+   * through `curl` into `tar`, where a kernel pipe supplies the backpressure.
+   * Neither side holds the archive, and the host no longer downloads it at all.
+   *
+   * The push remains for one case: a guest whose runtime predates the pull
+   * endpoint answers 404, and during that rollout window the old path is still
+   * the correct thing to do.
+   */
+  private async applyArchive(
+    handle: FcVmHandle,
+    env: Record<string, string>,
+    ref: ArchiveRef,
+    what: string,
+  ): Promise<void> {
     const token = env.RUNTIME_AUTH_SECRET
+    const auth = token ? { Authorization: `Bearer ${token}` } : {}
+    const budgetMs = this.hydrateBudgetMs(ref.bytes)
+
+    if (ref.url) {
+      const res = await fetch(`${handle.agentUrl}/pool/hydrate-url`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...auth },
+        body: JSON.stringify({ url: ref.url, bytes: ref.bytes, timeoutMs: budgetMs }),
+        // The guest holds the transfer open for the whole pull, so the host's
+        // own deadline has to cover it with room to answer.
+        signal: AbortSignal.timeout(budgetMs + 30_000),
+      })
+      if (res.ok) return
+      if (res.status !== 404) {
+        throw new Error(`/pool/hydrate-url (${what}) failed (${res.status}): ${await res.text()}`)
+      }
+      console.log(`[pool] guest has no pull endpoint — pushing ${what} instead`)
+    }
+
+    const bytes = await ref.load()
     const res = await fetch(`${handle.agentUrl}/pool/hydrate`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/gzip',
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-      ...this.archiveBody(archive.bytes),
-      signal: AbortSignal.timeout(this.hydrateBudgetMs(archive.bytes.byteLength)),
+      headers: { 'Content-Type': 'application/gzip', ...auth },
+      ...this.archiveBody(bytes),
+      signal: AbortSignal.timeout(this.hydrateBudgetMs(bytes.byteLength)),
     } as any)
-    if (!res.ok) throw new Error(`/pool/hydrate failed (${res.status}): ${await res.text()}`)
-    console.log(`[pool] hydrated ${projectId} from durable backup (${archive.bytes.byteLength} bytes, etag=${archive.etag ?? 'none'})`)
-    return { hydrated: true, parentEtag: archive.etag ?? undefined }
+    if (!res.ok) throw new Error(`/pool/hydrate (${what}) failed (${res.status}): ${await res.text()}`)
   }
 
   /**
    * Send an archive to the guest as a CHUNKED body rather than a sized one.
    *
-   * This is not a style choice. Bun.serve buffers a request body whole when
-   * Content-Length is set, no matter what the handler does with it — measured
-   * at +1978 MB of RSS for a 1 GB body against +91 MB for the same bytes sent
-   * chunked. Passing a Uint8Array sets that header, so a 2 GB hydrate filled
-   * the guest's 4 GiB and the kernel panicked ("Out of memory and no killable
-   * processes", with 3.7 GiB of anon in `bun`) before the guest's own streaming
-   * handler ever saw a byte. Sending the same archive without a Content-Length
-   * is what lets the guest stream it.
+   * Only the push fallback uses this. Bun.serve buffers a request body whole
+   * when Content-Length is set, no matter what the handler does with it —
+   * +1978 MB of RSS for a 1 GB body against +91 MB for the same bytes sent
+   * chunked — so passing a Uint8Array here would be strictly worse. It does not
+   * make the push safe at any size (see {@link applyArchive}); it makes the
+   * push as cheap as a push can be.
    */
   protected archiveBody(bytes: Uint8Array): { body: ReadableStream<Uint8Array>; duplex: 'half' } {
     const CHUNK = 1024 * 1024
@@ -1062,14 +1111,6 @@ export class MetalWarmPool {
     return { bytes: new Uint8Array(buf), tag: res.headers.get('etag') }
   }
 
-  /** Fetch a project's durable writable-state archive. `protected` for tests. */
-  protected fetchProjectData(projectId: string): Promise<{
-    bytes: Uint8Array
-    etag: string | null
-  } | null> {
-    return fetchProjectDataArchive(projectId, this.cfg)
-  }
-
   /** Guarded (conditional) upload of writable state. `protected` for tests. */
   protected uploadDataGuarded(
     projectId: string,
@@ -1093,29 +1134,22 @@ export class MetalWarmPool {
     handle: FcVmHandle,
     env: Record<string, string>,
   ): Promise<{ hydrated: boolean; parentEtag?: string }> {
-    const archive = await this.fetchProjectData(projectId)
-    if (!archive) {
+    const ref = await this.projectDataRef(projectId)
+    if (!ref) {
       console.log(`[pool] no durable writable state for ${projectId} — using the source's database`)
       return { hydrated: false }
     }
-    const token = env.RUNTIME_AUTH_SECRET
-    const res = await fetch(`${handle.agentUrl}/pool/hydrate`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/gzip',
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-      ...this.archiveBody(archive.bytes),
-      signal: AbortSignal.timeout(this.hydrateBudgetMs(archive.bytes.byteLength)),
-    } as any)
-    if (!res.ok) {
-      throw new Error(`/pool/hydrate (project data) failed (${res.status}): ${await res.text()}`)
-    }
+    await this.applyArchive(handle, env, ref, `${projectId} writable state`)
     console.log(
       `[pool] hydrated writable state for ${projectId} ` +
-        `(${archive.bytes.byteLength} bytes, etag=${archive.etag ?? 'none'})`,
+        `(${ref.bytes} bytes, etag=${ref.etag ?? 'none'})`,
     )
-    return { hydrated: true, parentEtag: archive.etag ?? undefined }
+    return { hydrated: true, parentEtag: ref.etag ?? undefined }
+  }
+
+  /** Describe the durable writable-state archive. `protected` for tests. */
+  protected projectDataRef(projectId: string): Promise<ArchiveRef | null> {
+    return describeProjectDataArchive(projectId, this.cfg, PRESIGN_TTL_SEC)
   }
 
   /**
@@ -1270,11 +1304,6 @@ export class MetalWarmPool {
   // periodically + on suspend. All best-effort — the site still serves without
   // durability, it just cold-boots a fresh DB.
 
-  /** Fetch a published subdomain's writable-state archive. `protected` for tests. */
-  protected fetchPublishedData(subdomain: string): Promise<Uint8Array | null> {
-    return fetchPublishedDataArchive(subdomain, this.cfg)
-  }
-
   /** Upload a published subdomain's writable-state archive. `protected` for tests. */
   protected uploadPublishedData(subdomain: string, bytes: Uint8Array): Promise<boolean> {
     return uploadPublishedDataArchive(subdomain, bytes, this.cfg)
@@ -1285,26 +1314,21 @@ export class MetalWarmPool {
     handle: FcVmHandle,
     env: Record<string, string>,
   ): Promise<void> {
-    const archive = await this.fetchPublishedData(subdomain)
-    if (!archive) {
+    const ref = await this.publishedDataRef(subdomain)
+    if (!ref) {
       console.log(`[pool] no published-data archive for ${subdomain} — booting fresh DB`)
       return
     }
-    const token = env.RUNTIME_AUTH_SECRET
-    // Reuse the guest's /pool/hydrate control endpoint: it extracts a tar over
-    // the workspace tree, so a data.tar.gz rooted at the writable paths
-    // (prisma/dev.db, uploads/) overlays cleanly on top of the git-restored source.
-    const res = await fetch(`${handle.agentUrl}/pool/hydrate`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/gzip',
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-      ...this.archiveBody(archive),
-      signal: AbortSignal.timeout(this.hydrateBudgetMs(archive.byteLength)),
-    } as any)
-    if (!res.ok) throw new Error(`/pool/hydrate (data) failed (${res.status}): ${await res.text()}`)
-    console.log(`[pool] hydrated published-data for ${subdomain} (${archive.byteLength} bytes)`)
+    // Goes through the same hydrate path as the other overlays: it extracts a
+    // tar over the workspace tree, so a data.tar.gz rooted at the writable
+    // paths (prisma/dev.db, uploads/) lands cleanly on the restored source.
+    await this.applyArchive(handle, env, ref, `${subdomain} published data`)
+    console.log(`[pool] hydrated published-data for ${subdomain} (${ref.bytes} bytes)`)
+  }
+
+  /** Describe a published subdomain's writable-state archive. `protected` for tests. */
+  protected publishedDataRef(subdomain: string): Promise<ArchiveRef | null> {
+    return describePublishedDataArchive(subdomain, this.cfg, PRESIGN_TTL_SEC)
   }
 
   /**

--- a/apps/metal-agent/src/project-data-archive.ts
+++ b/apps/metal-agent/src/project-data-archive.ts
@@ -48,6 +48,7 @@
  * purely as an observability signal — see its doc comment.
  */
 
+import { describeObject, type ArchiveRef } from './archive-ref'
 import type { MetalConfig } from './config'
 import { conditionalPutObject, type S3Target } from './s3-conditional'
 import { workspaceS3 } from './workspace-archive'
@@ -236,6 +237,21 @@ export async function fetchProjectDataArchive(
   const meta = await statMeta(file)
   const buf = await file.arrayBuffer()
   return { bytes: new Uint8Array(buf), etag: meta.etag }
+}
+
+/**
+ * Describe `{projectId}/project-data.tar.gz` without downloading it, so the
+ * writable-state overlay can be pulled by the guest. Uploads can be large in
+ * their own right — this archive carries the database AND every user upload.
+ */
+export async function describeProjectDataArchive(
+  projectId: string,
+  cfg: MetalConfig,
+  expiresInSec: number,
+): Promise<ArchiveRef | null> {
+  const s3 = workspaceS3(cfg)
+  if (!s3) return null
+  return describeObject(s3.client, dataArchiveKey(projectId), expiresInSec)
 }
 
 /** Park bytes we would not write, so an operator can still recover them. */

--- a/apps/metal-agent/src/published-data-archive.ts
+++ b/apps/metal-agent/src/published-data-archive.ts
@@ -23,6 +23,7 @@
  * between the Knative pod, the manual dev->live data push, and the metal VM.
  */
 
+import { describeObject, type ArchiveRef } from './archive-ref'
 import type { MetalConfig } from './config'
 
 /** Key holding a published subdomain's writable-state archive. */
@@ -63,6 +64,20 @@ export async function fetchPublishedDataArchive(
   if (!(await file.exists())) return null
   const buf = await file.arrayBuffer()
   return new Uint8Array(buf)
+}
+
+/**
+ * Describe `{subdomain}/data.tar.gz` without downloading it, so a published
+ * site's accumulated data can be pulled by the guest like the other archives.
+ */
+export async function describePublishedDataArchive(
+  subdomain: string,
+  cfg: MetalConfig,
+  expiresInSec: number,
+): Promise<ArchiveRef | null> {
+  const s3 = publishedDataS3(cfg)
+  if (!s3) return null
+  return describeObject(s3.client, dataKey(subdomain), expiresInSec)
 }
 
 /**

--- a/apps/metal-agent/src/workspace-archive.ts
+++ b/apps/metal-agent/src/workspace-archive.ts
@@ -42,6 +42,7 @@
  * the snapshot bucket when `S3_WORKSPACES_BUCKET` is unset.
  */
 
+import { describeObject, type ArchiveRef } from './archive-ref'
 import type { MetalConfig } from './config'
 
 /** A durable source archive plus the S3 ETag that anchors its lineage. */
@@ -245,6 +246,23 @@ export async function fetchWorkspaceArchive(
   const etag = await statEtag(file)
   const buf = await file.arrayBuffer()
   return { bytes: new Uint8Array(buf), etag }
+}
+
+/**
+ * Describe `{projectId}/project-src.tar.gz` — lineage ETag, size, and a
+ * presigned GET — WITHOUT downloading it, so a cold boot can hand the guest a
+ * URL to pull instead of pushing gigabytes through the host. Null when there is
+ * no durable backup or S3 is not configured; transport errors propagate so the
+ * caller still fails closed.
+ */
+export async function describeWorkspaceArchive(
+  projectId: string,
+  cfg: MetalConfig,
+  expiresInSec: number,
+): Promise<ArchiveRef | null> {
+  const s3 = workspaceS3(cfg)
+  if (!s3) return null
+  return describeObject(s3.client, archiveKey(projectId), expiresInSec)
 }
 
 /**

--- a/packages/agent-runtime/src/__tests__/tar-stream.test.ts
+++ b/packages/agent-runtime/src/__tests__/tar-stream.test.ts
@@ -18,7 +18,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { extractTarStream, scanTarOutput } from '../tar-stream'
+import { extractTarFromUrl, extractTarStream, redactUrls, scanTarOutput } from '../tar-stream'
 import { archiveNeedsSidecarClear, SQLITE_SIDECAR_ENTRY } from '../writable-state'
 
 let dir: string
@@ -184,6 +184,137 @@ describe('extractTarStream', () => {
     // below 256 MB, not track GC timing.
     expect(grewMb).toBeLessThan(128)
   }, 120_000)
+})
+
+describe('extractTarFromUrl', () => {
+  /** Serve `body` once, so a pull can be pointed at something real. */
+  function serve(handler: (req: Request) => Response | Promise<Response>) {
+    const server = Bun.serve({ port: 0, fetch: handler })
+    return { url: `http://127.0.0.1:${server.port}/a.tar.gz`, stop: () => server.stop(true) }
+  }
+
+  async function tgzOf(files: Record<string, string>): Promise<string> {
+    const src = join(dir, `psrc-${Math.random().toString(36).slice(2)}`)
+    for (const [rel, content] of Object.entries(files)) {
+      mkdirSync(join(src, rel, '..'), { recursive: true })
+      writeFileSync(join(src, rel), content)
+    }
+    const tgz = join(dir, `p-${Math.random().toString(36).slice(2)}.tar.gz`)
+    await sh(['tar', '-czf', tgz, '-C', src, '.'])
+    return tgz
+  }
+
+  test('pulls the archive and extracts it, returning the filtered listing', async () => {
+    const tgz = await tgzOf({ 'prisma/dev.db': 'sqlite', 'src/a.ts': 'a' })
+    const s = serve(() => new Response(Bun.file(tgz)))
+    const out = outDir()
+    try {
+      const res = await extractTarFromUrl(s.url, out, SQLITE_SIDECAR_ENTRY, { maxSeconds: 30 })
+      expect(readFileSync(join(out, 'src/a.ts'), 'utf8')).toBe('a')
+      expect(res.matched.map((m) => m.replace(/^\.\//, ''))).toEqual(['prisma/dev.db'])
+    } finally {
+      s.stop()
+    }
+  }, 30_000)
+
+  test('a failed download fails the hydrate instead of passing as an empty one', async () => {
+    // THE pipefail CASE. Without it the exit status is tar's alone, and a curl
+    // that dies reads as success over a partial (or empty) tree — a project
+    // that silently opens as the template, which is the incident this whole
+    // subsystem exists to prevent.
+    const s = serve(() => new Response('nope', { status: 404 }))
+    const out = outDir()
+    try {
+      await expect(
+        extractTarFromUrl(s.url, out, /x/, { maxSeconds: 30 }),
+      ).rejects.toThrow(/pull-extract exited [1-9]/)
+    } finally {
+      s.stop()
+    }
+  }, 30_000)
+
+  test('a truncated transfer fails rather than leaving a plausible partial tree', async () => {
+    // gzip checks a CRC and length at the end of the stream, so a connection
+    // that dies mid-archive cannot be mistaken for a short project.
+    const tgz = await tgzOf({ 'a.txt': 'x'.repeat(200_000), 'b.txt': 'y'.repeat(200_000) })
+    const full = new Uint8Array(await Bun.file(tgz).arrayBuffer())
+    const s = serve(() => new Response(full.subarray(0, Math.floor(full.byteLength / 2))))
+    const out = outDir()
+    try {
+      await expect(extractTarFromUrl(s.url, out, /x/, { maxSeconds: 30 })).rejects.toThrow(
+        /pull-extract exited/,
+      )
+    } finally {
+      s.stop()
+    }
+  }, 30_000)
+
+  test('gives up on a stalled transfer at maxSeconds', async () => {
+    // A hung origin must not pin the hydrate open: the host is waiting on this
+    // call with a deadline of its own, and a cold boot that never resolves is
+    // a project that never opens.
+    const s = serve(
+      () =>
+        new Response(
+          new ReadableStream({
+            async pull(c) {
+              await Bun.sleep(10_000)
+              c.enqueue(new Uint8Array(1))
+            },
+          }),
+        ),
+    )
+    const out = outDir()
+    try {
+      const t0 = Date.now()
+      await expect(extractTarFromUrl(s.url, out, /x/, { maxSeconds: 2 })).rejects.toThrow()
+      expect(Date.now() - t0).toBeLessThan(20_000)
+    } finally {
+      s.stop()
+    }
+  }, 30_000)
+
+  test('memory stays flat across an archive far larger than any buffer', async () => {
+    // The whole reason this function exists. The push path accumulates the body
+    // in Bun's stream layer whenever the reader falls behind — +2423 MB of RSS
+    // for a 1 GB body — and tar always falls behind. Through a kernel pipe it
+    // does not.
+    const big = join(dir, 'pull-big.bin')
+    await sh(['dd', 'if=/dev/urandom', `of=${big}`, 'bs=1048576', 'count=256', 'status=none'])
+    const srcDir = join(dir, 'pullsrc')
+    mkdirSync(srcDir, { recursive: true })
+    await sh(['mv', big, join(srcDir, 'big.bin')])
+    const tgz = join(dir, 'pull-big.tar.gz')
+    await sh(['tar', '-czf', tgz, '-C', srcDir, '.'])
+
+    const s = serve(() => new Response(Bun.file(tgz)))
+    const out = outDir()
+    try {
+      Bun.gc(true)
+      const before = process.memoryUsage.rss()
+      await extractTarFromUrl(s.url, out, /nothing/, { maxSeconds: 120 })
+      Bun.gc(true)
+      const grewMb = (process.memoryUsage.rss() - before) / 1024 / 1024
+
+      expect(existsSync(join(out, 'big.bin'))).toBe(true)
+      expect(grewMb).toBeLessThan(128)
+    } finally {
+      s.stop()
+    }
+  }, 180_000)
+})
+
+describe('redactUrls', () => {
+  test('strips the query, which is where the signature lives', () => {
+    const line = 'curl: (22) failed on https://s3.example/p/src.tar.gz?X-Amz-Signature=deadbeef&e=1'
+    expect(redactUrls(line)).toBe('curl: (22) failed on https://s3.example/p/src.tar.gz?…')
+    expect(redactUrls(line)).not.toContain('deadbeef')
+  })
+
+  test('leaves text and unsigned URLs alone', () => {
+    expect(redactUrls('tar: ./prisma/dev.db: Cannot write')).toBe('tar: ./prisma/dev.db: Cannot write')
+    expect(redactUrls('see http://host/path')).toBe('see http://host/path')
+  })
 })
 
 describe('scanTarOutput', () => {

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -89,7 +89,7 @@ import {
   SQLITE_SIDECAR_ENTRY,
 } from './writable-state'
 import { spoolDir, spoolPath, spooledFileResponse, sweepSpool } from './spool'
-import { extractTarStream } from './tar-stream'
+import { extractTarFromUrl, extractTarStream, redactUrls } from './tar-stream'
 import { runtimeDiagnosticsRoutes } from './runtime-diagnostics-routes'
 import { runtimeLspRoutes } from './runtime-lsp-routes'
 import { computePublishedReadiness } from './published-readiness'
@@ -2599,6 +2599,81 @@ function scheduleHydrateRebuild(): void {
   }, HYDRATE_REBUILD_DEBOUNCE_MS)
 }
 
+/**
+ * Everything a hydrate does once the bytes have landed in the workspace,
+ * shared by the pull and push endpoints.
+ *
+ * `entries` is the filtered listing of what was extracted: a database restored
+ * WITHOUT its WAL must not be opened next to someone else's. A `-wal` left over
+ * from the rootfs template still holds live frames, and SQLite replays them
+ * over the file just installed — the result reads back as a healthy database
+ * containing the TEMPLATE's rows, with `integrity_check` reporting "ok". The
+ * restore is silently undone.
+ */
+function finishHydrate(entries: string[]): void {
+  if (archiveNeedsSidecarClear(entries)) {
+    const removed = clearSqliteSidecars(WORKSPACE_DIR)
+    if (removed.length) {
+      console.log(`[pool/hydrate] cleared stale SQLite sidecars: ${removed.join(', ')}`)
+    }
+  }
+  // Rebuild so the served dist reflects everything that was hydrated —
+  // debounced, because more overlays are usually still arriving.
+  scheduleHydrateRebuild()
+}
+
+/** Ceiling on a pull, however generous a deadline the host asks for. */
+const PULL_MAX_SECONDS = 30 * 60
+
+/**
+ * Pull-based hydrate: the host hands over a short-lived presigned URL and the
+ * guest fetches the archive itself.
+ *
+ * This is the endpoint that makes multi-gigabyte projects openable. Pushing the
+ * bytes cannot work at that size no matter how either side frames the request,
+ * because Bun.serve accumulates a request body in memory whenever the handler
+ * reads slower than the wire delivers it — and `tar` always does. Pulling puts
+ * a kernel pipe between the download and the extraction, which is the only part
+ * of this path that has ever applied real backpressure.
+ *
+ * A host that predates this endpoint gets a 404 and falls back to pushing, so
+ * the two sides can roll out in either order.
+ */
+app.post('/pool/hydrate-url', async (c) => {
+  let body: { url?: unknown; bytes?: unknown; timeoutMs?: unknown }
+  try {
+    body = await c.req.json()
+  } catch {
+    return c.json({ error: 'expected a JSON body' }, 400)
+  }
+
+  const url = typeof body.url === 'string' ? body.url : ''
+  // The host is authenticated, but a URL is still an instruction to make an
+  // outbound request: keep it to the two schemes this can legitimately be.
+  if (!/^https?:\/\//.test(url)) return c.json({ error: 'url must be http(s)' }, 400)
+
+  const expected = typeof body.bytes === 'number' ? body.bytes : 0
+  const timeoutMs = typeof body.timeoutMs === 'number' ? body.timeoutMs : 0
+  const maxSeconds = Math.min(PULL_MAX_SECONDS, Math.max(30, Math.ceil(timeoutMs / 1000)))
+
+  sweepSpool()
+  try {
+    const { matched } = await extractTarFromUrl(url, WORKSPACE_DIR, SQLITE_SIDECAR_ENTRY, {
+      maxSeconds,
+    })
+    finishHydrate(matched)
+    // The URL carries a live read capability in its signature; log where it
+    // pointed, never how to get there again.
+    console.log(
+      `[pool/hydrate] pulled ${new URL(url).pathname} into the workspace (${expected} bytes)`,
+    )
+    return c.json({ ok: true, bytes: expected })
+  } catch (err: any) {
+    console.error('[pool/hydrate] pull failed:', redactUrls(String(err?.message ?? err)))
+    return c.json({ error: redactUrls(String(err?.message ?? 'hydrate failed')) }, 500)
+  }
+})
+
 app.post('/pool/hydrate', async (c) => {
   const stream = c.req.raw.body
   if (!stream) return c.json({ error: 'empty archive' }, 400)
@@ -2608,34 +2683,15 @@ app.post('/pool/hydrate', async (c) => {
     // Extract straight from the request body — the archive is never written
     // down as a whole, in memory or on disk.
     //
-    // The two previous attempts each moved the cost rather than removing it:
-    // `arrayBuffer()` charged it to the guest's 4 GiB of RAM, and spooling to a
-    // file charged it to disk TWICE (the archive plus what comes out of it),
-    // against the ~3.8 GiB actually free on the rootfs. Piping into tar makes
-    // the peak the extracted tree alone, which is the irreducible cost of
-    // having the project on the machine.
-    // Only the database and its WAL affect the decision below, so the listing
+    // Bounded only by what the SENDER chooses to have in flight; see
+    // `/pool/hydrate-url` for why that is not something this side can fix.
+    // Only the database and its WAL affect the sidecar decision, so the listing
     // is filtered as it streams instead of being accumulated.
     const result = await extractTarStream(stream, WORKSPACE_DIR, SQLITE_SIDECAR_ENTRY)
     bytes = result.bytes
-    const entries = result.matched
     if (bytes === 0) return c.json({ error: 'empty archive' }, 400)
 
-    // A database restored WITHOUT its WAL must not be opened next to someone
-    // else's. A `-wal` left over from the rootfs template still holds live
-    // frames, and SQLite replays them over the file we just installed: the
-    // result reads back as a healthy database containing the template's rows,
-    // with `integrity_check` reporting "ok". The restore is silently undone.
-    if (archiveNeedsSidecarClear(entries)) {
-      const removed = clearSqliteSidecars(WORKSPACE_DIR)
-      if (removed.length) {
-        console.log(`[pool/hydrate] cleared stale SQLite sidecars: ${removed.join(', ')}`)
-      }
-    }
-
-    // Rebuild so the served dist reflects everything that was hydrated —
-    // debounced, because more overlays are usually still arriving.
-    scheduleHydrateRebuild()
+    finishHydrate(result.matched)
     console.log(`[pool/hydrate] hydrated workspace from durable backup (${bytes} bytes)`)
     return c.json({ ok: true, bytes })
   } catch (err: any) {

--- a/packages/agent-runtime/src/tar-stream.ts
+++ b/packages/agent-runtime/src/tar-stream.ts
@@ -118,6 +118,103 @@ export async function extractTarStream(
 }
 
 /**
+ * Extract a gzipped tar by PULLING it from `url`, straight into `cwd`.
+ *
+ * The push equivalent above cannot survive a multi-gigabyte archive, and not
+ * for want of streaming in the handler: Bun.serve queues a request body in
+ * memory whenever the handler reads slower than the wire delivers it, measured
+ * at +2423 MB of RSS for a 1 GB body against +94 MB when the reader keeps up.
+ * `tar` extracting gigabytes never keeps up, so the archive accumulated in the
+ * guest's 4 GiB and the kernel panicked. Reading the body more carefully cannot
+ * help, because the accumulation is below the handler.
+ *
+ * Pulling moves the transfer out of Bun's stream layer entirely: `curl | tar`
+ * is a kernel pipe, which blocks the writer when the reader falls behind. That
+ * is the backpressure the whole path was missing, and it costs one 64 KB pipe
+ * buffer rather than the archive.
+ *
+ * Integrity is gzip's: a truncated or corrupted transfer fails the CRC and
+ * ISIZE check at the end of the stream, so `tar` exits non-zero rather than
+ * leaving a plausible-looking partial workspace. Callers treat hydrate as
+ * fail-closed, so that is the correct outcome.
+ */
+export async function extractTarFromUrl(
+  url: string,
+  cwd: string,
+  keep: RegExp,
+  opts: { maxSeconds: number; spawn?: typeof Bun.spawn },
+): Promise<{ matched: string[] }> {
+  const spawn = opts.spawn ?? Bun.spawn
+  const listingPath = spoolPath('tar-listing.txt')
+  const fd = openSync(listingPath, 'w')
+  let fdOpen = true
+
+  try {
+    // No `--retry`: curl restarts a failed transfer from the beginning, and
+    // with the output already partly consumed by tar that produces a corrupt
+    // extraction rather than a clean failure. Hydrate is fail-closed and the
+    // control plane retries the whole assign, which is the safe granularity.
+    const proc = spawn(['bash', '-c', PULL_SCRIPT, 'hydrate', url, cwd, String(opts.maxSeconds)], {
+      stdout: fd,
+      stderr: fd,
+    })
+
+    const code = await proc.exited
+    closeSync(fd)
+    fdOpen = false
+
+    const { matched, tail } = await scanTarOutput(
+      Bun.file(listingPath).stream() as unknown as ReadableStream<Uint8Array>,
+      keep,
+      STDERR_TAIL_BYTES,
+    )
+    if (code !== 0) {
+      throw new Error(`pull-extract exited ${code}: ${redactUrls(tail).trim().slice(-400) || 'no output'}`)
+    }
+    return { matched }
+  } finally {
+    if (fdOpen) {
+      try {
+        closeSync(fd)
+      } catch {}
+    }
+    try {
+      unlinkSync(listingPath)
+    } catch {}
+  }
+}
+
+/**
+ * `$1` url, `$2` destination, `$3` max seconds.
+ *
+ * `pipefail` is what makes a failed download a failed hydrate. Without it the
+ * exit status is tar's alone, and a curl that dies mid-transfer reads as
+ * success on a partial tree — the silent-wrong-answer shape this path has
+ * already produced once.
+ */
+const PULL_SCRIPT = `set -o pipefail
+curl -fsS --max-time "$3" -- "$1" | tar ${TAR_ARGS.join(' ')} -C "$2"`
+
+/**
+ * Strip query strings from any URL in text bound for a log or an error.
+ *
+ * The pull URL carries its own credential in `X-Amz-Signature`. curl does not
+ * normally echo the URL, but "normally" is not a property worth relying on for
+ * something that would put a live, if short-lived, read capability into the log
+ * stream.
+ */
+export function redactUrls(text: string): string {
+  return text.replace(/\bhttps?:\/\/\S+/g, (m) => {
+    try {
+      const u = new URL(m)
+      return u.search ? `${u.origin}${u.pathname}?…` : m
+    } catch {
+      return m
+    }
+  })
+}
+
+/**
  * Scan a tar output stream line by line, keeping only what the caller asked
  * for plus (optionally) a bounded tail for error reporting.
  *


### PR DESCRIPTION
The fix for the 2 GB cold boot. Follow-up to #856, #857, #858, #859 — and the reason none of them worked.

## What was actually wrong

`Bun.serve` queues a request body in memory whenever the handler reads slower than the wire delivers it. Same server, same 1 GB chunked body, measured on the staging host:

| handler | peak RSS |
| --- | --- |
| reads at wire speed | +94 MB |
| held to 60 MB/s | +2423 MB |

`tar` extracting gigabytes is far slower than the virtio link, so it is always the second row. The archive accumulated in the guest's 4 GiB and the kernel panicked: `Out of memory and no killable processes`, 3.88 GB of `inactive_anon`, PID 1 `bun`.

Every earlier probe measured a consumer that drained at wire speed, which is why this kept reading as fixed. Streaming the handler (#857), removing its spool (#858), and dropping `Content-Length` (#859) were each real fixes to real problems — 1.1 GB cold-boots in 44.6 s where it used to 413 — but none could reach this, because the accumulation happens below the handler. Reading the body more carefully cannot fix a body that is already resident.

Pulling can. The response direction is no better in Bun (+1728 MB for a slow consumer), so the transfer has to leave Bun's stream layer entirely: `curl | tar` is a kernel pipe, which blocks the writer when the reader falls behind. The host HEADs the object for the lineage ETag and size it needs, mints a 30-minute presigned GET, and hands over a URL. Neither process holds the archive, and the host stops downloading it — today it buffers all 2 GB itself on every cold boot.

Verified against OCI's S3-compatibility endpoint before building on it: presigned GET returns 200 with byte-identical content, an expired URL 403s, and the same signature against a different key 403s.

## Notes for review

- **`set -o pipefail` is load-bearing.** Without it the exit status is tar's alone, and a curl that dies mid-transfer reads as success over a partial tree — a project that silently opens as the template, which is the incident this subsystem exists to prevent. Pinned by test.
- **No `--retry`.** curl restarts a failed transfer from the beginning, and with the output already partly consumed by tar that produces a corrupt extraction rather than a clean failure. Hydrate is fail-closed and the control plane retries the whole assign, which is the right granularity.
- **Integrity is gzip's.** A truncated transfer fails the CRC/ISIZE check at the end of the stream, so tar exits non-zero rather than leaving a plausible partial workspace.
- **The URL is a bearer capability** for one object, 30 minutes, read-only, handed to guest code. It never reaches a log: `redactUrls` strips the query from anything bound for an error or a log line.
- **Rollout ordering is free.** The guest runtime ships in a rootfs image and the host in an agent bundle, so for a window one side is new and the other is not. A guest without the pull endpoint answers 404 and the host pushes as before; without that the whole fleet fails to cold-boot during the window, and hydrate is fail-closed, so projects simply would not open.

## Test plan

- [x] Pull extracts, filters the listing, and feeds the SQLite sidecar check.
- [x] A 404 origin, a truncated transfer, and a stalled one all fail the hydrate rather than passing as an empty one.
- [x] Memory stays flat across a 256 MB pull.
- [x] Host prefers the pull, never downloads on that path, falls back on 404, and treats any other failure as an error rather than a reason to push gigabytes.
- [x] `describeObject` does not read the object, propagates transport errors instead of reporting "no backup", and degrades to a push when presigning is unavailable.
- [x] metal-agent 241 pass, 0 fail. agent-runtime spool/writable-state/tar-stream 57 pass, 0 fail. Typecheck unchanged.
- [ ] 2 GB staging cold boot. Needs a rootfs rebuild, so ~25 min after merge.

Made with [Cursor](https://cursor.com)