### PR TITLE
ci: run the desktop bundle + launcher assertions on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,5 +182,22 @@ jobs:
         # then add `--strict` here.
         run: bun run check:desktop-schema-drift
 
+      - name: Desktop bundle + launcher assertions
+        # test-web-bundle.ts / test-sync-web.ts / test-forge-config.ts are
+        # hand-rolled assertion scripts rather than `bun test` files, so
+        # `bun run test` never picked them up and nothing ran them in CI —
+        # they only fired if someone remembered `bun run test:desktop-bundle`
+        # locally. That let the guards they encode rot silently: the
+        # shogo://app/ routing + integrity logic that fixed Monaco's stuck
+        # "Loading…", the sync-web.mjs contract that kept v1.8.12 from
+        # shipping without Monaco at all, and the forge prePackage hooks.
+        #
+        # Runs the `:ci` subset, which drops test:shogo-ide-bundle — that one
+        # shells out to sync-shogo-ide.mjs and requires
+        # extensions/shogo-core/dist/extension.js, a gitignored build artifact
+        # absent from a bare CI checkout. The other three are pure/tmpdir-only
+        # and finish in well under a second.
+        run: bun run --cwd apps/desktop test:desktop-bundle:ci
+
       - name: Test
         run: bun run test

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,6 +20,8 @@
     "test:shogo-ide-bundle": "node scripts/sync-shogo-ide.mjs",
     "test:packaged-shogo-ide": "node scripts/assert-packaged-shogo-ide.mjs",
     "test:desktop-bundle": "bun test-web-bundle.ts && bun test-sync-web.ts && bun test-forge-config.ts && npm run test:shogo-ide-bundle",
+    "//test:desktop-bundle:ci": "The subset of test:desktop-bundle that needs no build artifacts, so PR CI can run it on a bare checkout. Excludes test:shogo-ide-bundle, which requires extensions/shogo-core/dist/extension.js (gitignored).",
+    "test:desktop-bundle:ci": "bun test-web-bundle.ts && bun test-sync-web.ts && bun test-forge-config.ts",
     "//package": "sync-web.mjs is invoked by forge's `prePackage` hook (see forge.config.ts) so it fires for both `npm run package` AND `npx electron-forge package` — the npm `prepackage` lifecycle hook only covered the former and let v1.8.12/v1.8.13 ship without Monaco.",
     "package": "electron-forge package",
     "make": "electron-forge make",


### PR DESCRIPTION
## Summary

Found while reviewing #828: it adds 7 assertions to `apps/desktop/test-forge-config.ts`, but **nothing in CI ever runs that file.**

`test-web-bundle.ts`, `test-sync-web.ts` and `test-forge-config.ts` are hand-rolled assertion scripts rather than `bun test` files, so `bun run test` never collects them, and no workflow invokes `test:desktop-bundle`. They only run when someone remembers to run them locally.

That means the guards they encode have been unenforced:

- the `shogo://app/` routing + integrity logic that fixed Monaco getting stuck on "Loading…"
- the `sync-web.mjs` contract whose absence shipped v1.8.12 without Monaco at all
- the forge `prePackage` hooks that pull the web bundle and Shogo IDE into the package

## Changes

- Adds a `test:desktop-bundle:ci` script — the subset of `test:desktop-bundle` that needs no build artifacts.
- Adds a CI step that runs it, placed with the other desktop guards ahead of `Test`.

`test:shogo-ide-bundle` is deliberately excluded: it shells out to `sync-shogo-ide.mjs`, which requires `extensions/shogo-core/dist/extension.js`, a gitignored build artifact that isn't in a bare CI checkout. Wiring that in would mean building the IDE extension in PR CI, which is a much bigger cost for a separate discussion.

## Test plan

- [x] `bun run --cwd apps/desktop test:desktop-bundle:ci` passes on `main` — 72 assertions (21 + 17 + 34)
- [x] Confirmed the excluded `test:shogo-ide-bundle` fails on a bare checkout for the stated reason
- [x] Workflow YAML parses; step resolves to the intended command
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)