### PR TITLE
fix(runtime): rebuild Expo canvas after IDE saves and poisoned stack markers

### DIFF
--- a/apps/api/src/__tests__/project-export-import.test.ts
+++ b/apps/api/src/__tests__/project-export-import.test.ts
@@ -346,6 +346,95 @@ describe('runImport', () => {
     expect(chatMessages.length).toBe(1)
   })
 
+  test('infers expo-app from workspace files when settings omit techStackId', async () => {
+    members.set('m-1', { id: 'm-1', userId: 'u-1', workspaceId: 'w-1' })
+    const buf = zipSync({
+      'project.json': strToU8(makeProjectJson()),
+      'workspace/package.json': strToU8(
+        JSON.stringify({
+          name: 'singing',
+          dependencies: { expo: '~57.0.14', 'expo-router': '~57.0.14' },
+        }),
+      ),
+      'workspace/app.json': strToU8(JSON.stringify({ expo: { name: 'Singing' } })),
+    })
+    const result = await runImport(
+      buf,
+      'w-1',
+      'u-1',
+      { includeChats: false, runBootstrap: false },
+      () => {},
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const row = projects.get(result.project.id)
+    expect(row?.settings).toMatchObject({
+      activeMode: 'canvas',
+      canvasEnabled: true,
+      techStackId: 'expo-app',
+    })
+    // Must be a real object — JSON.stringify here becomes a jsonb string
+    // scalar on Postgres and `settings?.techStackId` is undefined on cloud.
+    expect(typeof row?.settings).toBe('object')
+    const marker = join(tmpRoot, result.project.id, '.tech-stack')
+    expect(existsSync(marker)).toBe(true)
+    expect(readFileSync(marker, 'utf8')).toBe('expo-app')
+  })
+
+  test('does not override an explicit chat-only project that already has a stack id', async () => {
+    members.set('m-1', { id: 'm-1', userId: 'u-1', workspaceId: 'w-1' })
+    const bundle = JSON.parse(makeProjectJson())
+    bundle.project.settings = {
+      activeMode: 'none',
+      canvasEnabled: false,
+      techStackId: 'expo-app',
+    }
+    const buf = zipSync({
+      'project.json': strToU8(JSON.stringify(bundle)),
+      'workspace/package.json': strToU8(
+        JSON.stringify({ dependencies: { expo: '~57.0.0' } }),
+      ),
+    })
+    const result = await runImport(
+      buf,
+      'w-1',
+      'u-1',
+      { includeChats: false, runBootstrap: false },
+      () => {},
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(projects.get(result.project.id)?.settings).toMatchObject({
+      activeMode: 'none',
+      canvasEnabled: false,
+      techStackId: 'expo-app',
+    })
+  })
+
+  test('keeps an explicit settings.techStackId over file heuristics', async () => {
+    members.set('m-1', { id: 'm-1', userId: 'u-1', workspaceId: 'w-1' })
+    const bundle = JSON.parse(makeProjectJson())
+    bundle.project.settings = { activeMode: 'canvas', techStackId: 'python-data' }
+    const buf = zipSync({
+      'project.json': strToU8(JSON.stringify(bundle)),
+      'workspace/package.json': strToU8(
+        JSON.stringify({ dependencies: { expo: '~57.0.0' } }),
+      ),
+    })
+    const result = await runImport(
+      buf,
+      'w-1',
+      'u-1',
+      { includeChats: false, runBootstrap: false },
+      () => {},
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(projects.get(result.project.id)?.settings).toMatchObject({
+      techStackId: 'python-data',
+    })
+  })
+
   test('unsupported bundle version emits non-fatal warning but still imports', async () => {
     members.set('m-1', { id: 'm-1', userId: 'u-1', workspaceId: 'w-1' })
     const buf = zipSync({

--- a/apps/api/src/lib/__tests__/infer-tech-stack.test.ts
+++ b/apps/api/src/lib/__tests__/infer-tech-stack.test.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+import { describe, expect, test } from 'bun:test'
+import { inferTechStackId, isKnownTechStackId } from '../infer-tech-stack'
+
+function u8(text: string): Uint8Array {
+  return new TextEncoder().encode(text)
+}
+
+describe('isKnownTechStackId', () => {
+  test('accepts registry ids and rejects unknowns', () => {
+    expect(isKnownTechStackId('expo-app')).toBe(true)
+    expect(isKnownTechStackId('none')).toBe(true)
+    expect(isKnownTechStackId('expo-cli-tools')).toBe(false)
+    expect(isKnownTechStackId('')).toBe(false)
+    expect(isKnownTechStackId(null)).toBe(false)
+  })
+})
+
+describe('inferTechStackId', () => {
+  test('settings.techStackId wins when it is a known id', () => {
+    expect(
+      inferTechStackId({
+        settingsTechStackId: 'python-data',
+        files: {
+          'workspace/package.json': u8(JSON.stringify({ dependencies: { expo: '1' } })),
+        },
+      }),
+    ).toBe('python-data')
+  })
+
+  test('ignores unknown settings ids and falls through to the marker', () => {
+    expect(
+      inferTechStackId({
+        settingsTechStackId: 'totally-made-up',
+        files: { 'workspace/.tech-stack': u8('expo-three\n') },
+      }),
+    ).toBe('expo-three')
+  })
+
+  test('keeps an explicit none rather than inferring from files', () => {
+    expect(
+      inferTechStackId({
+        settingsTechStackId: 'none',
+        files: {
+          'workspace/package.json': u8(JSON.stringify({ dependencies: { expo: '1' } })),
+        },
+      }),
+    ).toBe('none')
+  })
+
+  test('expo + expo-router package.json (no three) → expo-app', () => {
+    expect(
+      inferTechStackId({
+        files: {
+          'workspace/package.json': u8(
+            JSON.stringify({
+              dependencies: {
+                expo: '~57.0.14',
+                'expo-router': '~57.0.14',
+                'react-native': '0.86.2',
+              },
+            }),
+          ),
+          'workspace/app.json': u8(JSON.stringify({ expo: { name: 'Singing' } })),
+        },
+      }),
+    ).toBe('expo-app')
+  })
+
+  test('expo + three.js → expo-three', () => {
+    expect(
+      inferTechStackId({
+        files: {
+          'package.json': u8(
+            JSON.stringify({
+              dependencies: { expo: '1', '@react-three/fiber': '8', 'expo-gl': '14' },
+            }),
+          ),
+        },
+      }),
+    ).toBe('expo-three')
+  })
+
+  test('react-native without expo → react-native', () => {
+    expect(
+      inferTechStackId({
+        files: {
+          'workspace/package.json': u8(
+            JSON.stringify({ dependencies: { 'react-native': '0.76.0' } }),
+          ),
+        },
+      }),
+    ).toBe('react-native')
+  })
+
+  test('phaser / three / python / unity file signals', () => {
+    expect(
+      inferTechStackId({
+        files: { 'workspace/package.json': u8(JSON.stringify({ dependencies: { phaser: '3' } })) },
+      }),
+    ).toBe('phaser-game')
+    expect(
+      inferTechStackId({
+        files: { 'workspace/package.json': u8(JSON.stringify({ dependencies: { three: '0.160' } })) },
+      }),
+    ).toBe('threejs-game')
+    expect(
+      inferTechStackId({ files: { 'workspace/requirements.txt': u8('numpy==1.0\n') } }),
+    ).toBe('python-data')
+    expect(
+      inferTechStackId({
+        files: { 'workspace/ProjectSettings/ProjectVersion.txt': u8('m_EditorVersion: 2022.3\n') },
+      }),
+    ).toBe('unity-game')
+  })
+
+  test('does not guess react-app for a generic workspace', () => {
+    expect(
+      inferTechStackId({
+        files: {
+          'workspace/README.md': u8('# hi\n'),
+          'workspace/package.json': u8(JSON.stringify({ dependencies: { react: '19' } })),
+        },
+      }),
+    ).toBeUndefined()
+  })
+})

--- a/apps/api/src/lib/infer-tech-stack.ts
+++ b/apps/api/src/lib/infer-tech-stack.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Infer a first-party tech-stack id from an imported .shogo bundle.
+ *
+ * `settings.techStackId` is the UI/runtime source of truth, but older
+ * bundles (and ports that never went through the stack picker) ship
+ * without it and without a workspace `.tech-stack` marker. Import then
+ * creates a project whose picker shows "None" and whose runtime falls
+ * back to Vite/`react-app` — even when the workspace is clearly Expo.
+ *
+ * Preference order:
+ *   1. `settings.techStackId` when it names a known registry entry
+ *   2. workspace `.tech-stack` marker
+ *   3. workspace files (`package.json`, `app.json`, …)
+ *
+ * Unknown / unconfident workspaces return `undefined` rather than
+ * guessing `react-app`.
+ */
+
+/** Keep in sync with `TECH_STACK_REGISTRY` in packages/core. */
+const KNOWN_STACK_IDS = new Set([
+  'react-app',
+  'threejs-game',
+  'phaser-game',
+  'expo-app',
+  'expo-three',
+  'react-native',
+  'python-data',
+  'unity-game',
+  'none',
+])
+
+export type WorkspaceFileMap = Record<string, Uint8Array | string>
+
+export function isKnownTechStackId(id: string | null | undefined): boolean {
+  if (!id) return false
+  return KNOWN_STACK_IDS.has(id.trim())
+}
+
+function asText(data: Uint8Array | string): string {
+  return typeof data === 'string' ? data : new TextDecoder().decode(data)
+}
+
+function fileText(files: WorkspaceFileMap, relPath: string): string | null {
+  const normalised = relPath.replace(/\\/g, '/')
+  const direct = files[normalised] ?? files[`workspace/${normalised}`]
+  if (direct != null) return asText(direct)
+  return null
+}
+
+function knownId(id: string | null | undefined): string | undefined {
+  if (!id) return undefined
+  const trimmed = id.trim()
+  return KNOWN_STACK_IDS.has(trimmed) ? trimmed : undefined
+}
+
+function packageDeps(files: WorkspaceFileMap): Set<string> {
+  const raw = fileText(files, 'package.json')
+  if (!raw) return new Set()
+  try {
+    const pkg = JSON.parse(raw) as {
+      dependencies?: Record<string, unknown>
+      devDependencies?: Record<string, unknown>
+    }
+    return new Set([
+      ...Object.keys(pkg.dependencies ?? {}),
+      ...Object.keys(pkg.devDependencies ?? {}),
+    ])
+  } catch {
+    return new Set()
+  }
+}
+
+function hasExpoAppConfig(files: WorkspaceFileMap): boolean {
+  if (fileText(files, 'app.config.js') || fileText(files, 'app.config.ts')) return true
+  const appJson = fileText(files, 'app.json')
+  if (!appJson) return false
+  try {
+    const parsed = JSON.parse(appJson) as { expo?: unknown }
+    return parsed != null && typeof parsed === 'object' && parsed.expo != null
+  } catch {
+    return false
+  }
+}
+
+function inferFromWorkspaceFiles(files: WorkspaceFileMap): string | undefined {
+  const deps = packageDeps(files)
+  const has = (name: string) => deps.has(name)
+  const expoish = has('expo') || has('expo-router') || hasExpoAppConfig(files)
+  const threeish =
+    has('three') || has('@react-three/fiber') || has('expo-gl') || has('expo-three')
+
+  if (expoish) return threeish ? 'expo-three' : 'expo-app'
+  if (has('react-native')) return 'react-native'
+  if (has('phaser')) return 'phaser-game'
+  if (threeish) return 'threejs-game'
+
+  if (
+    fileText(files, 'requirements.txt') ||
+    fileText(files, 'pyproject.toml') ||
+    fileText(files, 'Pipfile')
+  ) {
+    return 'python-data'
+  }
+
+  if (fileText(files, 'ProjectSettings/ProjectVersion.txt')) return 'unity-game'
+
+  return undefined
+}
+
+export function inferTechStackId(opts: {
+  settingsTechStackId?: unknown
+  files: WorkspaceFileMap
+}): string | undefined {
+  const fromSettings =
+    typeof opts.settingsTechStackId === 'string'
+      ? knownId(opts.settingsTechStackId)
+      : undefined
+  if (fromSettings) return fromSettings
+
+  const fromMarker = knownId(fileText(opts.files, '.tech-stack'))
+  if (fromMarker) return fromMarker
+
+  return inferFromWorkspaceFiles(opts.files)
+}

--- a/apps/api/src/routes/__tests__/project-import-install-marker.test.ts
+++ b/apps/api/src/routes/__tests__/project-import-install-marker.test.ts
@@ -180,6 +180,9 @@ describe('runImport — strip .shogo/install-marker', () => {
     expect(result.stats.filesSkipped).toBe(1)
     expect(result.stats.filesWritten).toBe(TOTAL_WORKSPACE_FILES_IN_BUNDLE - 1)
 
+    const created = [...prismaState.projects.values()][0]
+    expect(created?.settings).toMatchObject({ techStackId: 'expo-app' })
+
     // None of the writeFiles SSE events should report a path under
     // `.shogo/install-marker`. Prove by asserting that no such file
     // appears in either the writeFiles `path` payloads (if any) or the

--- a/apps/api/src/routes/project-export-import.ts
+++ b/apps/api/src/routes/project-export-import.ts
@@ -27,6 +27,8 @@ import {
   ZipPasswordError,
 } from '../lib/zip-encryption'
 import { deriveProjectRuntimeToken } from '../lib/project-runtime-token'
+import { normalizeProjectSettings, parseProjectSettings } from '../lib/project-settings'
+import { inferTechStackId, isKnownTechStackId } from '../lib/infer-tech-stack'
 
 const PROJECT_ROOT = resolve(import.meta.dir, '../../../..')
 const WORKSPACES_DIR = process.env.WORKSPACES_DIR || resolve(PROJECT_ROOT, 'workspaces')
@@ -534,6 +536,43 @@ export async function runImport(
   await emit({ phase: 'parse' })
 
   const bp = bundle.project
+  // Persist settings as a real object (not a JSON string). Stringifying
+  // here made Postgres store a jsonb string scalar, so
+  // `settings?.techStackId` was undefined on cloud even when the bundle
+  // carried a stack id. Also fill a missing stack from the workspace —
+  // older exports and ports that skipped the picker ship Expo/RN trees
+  // with `{ activeMode, canvasEnabled }` only.
+  const bundleSettings = parseProjectSettings(bp.settings)
+  const importedSettings: Record<string, unknown> = {
+    activeMode: 'none',
+    canvasEnabled: false,
+    ...(bundleSettings ?? {}),
+  }
+  const bundleHadKnownStack = isKnownTechStackId(
+    typeof bundleSettings?.techStackId === 'string' ? bundleSettings.techStackId : undefined,
+  )
+  const inferredStack = inferTechStackId({
+    settingsTechStackId: importedSettings.techStackId,
+    files: unzipped,
+  })
+  if (inferredStack) importedSettings.techStackId = inferredStack
+
+  // Bundles that skipped the stack picker ship the chat-only defaults
+  // (`activeMode: none`, `canvasEnabled: false`). Inferring Expo/Vite/…
+  // from the workspace means this is an app, not a chat-only agent —
+  // otherwise import lands in fullscreen chat with the Canvas tab hidden
+  // and Settings → Canvas does not leave that view (layout bug).
+  if (
+    inferredStack &&
+    inferredStack !== 'none' &&
+    !bundleHadKnownStack &&
+    importedSettings.activeMode === 'none' &&
+    importedSettings.canvasEnabled === false
+  ) {
+    importedSettings.activeMode = 'canvas'
+    importedSettings.canvasEnabled = true
+  }
+
   const project = await prisma.project.create({
     data: {
       name: bp.name || 'Imported Project',
@@ -547,14 +586,7 @@ export async function runImport(
       category: (bp.category as any) ?? null,
       siteTitle: bp.siteTitle ?? null,
       siteDescription: bp.siteDescription ?? null,
-      settings: bp.settings
-        ? typeof bp.settings === 'string'
-          ? bp.settings
-          : JSON.stringify(bp.settings)
-        : JSON.stringify({
-            activeMode: 'none',
-            canvasEnabled: false,
-          }),
+      settings: (normalizeProjectSettings(importedSettings) ?? importedSettings) as object,
     },
   })
 
@@ -661,6 +693,21 @@ export async function runImport(
     // client gets a smooth progress bar without flooding the SSE stream.
     if ((i + 1) % 25 === 0 || i === workspaceEntries.length - 1) {
       await emit({ phase: 'writeFiles', done: i + 1, total: totalFiles })
+    }
+  }
+
+  // Keep the workspace marker in lockstep with settings.techStackId so
+  // PreviewManager / seedTechStack don't fall back to Vite when the
+  // bundle omitted `.tech-stack` (the singing-expo import case).
+  if (inferredStack) {
+    try {
+      writeFileSync(join(projectDir, '.tech-stack'), inferredStack, 'utf-8')
+    } catch (err: any) {
+      await emit({
+        phase: 'error',
+        message: `Failed to write .tech-stack: ${err?.message || 'unknown error'}`,
+        fatal: false,
+      })
     }
   }
 
@@ -1036,17 +1083,7 @@ export function projectExportImportRoutes() {
         })
       : []
 
-    let settings: any = null
-    if (project.settings) {
-      try {
-        settings =
-          typeof project.settings === 'string'
-            ? JSON.parse(project.settings)
-            : project.settings
-      } catch {
-        settings = project.settings
-      }
-    }
+    let settings: Record<string, unknown> = parseProjectSettings(project.settings) ?? {}
 
     // Parse channels: Prisma SQLite returns Json columns as strings, while
     // Postgres returns parsed values.
@@ -1129,6 +1166,25 @@ export function projectExportImportRoutes() {
     for (const [relPath, data] of Object.entries(collectedFiles)) {
       zipContents[`workspace/${relPath}`] = data
     }
+
+    // Older projects (and ports) may have a real Expo/RN tree but an empty
+    // settings object. Fill techStackId from `.tech-stack` or workspace
+    // files so the next import doesn't land as "None".
+    if (typeof settings.techStackId !== 'string' || !String(settings.techStackId).trim()) {
+      const inferred = inferTechStackId({
+        settingsTechStackId: settings.techStackId,
+        files: collectedFiles,
+      })
+      if (inferred) settings.techStackId = inferred
+    }
+    if (
+      typeof settings.techStackId === 'string' &&
+      isKnownTechStackId(settings.techStackId) &&
+      zipContents['workspace/.tech-stack'] === undefined
+    ) {
+      zipContents['workspace/.tech-stack'] = strToU8(settings.techStackId)
+    }
+    zipContents['project.json'] = strToU8(JSON.stringify(projectJson, null, 2))
 
     // ─── Context Files seed ────────────────────────────────────────────
     // The 5 Context Files surfaced in the Studio Status panel must always

--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -52,6 +52,8 @@ import { API_URL, api } from '../../../../lib/api'
 import { openWebAppSession } from '../../../../lib/openWebAppSession'
 import { chatSessionEvents, chatActivityEvents } from '../../../../lib/chat-session-events'
 import { workspaceProjectFilter } from '../../../../lib/project-load'
+import { canvasDisabledRedirect } from '../../../../lib/project-preview-tab'
+import { getActiveWorkspaceId } from '../../../../lib/workspace-store'
 import { getActiveWorkspaceId } from '../../../../lib/workspace-store'
 import { usePlatformConfig } from '../../../../lib/platform-config'
 import { consumePendingFiles } from '../../../../lib/pending-image-store'
@@ -505,8 +507,12 @@ export default observer(function ProjectLayout() {
     if (!projectId) return
     const merged = { ...projectSettings, ...patch }
     const settingsStr = JSON.stringify(merged)
-    await actions.updateProject(projectId, { settings: settingsStr as any })
+    // Optimistic: the canvasEnabled effect used to snap previewTab back to
+    // chat-fullscreen whenever canvasEnabled was still false. Waiting for the
+    // PATCH before updating local settings left a one-render window where
+    // clicking Canvas bounced immediately.
     setProject((prev: any) => prev ? { ...prev, settings: settingsStr } : prev)
+    await actions.updateProject(projectId, { settings: settingsStr as any })
   }, [projectId, projectSettings, actions])
 
   const handleUpdateCanvasSettings = useCallback(async (themeSettings: Record<string, unknown>) => {
@@ -1512,6 +1518,10 @@ export default observer(function ProjectLayout() {
   // (and thus its `workingMode`) is known. Tracks the project it ran for so a
   // navigation to a different project re-applies.
   const previewTabInitForRef = useRef<string | null>(null)
+  // Set when the user (or Agent Type switch) explicitly asks for canvas this
+  // session. Stops the canvas-disabled effect and a stale `?tab=chat-fullscreen`
+  // from the sidebar from snapping them back to chat-only.
+  const userRequestedCanvasRef = useRef(false)
 
   // Sidebar "open project" tab intent. Clicking a project name in the sidebar
   // deep-links a `tab` param (canvas / chat-fullscreen / external-preview). It
@@ -1538,6 +1548,9 @@ export default observer(function ProjectLayout() {
     }
     const token = `${projectId}:${requested}:${params.tabNonce ?? ''}`
     if (appliedTabIntentRef.current === token) return
+    // A leftover `?tab=chat-fullscreen` from opening this project while it
+    // was still chat-only must not override a Canvas click this session.
+    if (userRequestedCanvasRef.current && requested === 'chat-fullscreen') return
     appliedTabIntentRef.current = token
     previewTabInitForRef.current = projectId
     setPreviewTab(requested)
@@ -1686,18 +1699,18 @@ export default observer(function ProjectLayout() {
       if (
         activeTab === 'canvas' &&
         previewTab !== 'app-preview' &&
+        previewTab !== 'canvas' &&
         !STANDALONE_PANELS.includes(previewTab)
       ) {
         setActiveTab('chat')
       }
-      // Canvas is off. For folder-linked external projects we have a
-      // first-class preview surface (the embedded Electron webview), so
-      // land there by default; users still get chat-fullscreen for
-      // managed-but-canvas-off projects, where there's no preview to
-      // show.
-      if (previewTab === 'canvas') {
-        setPreviewTab(isExternalProject ? 'external-preview' : 'chat-fullscreen')
-      }
+      const bounceTo = canvasDisabledRedirect({
+        canvasEnabled,
+        previewTab,
+        isExternalProject,
+        userRequestedCanvas: userRequestedCanvasRef.current,
+      })
+      if (bounceTo) setPreviewTab(bounceTo)
     } else if (canvasEnabled) {
       if (previewTab === 'app-preview') setPreviewTab('canvas')
     }
@@ -1728,8 +1741,20 @@ export default observer(function ProjectLayout() {
     }
     // Any explicit user navigation cancels an in-flight attention override.
     setAttentionTab(null)
+    if (tabId === 'canvas') {
+      userRequestedCanvasRef.current = true
+      if (!canvasEnabled || activeMode !== 'canvas') {
+        void updateProjectSettings({ activeMode: 'canvas', canvasEnabled: true })
+      }
+    }
     setPreviewTab(tabId)
-  }, [])
+    // Keep the sidebar landing-tab URL in sync. Opening this project while
+    // it was chat-only left `?tab=chat-fullscreen` in the URL; if that
+    // intent effect re-fires it would yank us back off Canvas.
+    if (typeof params.tab === 'string' && params.tab !== tabId) {
+      router.setParams({ tab: tabId } as any)
+    }
+  }, [activeMode, canvasEnabled, params.tab, router, updateProjectSettings])
 
   useEffect(() => {
     subagentStreamStore.onRequestTabSwitch((toolId?: string) => {
@@ -1789,19 +1814,25 @@ export default observer(function ProjectLayout() {
       }
     }
 
+    // Chat-only hides the Canvas tab (`activeMode !== 'canvas'`). Switching
+    // the agent type has to leave `chat-fullscreen` or the user stays
+    // trapped in a full-bleed chat with no preview — the previous branch
+    // only navigated on narrow + Settings, and even then kept `activeTab`
+    // on chat.
+    setAttentionTab(null)
     if (!enableCanvas) {
+      userRequestedCanvasRef.current = false
       setActiveTab('chat')
       setPreviewTab('chat-fullscreen')
-    } else if (
-      !isWide &&
-      previewTab === 'settings' &&
-      enableCanvas &&
-      activeMode === 'none'
-    ) {
-      setActiveTab('chat')
+    } else {
+      userRequestedCanvasRef.current = true
+      setActiveTab('canvas')
       setPreviewTab('canvas')
+      if (typeof params.tab === 'string' && params.tab !== 'canvas') {
+        router.setParams({ tab: 'canvas' } as any)
+      }
     }
-  }, [isWide, updateProjectSettings, agentUrl, nativeHeaders, previewTab, activeMode])
+  }, [updateProjectSettings, agentUrl, nativeHeaders, params.tab, router])
 
   const techStackId = projectSettings.techStackId as string | undefined
 
@@ -3099,6 +3130,10 @@ export default observer(function ProjectLayout() {
                 setAttentionTab(null)
                 setActiveTab(tab)
                 if (tab === 'canvas') {
+                  userRequestedCanvasRef.current = true
+                  if (!canvasEnabled || activeMode !== 'canvas') {
+                    void updateProjectSettings({ activeMode: 'canvas', canvasEnabled: true })
+                  }
                   setPreviewTab('canvas')
                 } else {
                   // Clear standalone preview (files, capabilities, …) so the chat column shows

--- a/apps/mobile/lib/__tests__/project-preview-tab.test.ts
+++ b/apps/mobile/lib/__tests__/project-preview-tab.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { defaultTabForProject } from '../project-preview-tab'
+import { canvasDisabledRedirect, defaultTabForProject } from '../project-preview-tab'
 
 describe('defaultTabForProject', () => {
   test('managed + canvas-enabled (default) → canvas', () => {
@@ -54,5 +54,51 @@ describe('defaultTabForProject', () => {
   test('null/undefined settings are tolerated', () => {
     expect(defaultTabForProject({ settings: null })).toBe('canvas')
     expect(defaultTabForProject({ settings: undefined })).toBe('canvas')
+  })
+})
+
+describe('canvasDisabledRedirect', () => {
+  test('does nothing when canvas is enabled', () => {
+    expect(
+      canvasDisabledRedirect({
+        canvasEnabled: true,
+        previewTab: 'canvas',
+        isExternalProject: false,
+        userRequestedCanvas: false,
+      }),
+    ).toBeNull()
+  })
+
+  test('bounces an unsolicited canvas tab back to chat-fullscreen', () => {
+    expect(
+      canvasDisabledRedirect({
+        canvasEnabled: false,
+        previewTab: 'canvas',
+        isExternalProject: false,
+        userRequestedCanvas: false,
+      }),
+    ).toBe('chat-fullscreen')
+  })
+
+  test('does not bounce after the user asked for canvas', () => {
+    expect(
+      canvasDisabledRedirect({
+        canvasEnabled: false,
+        previewTab: 'canvas',
+        isExternalProject: false,
+        userRequestedCanvas: true,
+      }),
+    ).toBeNull()
+  })
+
+  test('external projects bounce to external-preview, not chat', () => {
+    expect(
+      canvasDisabledRedirect({
+        canvasEnabled: false,
+        previewTab: 'canvas',
+        isExternalProject: true,
+        userRequestedCanvas: false,
+      }),
+    ).toBe('external-preview')
   })
 })

--- a/apps/mobile/lib/project-preview-tab.ts
+++ b/apps/mobile/lib/project-preview-tab.ts
@@ -52,3 +52,25 @@ export function defaultTabForProject(project: ProjectTabInput): PreviewTabId {
   // Canvas-capable builders land on the canvas.
   return 'canvas'
 }
+
+/**
+ * Auto-redirect when canvas is disabled. Returns the tab to switch to,
+ * or `null` to leave the current tab alone.
+ *
+ * A user click on Canvas must not bounce back to chat-fullscreen — that
+ * snap-back is what made Settings → Canvas / the Canvas tab unusable on
+ * imported chat-only projects. Callers pass `userRequestedCanvas` when
+ * the current `previewTab === 'canvas'` was an explicit click (or agent-
+ * type switch) this session.
+ */
+export function canvasDisabledRedirect(opts: {
+  canvasEnabled: boolean
+  previewTab: string
+  isExternalProject: boolean
+  userRequestedCanvas: boolean
+}): 'chat-fullscreen' | 'external-preview' | null {
+  if (opts.canvasEnabled) return null
+  if (opts.previewTab !== 'canvas') return null
+  if (opts.userRequestedCanvas) return null
+  return opts.isExternalProject ? 'external-preview' : 'chat-fullscreen'
+}

--- a/packages/agent-runtime/src/__tests__/canvas-build-manager.test.ts
+++ b/packages/agent-runtime/src/__tests__/canvas-build-manager.test.ts
@@ -348,6 +348,27 @@ describe('CanvasBuildManager waitForDeps gate', () => {
     await mgr.start()
     expect(completed).toBe(true)
   })
+
+  test('resolves expo bin that appears only after waitForDeps', async () => {
+    // Cloud/metal hydrate: CanvasBuildManager.start() races bun install.
+    // The bin is missing at first; waitForDeps is when it lands. If we
+    // resolveBundler() before the wait we skip forever and the imported
+    // dist/ never updates.
+    freshWorkspace({})
+    let completed = false
+    const mgr = new CanvasBuildManager(TMP, {
+      onBuildComplete: () => { completed = true },
+      onBuildError: () => {},
+      waitForDeps: async () => {
+        writeShim(join(TMP, 'node_modules', '.bin'), 'expo', {
+          stagingPayload: '<html>late-bin</html>',
+        })
+      },
+    })
+    await mgr.start()
+    expect(completed).toBe(true)
+    expect(readFileSync(join(TMP, 'dist', 'index.html'), 'utf-8')).toContain('late-bin')
+  })
 })
 
 /**

--- a/packages/agent-runtime/src/__tests__/canvas-file-watcher.test.ts
+++ b/packages/agent-runtime/src/__tests__/canvas-file-watcher.test.ts
@@ -121,6 +121,16 @@ describe('onFileChanged', () => {
     expect(calls).toBe(2)
   })
 
+  test('calls onRebuild for public/ worklets copied into dist unhashed', () => {
+    const watcher = new CanvasFileWatcher(tmpDir)
+    let rebuildCalled = false
+    watcher.setOnRebuild(() => { rebuildCalled = true })
+
+    watcher.onFileChanged('public/captureRelay.worklet.js', join(tmpDir, 'public', 'captureRelay.worklet.js'))
+
+    expect(rebuildCalled).toBe(true)
+  })
+
   test('ignores non-buildable paths', () => {
     const watcher = new CanvasFileWatcher(tmpDir)
     let rebuildCalled = false
@@ -166,6 +176,37 @@ describe('onFileDeleted', () => {
 
     watcher.onFileDeleted('MEMORY.md')
     expect(rebuildCalled).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// HTTP PUT/DELETE — same notifier the IDE uses after saving a file.
+// Firecracker guests often miss chokidar; without this path Expo dist
+// never rebuilds after an IDE save.
+// ---------------------------------------------------------------------------
+
+describe('IDE HTTP file notify', () => {
+  test('PUT-equivalent onFileChanged on src/*.ts triggers rebuild', () => {
+    const watcher = CanvasFileWatcher.getInstance(tmpDir)
+    let rebuildCalled = false
+    watcher.setOnRebuild(() => { rebuildCalled = true })
+
+    watcher.onFileChanged(
+      'src/hooks/useLiveEngine.web.ts',
+      join(tmpDir, 'src', 'hooks', 'useLiveEngine.web.ts'),
+    )
+
+    expect(rebuildCalled).toBe(true)
+  })
+
+  test('DELETE-equivalent onFileDeleted on src/*.tsx triggers rebuild', () => {
+    const watcher = CanvasFileWatcher.getInstance(tmpDir)
+    let rebuildCalled = false
+    watcher.setOnRebuild(() => { rebuildCalled = true })
+
+    watcher.onFileDeleted('src/hooks/useLiveEngine.web.ts')
+
+    expect(rebuildCalled).toBe(true)
   })
 })
 

--- a/packages/agent-runtime/src/__tests__/expo-cloud-rebuild.test.ts
+++ b/packages/agent-runtime/src/__tests__/expo-cloud-rebuild.test.ts
@@ -357,3 +357,123 @@ describe('Expo cloud rebuild repro', () => {
     }
   })
 })
+
+// ---------------------------------------------------------------------------
+// Repro: imported Expo preview never updates after edits (2026-08-30)
+// ---------------------------------------------------------------------------
+//
+// Project 2945c130 (Singing / Expo) was imported from a .shogo that had no
+// techStackId and no .tech-stack marker, but DID ship a prebuilt dist/.
+// Cloud boot then:
+//
+//   1. initializeEssentials: TECH_STACK_ID unset, no marker on disk
+//      → defaults to `react-app` and seedTechStack WRITES that marker.
+//   2. S3/hydrate overlays the Expo package.json + imported dist/.
+//      The react-app marker survives (the zip had none to overwrite it).
+//   3. CanvasBuildManager.markerNamesViteStack() sees react-app → bails.
+//      triggerRebuild() is a silent no-op. The iframe keeps serving the
+//      imported dist/ forever.
+//   4. PreviewManager.resolveDevServer() also reads react-app → vite.
+//      package.json has no vite, so vite-watch never starts either.
+//
+// The user-visible symptom: "I make changes and rebuild, preview doesn't
+// update." Dist contents never change.
+// ---------------------------------------------------------------------------
+
+function seedPoisonedImportedExpo(workspaceDir: string): void {
+  // What initializeEssentials writes when TECH_STACK_ID is missing.
+  writeFileSync(join(workspaceDir, '.tech-stack'), 'react-app')
+
+  const expoPkg = {
+    name: 'singing-expo',
+    private: true,
+    main: 'expo-router/entry',
+    dependencies: {
+      expo: '~57.0.14',
+      'expo-router': '~57.0.14',
+      react: '19.2.3',
+      'react-native': '0.86.2',
+    },
+  }
+  writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(expoPkg, null, 2))
+
+  mkdirSync(join(workspaceDir, 'app'), { recursive: true })
+  writeFileSync(
+    join(workspaceDir, 'app', 'index.tsx'),
+    `import { Text } from 'react-native'\nexport default () => <Text>original</Text>\n`,
+  )
+  mkdirSync(join(workspaceDir, 'dist'), { recursive: true })
+  writeFileSync(join(workspaceDir, 'dist', 'index.html'), '<html>imported-prebuilt-dist</html>')
+
+  writeBundlerShim(workspaceDir, 'expo')
+  writeBundlerShim(workspaceDir, 'vite')
+}
+
+describe('imported Expo preview never updates (poisoned react-app marker)', () => {
+  test('CanvasBuildManager rebuilds with expo despite .tech-stack=react-app', async () => {
+    seedPoisonedImportedExpo(TMP)
+
+    const mgr = new CanvasBuildManager(TMP, {
+      onBuildComplete: () => {},
+      onBuildError: () => {},
+    })
+    await mgr.start()
+
+    const dist = readFileSync(join(TMP, 'dist', 'index.html'), 'utf-8')
+    expect(dist).toContain('expo-built-this')
+    expect(dist).not.toContain('imported-prebuilt-dist')
+    expect(dist).not.toContain('vite-built-this')
+    expect(readInvocations()).toEqual(['expo'])
+  })
+
+  test('agent edit replaces the imported dist, not a no-op', async () => {
+    seedPoisonedImportedExpo(TMP)
+
+    const mgr = new CanvasBuildManager(TMP, {
+      onBuildComplete: () => {},
+      onBuildError: () => {},
+    })
+    const watcher = CanvasFileWatcher.getInstance(TMP)
+    watcher.setOnRebuild(() => mgr.triggerRebuild())
+    await mgr.start()
+
+    writeFileSync(
+      join(TMP, 'app', 'index.tsx'),
+      `import { Text } from 'react-native'\nexport default () => <Text>after-edit</Text>\n`,
+    )
+    watcher.onFileChanged('app/index.tsx', join(TMP, 'app', 'index.tsx'))
+
+    const sawSecondBuild = await waitFor(() => readInvocations().filter((s) => s === 'expo').length >= 2)
+    expect(sawSecondBuild).toBe(true)
+    expect(readFileSync(join(TMP, 'dist', 'index.html'), 'utf-8')).toContain('expo-built-this')
+    expect(readInvocations()).not.toContain('vite')
+  })
+
+  test('IDE save (HTTP PUT notify, not chokidar) replaces imported dist', async () => {
+    seedPoisonedImportedExpo(TMP)
+
+    const mgr = new CanvasBuildManager(TMP, {
+      onBuildComplete: () => {},
+      onBuildError: () => {},
+    })
+    const watcher = CanvasFileWatcher.getInstance(TMP)
+    watcher.setOnRebuild(() => mgr.triggerRebuild())
+    await mgr.start()
+
+    mkdirSync(join(TMP, 'src', 'hooks'), { recursive: true })
+    writeFileSync(
+      join(TMP, 'src', 'hooks', 'useLiveEngine.web.ts'),
+      'export function useLiveEngine() { return null }\n',
+    )
+    // Mirrors server.ts PUT /agent/workspace/files/* → onFileChanged.
+    watcher.onFileChanged(
+      'src/hooks/useLiveEngine.web.ts',
+      join(TMP, 'src', 'hooks', 'useLiveEngine.web.ts'),
+    )
+
+    const sawSecondBuild = await waitFor(() => readInvocations().filter((s) => s === 'expo').length >= 2)
+    expect(sawSecondBuild).toBe(true)
+    expect(readInvocations()).not.toContain('vite')
+  })
+})
+

--- a/packages/agent-runtime/src/__tests__/preview-manager.lifecycle.test.ts
+++ b/packages/agent-runtime/src/__tests__/preview-manager.lifecycle.test.ts
@@ -16,9 +16,11 @@ beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'pm-lc-'))
   delete process.env.PUBLIC_URL
   delete process.env.SHOGO_LOCAL_MODE
+  delete process.env.TECH_STACK_ID
 })
 afterEach(() => {
   rmSync(dir, { recursive: true, force: true })
+  delete process.env.TECH_STACK_ID
 })
 
 function mk(over: Partial<ConstructorParameters<typeof PreviewManager>[0]> = {}) {
@@ -129,6 +131,24 @@ describe('PreviewManager.resolveDevServer (via getStatus)', () => {
   it('defaults to "vite" when stack id is unknown', () => {
     writeFileSync(join(dir, '.tech-stack'), 'totally-made-up-stack')
     expect(mk().getStatus().devServer).toBe('vite')
+  })
+
+  it('uses metro when .tech-stack is react-app but package.json depends on expo', () => {
+    // Imported Expo projects land with a poisoned react-app marker because
+    // initializeEssentials defaults to react-app when TECH_STACK_ID is
+    // unset. Preview must still drive expo export, not vite-watch.
+    writeFileSync(join(dir, '.tech-stack'), 'react-app')
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ dependencies: { expo: '~57.0.14', 'expo-router': '~57.0.14' } }),
+    )
+    expect(mk().getStatus().devServer).toBe('metro')
+  })
+
+  it('TECH_STACK_ID=expo-app wins over a stale react-app marker', () => {
+    writeFileSync(join(dir, '.tech-stack'), 'react-app')
+    process.env.TECH_STACK_ID = 'expo-app'
+    expect(mk().getStatus().devServer).toBe('metro')
   })
 })
 

--- a/packages/agent-runtime/src/__tests__/static-asset-cache.test.ts
+++ b/packages/agent-runtime/src/__tests__/static-asset-cache.test.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+import { describe, expect, test } from 'bun:test'
+import {
+  isContentHashedFilename,
+  staticAssetCacheControl,
+} from '../static-asset-cache'
+
+describe('isContentHashedFilename', () => {
+  test('matches Expo export hashed JS/CSS', () => {
+    expect(isContentHashedFilename('entry-2a1fc96ca48b8c3d7e9f55403d900c70.js')).toBe(true)
+    expect(isContentHashedFilename('_expo/static/css/web-c0f8c76f038ca38fe232d90191304460.css')).toBe(true)
+  })
+
+  test('matches Vite hashed chunks', () => {
+    expect(isContentHashedFilename('index-B2xY9abc.js')).toBe(true)
+    expect(isContentHashedFilename('index-a1b2c3d4.js')).toBe(true)
+  })
+
+  test('rejects unhashed public/ worklets and wasm', () => {
+    expect(isContentHashedFilename('captureRelay.worklet.js')).toBe(false)
+    expect(isContentHashedFilename('pyin_f0_bg.wasm')).toBe(false)
+    expect(isContentHashedFilename('favicon.ico')).toBe(false)
+  })
+})
+
+describe('staticAssetCacheControl', () => {
+  test('pins hashed assets and revalidates the rest', () => {
+    expect(staticAssetCacheControl('entry-2a1fc96ca48b8c3d7e9f55403d900c70.js')).toBe(
+      'public, max-age=31536000, immutable',
+    )
+    expect(staticAssetCacheControl('captureRelay.worklet.js')).toBe('no-cache')
+  })
+})

--- a/packages/agent-runtime/src/__tests__/workspace-defaults-extra.test.ts
+++ b/packages/agent-runtime/src/__tests__/workspace-defaults-extra.test.ts
@@ -680,6 +680,52 @@ describe('workspaceUsesVite', () => {
   })
 })
 
+describe('resolveWorkspaceTechStackId + applyEnvTechStackMarker', () => {
+  afterEach(() => {
+    delete process.env.TECH_STACK_ID
+  })
+
+  test('TECH_STACK_ID env wins over a stale react-app marker', () => {
+    const dir = makeTmp()
+    writeFileSync(join(dir, '.tech-stack'), 'react-app')
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: { expo: '57' } }))
+    process.env.TECH_STACK_ID = 'expo-app'
+    expect(wd.resolveWorkspaceTechStackId(dir)).toBe('expo-app')
+  })
+
+  test('react-app marker on an Expo package.json resolves to expo-app', () => {
+    const dir = makeTmp()
+    writeFileSync(join(dir, '.tech-stack'), 'react-app')
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({
+      dependencies: { expo: '~57.0.14', 'expo-router': '~57.0.14' },
+    }))
+    expect(wd.resolveWorkspaceTechStackId(dir)).toBe('expo-app')
+  })
+
+  test('react-app marker on a real Vite package.json stays react-app', () => {
+    const dir = makeTmp()
+    writeFileSync(join(dir, '.tech-stack'), 'react-app')
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({
+      dependencies: { vite: '5', react: '18' },
+    }))
+    expect(wd.resolveWorkspaceTechStackId(dir)).toBe('react-app')
+  })
+
+  test('empty workspace defaults to react-app', () => {
+    expect(wd.resolveWorkspaceTechStackId(makeTmp())).toBe('react-app')
+  })
+
+  test('applyEnvTechStackMarker writes the env id and is a no-op without env', () => {
+    const dir = makeTmp()
+    writeFileSync(join(dir, '.tech-stack'), 'react-app')
+    expect(wd.applyEnvTechStackMarker(dir)).toBe(false)
+    expect(readFileSync(join(dir, '.tech-stack'), 'utf-8')).toBe('react-app')
+    process.env.TECH_STACK_ID = 'expo-app'
+    expect(wd.applyEnvTechStackMarker(dir)).toBe(true)
+    expect(readFileSync(join(dir, '.tech-stack'), 'utf-8')).toBe('expo-app')
+  })
+})
+
 describe('install-marker helpers', () => {
   test('readPlatformMarker null when missing; write+read round-trip via public re-exports', () => {
     const dir = makeTmp()

--- a/packages/agent-runtime/src/canvas-build-manager.ts
+++ b/packages/agent-runtime/src/canvas-build-manager.ts
@@ -65,6 +65,7 @@ import { spawn, type ChildProcess } from 'child_process'
 import { join } from 'path'
 import { existsSync, readFileSync } from 'fs'
 import { resolveBinInvocation } from '@shogo/shared-runtime'
+import { resolveWorkspaceTechStackId } from './workspace-defaults'
 import {
   commitBuildOutputAsync,
   cleanupStagingOutput,
@@ -274,9 +275,7 @@ export class CanvasBuildManager {
    */
   private preferredBundlerFromMarker(): BundlerKind | null {
     try {
-      const markerPath = join(this.workspaceDir, '.tech-stack')
-      if (!existsSync(markerPath)) return null
-      const stackId = readFileSync(markerPath, 'utf-8').trim()
+      const stackId = resolveWorkspaceTechStackId(this.workspaceDir)
       return STACK_TO_BUNDLER[stackId] ?? null
     } catch {
       return null
@@ -284,14 +283,15 @@ export class CanvasBuildManager {
   }
 
   /**
-   * Returns true when `.tech-stack` explicitly names a Vite stack.
-   * Used by `resolveBundler` to bail without falling through to
-   * `KNOWN_BUNDLERS` scan order — PreviewManager's vite-watch owns
-   * those workspaces. Kept as a tight string-set check so adding a
-   * new vite-flavored stack id only requires one edit (here).
+   * Skip this manager only when the workspace is *actually* a Vite
+   * stack. A missing marker still falls through to the Expo scan so
+   * marker-less workspaces keep working. A poisoned `react-app` marker
+   * on an Expo `package.json` resolves to `expo-app` and must not skip.
    */
   private markerNamesViteStack(): boolean {
     try {
+      const resolved = resolveWorkspaceTechStackId(this.workspaceDir)
+      if (STACK_TO_BUNDLER[resolved]) return false
       const markerPath = join(this.workspaceDir, '.tech-stack')
       if (!existsSync(markerPath)) return false
       const stackId = readFileSync(markerPath, 'utf-8').trim()
@@ -318,17 +318,17 @@ export class CanvasBuildManager {
     if (!existsSync(join(this.workspaceDir, 'package.json'))) {
       return
     }
-    const bundler = this.resolveBundler()
-    if (!bundler) {
-      return
-    }
 
     this.building = true
 
-    // Block the build on `PreviewManager.depsReady` if a gate is wired
-    // in. Critical for VM-isolated sessions on macOS hosts; harmless
-    // (resolves immediately) for cloud/k8s where the install has
-    // already completed by the time the gateway boots.
+    // Wait for deps BEFORE resolving the Expo bin. `start()` used to
+    // call `resolveBundler()` first and silently skip when
+    // `node_modules/.bin/expo` was not on disk yet — typical during
+    // metal hydrate / `bun install`. That skip never retried unless a
+    // later file notify arrived, so the imported `dist/` stayed
+    // frozen. Await `depsReady` first so the bin can appear, then
+    // resolve. Vite stacks still skip after the wait (see
+    // `markerNamesViteStack`).
     if (this.callbacks.waitForDeps) {
       try {
         await Promise.race([
@@ -345,6 +345,19 @@ export class CanvasBuildManager {
           `${LOG_PREFIX} waitForDeps gate did not settle (${err?.message ?? err}) — building anyway, expect platform-native errors if node_modules is incomplete`,
         )
       }
+    }
+
+    const bundler = this.resolveBundler()
+    if (!bundler) {
+      console.warn(
+        `${LOG_PREFIX} skip rebuild — no Expo bundler (missing node_modules/.bin/expo, or stack is Vite)`,
+      )
+      this.building = false
+      if (this.pendingBuild) {
+        this.pendingBuild = false
+        this.runBuild()
+      }
+      return
     }
 
     // Wipe any leftover staging dir from a prior crashed build so the

--- a/packages/agent-runtime/src/canvas-file-watcher.ts
+++ b/packages/agent-runtime/src/canvas-file-watcher.ts
@@ -3,13 +3,19 @@
 /**
  * CanvasFileWatcher — Detects workspace file changes and broadcasts events.
  *
- * Two input paths feed the same event stream:
+ * Three input paths feed the same event stream:
  *
  *   1. Explicit notifications from gateway-tools.ts when the chat agent's
  *      write_file / edit_file tools succeed. These are synchronous with the
  *      tool response and fire before the tool returns.
  *
- *   2. A chokidar watcher on the workspace root. This catches every write
+ *   2. Explicit notifications from `PUT`/`DELETE /agent/workspace/files/*`
+ *      (IDE / SDK saves). Those HTTP writes used to rely only on chokidar.
+ *      Firecracker guests often miss inotify, so IDE saves never reached
+ *      CanvasBuildManager and Expo `dist/` stayed frozen until a manual
+ *      `/preview/restart`.
+ *
+ *   3. A chokidar watcher on the workspace root. This catches every write
  *      regardless of source — Shogo external agents, the host user editing
  *      files directly on disk, git pulls, etc. Without this, the IDE live-
  *      edit experience is only reliable when the project's own chat agent
@@ -48,6 +54,8 @@ const BUILDABLE_PREFIXES = [
   'babel.config',
   'metro.config',
   'expo-router',
+  // Copied into dist/ without a content hash (worklets, wasm, static assets).
+  'public/',
 ] as const
 const BUILDABLE_EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js', '.css', '.html', '.json'] as const
 
@@ -501,9 +509,10 @@ export class CanvasFileWatcher {
   }
 
   /**
-   * Explicit notifier used by gateway-tools.ts. Runs synchronously before
-   * the tool call returns — redundant with chokidar but faster (no debounce
-   * or filesystem stat) and survives watcher init failures.
+   * Explicit notifier used by gateway-tools.ts and the HTTP file
+   * PUT/DELETE handlers. Runs synchronously before the caller returns —
+   * redundant with chokidar but faster (no debounce or filesystem stat)
+   * and survives watcher init failures / silent inotify on Firecracker.
    */
   onFileChanged(relativePath: string, _absolutePath: string): void {
     const path = relativePath.split('\\').join('/')

--- a/packages/agent-runtime/src/preview-manager.ts
+++ b/packages/agent-runtime/src/preview-manager.ts
@@ -109,6 +109,7 @@ import {
   findMissingTopLevelDeps,
   migrateLegacyShogoSdkPin,
   runWorkspaceInstall,
+  resolveWorkspaceTechStackId,
 } from './workspace-defaults'
 
 const LOG_PREFIX = 'preview-manager'
@@ -1042,20 +1043,18 @@ export class PreviewManager {
   }
 
   /**
-   * Read the project's `.tech-stack` marker and resolve the dev bundler
-   * declared in stack.json. Defaults to `vite` when no marker exists or
-   * the field is missing — preserves the historic default for the
+   * Read the project's resolved tech-stack id and map it through
+   * stack.json's `runtime.devServer`. Defaults to `vite` when the
+   * field is missing — preserves the historic default for the
    * `react-app` / `threejs-game` / `phaser-game` stacks.
    *
-   * The marker is always at the workspace root, regardless of whether the
-   * stack uses the legacy `<workspace>/project/` layout or seeds at the
-   * workspace root (Expo, RN).
+   * Resolution goes through `resolveWorkspaceTechStackId` so a
+   * poisoned `react-app` marker on an imported Expo workspace still
+   * selects Metro. The marker is always at the workspace root.
    */
   private resolveDevServer(): DevServerKind {
     try {
-      const markerPath = join(this.workspaceDir, '.tech-stack')
-      if (!existsSync(markerPath)) return 'vite'
-      const stackId = readFileSync(markerPath, 'utf-8').trim()
+      const stackId = resolveWorkspaceTechStackId(this.workspaceDir)
       if (!stackId) return 'vite'
       const meta = loadTechStackMeta(stackId)
       const decl = meta?.runtime?.devServer
@@ -3654,6 +3653,15 @@ export class PreviewManager {
             `[${LOG_PREFIX}] expo export succeeded but commit into dist/ failed — ` +
               `previous build (if any) remains live`,
           )
+        } else if (this.onBuildComplete) {
+          // Cloud Expo has no HMR. `/preview/restart` and the boot-time
+          // seed both land here; fire the same reload toast CBM uses so
+          // the canvas iframe picks up the new hashed `entry-*.js`.
+          try {
+            this.onBuildComplete()
+          } catch (err: any) {
+            console.warn(`[${LOG_PREFIX}] onBuildComplete subscriber threw: ${err?.message ?? err}`)
+          }
         }
       }
     } else {

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -81,6 +81,8 @@ import {
   wipeProjectFiles,
   getTechStackPath,
   workspaceUsesVite,
+  resolveWorkspaceTechStackId,
+  applyEnvTechStackMarker,
 } from './workspace-defaults'
 import {
   archiveNeedsSidecarClear,
@@ -95,6 +97,7 @@ import { extractTarFromUrl, extractTarStream, redactUrls } from './tar-stream'
 import { runtimeDiagnosticsRoutes } from './runtime-diagnostics-routes'
 import { runtimeLspRoutes } from './runtime-lsp-routes'
 import { computePublishedReadiness } from './published-readiness'
+import { staticAssetCacheControl } from './static-asset-cache'
 import {
   walkFilesTree,
   WORKSPACE_TREE_HIDDEN_DIRS,
@@ -964,12 +967,10 @@ function ensureWorkspaceFiles(): void {
   }
 
   // Seed tech stack if specified via env var or marker file.
-  // Projects without an explicit tech stack default to `react-app` (the
-  // canvas v2 Vite + React + Tailwind workspace).
-  const techStackMarker = join(WORKSPACE_DIR, '.tech-stack')
-  const techStackIdFromEnv = process.env.TECH_STACK_ID
-  const techStackIdFromFile = existsSync(techStackMarker) ? readFileSync(techStackMarker, 'utf-8').trim() : undefined
-  let techStackId = techStackIdFromEnv || techStackIdFromFile || 'react-app'
+  // `resolveWorkspaceTechStackId` also recovers imported Expo workspaces
+  // whose boot wrote a false `react-app` marker (no TECH_STACK_ID at
+  // first assign).
+  const techStackId = resolveWorkspaceTechStackId(WORKSPACE_DIR)
 
   if (techStackId) {
     seedTechStack(WORKSPACE_DIR, techStackId)
@@ -2562,6 +2563,27 @@ function getCanvasFileWatcher(): any {
   return _canvasFileWatcher
 }
 
+/**
+ * IDE / SDK file writes go through PUT/DELETE, not gateway-tools.
+ * Firecracker guests often miss chokidar/inotify, so without this
+ * CanvasBuildManager never sees the edit and Expo `dist/` stays stale.
+ */
+function notifyCanvasWorkspaceWrite(relativePath: string, absolutePath: string): void {
+  try {
+    getCanvasFileWatcher().onFileChanged(relativePath, absolutePath)
+  } catch (err) {
+    console.warn('[workspace] canvas watcher write-notify failed:', err)
+  }
+}
+
+function notifyCanvasWorkspaceDelete(relativePath: string): void {
+  try {
+    getCanvasFileWatcher().onFileDeleted(relativePath)
+  } catch (err) {
+    console.warn('[workspace] canvas watcher delete-notify failed:', err)
+  }
+}
+
 app.get('/preview/status', (c) => {
   const pm = getPreviewManager()
   return c.json(pm.getStatus())
@@ -2640,6 +2662,12 @@ function finishHydrate(entries: string[]): void {
     if (removed.length) {
       console.log(`[pool/hydrate] cleared stale SQLite sidecars: ${removed.join(', ')}`)
     }
+  }
+  // Hydrate can restore a `.tech-stack` written on an earlier boot that
+  // lacked TECH_STACK_ID (defaults to react-app). Re-stamp from env so
+  // the subsequent PreviewManager.restart() drives Expo, not vite.
+  if (applyEnvTechStackMarker(WORKSPACE_DIR)) {
+    console.log(`[pool/hydrate] re-applied TECH_STACK_ID=${process.env.TECH_STACK_ID} to .tech-stack`)
   }
   // Rebuild so the served dist reflects everything that was hydrated —
   // debounced, because more overlays are usually still arriving.
@@ -3614,6 +3642,7 @@ app.put('/agent/workspace/files/*', async (c) => {
       return c.json({ error: 'Invalid base64 in contentBase64' }, 400)
     }
     writeFileSync(resolved, buf)
+    notifyCanvasWorkspaceWrite(subPath, resolved)
     return c.json({
       ok: true,
       path: subPath,
@@ -3641,6 +3670,7 @@ app.put('/agent/workspace/files/*', async (c) => {
   }
 
   writeFileSync(resolved, body.content, 'utf-8')
+  notifyCanvasWorkspaceWrite(subPath, resolved)
   return c.json({
     ok: true,
     path: subPath,
@@ -3659,6 +3689,7 @@ app.delete('/agent/workspace/files/*', (c) => {
   if (!existsSync(resolved)) return c.json({ error: 'File not found' }, 404)
 
   unlinkSync(resolved)
+  notifyCanvasWorkspaceDelete(subPath)
   return c.json({ ok: true, deleted: subPath })
 })
 
@@ -3696,6 +3727,7 @@ app.post('/agent/workspace/upload', async (c) => {
 
       const buffer = await file.arrayBuffer()
       writeFileSync(resolved, Buffer.from(buffer))
+      notifyCanvasWorkspaceWrite(filePath, resolved)
       uploaded.push(filePath)
     }
 
@@ -5301,7 +5333,7 @@ function serveDistResponse(
     return new Response(readFileSync(filePath), {
       headers: {
         'Content-Type': mime,
-        'Cache-Control': 'public, max-age=31536000, immutable',
+        'Cache-Control': staticAssetCacheControl(safePath),
         [RUNTIME_MARKER_HEADER]: RUNTIME_MARKER_VALUE,
       },
     })
@@ -5507,6 +5539,9 @@ async function initializeEssentials(): Promise<void> {
         ) {
           await s3SyncInstance.markDepsPreSeeded()
         }
+        // Same poison as metal hydrate: the archive may contain a
+        // `react-app` marker written before TECH_STACK_ID was set.
+        applyEnvTechStackMarker(WORKSPACE_DIR)
         logTiming('S3 sync initialized')
       }
     } catch (error: any) {

--- a/packages/agent-runtime/src/static-asset-cache.ts
+++ b/packages/agent-runtime/src/static-asset-cache.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Cache-Control for files served out of `dist/`.
+ *
+ * Hashed bundler output (Expo `entry-<32hex>.js`, Vite `index-Ab12cd34.js`)
+ * is safe to pin forever: a rebuild emits a new name and `index.html` is
+ * already `no-cache`. Unhashed files — `captureRelay.worklet.js`, copied
+ * `public/` assets, `.wasm` without a hash — must revalidate, or a canvas
+ * refresh keeps serving yesterday's worklet for a year.
+ */
+export function isContentHashedFilename(fileName: string): boolean {
+  const base = fileName.split('/').pop() || fileName
+  // Bundlers put the hash in the last `-`/`_` segment before the extension.
+  // `captureRelay.worklet.js` uses a short extra extension and must not match.
+  return /[-_][A-Za-z0-9]{8,}\.[A-Za-z0-9]+$/.test(base)
+}
+
+export function staticAssetCacheControl(fileName: string): string {
+  return isContentHashedFilename(fileName)
+    ? 'public, max-age=31536000, immutable'
+    : 'no-cache'
+}

--- a/packages/agent-runtime/src/workspace-defaults.ts
+++ b/packages/agent-runtime/src/workspace-defaults.ts
@@ -1006,6 +1006,104 @@ export function workspaceUsesVite(dir: string): boolean {
   }
 }
 
+const VITE_STACK_IDS = new Set(['react-app', 'threejs-game', 'phaser-game'])
+
+function readPackageDeps(dir: string): Record<string, unknown> | null {
+  try {
+    const pkgPath = join(dir, 'package.json')
+    if (!existsSync(pkgPath)) return null
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as {
+      dependencies?: Record<string, unknown>
+      devDependencies?: Record<string, unknown>
+    }
+    return { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Infer a first-party stack id from on-disk `package.json` / `app.json`.
+ * Returns `null` when the workspace does not clearly belong to a known
+ * stack — callers fall back to the marker or `react-app`.
+ */
+function inferStackFromWorkspaceFiles(dir: string): string | null {
+  const deps = readPackageDeps(dir)
+  const has = (name: string) => !!(deps && deps[name])
+  let expoConfig = false
+  try {
+    const appJsonPath = join(dir, 'app.json')
+    if (existsSync(appJsonPath)) {
+      const parsed = JSON.parse(readFileSync(appJsonPath, 'utf-8')) as { expo?: unknown }
+      expoConfig = parsed?.expo != null
+    }
+  } catch {
+    /* ignore */
+  }
+  if (existsSync(join(dir, 'app.config.js')) || existsSync(join(dir, 'app.config.ts'))) {
+    expoConfig = true
+  }
+  const expoish = has('expo') || has('expo-router') || expoConfig
+  const threeish =
+    has('three') || has('@react-three/fiber') || has('expo-gl') || has('expo-three')
+  if (expoish) return threeish ? 'expo-three' : 'expo-app'
+  return null
+}
+
+function readTechStackMarker(dir: string): string {
+  try {
+    const markerPath = join(dir, '.tech-stack')
+    if (!existsSync(markerPath)) return ''
+    return readFileSync(markerPath, 'utf-8').trim()
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Resolve the workspace's real tech-stack id.
+ *
+ * Order:
+ *   1. `TECH_STACK_ID` env (set on `/pool/assign` from `settings.techStackId`)
+ *   2. On-disk `.tech-stack`, UNLESS it is a Vite default (`react-app` etc.)
+ *      sitting on a workspace whose `package.json` is clearly Expo — that
+ *      combination is the imported-Expo poison path: boot with no
+ *      TECH_STACK_ID writes `react-app`, hydrate overlays Expo files, and
+ *      both PreviewManager and CanvasBuildManager then refuse to rebuild.
+ *   3. Infer from `package.json` / `app.json`
+ *   4. `react-app` (historic default)
+ */
+export function resolveWorkspaceTechStackId(dir: string): string {
+  const fromEnv = (process.env.TECH_STACK_ID || '').trim()
+  if (fromEnv) return fromEnv
+
+  const fromFile = readTechStackMarker(dir)
+  const inferred = inferStackFromWorkspaceFiles(dir)
+  if (inferred && (!fromFile || VITE_STACK_IDS.has(fromFile))) {
+    return inferred
+  }
+  return fromFile || inferred || 'react-app'
+}
+
+/**
+ * Re-stamp `.tech-stack` from `TECH_STACK_ID` after a hydrate / S3 overlay.
+ * Those restores can resurrect a `react-app` marker written on a previous
+ * boot that lacked the env. Returns true when the marker was written.
+ */
+export function applyEnvTechStackMarker(dir: string): boolean {
+  const fromEnv = (process.env.TECH_STACK_ID || '').trim()
+  if (!fromEnv) return false
+  try {
+    writeFileSync(join(dir, '.tech-stack'), fromEnv, 'utf-8')
+    return true
+  } catch (err: any) {
+    console.warn(
+      `[workspace-defaults] Failed to apply TECH_STACK_ID marker (${err?.message ?? err})`,
+    )
+    return false
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Install-marker — sha256(package.json) under `.shogo/install-marker`
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Imported Expo projects kept serving a frozen `dist/` because IDE/SDK `PUT /agent/workspace/files` never notified `CanvasFileWatcher`, so `expo export` never ran after saves (Firecracker often misses inotify).
- A leftover `react-app` `.tech-stack` marker (first boot without `TECH_STACK_ID`) made Metro skip; import now infers `expo-app` from workspace files, persists settings as an object, and the runtime prefers env + package.json over a poisoned Vite marker.
- CanvasBuildManager waits for `bun install` before resolving the Expo bin; hashed `dist/` assets stay `immutable`, unhashed worklets revalidate; explicit Canvas tab clicks no longer snap back to chat.

## Test plan
- [ ] Import an Expo `.shogo` with no `techStackId` — picker shows Expo, `.tech-stack` is `expo-app`, preview is Metro not Vite
- [ ] Edit a `src/` or `app/` file in the IDE and confirm Expo rebuilds (~90s) and the canvas shows “Update available”
- [ ] Hard-refresh after rebuild; hashed `entry-*.js` changes
- [ ] Click Canvas on an imported chat-only-looking project — tab stays on canvas
- [ ] `bun test` for infer-tech-stack, expo-cloud-rebuild, canvas-build-manager, canvas-file-watcher, static-asset-cache, project-export-import, project-preview-tab


Made with [Cursor](https://cursor.com)