### PR TITLE
feat(api): add A2A protocol server for project agents

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,7 @@
     "stripe:migrate-tiers": "bun --env-file=../../.env.local scripts/migrate-tier-subscriptions.ts"
   },
   "dependencies": {
+    "@a2a-js/sdk": "1.1.0",
     "@ai-sdk/anthropic": "^3.0.37",
     "@ai-sdk/openai-compatible": "^2.0.41",
     "@aws-sdk/client-s3": "^3.975.0",

--- a/apps/api/scripts/test-a2a-external-client.ts
+++ b/apps/api/scripts/test-a2a-external-client.ts
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Standalone smoke test for the A2A protocol server — plays the role of an
+ * "external" caller talking to a locally-running `apps/api` over plain HTTP
+ * (localhost), the same way a real third-party A2A client would. Nothing in
+ * this script imports shogo internals; it only speaks the wire protocol via
+ * `@a2a-js/sdk/client`, exactly like `apps/api/src/routes/__tests__/a2a.test.ts`
+ * does, minus the mocking — this one hits a real, running server.
+ *
+ * Prereqs (see docs/a2a.md and apps/desktop/README.md "Browser Debugging"):
+ *   1. `apps/api` running locally with `A2A_ENABLED=true` (SQLite/local mode
+ *      is fine — no cloud infra needed for the protocol surface itself).
+ *   2. A project + a `shogo_a2a_*` key minted for it — either through the
+ *      product UI (Settings → integrations, once that ships) or directly:
+ *
+ *        bun -e '
+ *          import { prisma } from "./src/lib/prisma";
+ *          import { mintA2aApiKey } from "./src/lib/a2a/auth";
+ *          const p = await prisma.project.create({ data: { name: "A2A smoke test", workspaceId: "<ws-id>" } });
+ *          console.log(JSON.stringify(await mintA2aApiKey({ projectId: p.id, workspaceId: "<ws-id>", createdBy: "you" })));
+ *        '
+ *
+ * Usage:
+ *   A2A_BASE_URL=http://localhost:8091 \
+ *   A2A_PROJECT_ID=<projectId> \
+ *   A2A_KEY=shogo_a2a_<keyId>.<secret> \
+ *     bun apps/api/scripts/test-a2a-external-client.ts
+ *
+ * Flags: --no-stream skips the message/stream section (useful without a
+ * configured LLM key, where the turn fails fast and streaming has little
+ * to show); --skip-turn skips message/send AND message/stream entirely,
+ * testing only card discovery, auth, and JSON-RPC error shapes.
+ */
+
+import { TaskState, type SendMessageRequest, type StreamResponse } from '@a2a-js/sdk'
+import { ClientFactory, DefaultAgentCardResolver, JsonRpcTransportFactory } from '@a2a-js/sdk/client'
+
+const BASE_URL = (process.env.A2A_BASE_URL ?? 'http://localhost:8091').replace(/\/$/, '')
+const PROJECT_ID = process.env.A2A_PROJECT_ID
+const KEY = process.env.A2A_KEY
+const SKIP_STREAM = process.argv.includes('--no-stream')
+const SKIP_TURN = process.argv.includes('--skip-turn')
+
+if (!PROJECT_ID || !KEY) {
+  console.error('Usage: A2A_BASE_URL=... A2A_PROJECT_ID=... A2A_KEY=shogo_a2a_... bun apps/api/scripts/test-a2a-external-client.ts')
+  process.exit(1)
+}
+
+const CARD_URL = `/a2a/projects/${PROJECT_ID}/.well-known/agent-card.json`
+const RPC_URL_PATH = `/a2a/projects/${PROJECT_ID}/rpc`
+
+let passed = 0
+let failed = 0
+
+function ok(label: string, condition: boolean, detail?: string): void {
+  if (condition) {
+    passed++
+    console.log(`  \x1b[32m✓\x1b[0m ${label}`)
+  } else {
+    failed++
+    console.log(`  \x1b[31m✗\x1b[0m ${label}${detail ? ` — ${detail}` : ''}`)
+  }
+}
+
+function section(title: string): void {
+  console.log(`\n\x1b[1m${title}\x1b[0m`)
+}
+
+/** Bearer-injecting fetch — this is the ENTIRE client-side auth story; a
+ * real external caller wires this up the same way against their own HTTP
+ * client. Also demonstrates the authenticated-card-fetch requirement
+ * documented in docs/a2a.md — most A2A client libraries assume an
+ * unauthenticated card and need this same treatment. */
+function authedFetch(token: string | null): typeof fetch {
+  return (async (input: any, init: RequestInit = {}) => {
+    const headers = new Headers(init.headers)
+    if (token) headers.set('authorization', `Bearer ${token}`)
+    return fetch(input, { ...init, headers })
+  }) as typeof fetch
+}
+
+async function main() {
+  console.log(`A2A external-client smoke test against ${BASE_URL}`)
+  console.log(`  project: ${PROJECT_ID}`)
+
+  // ---------------------------------------------------------------------
+  section('1. Auth is enforced on the card route')
+  // ---------------------------------------------------------------------
+  {
+    const res = await fetch(`${BASE_URL}${CARD_URL}`)
+    ok('unauthenticated card fetch -> 401', res.status === 401, `got ${res.status}`)
+    ok('WWW-Authenticate: Bearer header present', res.headers.get('www-authenticate') === 'Bearer')
+
+    const wrongProjectKeyRes = await fetch(`${BASE_URL}${CARD_URL}`, {
+      headers: { authorization: 'Bearer shogo_a2a_deadbeefdeadbeefdeadbeef.' + '0'.repeat(64) },
+    })
+    ok('malformed/unknown key -> 401 (not a 500)', wrongProjectKeyRes.status === 401, `got ${wrongProjectKeyRes.status}`)
+  }
+
+  // ---------------------------------------------------------------------
+  section('2. Agent card (authenticated)')
+  // ---------------------------------------------------------------------
+  const cardRes = await fetch(`${BASE_URL}${CARD_URL}`, { headers: { authorization: `Bearer ${KEY}` } })
+  ok('authenticated card fetch -> 200', cardRes.status === 200, `got ${cardRes.status}`)
+  const card = await cardRes.json()
+  console.log(`  name:        ${card.name}`)
+  console.log(`  description: ${String(card.description).slice(0, 100)}`)
+  ok('protocolVersion is "1.0"', card.supportedInterfaces?.[0]?.protocolVersion === '1.0')
+  ok('tenant matches projectId', card.supportedInterfaces?.[0]?.tenant === PROJECT_ID)
+  ok('rpc url points back at this server', card.supportedInterfaces?.[0]?.url === `${BASE_URL}${RPC_URL_PATH}`)
+  ok('capabilities.streaming is true', card.capabilities?.streaming === true)
+  ok('bearerAuth security scheme declared', !!card.securitySchemes?.bearerAuth)
+
+  // ---------------------------------------------------------------------
+  section('3. JSON-RPC error shape for an unknown method')
+  // ---------------------------------------------------------------------
+  {
+    const res = await fetch(`${BASE_URL}${RPC_URL_PATH}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${KEY}` },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 'probe-1', method: 'totally/bogus', params: {} }),
+    })
+    const body = await res.json()
+    ok('unknown method returns a JSON-RPC error envelope', !!body.error, JSON.stringify(body))
+    console.log(`  error: ${JSON.stringify(body.error)}`)
+  }
+
+  if (SKIP_TURN) {
+    console.log('\n--skip-turn set: not exercising message/send or message/stream.')
+    summarize()
+    return
+  }
+
+  const factory = new ClientFactory({
+    transports: [new JsonRpcTransportFactory({ fetchImpl: authedFetch(KEY) })],
+    cardResolver: new DefaultAgentCardResolver({ fetchImpl: authedFetch(KEY) }),
+  })
+  const client = await factory.createFromUrl(BASE_URL, CARD_URL)
+
+  function sendRequest(text: string, contextId = ''): SendMessageRequest {
+    return {
+      tenant: '',
+      message: {
+        messageId: crypto.randomUUID(),
+        contextId,
+        taskId: '',
+        role: 1, // ROLE_USER
+        parts: [{ content: { $case: 'text', value: text }, metadata: undefined, filename: '', mediaType: 'text/plain' }],
+        metadata: undefined,
+        extensions: [],
+        referenceTaskIds: [],
+      },
+      configuration: undefined,
+      metadata: undefined,
+    } as SendMessageRequest
+  }
+
+  // ---------------------------------------------------------------------
+  section('4. message/send with returnImmediately + tasks/get poll')
+  // ---------------------------------------------------------------------
+  {
+    const req = sendRequest('Say hello in exactly three words.')
+    req.configuration = { returnImmediately: true } as any
+    const result = await client.sendMessage(req)
+    ok('sendMessage(returnImmediately) returns a Task, not a Message', 'status' in result)
+    if ('status' in result) {
+      console.log(`  taskId: ${result.id}  initial state: ${TaskState[result.status!.state!]}`)
+      ok(
+        'initial state is SUBMITTED or WORKING (not blocked on the full turn)',
+        result.status!.state === TaskState.TASK_STATE_SUBMITTED || result.status!.state === TaskState.TASK_STATE_WORKING,
+        TaskState[result.status!.state!],
+      )
+
+      let last = result
+      for (let i = 0; i < 30; i++) {
+        await new Promise((r) => setTimeout(r, 1000))
+        last = await client.getTask({ id: result.id, historyLength: 0 })
+        const state = TaskState[last.status!.state!]
+        console.log(`  [poll ${i + 1}] tasks/get -> ${state}`)
+        if (
+          [
+            TaskState.TASK_STATE_COMPLETED,
+            TaskState.TASK_STATE_FAILED,
+            TaskState.TASK_STATE_CANCELED,
+            TaskState.TASK_STATE_INPUT_REQUIRED,
+            TaskState.TASK_STATE_AUTH_REQUIRED,
+          ].includes(last.status!.state!)
+        ) {
+          break
+        }
+      }
+      console.log(`  final state: ${TaskState[last.status!.state!]}`)
+      if (last.status?.message?.parts?.length) {
+        const text = last.status.message.parts.map((p: any) => p.content?.value ?? '').join(' ')
+        console.log(`  status message: ${text.slice(0, 300)}`)
+      }
+      const terminalOrInteractive = [
+        TaskState.TASK_STATE_COMPLETED,
+        TaskState.TASK_STATE_FAILED,
+        TaskState.TASK_STATE_CANCELED,
+        TaskState.TASK_STATE_INPUT_REQUIRED,
+        TaskState.TASK_STATE_AUTH_REQUIRED,
+      ].includes(last.status!.state!)
+      ok(
+        'task reached a terminal or interactive state within 30s',
+        terminalOrInteractive,
+        terminalOrInteractive ? undefined : `still ${TaskState[last.status!.state!]} — likely still spawning the project runtime; this is a slow-first-run cost, not a protocol bug`,
+      )
+    }
+  }
+
+  if (SKIP_STREAM) {
+    console.log('\n--no-stream set: not exercising message/stream.')
+    summarize()
+    return
+  }
+
+  // ---------------------------------------------------------------------
+  section('5. message/stream (SSE) — full event lifecycle')
+  // ---------------------------------------------------------------------
+  {
+    const contextId = `smoke-${crypto.randomUUID()}`
+    const received: StreamResponse['payload'][] = []
+    for await (const event of client.sendMessageStream(sendRequest('Reply with a short haiku about testing software.', contextId))) {
+      const p = event.payload
+      received.push(p)
+      if (p?.$case === 'task') console.log(`  [stream] task created: ${p.value.id}`)
+      else if (p?.$case === 'artifactUpdate') {
+        const text = p.value.artifact?.parts?.map((part: any) => part.content?.value ?? '').join('')
+        console.log(`  [stream] artifactUpdate: ${JSON.stringify(text)}`)
+      } else if (p?.$case === 'statusUpdate') {
+        console.log(`  [stream] statusUpdate: ${TaskState[p.value.status!.state!]}`)
+      }
+    }
+    ok('stream yielded at least one event', received.length > 0)
+    ok('first event is a task', received[0]?.$case === 'task')
+    const last = received[received.length - 1]
+    ok('last event is a terminal/interactive statusUpdate', last?.$case === 'statusUpdate')
+
+    // -------------------------------------------------------------------
+    section('6. One in-flight turn per contextId')
+    // -------------------------------------------------------------------
+    // Fire two message/stream calls on a fresh shared contextId back to
+    // back; the runtime pod call for the first is in flight long enough
+    // (a real HTTP round trip, unlike the mocked integration test) that
+    // the second should reliably observe the guard.
+    const sharedCtx = `smoke-concurrent-${crypto.randomUUID()}`
+    const drain = async (text: string) => {
+      const events: StreamResponse['payload'][] = []
+      for await (const event of client.sendMessageStream(sendRequest(text, sharedCtx))) events.push(event.payload)
+      return events
+    }
+    const [firstEvents, secondEvents] = await Promise.all([drain('first concurrent message'), drain('second concurrent message')])
+    const messageText = (evts: StreamResponse['payload'][]): string => {
+      const l = evts[evts.length - 1]
+      if (l?.$case !== 'statusUpdate') return ''
+      return (l.value.status?.message?.parts ?? []).map((p: any) => p.content?.value ?? '').join(' ')
+    }
+    const terminalStates = [firstEvents, secondEvents].map((evts) => {
+      const l = evts[evts.length - 1]
+      return l?.$case === 'statusUpdate' ? TaskState[l.value.status!.state!] : l?.$case
+    })
+    const texts = [messageText(firstEvents), messageText(secondEvents)]
+    console.log(`  concurrent call outcomes: [${terminalStates.join(', ')}]`)
+    texts.forEach((t, i) => t && console.log(`  [${i === 0 ? 'first' : 'second'}] status message: ${t.slice(0, 200)}`))
+    const guardFired = texts.some((t) => t.includes('already in progress'))
+    ok(
+      'the one-turn-per-contextId guard rejected one of the two sends (status message mentions "already in progress")',
+      guardFired,
+      guardFired ? undefined : `no status message mentioned the guard — outcomes were [${terminalStates.join(', ')}]`,
+    )
+  }
+
+  summarize()
+}
+
+function summarize(): void {
+  console.log(`\n${passed} passed, ${failed} failed`)
+  if (failed > 0) process.exit(1)
+}
+
+main().catch((err) => {
+  console.error('\nFATAL:', err)
+  process.exit(1)
+})

--- a/apps/api/src/lib/a2a/__tests__/auth.test.ts
+++ b/apps/api/src/lib/a2a/__tests__/auth.test.ts
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+//
+// Unit tests for src/lib/a2a/auth.ts (mint/list/revoke/verify
+// shogo_a2a_<keyId>.<secret> keys). Prisma is mocked with a tiny in-memory
+// store; hashApiKey is left real (cheap, deterministic SHA-256) so the
+// mint -> verify round trip exercises the actual hashing path.
+
+import { beforeEach, describe, expect, it } from 'bun:test'
+import { mock } from 'bun:test'
+
+interface FakeRow {
+  id: string
+  name: string
+  keyId: string
+  hashedSecret: string
+  projectId: string
+  workspaceId: string
+  createdBy: string
+  lastUsedAt: Date | null
+  expiresAt: Date | null
+  revokedAt: Date | null
+  createdAt: Date
+}
+
+let rows: FakeRow[] = []
+let idCounter = 0
+
+mock.module('../../prisma', () => ({
+  prisma: {
+    a2aApiKey: {
+      create: async ({ data }: any) => {
+        const row: FakeRow = {
+          id: `key_${++idCounter}`,
+          name: data.name,
+          keyId: data.keyId,
+          hashedSecret: data.hashedSecret,
+          projectId: data.projectId,
+          workspaceId: data.workspaceId,
+          createdBy: data.createdBy,
+          lastUsedAt: null,
+          expiresAt: data.expiresAt ?? null,
+          revokedAt: null,
+          createdAt: new Date(Date.now() + idCounter), // monotonically increasing
+        }
+        rows.push(row)
+        return row
+      },
+      findMany: async ({ where, orderBy }: any) => {
+        let result = rows.filter((r) => r.projectId === where.projectId)
+        if (orderBy?.createdAt === 'desc') {
+          result = [...result].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+        }
+        return result
+      },
+      findUnique: async ({ where }: any) => rows.find((r) => r.keyId === where.keyId) ?? null,
+      update: async ({ where, data }: any) => {
+        const row = rows.find((r) => r.id === where.id)
+        if (!row) throw new Error('row not found')
+        Object.assign(row, data)
+        return row
+      },
+      updateMany: async ({ where, data }: any) => {
+        const matches = rows.filter(
+          (r) => r.id === where.id && r.projectId === where.projectId && r.revokedAt === where.revokedAt,
+        )
+        matches.forEach((r) => Object.assign(r, data))
+        return { count: matches.length }
+      },
+    },
+  },
+}))
+
+const { SHOGO_A2A_KEY_PREFIX, mintA2aApiKey, listA2aApiKeys, revokeA2aApiKey, verifyA2aApiKey } = await import(
+  '../auth'
+)
+
+beforeEach(() => {
+  rows = []
+  idCounter = 0
+})
+
+describe('SHOGO_A2A_KEY_PREFIX', () => {
+  it('is "shogo_a2a_"', () => {
+    expect(SHOGO_A2A_KEY_PREFIX).toBe('shogo_a2a_')
+  })
+})
+
+describe('mintA2aApiKey', () => {
+  it('mints a fullKey shaped shogo_a2a_<24-hex-keyId>.<64-hex-secret>', async () => {
+    const minted = await mintA2aApiKey({ projectId: 'p1', workspaceId: 'w1', createdBy: 'u1' })
+    expect(minted.fullKey.startsWith(SHOGO_A2A_KEY_PREFIX)).toBe(true)
+    const rest = minted.fullKey.slice(SHOGO_A2A_KEY_PREFIX.length)
+    const [keyId, secret] = rest.split('.')
+    expect(keyId).toMatch(/^[0-9a-f]{24}$/)
+    expect(secret).toMatch(/^[0-9a-f]{64}$/)
+    expect(minted.keyId).toBe(keyId)
+  })
+
+  it('persists a hashed secret, never the raw secret', async () => {
+    const minted = await mintA2aApiKey({ projectId: 'p1', workspaceId: 'w1', createdBy: 'u1' })
+    const row = rows.find((r) => r.keyId === minted.keyId)!
+    const secret = minted.fullKey.split('.')[1]
+    expect(row.hashedSecret).not.toBe(secret)
+    expect(row.hashedSecret).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('defaults name to "A2A key" and truncates a long name to 120 chars', async () => {
+    const noName = await mintA2aApiKey({ projectId: 'p1', workspaceId: 'w1', createdBy: 'u1' })
+    expect(noName.name).toBe('A2A key')
+
+    const long = await mintA2aApiKey({ projectId: 'p1', workspaceId: 'w1', createdBy: 'u1', name: 'x'.repeat(500) })
+    expect(long.name.length).toBe(120)
+  })
+
+  it('produces a unique key on every call', async () => {
+    const a = await mintA2aApiKey({ projectId: 'p1', workspaceId: 'w1', createdBy: 'u1' })
+    const b = await mintA2aApiKey({ projectId: 'p1', workspaceId: 'w1', createdBy: 'u1' })
+    expect(a.fullKey).not.toBe(b.fullKey)
+    expect(a.keyId).not.toBe(b.keyId)
+  })
+
+  it('does not dedupe against existing keys for the same project', async () => {
+    await mintA2aApiKey({ projectId: 'p1', workspaceId: 'w1', createdBy: 'u1', name: 'first' })
+    await mintA2aApiKey({ projectId: 'p1', workspaceId: 'w1', createdBy: 'u1', name: 'second' })
+    expect(rows.filter((r) => r.projectId === 'p1')).toHaveLength(2)
+  })
+})
+
+describe('listA2aApiKeys', () => {
+  it('returns only keys for the given project, newest first, without hashedSecret', async () => {
+    await mintA2aApiKey({ projectId: 'p1', workspaceId: 'w1', createdBy: 'u1', name: 'older' })
+    const newer = await mintA2aApiKey({ projectId: 'p1', workspaceId: 'w1', createdBy: 'u1', name: 'newer' })
+    await mintA2aApiKey({ projectId: 'p2', workspaceId: 'w2', createdBy: 'u2', name: 'other project' })
+
+    const list = await listA2aApiKeys('p1')
+    expect(list).toHaveLength(2)
+    expect(list[0].name).toBe(newer.name)
+    expect(list.every((k) => !('hashedSecret' in k))).toBe(true)
+  })
+})
+
+describe('revokeA2aApiKey', () => {
+  it('revokes a key scoped to the correct project and returns true', async () => {
+    const minted = await mintA2aApiKey({ projectId: 'p1', workspaceId: 'w1', createdBy: 'u1' })
+    const ok = await revokeA2aApiKey({ id: minted.id, projectId: 'p1' })
+    expect(ok).toBe(true)
+    expect(rows.find((r) => r.id === minted.id)?.revokedAt).toBeInstanceOf(Date)
+  })
+
+  it('returns false for a key belonging to a different project (no cross-project revoke)', async () => {
+    const minted = await mintA2aApiKey({ projectId: 'p1', workspaceId: 'w1', createdBy: 'u1' })
+    const ok = await revokeA2aApiKey({ id: minted.id, projectId: 'p2' })
+    expect(ok).toBe(false)
+    expect(rows.find((r) => r.id === minted.id)?.revokedAt).toBeNull()
+  })
+
+  it('returns false when already revoked', async () => {
+    const minted = await mintA2aApiKey({ projectId: 'p1', workspaceId: 'w1', createdBy: 'u1' })
+    expect(await revokeA2aApiKey({ id: minted.id, projectId: 'p1' })).toBe(true)
+    expect(await revokeA2aApiKey({ id: minted.id, projectId: 'p1' })).toBe(false)
+  })
+
+  it('returns false for an unknown id', async () => {
+    expect(await revokeA2aApiKey({ id: 'nope', projectId: 'p1' })).toBe(false)
+  })
+})
+
+describe('verifyA2aApiKey', () => {
+  it('accepts a freshly minted key for its own project', async () => {
+    const minted = await mintA2aApiKey({ projectId: 'p1', workspaceId: 'w1', createdBy: 'u1' })
+    const result = await verifyA2aApiKey(minted.fullKey, 'p1')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.key).toEqual({ id: minted.id, keyId: minted.keyId, projectId: 'p1', workspaceId: 'w1' })
+    }
+  })
+
+  it('bumps lastUsedAt on success (fire-and-forget)', async () => {
+    const minted = await mintA2aApiKey({ projectId: 'p1', workspaceId: 'w1', createdBy: 'u1' })
+    await verifyA2aApiKey(minted.fullKey, 'p1')
+    // The update is fire-and-forget; flush microtasks before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(rows.find((r) => r.id === minted.id)?.lastUsedAt).toBeInstanceOf(Date)
+  })
+
+  it('rejects a token with the wrong prefix', async () => {
+    expect((await verifyA2aApiKey('shogo_sk_deadbeef.secret', 'p1')).ok).toBe(false)
+  })
+
+  it('rejects a malformed token with no dot separator', async () => {
+    expect((await verifyA2aApiKey(`${SHOGO_A2A_KEY_PREFIX}abcdef`, 'p1')).ok).toBe(false)
+  })
+
+  it('rejects a malformed token with an empty keyId or empty secret', async () => {
+    expect((await verifyA2aApiKey(`${SHOGO_A2A_KEY_PREFIX}.secret`, 'p1')).ok).toBe(false)
+    expect((await verifyA2aApiKey(`${SHOGO_A2A_KEY_PREFIX}abcdef.`, 'p1')).ok).toBe(false)
+  })
+
+  it('rejects an unknown keyId', async () => {
+    expect((await verifyA2aApiKey(`${SHOGO_A2A_KEY_PREFIX}000000000000000000000000.deadbeef`, 'p1')).ok).toBe(false)
+  })
+
+  it('rejects a revoked key', async () => {
+    const minted = await mintA2aApiKey({ projectId: 'p1', workspaceId: 'w1', createdBy: 'u1' })
+    await revokeA2aApiKey({ id: minted.id, projectId: 'p1' })
+    expect((await verifyA2aApiKey(minted.fullKey, 'p1')).ok).toBe(false)
+  })
+
+  it('rejects an expired key', async () => {
+    const minted = await mintA2aApiKey({
+      projectId: 'p1',
+      workspaceId: 'w1',
+      createdBy: 'u1',
+      expiresAt: new Date(Date.now() - 1000),
+    })
+    expect((await verifyA2aApiKey(minted.fullKey, 'p1')).ok).toBe(false)
+  })
+
+  it('accepts a key that has not expired yet', async () => {
+    const minted = await mintA2aApiKey({
+      projectId: 'p1',
+      workspaceId: 'w1',
+      createdBy: 'u1',
+      expiresAt: new Date(Date.now() + 60_000),
+    })
+    expect((await verifyA2aApiKey(minted.fullKey, 'p1')).ok).toBe(true)
+  })
+
+  it('rejects a key presented for the wrong project', async () => {
+    const minted = await mintA2aApiKey({ projectId: 'p1', workspaceId: 'w1', createdBy: 'u1' })
+    expect((await verifyA2aApiKey(minted.fullKey, 'p2')).ok).toBe(false)
+  })
+
+  it('rejects a valid keyId with a tampered secret', async () => {
+    const minted = await mintA2aApiKey({ projectId: 'p1', workspaceId: 'w1', createdBy: 'u1' })
+    const tampered = `${SHOGO_A2A_KEY_PREFIX}${minted.keyId}.${'0'.repeat(64)}`
+    expect((await verifyA2aApiKey(tampered, 'p1')).ok).toBe(false)
+  })
+})

--- a/apps/api/src/lib/a2a/__tests__/card.test.ts
+++ b/apps/api/src/lib/a2a/__tests__/card.test.ts
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+//
+// Unit tests for src/lib/a2a/card.ts (buildAgentCard / getA2aBaseUrl).
+// `resolveProjectAgent` and `prisma.project` are mocked; `getFrontendUrl`
+// is mocked so getA2aBaseUrl's fallback path is deterministic.
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+let resolvedAgent: any = null
+let projectRow: any = null
+
+mock.module('../../../services/projectAgent.service', () => ({
+  resolveProjectAgent: async (_params: { projectId: string }) => resolvedAgent,
+}))
+
+mock.module('../../prisma', () => ({
+  prisma: {
+    project: {
+      findUnique: async (_args: any) => projectRow,
+    },
+  },
+}))
+
+mock.module('../../cloud-urls', () => ({
+  getFrontendUrl: () => 'https://app.example.test/',
+}))
+
+const { buildAgentCard, getA2aBaseUrl, A2A_PROTOCOL_VERSION } = await import('../card')
+
+const ORIGINAL_ENV = { ...process.env }
+
+beforeEach(() => {
+  resolvedAgent = null
+  projectRow = null
+})
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV }
+})
+
+describe('getA2aBaseUrl', () => {
+  it('prefers SHOGO_A2A_BASE_URL and strips a trailing slash', () => {
+    process.env.SHOGO_A2A_BASE_URL = 'https://a2a.example.com/'
+    expect(getA2aBaseUrl()).toBe('https://a2a.example.com')
+  })
+
+  it('falls back to getFrontendUrl() when unset', () => {
+    delete process.env.SHOGO_A2A_BASE_URL
+    expect(getA2aBaseUrl()).toBe('https://app.example.test')
+  })
+})
+
+describe('buildAgentCard', () => {
+  it('returns null when the project does not exist and there is no ProjectAgent row', async () => {
+    resolvedAgent = null
+    projectRow = null
+    const card = await buildAgentCard({ projectId: 'missing', baseUrl: 'https://base.test' })
+    expect(card).toBeNull()
+  })
+
+  it('falls back to the bare Project row when no ProjectAgent exists', async () => {
+    resolvedAgent = null
+    projectRow = { name: 'My Cool App', description: 'Does cool things' }
+    const card = await buildAgentCard({ projectId: 'p1', baseUrl: 'https://base.test' })
+    expect(card?.name).toBe('My Cool App')
+    expect(card?.description).toBe('Does cool things')
+    // No ProjectAgent tools -> only the built-in chat skill.
+    expect(card?.skills.map((s) => s.id)).toEqual(['chat'])
+  })
+
+  it('uses Project.name as a description fallback and "Shogo Agent" as a name fallback', async () => {
+    resolvedAgent = null
+    projectRow = { name: '', description: '' }
+    const card = await buildAgentCard({ projectId: 'p1', baseUrl: 'https://base.test' })
+    expect(card?.name).toBe('Shogo Agent')
+    expect(card?.description).toContain('Shogo coding agent for project')
+  })
+
+  it('prefers ProjectAgent metadata (displayName, systemPrompt, tools) when present', async () => {
+    resolvedAgent = {
+      id: 'agent-1',
+      name: 'default',
+      projectId: 'p1',
+      workspaceId: 'w1',
+      systemPrompt: 'You are a helpful assistant that ships code fast.',
+      tools: [{ name: 'read_file', description: 'Reads a file from disk' }],
+      characterName: 'Ada',
+      displayName: 'Ada the Coder',
+      voiceId: null,
+      firstMessage: null,
+      elevenlabsAgentId: null,
+      model: null,
+    }
+    const card = await buildAgentCard({ projectId: 'p1', baseUrl: 'https://base.test' })
+    expect(card?.name).toBe('Ada the Coder')
+    expect(card?.description).toBe('You are a helpful assistant that ships code fast.')
+    expect(card?.skills.map((s) => s.id)).toEqual(['chat', 'read_file'])
+    const toolSkill = card?.skills.find((s) => s.id === 'read_file')
+    expect(toolSkill?.description).toBe('Reads a file from disk')
+    expect(toolSkill?.tags).toEqual(['shogo', 'tool'])
+  })
+
+  it('falls back name to characterName, then "Shogo Agent", when displayName is unset', async () => {
+    resolvedAgent = {
+      id: 'agent-1', name: 'default', projectId: 'p1', workspaceId: 'w1',
+      systemPrompt: null, tools: null, characterName: 'Ada', displayName: null,
+      voiceId: null, firstMessage: null, elevenlabsAgentId: null, model: null,
+    }
+    const withCharacterName = await buildAgentCard({ projectId: 'p1', baseUrl: 'https://base.test' })
+    expect(withCharacterName?.name).toBe('Ada')
+
+    resolvedAgent = { ...resolvedAgent, characterName: null }
+    const withNeither = await buildAgentCard({ projectId: 'p1', baseUrl: 'https://base.test' })
+    expect(withNeither?.name).toBe('Shogo Agent')
+  })
+
+  it('truncates a long systemPrompt description to 500 chars', async () => {
+    resolvedAgent = {
+      id: 'agent-1', name: 'default', projectId: 'p1', workspaceId: 'w1',
+      systemPrompt: 'x'.repeat(2000), tools: null, characterName: null, displayName: 'Ada',
+      voiceId: null, firstMessage: null, elevenlabsAgentId: null, model: null,
+    }
+    const card = await buildAgentCard({ projectId: 'p1', baseUrl: 'https://base.test' })
+    expect(card?.description.length).toBe(500)
+  })
+
+  it('builds a single supportedInterfaces entry with the project-scoped RPC URL, tenant, and protocol version', async () => {
+    projectRow = { name: 'p', description: '' }
+    const card = await buildAgentCard({ projectId: 'proj-123', baseUrl: 'https://base.test' })
+    expect(card?.supportedInterfaces).toHaveLength(1)
+    expect(card?.supportedInterfaces[0]).toEqual({
+      url: 'https://base.test/a2a/projects/proj-123/rpc',
+      protocolBinding: 'JSONRPC',
+      protocolVersion: A2A_PROTOCOL_VERSION,
+      tenant: 'proj-123',
+    })
+  })
+
+  it('advertises streaming capability and no push notifications', async () => {
+    projectRow = { name: 'p', description: '' }
+    const card = await buildAgentCard({ projectId: 'p1', baseUrl: 'https://base.test' })
+    expect(card?.capabilities).toEqual({
+      streaming: true,
+      pushNotifications: false,
+      extensions: [],
+      extendedAgentCard: false,
+    })
+  })
+
+  it('declares a Bearer HTTP auth security scheme named bearerAuth', async () => {
+    projectRow = { name: 'p', description: '' }
+    const card = await buildAgentCard({ projectId: 'p1', baseUrl: 'https://base.test' })
+    expect(card?.securitySchemes.bearerAuth?.scheme).toMatchObject({
+      $case: 'httpAuthSecurityScheme',
+      value: { scheme: 'Bearer' },
+    })
+    expect(card?.securityRequirements).toEqual([{ schemes: { bearerAuth: { list: [] } } }])
+  })
+
+  it('uses getA2aBaseUrl() when no baseUrl override is passed', async () => {
+    process.env.SHOGO_A2A_BASE_URL = 'https://from-env.test'
+    projectRow = { name: 'p', description: '' }
+    const card = await buildAgentCard({ projectId: 'p1' })
+    expect(card?.supportedInterfaces[0].url).toBe('https://from-env.test/a2a/projects/p1/rpc')
+  })
+})

--- a/apps/api/src/lib/a2a/__tests__/event-mapper.test.ts
+++ b/apps/api/src/lib/a2a/__tests__/event-mapper.test.ts
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+//
+// Unit tests for src/lib/a2a/event-mapper.ts — pure functions, no mocking
+// required. Covers every pod chunk type, the ask_user -> INPUT_REQUIRED
+// override, and the data-permission-request -> AUTH_REQUIRED transient
+// status update.
+
+import { describe, expect, it } from 'bun:test'
+import { TaskState } from '@a2a-js/sdk'
+import type { TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2a-js/sdk'
+import { createEventMapperState, mapPodChunkToA2AEvents, type EventMapperState } from '../event-mapper'
+
+const ctx = { taskId: 'task-1', contextId: 'ctx-1' }
+
+function freshState(): EventMapperState {
+  return createEventMapperState()
+}
+
+describe('createEventMapperState', () => {
+  it('starts with lastSeq 0 and no usage/askUserPending', () => {
+    const state = freshState()
+    expect(state.lastSeq).toBe(0)
+    expect(state.usage).toBeUndefined()
+    expect(state.askUserPending).toBeUndefined()
+  })
+})
+
+describe('mapPodChunkToA2AEvents — malformed input', () => {
+  it('returns [] for null', () => {
+    expect(mapPodChunkToA2AEvents(null, freshState(), ctx)).toEqual([])
+  })
+  it('returns [] for a non-object', () => {
+    expect(mapPodChunkToA2AEvents('oops', freshState(), ctx)).toEqual([])
+  })
+  it('returns [] for an unknown chunk type', () => {
+    expect(mapPodChunkToA2AEvents({ type: 'something-unhandled' }, freshState(), ctx)).toEqual([])
+  })
+})
+
+describe('text-delta / text-end', () => {
+  it('text-delta emits one artifactUpdate with append:true, lastChunk:false', () => {
+    const events = mapPodChunkToA2AEvents({ type: 'text-delta', delta: 'Hello' }, freshState(), ctx)
+    expect(events).toHaveLength(1)
+    expect(events[0].kind).toBe('artifactUpdate')
+    const data = events[0].data as TaskArtifactUpdateEvent
+    expect(data.taskId).toBe('task-1')
+    expect(data.contextId).toBe('ctx-1')
+    expect(data.append).toBe(true)
+    expect(data.lastChunk).toBe(false)
+    expect(data.artifact?.artifactId).toBe('response')
+    expect(data.artifact?.parts[0]).toMatchObject({ content: { $case: 'text', value: 'Hello' } })
+  })
+
+  it('text-delta with an empty delta emits nothing', () => {
+    expect(mapPodChunkToA2AEvents({ type: 'text-delta', delta: '' }, freshState(), ctx)).toEqual([])
+  })
+
+  it('text-end emits nothing (lastChunk comes from the terminal status instead)', () => {
+    expect(mapPodChunkToA2AEvents({ type: 'text-end' }, freshState(), ctx)).toEqual([])
+  })
+})
+
+describe('tool-input-available / tool-output-available / tool-output-error', () => {
+  it('non-ask_user tool call emits a WORKING statusUpdate carrying a DataPart', () => {
+    const events = mapPodChunkToA2AEvents(
+      { type: 'tool-input-available', toolCallId: 'call-1', toolName: 'read_file', input: { path: 'a.ts' } },
+      freshState(),
+      ctx,
+    )
+    expect(events).toHaveLength(1)
+    expect(events[0].kind).toBe('statusUpdate')
+    const data = events[0].data as TaskStatusUpdateEvent
+    expect(data.status?.state).toBe(TaskState.TASK_STATE_WORKING)
+    const part = data.status?.message?.parts[0]
+    expect(part?.content).toMatchObject({
+      $case: 'data',
+      value: { toolCallId: 'call-1', toolName: 'read_file', input: { path: 'a.ts' } },
+    })
+  })
+
+  it('ask_user tool call sets state.askUserPending with parsed questions', () => {
+    const state = freshState()
+    mapPodChunkToA2AEvents(
+      {
+        type: 'tool-input-available',
+        toolCallId: 'call-ask',
+        toolName: 'ask_user',
+        input: { questions: [{ header: 'Name', question: 'What is your name?' }] },
+      },
+      state,
+      ctx,
+    )
+    expect(state.askUserPending).toEqual({
+      toolCallId: 'call-ask',
+      questions: [{ header: 'Name', question: 'What is your name?' }],
+    })
+  })
+
+  it('ask_user with malformed/missing questions still sets askUserPending with an empty list', () => {
+    const state = freshState()
+    mapPodChunkToA2AEvents({ type: 'tool-input-available', toolCallId: 'call-ask', toolName: 'ask_user' }, state, ctx)
+    expect(state.askUserPending).toEqual({ toolCallId: 'call-ask', questions: [] })
+  })
+
+  it('tool-output-available for the pending ask_user toolCallId clears askUserPending', () => {
+    const state = freshState()
+    state.askUserPending = { toolCallId: 'call-1', questions: [] }
+    mapPodChunkToA2AEvents({ type: 'tool-output-available', toolCallId: 'call-1', output: 'ok' }, state, ctx)
+    expect(state.askUserPending).toBeUndefined()
+  })
+
+  it('tool-output-available for a different toolCallId leaves askUserPending untouched', () => {
+    const state = freshState()
+    state.askUserPending = { toolCallId: 'call-1', questions: [] }
+    mapPodChunkToA2AEvents({ type: 'tool-output-available', toolCallId: 'call-2', output: 'ok' }, state, ctx)
+    expect(state.askUserPending).toEqual({ toolCallId: 'call-1', questions: [] })
+  })
+
+  it('tool-output-error emits WORKING with the error message and clears matching askUserPending', () => {
+    const state = freshState()
+    state.askUserPending = { toolCallId: 'call-1', questions: [] }
+    const events = mapPodChunkToA2AEvents(
+      { type: 'tool-output-error', toolCallId: 'call-1', errorText: 'boom' },
+      state,
+      ctx,
+    )
+    expect(state.askUserPending).toBeUndefined()
+    const data = events[0].data as TaskStatusUpdateEvent
+    expect(data.status?.message?.parts[0].content).toMatchObject({
+      $case: 'data',
+      value: { toolCallId: 'call-1', error: 'boom' },
+    })
+  })
+})
+
+describe('reasoning-*', () => {
+  it('is suppressed by default (includeReasoning unset)', () => {
+    expect(mapPodChunkToA2AEvents({ type: 'reasoning-delta', delta: 'thinking...' }, freshState(), ctx)).toEqual([])
+  })
+
+  it('is surfaced as a WORKING update with metadata.kind=reasoning when includeReasoning:true', () => {
+    const events = mapPodChunkToA2AEvents(
+      { type: 'reasoning-delta', delta: 'thinking...' },
+      freshState(),
+      ctx,
+      { includeReasoning: true },
+    )
+    expect(events).toHaveLength(1)
+    const data = events[0].data as TaskStatusUpdateEvent
+    expect(data.status?.state).toBe(TaskState.TASK_STATE_WORKING)
+    expect(data.metadata).toMatchObject({ kind: 'reasoning', phase: 'reasoning-delta' })
+    expect(data.status?.message?.parts[0].content).toMatchObject({ $case: 'text', value: 'thinking...' })
+  })
+})
+
+describe('data-usage', () => {
+  it('accumulates fields across multiple chunks without emitting an event', () => {
+    const state = freshState()
+    expect(mapPodChunkToA2AEvents({ type: 'data-usage', data: { inputTokens: 10 } }, state, ctx)).toEqual([])
+    expect(state.usage).toMatchObject({ inputTokens: 10 })
+    mapPodChunkToA2AEvents({ type: 'data-usage', data: { outputTokens: 5 } }, state, ctx)
+    // Previously recorded inputTokens must survive the second, partial update.
+    expect(state.usage).toMatchObject({ inputTokens: 10, outputTokens: 5 })
+  })
+
+  it('accepts the promptTokens/completionTokens aliases', () => {
+    const state = freshState()
+    mapPodChunkToA2AEvents({ type: 'data-usage', data: { promptTokens: 3, completionTokens: 7 } }, state, ctx)
+    expect(state.usage).toMatchObject({ inputTokens: 3, outputTokens: 7 })
+  })
+})
+
+describe('data-turn-seq', () => {
+  it('only moves lastSeq forward, never backward', () => {
+    const state = freshState()
+    mapPodChunkToA2AEvents({ type: 'data-turn-seq', data: { seq: 5 } }, state, ctx)
+    expect(state.lastSeq).toBe(5)
+    mapPodChunkToA2AEvents({ type: 'data-turn-seq', data: { seq: 2 } }, state, ctx)
+    expect(state.lastSeq).toBe(5)
+    mapPodChunkToA2AEvents({ type: 'data-turn-seq', data: { seq: 9 } }, state, ctx)
+    expect(state.lastSeq).toBe(9)
+  })
+  it('emits no event', () => {
+    expect(mapPodChunkToA2AEvents({ type: 'data-turn-seq', data: { seq: 1 } }, freshState(), ctx)).toEqual([])
+  })
+})
+
+describe('data-permission-request', () => {
+  it('maps to a transient AUTH_REQUIRED statusUpdate', () => {
+    const events = mapPodChunkToA2AEvents(
+      { type: 'data-permission-request', data: { tool: 'run_command', command: 'rm -rf /' } },
+      freshState(),
+      ctx,
+    )
+    expect(events).toHaveLength(1)
+    const data = events[0].data as TaskStatusUpdateEvent
+    expect(data.status?.state).toBe(TaskState.TASK_STATE_AUTH_REQUIRED)
+    expect(data.metadata).toMatchObject({ transient: true, reason: 'permission-request' })
+  })
+})
+
+describe('error', () => {
+  it('maps to a FAILED statusUpdate carrying the error text', () => {
+    const events = mapPodChunkToA2AEvents({ type: 'error', errorText: 'pod crashed' }, freshState(), ctx)
+    const data = events[0].data as TaskStatusUpdateEvent
+    expect(data.status?.state).toBe(TaskState.TASK_STATE_FAILED)
+    expect(data.status?.message?.parts[0].content).toMatchObject({ $case: 'text', value: 'pod crashed' })
+  })
+
+  it('falls back to a generic message when no error text is present', () => {
+    const events = mapPodChunkToA2AEvents({ type: 'error' }, freshState(), ctx)
+    const data = events[0].data as TaskStatusUpdateEvent
+    expect(data.status?.message?.parts[0].content).toMatchObject({ $case: 'text', value: 'Unknown error' })
+  })
+})
+
+describe('data-turn-complete', () => {
+  it('maps a normal completion to COMPLETED, merging accumulated usage into metadata', () => {
+    const state = freshState()
+    mapPodChunkToA2AEvents({ type: 'data-usage', data: { totalTokens: 42 } }, state, ctx)
+    const events = mapPodChunkToA2AEvents({ type: 'data-turn-complete', data: { status: 'completed' } }, state, ctx)
+    const data = events[0].data as TaskStatusUpdateEvent
+    expect(data.status?.state).toBe(TaskState.TASK_STATE_COMPLETED)
+    expect(data.metadata).toMatchObject({ usage: { totalTokens: 42 } })
+  })
+
+  it('maps status:"aborted" to CANCELED', () => {
+    const events = mapPodChunkToA2AEvents({ type: 'data-turn-complete', data: { status: 'aborted' } }, freshState(), ctx)
+    expect((events[0].data as TaskStatusUpdateEvent).status?.state).toBe(TaskState.TASK_STATE_CANCELED)
+  })
+
+  it('maps status:"failed" to FAILED', () => {
+    const events = mapPodChunkToA2AEvents({ type: 'data-turn-complete', data: { status: 'failed' } }, freshState(), ctx)
+    expect((events[0].data as TaskStatusUpdateEvent).status?.state).toBe(TaskState.TASK_STATE_FAILED)
+  })
+
+  it('overrides to INPUT_REQUIRED when an ask_user call is still pending, regardless of data.status', () => {
+    const state = freshState()
+    state.askUserPending = {
+      toolCallId: 'call-1',
+      questions: [{ header: 'Confirm', question: 'Proceed with deletion?' }],
+    }
+    const events = mapPodChunkToA2AEvents({ type: 'data-turn-complete', data: { status: 'completed' } }, state, ctx)
+    expect(events).toHaveLength(1)
+    const data = events[0].data as TaskStatusUpdateEvent
+    expect(data.status?.state).toBe(TaskState.TASK_STATE_INPUT_REQUIRED)
+    expect(data.status?.message?.parts[0].content).toMatchObject({
+      $case: 'text',
+      value: 'Confirm: Proceed with deletion?',
+    })
+  })
+
+  it('uses a generic prompt when the pending ask_user call had no parsed questions', () => {
+    const state = freshState()
+    state.askUserPending = { toolCallId: 'call-1', questions: [] }
+    const events = mapPodChunkToA2AEvents({ type: 'data-turn-complete', data: {} }, state, ctx)
+    const data = events[0].data as TaskStatusUpdateEvent
+    expect(data.status?.message?.parts[0].content).toMatchObject({
+      $case: 'text',
+      value: 'The agent is waiting for your input.',
+    })
+  })
+})

--- a/apps/api/src/lib/a2a/__tests__/executor.test.ts
+++ b/apps/api/src/lib/a2a/__tests__/executor.test.ts
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+//
+// Failure-mode tests for src/lib/a2a/executor.ts (ShogoAgentExecutor),
+// driven directly against the executor (no HTTP/JSON-RPC layer) with a
+// fully mocked "pod": resolveProjectPodUrl, deriveProjectRuntimeToken,
+// trackUsageFromStream, and global fetch. Covers:
+//   - happy-path turn completion
+//   - EOF without data-turn-complete -> resume from the pod buffer
+//   - resume returning HTTP 204 (buffer expired) -> terminal FAILED
+//   - an unanswered ask_user call -> terminal INPUT_REQUIRED
+//   - two execute() calls sharing a contextId -> the second is rejected
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { Role, TaskState, type SendMessageRequest, type TaskStatusUpdateEvent } from '@a2a-js/sdk'
+import { RequestContext, ServerCallContext, type AgentExecutionEvent, type ExecutionEventBus } from '@a2a-js/sdk/server'
+import type { PrismaA2ATaskStore } from '../task-store'
+
+process.env.CHAT_UPSTREAM_FETCH_TIMEOUT_MS = '600000'
+process.env.CHAT_STREAM_IDLE_TIMEOUT_MS = '600000'
+
+mock.module('../../prisma', () => ({
+  prisma: {
+    chatSession: {
+      findUnique: async () => null,
+      create: async () => ({}),
+    },
+  },
+}))
+
+mock.module('../../resolve-pod-url', () => ({
+  resolveProjectPodUrl: async () => ({ url: 'http://fake-pod.test' }),
+}))
+
+mock.module('../../project-runtime-token', () => ({
+  deriveProjectRuntimeToken: async () => 'fake-runtime-token',
+}))
+
+mock.module('../../../routes/project-chat', () => ({
+  trackUsageFromStream: async (stream: ReadableStream<Uint8Array>) => {
+    // Drain the billing branch so the mapper branch's tee() doesn't stall.
+    const reader = stream.getReader()
+    while (true) {
+      const { done } = await reader.read()
+      if (done) break
+    }
+  },
+}))
+
+const { ShogoAgentExecutor } = await import('../executor')
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function sseStream(chunks: any[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder()
+  let i = 0
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i >= chunks.length) {
+        controller.close()
+        return
+      }
+      controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunks[i++])}\n\n`))
+    },
+  })
+}
+
+const fakeTaskStore = {
+  save: async () => {},
+  load: async () => undefined,
+  list: async () => ({ tasks: [], nextPageToken: '', pageSize: 0, totalSize: 0 }),
+} as unknown as PrismaA2ATaskStore
+
+function makeBus(): { bus: ExecutionEventBus; events: AgentExecutionEvent[] } {
+  const events: AgentExecutionEvent[] = []
+  const bus: ExecutionEventBus = {
+    publish: (e) => {
+      events.push(e)
+    },
+    on: () => bus,
+    off: () => bus,
+    once: () => bus,
+    removeAllListeners: () => bus,
+    finished: () => {},
+  }
+  return { bus, events }
+}
+
+function makeSendMessageRequest(text: string, extensions: string[] = []): SendMessageRequest {
+  return {
+    tenant: '',
+    message: {
+      messageId: 'msg-1',
+      contextId: '',
+      taskId: '',
+      role: Role.ROLE_USER,
+      parts: [{ content: { $case: 'text', value: text }, metadata: undefined, filename: '', mediaType: 'text/plain' }],
+      metadata: undefined,
+      extensions,
+      referenceTaskIds: [],
+    },
+    configuration: undefined,
+    metadata: undefined,
+  }
+}
+
+function makeReqCtx(opts: { taskId: string; contextId: string; text: string; requestedExtensions?: string[] }) {
+  const context = new ServerCallContext({ tenant: 'proj-1', requestedExtensions: opts.requestedExtensions })
+  return new RequestContext(makeSendMessageRequest(opts.text, opts.requestedExtensions), opts.taskId, opts.contextId, context)
+}
+
+function lastStatus(events: AgentExecutionEvent[]): TaskStatusUpdateEvent {
+  const statusEvents = events.filter((e) => e.kind === 'statusUpdate')
+  return statusEvents[statusEvents.length - 1].data as TaskStatusUpdateEvent
+}
+
+const originalFetch = globalThis.fetch
+let fetchImpl: (url: string, init?: any) => Promise<Response>
+let fetchCalls: string[]
+
+beforeEach(() => {
+  fetchCalls = []
+  fetchImpl = async () => new Response(null, { status: 500 })
+  globalThis.fetch = (async (url: any, init?: any) => {
+    fetchCalls.push(String(url))
+    return fetchImpl(String(url), init)
+  }) as any
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+function newExecutor() {
+  return new ShogoAgentExecutor({ projectId: 'proj-1', workspaceId: 'ws-1', taskStore: fakeTaskStore })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ShogoAgentExecutor.execute — happy path', () => {
+  it('publishes task -> WORKING -> artifact text -> terminal COMPLETED', async () => {
+    fetchImpl = async (url) => {
+      if (url.endsWith('/agent/chat')) {
+        return new Response(
+          sseStream([{ type: 'text-delta', delta: 'Hi there' }, { type: 'data-turn-complete', data: { status: 'completed' } }]),
+          { status: 200 },
+        )
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }
+
+    const executor = newExecutor()
+    const { bus, events } = makeBus()
+    await executor.execute(makeReqCtx({ taskId: 't1', contextId: 'c1', text: 'hello' }), bus)
+
+    expect(events[0].kind).toBe('task')
+    expect(events.some((e) => e.kind === 'artifactUpdate')).toBe(true)
+    expect(lastStatus(events).status?.state).toBe(TaskState.TASK_STATE_COMPLETED)
+    expect(executor.hasActiveWork).toBe(false)
+  })
+
+  it('fails the turn when the message has no text parts', async () => {
+    const executor = newExecutor()
+    const { bus, events } = makeBus()
+    await executor.execute(makeReqCtx({ taskId: 't1', contextId: 'c1', text: '' }), bus)
+    expect(lastStatus(events).status?.state).toBe(TaskState.TASK_STATE_FAILED)
+    expect(fetchCalls).toHaveLength(0) // never reaches the pod
+  })
+})
+
+describe('ShogoAgentExecutor.execute — resume on missing data-turn-complete', () => {
+  it('re-fetches the pod buffer at fromSeq and completes once the resume stream sees data-turn-complete', async () => {
+    fetchImpl = async (url) => {
+      if (url.endsWith('/agent/chat')) {
+        // EOFs after a partial chunk, no data-turn-complete.
+        return new Response(sseStream([{ type: 'text-delta', delta: 'partial' }]), { status: 200 })
+      }
+      if (url.includes('/stream?fromSeq=')) {
+        return new Response(sseStream([{ type: 'data-turn-complete', data: { status: 'completed' } }]), { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }
+
+    const executor = newExecutor()
+    const { bus, events } = makeBus()
+    await executor.execute(makeReqCtx({ taskId: 't1', contextId: 'c1', text: 'hello' }), bus)
+
+    expect(fetchCalls.filter((u) => u.includes('/stream?fromSeq='))).toHaveLength(1)
+    expect(lastStatus(events).status?.state).toBe(TaskState.TASK_STATE_COMPLETED)
+  })
+
+  it('publishes terminal FAILED when the resume buffer has expired (HTTP 204)', async () => {
+    fetchImpl = async (url) => {
+      if (url.endsWith('/agent/chat')) return new Response(sseStream([]), { status: 200 })
+      if (url.includes('/stream?fromSeq=')) return new Response(null, { status: 204 })
+      throw new Error(`unexpected fetch: ${url}`)
+    }
+
+    const executor = newExecutor()
+    const { bus, events } = makeBus()
+    await executor.execute(makeReqCtx({ taskId: 't1', contextId: 'c1', text: 'hello' }), bus)
+
+    const status = lastStatus(events)
+    expect(status.status?.state).toBe(TaskState.TASK_STATE_FAILED)
+    const text = (status.status?.message?.parts[0].content as any)?.value
+    expect(text).toMatch(/buffer has since expired/)
+  })
+
+  it('publishes terminal FAILED when the resume itself never sees data-turn-complete', async () => {
+    fetchImpl = async (url) => {
+      if (url.endsWith('/agent/chat')) return new Response(sseStream([]), { status: 200 })
+      if (url.includes('/stream?fromSeq=')) return new Response(sseStream([]), { status: 200 })
+      throw new Error(`unexpected fetch: ${url}`)
+    }
+
+    const executor = newExecutor()
+    const { bus, events } = makeBus()
+    await executor.execute(makeReqCtx({ taskId: 't1', contextId: 'c1', text: 'hello' }), bus)
+
+    const status = lastStatus(events)
+    expect(status.status?.state).toBe(TaskState.TASK_STATE_FAILED)
+    expect((status.status?.message?.parts[0].content as any)?.value).toMatch(/ended unexpectedly/)
+  })
+})
+
+describe('ShogoAgentExecutor.execute — ask_user', () => {
+  it('maps an unanswered ask_user call to terminal INPUT_REQUIRED', async () => {
+    fetchImpl = async (url) => {
+      if (url.endsWith('/agent/chat')) {
+        return new Response(
+          sseStream([
+            {
+              type: 'tool-input-available',
+              toolCallId: 'call-1',
+              toolName: 'ask_user',
+              input: { questions: [{ header: 'Confirm', question: 'Delete the file?' }] },
+            },
+            { type: 'data-turn-complete', data: { status: 'completed' } },
+          ]),
+          { status: 200 },
+        )
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }
+
+    const executor = newExecutor()
+    const { bus, events } = makeBus()
+    await executor.execute(makeReqCtx({ taskId: 't1', contextId: 'c1', text: 'delete a.txt' }), bus)
+
+    const status = lastStatus(events)
+    expect(status.status?.state).toBe(TaskState.TASK_STATE_INPUT_REQUIRED)
+    expect((status.status?.message?.parts[0].content as any)?.value).toBe('Confirm: Delete the file?')
+  })
+})
+
+describe('ShogoAgentExecutor.execute — concurrent same-context tasks', () => {
+  it('rejects a second execute() call for a contextId that already has a turn in flight', async () => {
+    let releasePod: ((res: Response) => void) | undefined
+    fetchImpl = async (url) => {
+      if (url.endsWith('/agent/chat')) {
+        return new Promise<Response>((resolve) => {
+          releasePod = resolve
+        })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }
+
+    const executor = newExecutor()
+    const { bus: bus1, events: events1 } = makeBus()
+    const { bus: bus2, events: events2 } = makeBus()
+
+    const p1 = executor.execute(makeReqCtx({ taskId: 't1', contextId: 'shared-ctx', text: 'first' }), bus1)
+    // Fired before p1 has resolved: the synchronous prefix of execute()/runTurn()
+    // (up to its first await) has already registered 'shared-ctx' as in-flight.
+    expect(executor.hasActiveWork).toBe(true)
+    const p2 = executor.execute(makeReqCtx({ taskId: 't2', contextId: 'shared-ctx', text: 'second' }), bus2)
+
+    await expect(p2).rejects.toThrow(/already in progress/)
+    expect(events2).toEqual([]) // rejected before publishing anything
+
+    // p1's chain (ensureChatSession -> resolveProjectPodUrl ->
+    // deriveProjectRuntimeToken -> fetch) still needs a few microtask/
+    // macrotask hops to reach the pod fetch and populate `releasePod`.
+    while (!releasePod) {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+    releasePod!(new Response(sseStream([{ type: 'data-turn-complete', data: { status: 'completed' } }]), { status: 200 }))
+    await p1
+    expect(lastStatus(events1).status?.state).toBe(TaskState.TASK_STATE_COMPLETED)
+    expect(executor.hasActiveWork).toBe(false)
+  })
+
+  it('allows a second execute() call once the first contextId turn has settled', async () => {
+    fetchImpl = async (url) => {
+      if (url.endsWith('/agent/chat')) {
+        return new Response(sseStream([{ type: 'data-turn-complete', data: { status: 'completed' } }]), { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }
+    const executor = newExecutor()
+    const { bus: bus1, events: events1 } = makeBus()
+    const { bus: bus2, events: events2 } = makeBus()
+
+    await executor.execute(makeReqCtx({ taskId: 't1', contextId: 'shared-ctx', text: 'first' }), bus1)
+    await executor.execute(makeReqCtx({ taskId: 't2', contextId: 'shared-ctx', text: 'second' }), bus2)
+
+    expect(lastStatus(events1).status?.state).toBe(TaskState.TASK_STATE_COMPLETED)
+    expect(lastStatus(events2).status?.state).toBe(TaskState.TASK_STATE_COMPLETED)
+  })
+})

--- a/apps/api/src/lib/a2a/__tests__/task-store.test.ts
+++ b/apps/api/src/lib/a2a/__tests__/task-store.test.ts
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+//
+// Unit tests for src/lib/a2a/task-store.ts (PrismaA2ATaskStore). Prisma is
+// mocked with a tiny in-memory `a2aTask` table so save/load/list can be
+// exercised without a real database.
+
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { ServerCallContext, type TaskStore } from '@a2a-js/sdk/server'
+import { TaskState, type ListTasksRequest, type Task } from '@a2a-js/sdk'
+
+interface FakeRow {
+  id: string
+  contextId: string
+  projectId: string
+  state: string
+  taskJson: string
+  chatSessionId: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+let rows: FakeRow[] = []
+let clock = 0
+
+mock.module('../../prisma', () => ({
+  prisma: {
+    a2aTask: {
+      upsert: async ({ where, create, update }: any) => {
+        const existing = rows.find((r) => r.id === where.id)
+        clock += 1
+        if (existing) {
+          Object.assign(existing, update, { updatedAt: new Date(clock) })
+          return existing
+        }
+        const row: FakeRow = {
+          id: create.id,
+          contextId: create.contextId,
+          projectId: create.projectId,
+          state: create.state,
+          taskJson: create.taskJson,
+          chatSessionId: create.chatSessionId ?? null,
+          createdAt: new Date(clock),
+          updatedAt: new Date(clock),
+        }
+        rows.push(row)
+        return row
+      },
+      findUnique: async ({ where }: any) => rows.find((r) => r.id === where.id) ?? null,
+      findMany: async ({ where, orderBy, skip, take }: any) => {
+        let result = rows.filter((r) => matchesWhere(r, where))
+        if (orderBy?.updatedAt === 'desc') result = [...result].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+        return result.slice(skip ?? 0, (skip ?? 0) + (take ?? result.length))
+      },
+      count: async ({ where }: any) => rows.filter((r) => matchesWhere(r, where)).length,
+    },
+  },
+}))
+
+function matchesWhere(row: FakeRow, where: any): boolean {
+  if (where.projectId !== undefined && row.projectId !== where.projectId) return false
+  if (where.contextId !== undefined && row.contextId !== where.contextId) return false
+  if (where.state !== undefined && row.state !== where.state) return false
+  if (where.updatedAt?.gte !== undefined && row.updatedAt.getTime() < where.updatedAt.gte.getTime()) return false
+  return true
+}
+
+const { PrismaA2ATaskStore } = await import('../task-store')
+
+function ctx(tenant: string | undefined): ServerCallContext {
+  return new ServerCallContext({ tenant })
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: overrides.id ?? 'task-1',
+    contextId: overrides.contextId ?? 'ctx-1',
+    status: overrides.status ?? { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: '2026-01-01T00:00:00Z' },
+    artifacts: overrides.artifacts ?? [],
+    history: overrides.history ?? [],
+    metadata: overrides.metadata,
+  }
+}
+
+let store: TaskStore
+
+beforeEach(() => {
+  rows = []
+  clock = 0
+  store = new PrismaA2ATaskStore()
+})
+
+describe('save', () => {
+  it('persists a new task scoped to context.tenant', async () => {
+    const task = makeTask({ id: 't1', contextId: 'c1' })
+    await store.save(task, ctx('p1'))
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ id: 't1', contextId: 'c1', projectId: 'p1', state: 'TASK_STATE_WORKING' })
+    expect(JSON.parse(rows[0].taskJson)).toEqual(task)
+  })
+
+  it('extracts chatSessionId from task.metadata on create', async () => {
+    const task = makeTask({ id: 't1', metadata: { chatSessionId: 'sess-1' } })
+    await store.save(task, ctx('p1'))
+    expect(rows[0].chatSessionId).toBe('sess-1')
+  })
+
+  it('upserts (overwrites) an existing task with the same id', async () => {
+    await store.save(makeTask({ id: 't1', status: { state: TaskState.TASK_STATE_SUBMITTED, message: undefined, timestamp: 't' } }), ctx('p1'))
+    await store.save(makeTask({ id: 't1', status: { state: TaskState.TASK_STATE_COMPLETED, message: undefined, timestamp: 't2' } }), ctx('p1'))
+    expect(rows).toHaveLength(1)
+    expect(rows[0].state).toBe('TASK_STATE_COMPLETED')
+  })
+
+  it('does not clear chatSessionId on an update that omits metadata', async () => {
+    await store.save(makeTask({ id: 't1', metadata: { chatSessionId: 'sess-1' } }), ctx('p1'))
+    await store.save(makeTask({ id: 't1', metadata: undefined }), ctx('p1'))
+    expect(rows[0].chatSessionId).toBe('sess-1')
+  })
+
+  it('throws when context.tenant is missing', async () => {
+    await expect(store.save(makeTask(), ctx(undefined))).rejects.toThrow(/context.tenant/)
+  })
+
+  it('defaults state to TASK_STATE_UNSPECIFIED when task.status is absent', async () => {
+    const task = makeTask({ id: 't1' })
+    delete (task as any).status
+    await store.save(task, ctx('p1'))
+    expect(rows[0].state).toBe('TASK_STATE_UNSPECIFIED')
+  })
+})
+
+describe('load', () => {
+  it('round-trips a saved task', async () => {
+    const task = makeTask({ id: 't1' })
+    await store.save(task, ctx('p1'))
+    const loaded = await store.load('t1', ctx('p1'))
+    expect(loaded).toEqual(task)
+  })
+
+  it('returns undefined for an unknown taskId', async () => {
+    expect(await store.load('nope', ctx('p1'))).toBeUndefined()
+  })
+
+  it('returns undefined when context.tenant is missing', async () => {
+    await store.save(makeTask({ id: 't1' }), ctx('p1'))
+    expect(await store.load('t1', ctx(undefined))).toBeUndefined()
+  })
+
+  it('never returns a task belonging to a different project (tenant isolation)', async () => {
+    await store.save(makeTask({ id: 't1' }), ctx('p1'))
+    expect(await store.load('t1', ctx('p2'))).toBeUndefined()
+  })
+})
+
+describe('list', () => {
+  async function seed() {
+    await store.save(makeTask({ id: 't1', contextId: 'c1', status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: 't' } }), ctx('p1'))
+    await store.save(makeTask({ id: 't2', contextId: 'c1', status: { state: TaskState.TASK_STATE_COMPLETED, message: undefined, timestamp: 't' } }), ctx('p1'))
+    await store.save(makeTask({ id: 't3', contextId: 'c2', status: { state: TaskState.TASK_STATE_COMPLETED, message: undefined, timestamp: 't' } }), ctx('p1'))
+    await store.save(makeTask({ id: 't4', contextId: 'c1' }), ctx('p2'))
+  }
+
+  function req(overrides: Partial<ListTasksRequest> = {}): ListTasksRequest {
+    return {
+      tenant: '',
+      contextId: '',
+      status: TaskState.TASK_STATE_UNSPECIFIED,
+      pageToken: '',
+      statusTimestampAfter: undefined,
+      ...overrides,
+    } as ListTasksRequest
+  }
+
+  it('scopes results to context.tenant, never leaking another project', async () => {
+    await seed()
+    const result = await store.list(req(), ctx('p1'))
+    expect(result.totalSize).toBe(3)
+    expect(result.tasks.map((t) => t.id).sort()).toEqual(['t1', 't2', 't3'])
+  })
+
+  it('filters by contextId', async () => {
+    await seed()
+    const result = await store.list(req({ contextId: 'c2' }), ctx('p1'))
+    expect(result.tasks.map((t) => t.id)).toEqual(['t3'])
+  })
+
+  it('filters by status', async () => {
+    await seed()
+    const result = await store.list(req({ status: TaskState.TASK_STATE_COMPLETED }), ctx('p1'))
+    expect(result.tasks.map((t) => t.id).sort()).toEqual(['t2', 't3'])
+  })
+
+  it('returns an empty page when context.tenant is missing and params.tenant is also empty', async () => {
+    await seed()
+    const result = await store.list(req(), ctx(undefined))
+    expect(result).toEqual({ tasks: [], nextPageToken: '', pageSize: 0, totalSize: 0 })
+  })
+
+  it('paginates with pageSize and an opaque pageToken, terminating with an empty nextPageToken', async () => {
+    await seed()
+    const page1 = await store.list(req({ pageSize: 2 }), ctx('p1'))
+    expect(page1.tasks).toHaveLength(2)
+    expect(page1.pageSize).toBe(2)
+    expect(page1.totalSize).toBe(3)
+    expect(page1.nextPageToken).not.toBe('')
+
+    const page2 = await store.list(req({ pageSize: 2, pageToken: page1.nextPageToken }), ctx('p1'))
+    expect(page2.tasks).toHaveLength(1)
+    expect(page2.nextPageToken).toBe('')
+
+    const seenIds = new Set([...page1.tasks, ...page2.tasks].map((t) => t.id))
+    expect(seenIds.size).toBe(3)
+  })
+
+  it('clamps pageSize to [1, 100] and defaults to 50 when unset/invalid', async () => {
+    await seed()
+    expect((await store.list(req(), ctx('p1'))).pageSize).toBe(50)
+    expect((await store.list(req({ pageSize: 0 }), ctx('p1'))).pageSize).toBe(50)
+    expect((await store.list(req({ pageSize: 500 }), ctx('p1'))).pageSize).toBe(100)
+  })
+
+  it('omits artifacts unless includeArtifacts is true', async () => {
+    const task = makeTask({
+      id: 't1',
+      artifacts: [{ artifactId: 'a1', name: 'a1', description: '', parts: [], metadata: undefined, extensions: [] }],
+    })
+    await store.save(task, ctx('p1'))
+
+    const withoutArtifacts = await store.list(req(), ctx('p1'))
+    expect(withoutArtifacts.tasks[0].artifacts).toEqual([])
+
+    const withArtifacts = await store.list(req({ includeArtifacts: true }), ctx('p1'))
+    expect(withArtifacts.tasks[0].artifacts).toHaveLength(1)
+  })
+
+  it('applies historyLength trimming, keeping only the most recent N messages', async () => {
+    const history = [1, 2, 3, 4].map((n) => ({
+      messageId: `m${n}`,
+      contextId: 'c1',
+      taskId: 't1',
+      role: 1,
+      parts: [],
+      metadata: undefined,
+      extensions: [],
+      referenceTaskIds: [],
+    })) as any
+    await store.save(makeTask({ id: 't1', history }), ctx('p1'))
+
+    const trimmed = await store.list(req({ historyLength: 2 }), ctx('p1'))
+    expect(trimmed.tasks[0].history.map((m) => m.messageId)).toEqual(['m3', 'm4'])
+
+    const zero = await store.list(req({ historyLength: 0 }), ctx('p1'))
+    expect(zero.tasks[0].history).toEqual([])
+
+    const untrimmed = await store.list(req(), ctx('p1'))
+    expect(untrimmed.tasks[0].history).toHaveLength(4)
+  })
+})

--- a/apps/api/src/lib/a2a/auth.ts
+++ b/apps/api/src/lib/a2a/auth.ts
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * A2A bearer-key auth: mint / verify / revoke `shogo_a2a_<keyId>.<secret>`
+ * tokens, one per project.
+ *
+ * Shape mirrors Odin's `odin_a2a_<key_id>.<secret>` (see
+ * `alignment-project-server/services/a2a/auth.py`), but the secret is
+ * hashed with the repo's existing SHA-256 `hashApiKey()`
+ * (`lib/api-keys-mint.ts`) instead of Odin's bcrypt, for consistency with
+ * `shogo_sk_*` keys elsewhere in this codebase. The secret is 32 random
+ * bytes of entropy, so a fast hash is fine here (unlike a user-chosen
+ * password, there's no offline-guessing risk to mitigate with a slow KDF).
+ *
+ * The `keyId` half is NOT secret — it's a lookup key, persisted plaintext
+ * in `A2aApiKey.keyId` (unique-indexed) so verification is a single
+ * `findUnique` rather than a table scan comparing hashes. Only the
+ * `secret` half is hashed.
+ *
+ * Every verification failure — malformed token, unknown keyId, revoked,
+ * expired, wrong project, hash mismatch — must be indistinguishable to
+ * the caller (uniform 401 + `WWW-Authenticate: Bearer`), so a probing
+ * client can't use error shape/timing to enumerate projects or valid
+ * keyIds. `verifyA2aApiKey` returns a single `{ ok: false }` shape for
+ * all of these; the route layer is responsible for not leaking more.
+ */
+
+import crypto from 'crypto'
+import { hashApiKey } from '../api-keys-mint'
+import { prisma } from '../prisma'
+
+/** Public prefix on every minted A2A key, before `<keyId>.<secret>`. */
+export const SHOGO_A2A_KEY_PREFIX = 'shogo_a2a_'
+
+/** Random bytes (hex-encoded) making up the lookup-key half. Not secret. */
+const KEY_ID_RANDOM_BYTES = 12
+
+/** Random bytes (hex-encoded) making up the secret half. Hashed at rest. */
+const SECRET_RANDOM_BYTES = 32
+
+function randomHex(bytes: number): string {
+  return Array.from(crypto.getRandomValues(new Uint8Array(bytes)))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+export interface MintA2aKeyArgs {
+  projectId: string
+  workspaceId: string
+  createdBy: string
+  /** Defaults to `'A2A key'` if blank. Truncated to 120 chars. */
+  name?: string
+  /** Optional absolute expiry. */
+  expiresAt?: Date | null
+}
+
+export interface MintedA2aKey {
+  /** The bearer token — hand to the caller exactly once. */
+  fullKey: string
+  id: string
+  keyId: string
+  name: string
+  projectId: string
+  createdAt: Date
+  expiresAt: Date | null
+}
+
+/**
+ * Mint a new `shogo_a2a_*` key for a project. Does not dedupe against
+ * existing keys — unlike device keys, a project can (and typically will)
+ * hand out several named A2A keys to different external callers, and
+ * revoking one must not touch the others.
+ */
+export async function mintA2aApiKey(args: MintA2aKeyArgs): Promise<MintedA2aKey> {
+  const keyId = randomHex(KEY_ID_RANDOM_BYTES)
+  const secret = randomHex(SECRET_RANDOM_BYTES)
+  const fullKey = `${SHOGO_A2A_KEY_PREFIX}${keyId}.${secret}`
+  const hashedSecret = await hashApiKey(secret)
+  const name = args.name?.slice(0, 120) || 'A2A key'
+
+  const row = await prisma.a2aApiKey.create({
+    data: {
+      name,
+      keyId,
+      hashedSecret,
+      projectId: args.projectId,
+      workspaceId: args.workspaceId,
+      createdBy: args.createdBy,
+      expiresAt: args.expiresAt ?? null,
+    },
+  })
+
+  return {
+    fullKey,
+    id: row.id,
+    keyId: row.keyId,
+    name: row.name,
+    projectId: row.projectId,
+    createdAt: row.createdAt,
+    expiresAt: row.expiresAt,
+  }
+}
+
+export interface A2aKeyListItem {
+  id: string
+  name: string
+  keyId: string
+  projectId: string
+  createdAt: Date
+  lastUsedAt: Date | null
+  expiresAt: Date | null
+  revokedAt: Date | null
+}
+
+/** List keys for a project, newest first. Never returns `hashedSecret`. */
+export async function listA2aApiKeys(projectId: string): Promise<A2aKeyListItem[]> {
+  const rows = await prisma.a2aApiKey.findMany({
+    where: { projectId },
+    orderBy: { createdAt: 'desc' },
+  })
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    keyId: r.keyId,
+    projectId: r.projectId,
+    createdAt: r.createdAt,
+    lastUsedAt: r.lastUsedAt,
+    expiresAt: r.expiresAt,
+    revokedAt: r.revokedAt,
+  }))
+}
+
+/**
+ * Revoke a key. Scoped to `projectId` so one project can't revoke
+ * another's key by guessing/enumerating ids — callers must have already
+ * passed `authorizeProject` for `projectId` before calling this.
+ *
+ * Returns `false` (rather than throwing) when the id doesn't exist or
+ * belongs to a different project, so the route can 404 uniformly.
+ */
+export async function revokeA2aApiKey(args: { id: string; projectId: string }): Promise<boolean> {
+  const result = await prisma.a2aApiKey.updateMany({
+    where: { id: args.id, projectId: args.projectId, revokedAt: null },
+    data: { revokedAt: new Date() },
+  })
+  return result.count > 0
+}
+
+export interface VerifiedA2aKey {
+  id: string
+  keyId: string
+  projectId: string
+  workspaceId: string
+}
+
+export type VerifyA2aKeyResult =
+  | { ok: true; key: VerifiedA2aKey }
+  | { ok: false }
+
+/**
+ * Parse a `shogo_a2a_<keyId>.<secret>` token and verify it's valid for
+ * `projectId`. Every rejection path returns the same `{ ok: false }` —
+ * do not branch on the reason in caller-visible responses.
+ *
+ * Fires a best-effort (non-blocking) `lastUsedAt` bump on success —
+ * mirrors `resolveApiKey`'s pattern for `shogo_sk_*` keys — so a slow/
+ * failed write never delays the A2A call it's authenticating.
+ */
+export async function verifyA2aApiKey(
+  bearerToken: string,
+  projectId: string,
+): Promise<VerifyA2aKeyResult> {
+  if (!bearerToken.startsWith(SHOGO_A2A_KEY_PREFIX)) return { ok: false }
+
+  const rest = bearerToken.slice(SHOGO_A2A_KEY_PREFIX.length)
+  const dot = rest.indexOf('.')
+  if (dot <= 0 || dot === rest.length - 1) return { ok: false }
+
+  const keyId = rest.slice(0, dot)
+  const secret = rest.slice(dot + 1)
+
+  let row: {
+    id: string
+    keyId: string
+    hashedSecret: string
+    projectId: string
+    workspaceId: string
+    revokedAt: Date | null
+    expiresAt: Date | null
+  } | null = null
+  try {
+    row = await prisma.a2aApiKey.findUnique({ where: { keyId } })
+  } catch {
+    return { ok: false }
+  }
+  if (!row) return { ok: false }
+  if (row.revokedAt) return { ok: false }
+  if (row.expiresAt && row.expiresAt.getTime() < Date.now()) return { ok: false }
+  if (row.projectId !== projectId) return { ok: false }
+
+  const presentedHash = await hashApiKey(secret)
+  if (!timingSafeEqualHex(presentedHash, row.hashedSecret)) return { ok: false }
+
+  // Best-effort, fire-and-forget — never block or fail the request on this.
+  prisma.a2aApiKey
+    .update({ where: { id: row.id }, data: { lastUsedAt: new Date() } })
+    .catch(() => {})
+
+  return {
+    ok: true,
+    key: {
+      id: row.id,
+      keyId: row.keyId,
+      projectId: row.projectId,
+      workspaceId: row.workspaceId,
+    },
+  }
+}
+
+/**
+ * Timing-safe compare of two equal-shape hex strings (both are SHA-256
+ * hex digests, so always 64 chars — but guard the length anyway since
+ * `crypto.timingSafeEqual` throws on mismatched buffer lengths rather
+ * than returning `false`, which would otherwise turn a corrupt DB row
+ * into a 500 instead of a clean auth rejection).
+ */
+function timingSafeEqualHex(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, 'hex')
+  const bufB = Buffer.from(b, 'hex')
+  if (bufA.length !== bufB.length) return false
+  return crypto.timingSafeEqual(bufA, bufB)
+}

--- a/apps/api/src/lib/a2a/card.ts
+++ b/apps/api/src/lib/a2a/card.ts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Builds the A2A `AgentCard` for a project — the shogo equivalent of
+ * Odin's `services/a2a/card.py`.
+ *
+ * Built fresh on every request (not cached), so project edits show up
+ * immediately — same posture as Odin. The v1.0 `AgentCard` type has more
+ * REQUIRED fields than Odin's Python card builder needed (`protocolVersion`
+ * and `tenant` on every `AgentInterface`, `capabilities.extensions`,
+ * per-skill `examples`/`inputModes`/`outputModes`/`securityRequirements`,
+ * `signatures`) — see the field-by-field notes inline below.
+ *
+ * Card metadata source, and what "the shogo agent" means here:
+ *
+ *   - `ProjectAgent` (prisma/schema.prisma) is a persona row backing
+ *     `POST /api/chat/turn` and the voice stack — `displayName`,
+ *     `characterName`, `systemPrompt`, `tools` descriptors.
+ *   - The actual A2A-reachable agent is the runtime pod (`AgentGateway`,
+ *     reached via `POST /agent/chat`), which has no notion of named
+ *     personas — `POST /agent/chat` takes no `agentName` parameter.
+ *
+ * So `ProjectAgent` is used ONLY as card metadata (name/description, and
+ * its `tools` as extra `AgentSkill`s when present) — never to select a
+ * runtime agent. There's no `resolveProjectAgentOrLegacyDefault` helper
+ * in this codebase (that name in the plan was aspirational); the
+ * fallback to a project's bare name/description when no `ProjectAgent`
+ * row exists is implemented directly in `resolveCardMetadata` below.
+ */
+
+import type { AgentCard, AgentSkill } from '@a2a-js/sdk'
+import { prisma } from '../prisma'
+import { resolveProjectAgent, type ResolvedAgent } from '../../services/projectAgent.service'
+import { getFrontendUrl } from '../cloud-urls'
+
+/** A2A protocol version this server implements. No implicit default —
+ * `validateVersion()` in the SDK rejects any version not explicitly
+ * declared on an `AgentInterface`. */
+export const A2A_PROTOCOL_VERSION = '1.0'
+
+const CHAT_SKILL: AgentSkill = {
+  id: 'chat',
+  name: 'Chat',
+  description:
+    'General-purpose coding-agent chat. Send a message and the agent reads/writes ' +
+    "the project's files, runs commands, and answers using the full runtime tool set.",
+  tags: ['shogo', 'chat', 'coding-agent'],
+  examples: [
+    'Add a dark mode toggle to the settings page',
+    'Why is the build failing?',
+  ],
+  inputModes: ['text/plain'],
+  outputModes: ['text/plain'],
+  securityRequirements: [],
+}
+
+/**
+ * Base URL A2A clients should use to reach this server. Priority:
+ * `SHOGO_A2A_BASE_URL` (Odin's `BACKEND_ROOT_URL` equivalent) →
+ * `getFrontendUrl()` (`APP_URL` → first `ALLOWED_ORIGINS` entry →
+ * localhost). Trailing slash trimmed so callers can concat safely.
+ */
+export function getA2aBaseUrl(): string {
+  const override = process.env.SHOGO_A2A_BASE_URL
+  const base = override || getFrontendUrl()
+  return base.replace(/\/$/, '')
+}
+
+interface CardMetadata {
+  name: string
+  description: string
+  extraSkills: AgentSkill[]
+}
+
+/**
+ * Resolve card metadata from the project's `default` `ProjectAgent` row,
+ * falling back to the bare `Project` row when no agent row exists
+ * (projects created before the `project_agents` table, or that never
+ * configured a named agent). Never returns `null` — a project that
+ * exists always has at least a name to show.
+ */
+async function resolveCardMetadata(projectId: string): Promise<CardMetadata | null> {
+  const agent: ResolvedAgent | null = await resolveProjectAgent({ projectId })
+
+  if (agent) {
+    const name = agent.displayName || agent.characterName || 'Shogo Agent'
+    const description =
+      agent.systemPrompt?.trim().slice(0, 500) ||
+      `Shogo coding agent for this project (agent: ${agent.name}).`
+    const extraSkills: AgentSkill[] = (agent.tools ?? []).map((tool) => ({
+      id: tool.name,
+      name: tool.name,
+      description: tool.description || `Tool: ${tool.name}`,
+      tags: ['shogo', 'tool'],
+      examples: [],
+      inputModes: [],
+      outputModes: [],
+      securityRequirements: [],
+    }))
+    return { name, description, extraSkills }
+  }
+
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: { name: true, description: true },
+  })
+  if (!project) return null
+
+  return {
+    name: project.name || 'Shogo Agent',
+    description: project.description || `Shogo coding agent for project ${project.name}.`,
+    extraSkills: [],
+  }
+}
+
+export interface BuildAgentCardOptions {
+  projectId: string
+  /** Override the computed base URL — mainly for tests. */
+  baseUrl?: string
+}
+
+/**
+ * Build the `AgentCard` for `projectId`. Returns `null` if the project
+ * doesn't exist (caller should 404, not fabricate a card).
+ */
+export async function buildAgentCard(options: BuildAgentCardOptions): Promise<AgentCard | null> {
+  const { projectId } = options
+  const meta = await resolveCardMetadata(projectId)
+  if (!meta) return null
+
+  const base = options.baseUrl ?? getA2aBaseUrl()
+  const rpcUrl = `${base}/a2a/projects/${projectId}/rpc`
+
+  const card: AgentCard = {
+    name: meta.name,
+    description: meta.description,
+    version: '1.0.0',
+    provider: undefined,
+    documentationUrl: `${base}/docs/a2a`,
+    // First (and only) entry is preferred per `AgentInterface` doc comment.
+    supportedInterfaces: [
+      {
+        url: rpcUrl,
+        protocolBinding: 'JSONRPC',
+        // Both mandatory in v1.0 — see module doc comment.
+        protocolVersion: A2A_PROTOCOL_VERSION,
+        tenant: projectId,
+      },
+    ],
+    capabilities: {
+      // The main departure from Odin (`capabilities.streaming=False`) —
+      // shogo's runtime pod already streams rich events end to end.
+      streaming: true,
+      pushNotifications: false,
+      extensions: [],
+      extendedAgentCard: false,
+    },
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [CHAT_SKILL, ...meta.extraSkills],
+    securitySchemes: {
+      bearerAuth: {
+        scheme: {
+          $case: 'httpAuthSecurityScheme',
+          value: {
+            description: 'Project-scoped shogo_a2a_<keyId>.<secret> bearer key.',
+            scheme: 'Bearer',
+            bearerFormat: 'opaque',
+          },
+        },
+      },
+    },
+    securityRequirements: [{ schemes: { bearerAuth: { list: [] } } }],
+    signatures: [],
+    iconUrl: undefined,
+  }
+
+  return card
+}

--- a/apps/api/src/lib/a2a/event-mapper.ts
+++ b/apps/api/src/lib/a2a/event-mapper.ts
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Maps the agent-runtime pod's AI SDK `UIMessageChunk` SSE stream (see
+ * `packages/agent-runtime/src/server.ts`'s `createUIMessageStream`) onto
+ * A2A `AgentExecutionEvent`s.
+ *
+ * This has no equivalent in Odin — `alignment-project-server` doesn't
+ * stream (`capabilities.streaming=False`); this is shogo's actual
+ * departure from the reference implementation.
+ *
+ * Mapping (see the plan's "Event mapping" section for the full table):
+ *   - `text-start` / `text-delta` / `text-end` → `artifactUpdate` on a
+ *     single `response` artifact, `append: true` throughout,
+ *     `lastChunk: true` only on `text-end`.
+ *   - `tool-input-available` → `statusUpdate(WORKING)` with a `DataPart`
+ *     of `{ toolCallId, toolName, input }`.
+ *   - `tool-output-available` → `statusUpdate(WORKING)` with
+ *     `{ toolCallId, output }`.
+ *   - `tool-output-error` → `statusUpdate(WORKING)` with error data.
+ *   - `reasoning-*` → `statusUpdate(WORKING)` with `metadata.kind =
+ *     'reasoning'`, gated behind `opts.includeReasoning` (an opt-in card
+ *     extension in the executor) so reasoning isn't leaked by default.
+ *   - `data-usage` → accumulated into `state.usage`; merged into the
+ *     final status's `metadata` by the caller (not emitted as its own
+ *     event).
+ *   - `data-turn-seq` → no A2A event (persisted to `A2aTask.lastSeq` by
+ *     the executor directly, for resume diagnostics).
+ *   - `error` → `statusUpdate(FAILED, final: true)`.
+ *   - `data-turn-complete` → `statusUpdate(COMPLETED | CANCELED | FAILED,
+ *     final: true)` based on `status` — UNLESS the turn's last
+ *     unanswered tool call was `ask_user`, in which case it maps to
+ *     `INPUT_REQUIRED` instead (see below).
+ *
+ * Two interactive cases the first draft of this plan missed:
+ *
+ *   - **`ask_user` → `TASK_STATE_INPUT_REQUIRED`.** The tool deliberately
+ *     suppresses `tool-output-available` and ends the turn
+ *     (`gateway.ts`'s `onAfterToolCall`), so `state.askUserPending` is
+ *     set on `tool-input-available` and only cleared by a matching
+ *     `tool-output-available` (defensive; ask_user never sends one).
+ *     When `data-turn-complete` arrives with it still set, we override
+ *     the terminal state to `INPUT_REQUIRED` with the question(s) as the
+ *     status message, regardless of what `data.status` said — an
+ *     unanswered `ask_user` is never actually "completed".
+ *
+ *   - **`data-permission-request` → `TASK_STATE_AUTH_REQUIRED`.** Only
+ *     ever emitted when `SHOGO_LOCAL_MODE=true` with a non-default
+ *     `strict`/`balanced` security policy (`PermissionEngine` doesn't
+ *     exist on cloud pods). The underlying `requestApproval()` call
+ *     blocks the pod's tool execution — and therefore the whole
+ *     `/agent/chat` HTTP response — for up to 30s before auto-denying,
+ *     so this is a TRANSIENT status update, not a terminal one: we
+ *     surface it immediately (rather than silently eating the stall)
+ *     and keep consuming the same stream, which resumes on its own
+ *     once the pod's timeout or an operator's out-of-band response
+ *     fires `handleApprovalResponse`. There is intentionally no v1 path
+ *     for an A2A client to answer this itself — see the module's
+ *     "Known limitations" note in the plan.
+ */
+
+import { Role, TaskState, type Message, type Part } from '@a2a-js/sdk'
+import { AgentEvent, type AgentExecutionEvent } from '@a2a-js/sdk/server'
+
+/** Artifact id/name every text chunk of a turn's response is appended to. */
+const RESPONSE_ARTIFACT_ID = 'response'
+
+export interface EventMapperContext {
+  taskId: string
+  contextId: string
+}
+
+export interface EventMapperOptions {
+  /** Surface `reasoning-*` chunks as WORKING updates. Default false. */
+  includeReasoning?: boolean
+}
+
+export interface UsageSnapshot {
+  inputTokens?: number
+  outputTokens?: number
+  cacheReadTokens?: number
+  cacheWriteTokens?: number
+  totalTokens?: number
+}
+
+export interface AskUserPending {
+  toolCallId: string
+  questions: Array<{ header: string; question: string }>
+}
+
+/** Per-turn accumulator threaded through every `mapPodChunkToA2AEvents` call. */
+export interface EventMapperState {
+  askUserPending?: AskUserPending
+  usage?: UsageSnapshot
+  /** Highest `data-turn-seq` observed — for the executor's resume bookkeeping. */
+  lastSeq: number
+}
+
+export function createEventMapperState(): EventMapperState {
+  return { lastSeq: 0 }
+}
+
+function textPart(text: string): Part {
+  return { content: { $case: 'text', value: text }, metadata: undefined, filename: '', mediaType: 'text/plain' }
+}
+
+function dataPart(value: unknown): Part {
+  return { content: { $case: 'data', value }, metadata: undefined, filename: '', mediaType: 'application/json' }
+}
+
+function agentMessage(ctx: EventMapperContext, parts: Part[]): Message {
+  return {
+    messageId: crypto.randomUUID(),
+    contextId: ctx.contextId,
+    taskId: ctx.taskId,
+    role: Role.ROLE_AGENT,
+    parts,
+    metadata: undefined,
+    extensions: [],
+    referenceTaskIds: [],
+  }
+}
+
+function statusUpdate(
+  ctx: EventMapperContext,
+  state: TaskState,
+  opts: { message?: Message; metadata?: Record<string, unknown> } = {},
+): AgentExecutionEvent {
+  return AgentEvent.statusUpdate({
+    taskId: ctx.taskId,
+    contextId: ctx.contextId,
+    status: {
+      state,
+      message: opts.message,
+      timestamp: new Date().toISOString(),
+    },
+    metadata: opts.metadata,
+  })
+}
+
+function workingWithData(ctx: EventMapperContext, value: unknown): AgentExecutionEvent {
+  return statusUpdate(ctx, TaskState.TASK_STATE_WORKING, {
+    message: agentMessage(ctx, [dataPart(value)]),
+  })
+}
+
+/**
+ * Process one already-JSON-parsed pod SSE chunk. Returns zero or more
+ * `AgentExecutionEvent`s to publish, in order. Mutates `state` in place
+ * (mirrors the pattern in `evals/runner.ts` / `project-chat.ts`).
+ */
+export function mapPodChunkToA2AEvents(
+  chunk: any,
+  state: EventMapperState,
+  ctx: EventMapperContext,
+  opts: EventMapperOptions = {},
+): AgentExecutionEvent[] {
+  if (!chunk || typeof chunk !== 'object') return []
+  const type = chunk.type
+
+  switch (type) {
+    case 'text-delta': {
+      const delta = chunk.delta ?? ''
+      if (!delta) return []
+      return [
+        AgentEvent.artifactUpdate({
+          taskId: ctx.taskId,
+          contextId: ctx.contextId,
+          artifact: {
+            artifactId: RESPONSE_ARTIFACT_ID,
+            name: RESPONSE_ARTIFACT_ID,
+            description: '',
+            parts: [textPart(delta)],
+            metadata: undefined,
+            extensions: [],
+          },
+          append: true,
+          lastChunk: false,
+          metadata: undefined,
+        }),
+      ]
+    }
+
+    case 'text-end': {
+      // Deliberately no event here. `append: true` artifact updates PUSH a
+      // new `Part` onto `artifact.parts` (see `ResultManager.applyArtifactUpdate`
+      // in `@a2a-js/sdk` — it's an array push, not a string concat), so an
+      // empty trailing part would just be dead weight in the persisted
+      // task. `lastChunk` on the terminal `data-turn-complete` status
+      // update is the actual "this task is done" signal; a listener
+      // wanting "this text run is done" can infer it from the next
+      // WORKING update (tool call) or the terminal state.
+      return []
+    }
+
+    case 'tool-input-available': {
+      const toolCallId = chunk.toolCallId ?? ''
+      const toolName = chunk.toolName ?? 'unknown'
+      if (toolName === 'ask_user') {
+        const questions: Array<{ header: string; question: string }> =
+          Array.isArray(chunk.input?.questions)
+            ? chunk.input.questions.map((q: any) => ({
+                header: String(q?.header ?? ''),
+                question: String(q?.question ?? ''),
+              }))
+            : []
+        state.askUserPending = { toolCallId, questions }
+      }
+      return [workingWithData(ctx, { toolCallId, toolName, input: chunk.input })]
+    }
+
+    case 'tool-output-available': {
+      const toolCallId = chunk.toolCallId ?? ''
+      if (state.askUserPending?.toolCallId === toolCallId) state.askUserPending = undefined
+      return [workingWithData(ctx, { toolCallId, output: chunk.output })]
+    }
+
+    case 'tool-output-error': {
+      const toolCallId = chunk.toolCallId ?? ''
+      if (state.askUserPending?.toolCallId === toolCallId) state.askUserPending = undefined
+      return [workingWithData(ctx, { toolCallId, error: chunk.errorText ?? chunk.error ?? 'tool error' })]
+    }
+
+    case 'reasoning-start':
+    case 'reasoning-delta':
+    case 'reasoning-end': {
+      if (!opts.includeReasoning) return []
+      const text = type === 'reasoning-delta' ? String(chunk.delta ?? '') : ''
+      return [
+        statusUpdate(ctx, TaskState.TASK_STATE_WORKING, {
+          message: agentMessage(ctx, [textPart(text)]),
+          metadata: { kind: 'reasoning', phase: type },
+        }),
+      ]
+    }
+
+    case 'data-usage': {
+      const u = chunk.data ?? chunk
+      state.usage = {
+        inputTokens: u.inputTokens ?? u.promptTokens ?? state.usage?.inputTokens,
+        outputTokens: u.outputTokens ?? u.completionTokens ?? state.usage?.outputTokens,
+        cacheReadTokens: u.cacheReadTokens ?? state.usage?.cacheReadTokens,
+        cacheWriteTokens: u.cacheWriteTokens ?? state.usage?.cacheWriteTokens,
+        totalTokens: u.totalTokens ?? state.usage?.totalTokens,
+      }
+      return []
+    }
+
+    case 'data-turn-seq': {
+      const seq = chunk.data?.seq
+      if (typeof seq === 'number' && seq > state.lastSeq) state.lastSeq = seq
+      return []
+    }
+
+    case 'data-permission-request': {
+      return [
+        statusUpdate(ctx, TaskState.TASK_STATE_AUTH_REQUIRED, {
+          message: agentMessage(ctx, [dataPart(chunk.data ?? {})]),
+          metadata: { transient: true, reason: 'permission-request' },
+        }),
+      ]
+    }
+
+    case 'error': {
+      const text = chunk.errorText ?? chunk.message ?? chunk.error ?? 'Unknown error'
+      return [
+        statusUpdate(ctx, TaskState.TASK_STATE_FAILED, {
+          message: agentMessage(ctx, [textPart(String(text))]),
+        }),
+      ]
+    }
+
+    case 'data-turn-complete': {
+      const status = chunk.data?.status
+      if (state.askUserPending) {
+        const questionText = state.askUserPending.questions
+          .map((q) => `${q.header}: ${q.question}`)
+          .join('\n')
+        return [
+          statusUpdate(ctx, TaskState.TASK_STATE_INPUT_REQUIRED, {
+            message: agentMessage(ctx, [textPart(questionText || 'The agent is waiting for your input.')]),
+          }),
+        ]
+      }
+      const finalState =
+        status === 'aborted'
+          ? TaskState.TASK_STATE_CANCELED
+          : status === 'failed'
+            ? TaskState.TASK_STATE_FAILED
+            : TaskState.TASK_STATE_COMPLETED
+      return [statusUpdate(ctx, finalState, { metadata: state.usage ? { usage: state.usage } : undefined })]
+    }
+
+    default:
+      return []
+  }
+}

--- a/apps/api/src/lib/a2a/executor.ts
+++ b/apps/api/src/lib/a2a/executor.ts
@@ -1,0 +1,474 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * `ShogoAgentExecutor` — the shogo equivalent of Odin's `OdinAgentExecutor`
+ * (`services/a2a/executor.py`).
+ *
+ * Odin's executor bridges A2A directly into an in-process
+ * `ToolUseAgent.ainvoke()`. Shogo's agent is a per-project pod
+ * (`AgentGateway`, reached over HTTP), so this executor is a *stream
+ * consumer*, not an in-process invoker: it POSTs to the pod's
+ * `/agent/chat`, tees the SSE response one branch into
+ * `trackUsageFromStream` (billing + `ChatMessage`/`ToolCallLog`
+ * persistence, exactly like a UI turn) and one branch into
+ * `mapPodChunkToA2AEvents` (published on the A2A `ExecutionEventBus`).
+ */
+
+import crypto from 'crypto'
+import { JsonRpcTaskNotCancelableError } from '@a2a-js/sdk/errors'
+import { Role, TaskState, type Task } from '@a2a-js/sdk'
+import {
+  AgentEvent,
+  ServerCallContext,
+  type AgentExecutor,
+  type ExecutionEventBus,
+  type RequestContext,
+} from '@a2a-js/sdk/server'
+import { prisma } from '../prisma'
+import { resolveProjectPodUrl } from '../resolve-pod-url'
+import { deriveProjectRuntimeToken } from '../project-runtime-token'
+import { trackUsageFromStream } from '../../routes/project-chat'
+import {
+  createEventMapperState,
+  mapPodChunkToA2AEvents,
+  type EventMapperState,
+} from './event-mapper'
+import type { PrismaA2ATaskStore } from './task-store'
+
+const FETCH_TIMEOUT_MS = parseInt(process.env.CHAT_UPSTREAM_FETCH_TIMEOUT_MS || '14400000', 10)
+const IDLE_TIMEOUT_MS = parseInt(process.env.CHAT_STREAM_IDLE_TIMEOUT_MS || '3600000', 10)
+
+/**
+ * Extension URI a client declares (via `A2A-Extensions` / requested
+ * extensions) to opt into receiving `reasoning-*` chunks as WORKING
+ * updates. Off by default — see the event-mapper module doc.
+ */
+export const A2A_REASONING_EXTENSION_URI = 'https://shogo.ai/a2a/extensions/reasoning'
+
+export interface ShogoAgentExecutorOptions {
+  projectId: string
+  workspaceId: string
+  taskStore: PrismaA2ATaskStore
+}
+
+/**
+ * Deterministic `chatSessionId` for an A2A `(projectId, contextId)` pair
+ * so the pod's `SessionManager` gives repeat sends on the same `contextId`
+ * continuous conversation memory — the entire reason A2A has a `contextId`
+ * concept distinct from `taskId`.
+ */
+function deriveChatSessionId(projectId: string, contextId: string): string {
+  const hash = crypto.createHash('sha256').update(`${projectId}:${contextId}`).digest('hex')
+  return `a2a-${hash.slice(0, 32)}`
+}
+
+/** Ensures a `ChatSession` row exists so `trackUsageFromStream` can persist into it. */
+async function ensureChatSession(projectId: string, chatSessionId: string): Promise<void> {
+  const existing = await prisma.chatSession.findUnique({ where: { id: chatSessionId } })
+  if (existing) return
+  try {
+    await prisma.chatSession.create({
+      data: {
+        id: chatSessionId,
+        contextType: 'project',
+        contextId: projectId,
+        inferredName: 'A2A session',
+      } as any,
+    })
+  } catch (err: any) {
+    // Benign race: a concurrent request for the same contextId created it
+    // first. The one-in-flight-turn-per-contextId guard in `execute()`
+    // makes this vanishingly rare, but don't fail the turn over it.
+    if (err?.code !== 'P2002') throw err
+  }
+}
+
+/** Extract plain text from an A2A `Message`'s `text` parts, joined with newlines. */
+function extractText(message: { parts: Array<{ content?: { $case: string; value: unknown } }> }): string {
+  return message.parts
+    .filter((p) => p.content?.$case === 'text')
+    .map((p) => String((p.content as any).value ?? ''))
+    .join('\n')
+}
+
+/** True if the message carries any file part not expressed as inline base64. */
+function hasRejectedFilePart(message: { parts: Array<{ content?: { $case: string } }> }): string | null {
+  for (const part of message.parts) {
+    if (part.content?.$case === 'url') {
+      return 'Remote file URLs are not supported — the agent runtime does not fetch them server-side. Inline the file as a base64 data URL part instead.'
+    }
+    if (part.content?.$case === 'raw') {
+      return 'File uploads are not yet supported over A2A in this version.'
+    }
+  }
+  return null
+}
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+function emptyTask(taskId: string, contextId: string, state: TaskState, metadata?: Record<string, unknown>): Task {
+  return {
+    id: taskId,
+    contextId,
+    status: { state, message: undefined, timestamp: nowIso() },
+    artifacts: [],
+    history: [],
+    metadata,
+  }
+}
+
+/** Parses one already-`\n`-split SSE line into a JSON chunk, or `null`. Tolerant of `event:`/`id:`/`retry:` lines and `[DONE]`. */
+function parseSseDataLine(line: string): any | null {
+  if (!line.trim()) return null
+  let payload: string
+  if (line.startsWith('data: ')) payload = line.slice(6)
+  else if (line.startsWith('data:')) payload = line.slice(5)
+  else return null
+  if (payload === '[DONE]' || !payload.trim()) return null
+  try {
+    return JSON.parse(payload)
+  } catch {
+    return null
+  }
+}
+
+interface ConsumeResult {
+  sawTurnComplete: boolean
+}
+
+/** Reads an SSE `ReadableStream`, mapping each chunk to A2A events and publishing them. */
+async function consumeAndPublish(
+  stream: ReadableStream<Uint8Array>,
+  mapperState: EventMapperState,
+  ctx: { taskId: string; contextId: string },
+  bus: ExecutionEventBus,
+  includeReasoning: boolean,
+): Promise<ConsumeResult> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let sawTurnComplete = false
+  try {
+    while (true) {
+      let idleTimer: ReturnType<typeof setTimeout> | undefined
+      const idleTimeout = new Promise<never>((_, reject) => {
+        idleTimer = setTimeout(() => reject(new Error('A2A chat stream idle timeout')), IDLE_TIMEOUT_MS)
+      })
+      let result: Awaited<ReturnType<typeof reader.read>>
+      try {
+        result = await Promise.race([reader.read(), idleTimeout])
+      } finally {
+        clearTimeout(idleTimer)
+      }
+      const { done, value } = result
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split('\n')
+      buffer = lines.pop() || ''
+      for (const line of lines) {
+        const chunk = parseSseDataLine(line)
+        if (!chunk) continue
+        if (chunk.type === 'data-turn-complete') sawTurnComplete = true
+        const events = mapPodChunkToA2AEvents(chunk, mapperState, ctx, { includeReasoning })
+        for (const event of events) bus.publish(event)
+      }
+    }
+  } finally {
+    try {
+      reader.releaseLock()
+    } catch {
+      /* already released */
+    }
+  }
+  return { sawTurnComplete }
+}
+
+export class ShogoAgentExecutor implements AgentExecutor {
+  private readonly opts: ShogoAgentExecutorOptions
+  /** Guards "one in-flight turn per contextId" — queuing a second
+   * `/agent/chat` on the same `chatSessionId` would silently hang behind
+   * the gateway's own `turnLocks`, with no way for the caller to tell. */
+  private readonly inFlightContexts = new Set<string>()
+  /** `taskId` → abort controller for the in-flight fetch, used by `cancelTask`. */
+  private readonly abortControllers = new Map<string, AbortController>()
+
+  constructor(opts: ShogoAgentExecutorOptions) {
+    this.opts = opts
+  }
+
+  /**
+   * True while any turn is executing for this project. Used by the
+   * router's handler LRU as a proxy for "has a live event bus" —
+   * `ExecutionEventBusManager` doesn't expose a way to enumerate its
+   * buses, but an in-flight turn always has one, so evicting the
+   * cached `DefaultRequestHandler` (and this executor with it) while
+   * this is true would orphan a running turn and any `message/stream`
+   * subscriber attached to it.
+   */
+  get hasActiveWork(): boolean {
+    return this.inFlightContexts.size > 0
+  }
+
+  async execute(reqCtx: RequestContext, bus: ExecutionEventBus): Promise<void> {
+    const { taskId, contextId } = reqCtx
+
+    if (this.inFlightContexts.has(contextId)) {
+      // Thrown before publishing anything — `DefaultRequestHandler`
+      // synthesizes the required Task + statusUpdate(FAILED) lifecycle
+      // and maps this to A2A_ERROR_CODE.TASK_NOT_CANCELABLE (-32002) on
+      // the wire. Not a perfect semantic fit (this is a "not startable"
+      // rather than "not cancelable" rejection), but it's the closest
+      // existing A2A error class to "a turn is already running on this
+      // context" without inventing a custom JSON-RPC code.
+      throw new JsonRpcTaskNotCancelableError({
+        message:
+          'A turn is already in progress for this contextId. Concurrent sends on the same context queue ' +
+          "silently in the runtime pod; wait for the in-flight task to reach a terminal or interrupted state " +
+          'before sending another message.',
+      })
+    }
+
+    this.inFlightContexts.add(contextId)
+    const abortController = new AbortController()
+    this.abortControllers.set(taskId, abortController)
+
+    try {
+      await this.runTurn(reqCtx, bus, abortController)
+    } finally {
+      this.inFlightContexts.delete(contextId)
+      this.abortControllers.delete(taskId)
+    }
+  }
+
+  private async runTurn(
+    reqCtx: RequestContext,
+    bus: ExecutionEventBus,
+    abortController: AbortController,
+  ): Promise<void> {
+    const { taskId, contextId } = reqCtx
+    const { projectId, workspaceId } = this.opts
+    const chatSessionId = deriveChatSessionId(projectId, contextId)
+    const mapperCtx = { taskId, contextId }
+    const includeReasoning = reqCtx.context.requestedExtensions?.includes(A2A_REASONING_EXTENSION_URI) ?? false
+
+    bus.publish(AgentEvent.task(emptyTask(taskId, contextId, TaskState.TASK_STATE_SUBMITTED, { chatSessionId })))
+    bus.publish(
+      AgentEvent.statusUpdate({
+        taskId,
+        contextId,
+        status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: nowIso() },
+        metadata: undefined,
+      }),
+    )
+
+    const userMessage = reqCtx.userMessage
+    const rejectReason = hasRejectedFilePart(userMessage)
+    if (rejectReason) {
+      this.publishFailure(bus, mapperCtx, rejectReason)
+      return
+    }
+    const userText = extractText(userMessage)
+    if (!userText.trim()) {
+      this.publishFailure(bus, mapperCtx, 'The message must contain at least one text part.')
+      return
+    }
+
+    await ensureChatSession(projectId, chatSessionId)
+
+    let podUrl: string
+    let runtimeToken: string
+    try {
+      const pod = await resolveProjectPodUrl(projectId, {
+        logTag: 'A2A',
+        metalWaitMs: parseInt(process.env.A2A_METAL_WAIT_MS || '90000', 10),
+        metalRetryDelayMs: 1000,
+      })
+      podUrl = pod.url
+      runtimeToken = await deriveProjectRuntimeToken(projectId, { workspaceId })
+    } catch (err: any) {
+      this.publishFailure(bus, mapperCtx, `Failed to reach the project's agent runtime: ${err?.message ?? err}`)
+      return
+    }
+
+    const requestBody = {
+      messages: [{ role: 'user', parts: [{ type: 'text', text: userText }] }],
+      chatSessionId,
+      // Never omit — the pod's own default matches this today, but a
+      // future default change must not silently move A2A into 'plan'
+      // mode, whose tool set is a read-only allowlist expecting a
+      // `confirmedPlan` the caller has no way to supply.
+      interactionMode: 'agent' as const,
+    }
+
+    let res: Response
+    try {
+      res = await fetch(`${podUrl}/agent/chat`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-runtime-token': runtimeToken,
+          'X-Chat-Session-Id': chatSessionId,
+        },
+        body: JSON.stringify(requestBody),
+        signal: AbortSignal.any([abortController.signal, AbortSignal.timeout(FETCH_TIMEOUT_MS)]),
+      })
+    } catch (err: any) {
+      if (abortController.signal.aborted) return // cancelTask already published CANCELED
+      this.publishFailure(bus, mapperCtx, `Agent runtime request failed: ${err?.message ?? err}`)
+      return
+    }
+
+    if (!res.ok || !res.body) {
+      const detail = await res.text().catch(() => '')
+      this.publishFailure(bus, mapperCtx, `Agent runtime returned HTTP ${res.status}${detail ? `: ${detail.slice(0, 300)}` : ''}`)
+      return
+    }
+
+    const [mapperStream, billingStream] = res.body.tee()
+    const mapperState = createEventMapperState()
+
+    const billingPromise = trackUsageFromStream(
+      billingStream,
+      requestBody,
+      { id: projectId, workspaceId },
+      {
+        chatSessionId,
+        resume: async (fromSeq: number) => {
+          try {
+            return await fetch(`${podUrl}/agent/chat/${encodeURIComponent(chatSessionId)}/stream?fromSeq=${fromSeq}`, {
+              method: 'GET',
+              headers: { 'x-runtime-token': runtimeToken },
+            })
+          } catch {
+            return null
+          }
+        },
+      },
+    ).catch((err) => {
+      console.error(`[A2A] trackUsageFromStream failed for project ${projectId}:`, err)
+    })
+
+    let sawTurnComplete: boolean
+    try {
+      ;({ sawTurnComplete } = await consumeAndPublish(mapperStream, mapperState, mapperCtx, bus, includeReasoning))
+    } catch (err: any) {
+      await billingPromise
+      if (abortController.signal.aborted) return
+      this.publishFailure(bus, mapperCtx, `Agent stream read failed: ${err?.message ?? err}`)
+      return
+    }
+
+    // EOF without `data-turn-complete` is a normal occurrence, not an edge
+    // case: the Knative activator cuts pod-facing HTTP at ~5 minutes while
+    // the agent keeps running in the pod's buffer. Resume with
+    // `fromSeq = mapperState.lastSeq` (NOT 0/full-replay like
+    // `trackUsageFromStream` uses for its own single-accumulator use
+    // case) — `append: true` artifact updates PUSH a new Part onto the
+    // task's artifact (see `ResultManager.applyArtifactUpdate` in
+    // `@a2a-js/sdk`), so a full replay from 0 would duplicate every
+    // already-published text chunk in the persisted Task and to any live
+    // `message/stream` subscriber. The heartbeat lag documented in
+    // `project-chat.ts` means a handful of frames may still be
+    // re-delivered at the seam; that's an accepted, documented tradeoff.
+    if (!sawTurnComplete && !abortController.signal.aborted) {
+      let resumeRes: Response | null = null
+      try {
+        resumeRes = await fetch(
+          `${podUrl}/agent/chat/${encodeURIComponent(chatSessionId)}/stream?fromSeq=${mapperState.lastSeq}`,
+          { method: 'GET', headers: { 'x-runtime-token': runtimeToken } },
+        )
+      } catch (err: any) {
+        console.warn(`[A2A] Resume fetch failed for ${projectId}/${chatSessionId}:`, err?.message ?? err)
+      }
+
+      if (resumeRes && resumeRes.status === 200 && resumeRes.body) {
+        try {
+          ;({ sawTurnComplete } = await consumeAndPublish(resumeRes.body, mapperState, mapperCtx, bus, includeReasoning))
+        } catch (err: any) {
+          sawTurnComplete = false
+          console.warn(`[A2A] Resume stream read failed for ${projectId}/${chatSessionId}:`, err?.message ?? err)
+        }
+      } else if (resumeRes && resumeRes.status === 204) {
+        // Buffer is gone — stop, expiry, or pod restart. Terminal FAILED.
+        this.publishFailure(
+          bus,
+          mapperCtx,
+          "Connection to the agent was interrupted and the turn's buffer has since expired " +
+            '(stop, pod restart, or crash). Any work completed before the interruption may still be persisted.',
+        )
+        await billingPromise
+        return
+      }
+    }
+
+    await billingPromise
+
+    if (!sawTurnComplete) {
+      this.publishFailure(bus, mapperCtx, 'The agent stream ended unexpectedly without completing the turn.')
+    }
+  }
+
+  private publishFailure(bus: ExecutionEventBus, ctx: { taskId: string; contextId: string }, text: string): void {
+    bus.publish(
+      AgentEvent.statusUpdate({
+        taskId: ctx.taskId,
+        contextId: ctx.contextId,
+        status: {
+          state: TaskState.TASK_STATE_FAILED,
+          message: {
+            messageId: crypto.randomUUID(),
+            contextId: ctx.contextId,
+            taskId: ctx.taskId,
+            role: Role.ROLE_AGENT,
+            parts: [{ content: { $case: 'text', value: text }, metadata: undefined, filename: '', mediaType: 'text/plain' }],
+            metadata: undefined,
+            extensions: [],
+            referenceTaskIds: [],
+          },
+          timestamp: nowIso(),
+        },
+        metadata: undefined,
+      }),
+    )
+  }
+
+  async cancelTask(taskId: string, bus: ExecutionEventBus): Promise<void> {
+    this.abortControllers.get(taskId)?.abort()
+
+    const context = new ServerCallContext({ tenant: this.opts.projectId })
+    const task = await this.opts.taskStore.load(taskId, context)
+    const contextId = task?.contextId ?? ''
+    const chatSessionId = (task?.metadata as Record<string, unknown> | undefined)?.chatSessionId
+
+    if (typeof chatSessionId === 'string') {
+      try {
+        const pod = await resolveProjectPodUrl(this.opts.projectId, { logTag: 'A2A' })
+        const runtimeToken = await deriveProjectRuntimeToken(this.opts.projectId, {
+          workspaceId: this.opts.workspaceId,
+        })
+        await fetch(`${pod.url}/agent/stop`, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-runtime-token': runtimeToken,
+            'X-Chat-Session-Id': chatSessionId,
+          },
+          body: JSON.stringify({ chatSessionId }),
+        })
+      } catch (err: any) {
+        console.warn(`[A2A] /agent/stop failed for task ${taskId}:`, err?.message ?? err)
+      }
+    }
+
+    bus.publish(
+      AgentEvent.statusUpdate({
+        taskId,
+        contextId,
+        status: { state: TaskState.TASK_STATE_CANCELED, message: undefined, timestamp: nowIso() },
+        metadata: undefined,
+      }),
+    )
+  }
+}

--- a/apps/api/src/lib/a2a/hono-transport.ts
+++ b/apps/api/src/lib/a2a/hono-transport.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Hono glue around `@a2a-js/sdk/server`'s framework-agnostic
+ * `JsonRpcTransportHandler`. No Odin equivalent — `alignment-project-server`
+ * gets this for free from the Python SDK's FastAPI integration
+ * (`a2a-sdk[http-server]`); the JS SDK's transport adapters
+ * (`@a2a-js/sdk/server/express`) need Express, which shogo doesn't use,
+ * so this is the ~80-line Hono-specific adapter the plan called for.
+ *
+ * `JsonRpcTransportHandler.handle()` returns either:
+ *   - a single `JSONRPCResponse` for `message/send`, `tasks/get`,
+ *     `tasks/cancel`, `tasks/list`, push-notification-config methods →
+ *     rendered as one `c.json(...)`.
+ *   - an `AsyncGenerator<JSONRPCResponse>` for `message/stream` and
+ *     `tasks/resubscribe` → rendered as an SSE `ReadableStream`, one
+ *     `formatSSEEvent(response)` frame per yielded item, with periodic
+ *     keep-alive comment frames (mirrors the pod's own
+ *     `wrapStreamWithKeepalive` / the API's `proxy-keep-alive` pattern in
+ *     `routes/project-chat.ts`) so intermediate proxies/load balancers
+ *     don't time out an idle long-running task.
+ */
+
+import type { Context } from 'hono'
+import {
+  JsonRpcTransportHandler,
+  ServerCallContext,
+  type A2ARequestHandler,
+} from '@a2a-js/sdk/server'
+import { formatSSEErrorEvent, formatSSEEvent, SSE_HEADERS } from '@a2a-js/sdk'
+
+/** How often to write an SSE keep-alive comment frame during a long-running stream. */
+const KEEPALIVE_INTERVAL_MS = 15_000
+
+function isAsyncGenerator(value: unknown): value is AsyncGenerator<unknown, void, undefined> {
+  return !!value && typeof value === 'object' && typeof (value as any)[Symbol.asyncIterator] === 'function'
+}
+
+/**
+ * Builds a `ServerCallContext` for one A2A request from the verified
+ * caller identity and project (tenant) scope. `tenant` is what makes
+ * `PrismaA2ATaskStore` (and the SDK's own `InMemoryTaskStore` /
+ * `InMemoryPushNotificationStore`) scope data per-project for free.
+ */
+export function buildA2AServerCallContext(opts: { projectId: string; requestedVersion?: string }): ServerCallContext {
+  return new ServerCallContext({
+    tenant: opts.projectId,
+    requestedVersion: opts.requestedVersion ?? '1.0',
+  })
+}
+
+/**
+ * Handles one JSON-RPC POST to `/a2a/projects/:projectId/rpc`. Reads the
+ * body, dispatches through `JsonRpcTransportHandler`, and renders either a
+ * single JSON response or an SSE stream depending on the method.
+ */
+export async function handleA2AJsonRpc(
+  c: Context,
+  requestHandler: A2ARequestHandler,
+  context: ServerCallContext,
+): Promise<Response> {
+  const transport = new JsonRpcTransportHandler(requestHandler)
+
+  let body: string | Record<string, unknown>
+  try {
+    body = await c.req.text()
+  } catch (err: any) {
+    return c.json(
+      { jsonrpc: '2.0', id: null, error: { code: -32700, message: `Failed to read request body: ${err?.message ?? err}` } },
+      400,
+    )
+  }
+
+  const result = await transport.handle(body, context)
+
+  if (isAsyncGenerator(result)) {
+    return sseResponseFromGenerator(result)
+  }
+
+  // Single JSON-RPC response. The envelope itself always carries its own
+  // `error`/`result` per spec — HTTP status is 200 even for JSON-RPC-level
+  // errors (transport-level failures only, which `transport.handle` doesn't
+  // throw for since it catches and maps internally).
+  return c.json(result, 200)
+}
+
+/**
+ * Renders an `AsyncGenerator<JSONRPCResponse>` (the `message/stream` /
+ * `tasks/resubscribe` path) as an SSE `Response`. Draining the generator
+ * to completion also drains the underlying `ExecutionEventBus` subscription
+ * — cancelling the stream (client disconnect) calls the generator's
+ * `.return()` so `ExecutionEventQueue` unsubscribes promptly rather than
+ * leaking a listener until the task naturally finishes.
+ */
+function sseResponseFromGenerator(gen: AsyncGenerator<unknown, void, undefined>): Response {
+  const encoder = new TextEncoder()
+  let keepaliveTimer: ReturnType<typeof setInterval> | undefined
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const keepaliveFrame = encoder.encode(': a2a-keep-alive\n\n')
+      keepaliveTimer = setInterval(() => {
+        try {
+          controller.enqueue(keepaliveFrame)
+        } catch {
+          clearInterval(keepaliveTimer)
+        }
+      }, KEEPALIVE_INTERVAL_MS)
+    },
+    async pull(controller) {
+      try {
+        const { value, done } = await gen.next()
+        if (done) {
+          clearInterval(keepaliveTimer)
+          controller.close()
+          return
+        }
+        controller.enqueue(encoder.encode(formatSSEEvent(value)))
+      } catch (err) {
+        clearInterval(keepaliveTimer)
+        try {
+          controller.enqueue(encoder.encode(formatSSEErrorEvent({ code: -32603, message: err instanceof Error ? err.message : String(err) })))
+        } catch {
+          /* controller already closed */
+        }
+        controller.close()
+      }
+    },
+    async cancel() {
+      clearInterval(keepaliveTimer)
+      try {
+        await gen.return(undefined)
+      } catch {
+        /* generator already finished */
+      }
+    },
+  })
+
+  return new Response(stream, { headers: { ...SSE_HEADERS, 'X-Accel-Buffering': 'no' } })
+}

--- a/apps/api/src/lib/a2a/task-store.ts
+++ b/apps/api/src/lib/a2a/task-store.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * Prisma-backed `TaskStore` for the A2A server — the shogo equivalent of
+ * Odin's `A2ADatabaseTaskStore` (`services/a2a/task_store.py`) over
+ * Postgres `a2a_tasks` (there: JSONB `task_json`; here: `taskJson String`,
+ * see the comment on the `A2aTask` model in `prisma/schema.prisma` for why).
+ *
+ * Tenant scoping: `@a2a-js/sdk`'s `TaskStore` contract says implementations
+ * "SHOULD use `context.tenant`... so each authenticated client only sees
+ * its own tasks." Our transport layer (`hono-transport.ts` / `routes/a2a.ts`)
+ * always sets `context.tenant = projectId` from the verified bearer key, so
+ * every method here filters — and on `load`, double-checks — against
+ * `context.tenant` rather than trusting the caller-supplied `taskId` alone.
+ * `taskId`s are server-generated UUIDs (per-request, effectively globally
+ * unique), so a cross-tenant collision is not a realistic concern, but the
+ * check costs nothing and matches the contract's intent.
+ */
+
+import type { ServerCallContext, TaskStore } from '@a2a-js/sdk/server'
+import { TaskState, type ListTasksRequest, type ListTasksResponse, type Task } from '@a2a-js/sdk'
+import { prisma } from '../prisma'
+
+/** Default/limits for `ListTasksRequest.pageSize` — mirrors the SDK's doc comment. */
+const DEFAULT_PAGE_SIZE = 50
+const MAX_PAGE_SIZE = 100
+
+function taskStateName(state: TaskState): string {
+  return TaskState[state] ?? String(state)
+}
+
+/**
+ * Row → `Task`. Round-trips through plain `JSON.parse` rather than the
+ * SDK's proto3 `Task.fromJSON` — `taskJson` is OUR OWN serialization of
+ * the SDK's in-memory TS shape (written by `serialize` below with plain
+ * `JSON.stringify`), not the wire-format JSON the SDK's `MessageFns`
+ * expect. This is deliberately internal and lossy only for the one case
+ * v1 doesn't support anyway: raw (`Buffer`) file-part bytes — see the
+ * "File input must be inlined as base64" / rejected-uri-parts note in
+ * the executor; A2A tasks in this codebase never carry binary parts.
+ */
+function deserialize(taskJson: string): Task {
+  return JSON.parse(taskJson) as Task
+}
+
+function serialize(task: Task): string {
+  return JSON.stringify(task)
+}
+
+function extractChatSessionId(task: Task): string | undefined {
+  const meta = task.metadata as Record<string, unknown> | undefined
+  const v = meta?.chatSessionId
+  return typeof v === 'string' ? v : undefined
+}
+
+export class PrismaA2ATaskStore implements TaskStore {
+  async save(task: Task, context: ServerCallContext): Promise<void> {
+    const projectId = context.tenant
+    if (!projectId) {
+      throw new Error('PrismaA2ATaskStore.save: context.tenant (projectId) is required')
+    }
+    const state = task.status?.state ?? TaskState.TASK_STATE_UNSPECIFIED
+    const taskJson = serialize(task)
+    const chatSessionId = extractChatSessionId(task)
+
+    await prisma.a2aTask.upsert({
+      where: { id: task.id },
+      create: {
+        id: task.id,
+        contextId: task.contextId,
+        projectId,
+        state: taskStateName(state),
+        taskJson,
+        chatSessionId: chatSessionId ?? null,
+      },
+      update: {
+        contextId: task.contextId,
+        state: taskStateName(state),
+        taskJson,
+        ...(chatSessionId ? { chatSessionId } : {}),
+      },
+    })
+  }
+
+  async load(taskId: string, context: ServerCallContext): Promise<Task | undefined> {
+    const projectId = context.tenant
+    if (!projectId) return undefined
+
+    const row = await prisma.a2aTask.findUnique({ where: { id: taskId } })
+    if (!row) return undefined
+    // Tenant isolation: never return a task belonging to another project,
+    // even if the raw id happened to be guessed/known.
+    if (row.projectId !== projectId) return undefined
+
+    return deserialize(row.taskJson)
+  }
+
+  async list(params: ListTasksRequest, context: ServerCallContext): Promise<ListTasksResponse> {
+    const projectId = context.tenant ?? params.tenant
+    if (!projectId) {
+      return { tasks: [], nextPageToken: '', pageSize: 0, totalSize: 0 }
+    }
+
+    const where: Record<string, unknown> = { projectId }
+    if (params.contextId) where.contextId = params.contextId
+    // `params.status` is a numeric TaskState; TASK_STATE_UNSPECIFIED === 0 is
+    // falsy, so a truthiness check alone already excludes "no filter".
+    if (params.status) {
+      where.state = taskStateName(params.status)
+    }
+    if (params.statusTimestampAfter) {
+      const after = new Date(params.statusTimestampAfter)
+      if (!Number.isNaN(after.getTime())) {
+        where.updatedAt = { gte: after }
+      }
+    }
+
+    const pageSize = Math.min(
+      MAX_PAGE_SIZE,
+      Math.max(1, params.pageSize && params.pageSize > 0 ? params.pageSize : DEFAULT_PAGE_SIZE),
+    )
+    const offset = decodePageToken(params.pageToken)
+
+    const [rows, totalSize] = await Promise.all([
+      prisma.a2aTask.findMany({
+        where,
+        orderBy: { updatedAt: 'desc' },
+        skip: offset,
+        take: pageSize,
+      }),
+      prisma.a2aTask.count({ where }),
+    ])
+
+    const tasks = rows.map((row) => {
+      const task = deserialize(row.taskJson)
+      return applyResponseShaping(task, params)
+    })
+
+    const nextOffset = offset + rows.length
+    const nextPageToken = nextOffset < totalSize ? encodePageToken(nextOffset) : ''
+
+    return { tasks, nextPageToken, pageSize, totalSize }
+  }
+}
+
+/** Applies `historyLength` / `includeArtifacts` trimming to a listed task. */
+function applyResponseShaping(task: Task, params: ListTasksRequest): Task {
+  let { history, artifacts } = task
+  if (typeof params.historyLength === 'number') {
+    history = params.historyLength <= 0 ? [] : history.slice(-params.historyLength)
+  }
+  if (!params.includeArtifacts) {
+    artifacts = []
+  }
+  return { ...task, history, artifacts }
+}
+
+function encodePageToken(offset: number): string {
+  return Buffer.from(`offset:${offset}`, 'utf8').toString('base64url')
+}
+
+function decodePageToken(token: string | undefined): number {
+  if (!token) return 0
+  try {
+    const decoded = Buffer.from(token, 'base64url').toString('utf8')
+    const match = /^offset:(\d+)$/.exec(decoded)
+    if (!match) return 0
+    return Math.max(0, parseInt(match[1], 10) || 0)
+  } catch {
+    return 0
+  }
+}

--- a/apps/api/src/routes/__tests__/a2a.test.ts
+++ b/apps/api/src/routes/__tests__/a2a.test.ts
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+//
+// Integration test: a real @a2a-js/sdk/client, over real HTTP (Bun.serve),
+// against the actual a2aProtocolRoutes() router — card discovery + JSON-RPC
+// message/stream — with only the "outside world" mocked: prisma, the
+// project's runtime pod (a stub replaying a recorded SSE transcript), pod
+// resolution, and billing persistence.
+//
+// This is the "drive @a2a-js/sdk/client against a stub pod" test called for
+// by the A2A implementation plan.
+
+import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test'
+import { TaskState, type SendMessageRequest, type StreamResponse } from '@a2a-js/sdk'
+import { ClientFactory, DefaultAgentCardResolver, JsonRpcTransportFactory } from '@a2a-js/sdk/client'
+
+const PROJECT_ID = 'proj-integration-1'
+const FAKE_POD_URL = 'http://fake-pod.internal'
+
+// ---------------------------------------------------------------------------
+// Mocks — everything a2a.ts touches outside the process boundary.
+// ---------------------------------------------------------------------------
+
+// routes/a2a.ts pulls in middleware/auth.ts (for the key-CRUD router), which
+// pulls in ../auth (real Better Auth setup) and ../routes/api-keys. Neither
+// is exercised by this test (only a2aProtocolRoutes is mounted), but both
+// must be safe to *import* — mock them the same way middleware/auth.test.ts
+// does to avoid constructing a real Better Auth instance.
+mock.module('../../auth', () => ({ auth: { api: { getSession: async () => null } } }))
+mock.module('../api-keys', () => ({ resolveApiKey: async () => null }))
+mock.module('../../lib/runtime-token', () => ({ verifyRuntimeToken: () => ({ ok: false }) }))
+
+interface FakeApiKeyRow {
+  id: string
+  keyId: string
+  hashedSecret: string
+  projectId: string
+  workspaceId: string
+  revokedAt: Date | null
+  expiresAt: Date | null
+  lastUsedAt: Date | null
+}
+interface FakeTaskRow {
+  id: string
+  contextId: string
+  projectId: string
+  state: string
+  taskJson: string
+  chatSessionId: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+const apiKeyRows: FakeApiKeyRow[] = []
+const taskRows: FakeTaskRow[] = []
+let taskClock = 0
+
+mock.module('../../lib/prisma', () => ({
+  prisma: {
+    a2aApiKey: {
+      create: async ({ data }: any) => {
+        const row: FakeApiKeyRow = { ...data, revokedAt: null, lastUsedAt: null, expiresAt: data.expiresAt ?? null }
+        apiKeyRows.push(row)
+        return row
+      },
+      findUnique: async ({ where }: any) => apiKeyRows.find((r) => r.keyId === where.keyId) ?? null,
+      update: async ({ where, data }: any) => {
+        const row = apiKeyRows.find((r) => r.id === where.id)
+        if (row) Object.assign(row, data)
+        return row
+      },
+    },
+    a2aTask: {
+      upsert: async ({ where, create, update }: any) => {
+        taskClock += 1
+        const existing = taskRows.find((r) => r.id === where.id)
+        if (existing) {
+          Object.assign(existing, update, { updatedAt: new Date(taskClock) })
+          return existing
+        }
+        const row: FakeTaskRow = { ...create, chatSessionId: create.chatSessionId ?? null, createdAt: new Date(taskClock), updatedAt: new Date(taskClock) }
+        taskRows.push(row)
+        return row
+      },
+      findUnique: async ({ where }: any) => taskRows.find((r) => r.id === where.id) ?? null,
+      findMany: async ({ where }: any) => taskRows.filter((r) => r.projectId === where.projectId),
+      count: async ({ where }: any) => taskRows.filter((r) => r.projectId === where.projectId).length,
+    },
+    project: {
+      findUnique: async ({ where }: any) =>
+        where.id === PROJECT_ID ? { name: 'Integration Project', description: 'A stub project for A2A tests' } : null,
+    },
+    chatSession: {
+      findUnique: async () => null,
+      create: async () => ({}),
+    },
+  },
+}))
+
+mock.module('../../services/projectAgent.service', () => ({
+  resolveProjectAgent: async () => null,
+}))
+
+mock.module('../../lib/resolve-pod-url', () => ({
+  resolveProjectPodUrl: async () => ({ url: FAKE_POD_URL }),
+}))
+
+mock.module('../../lib/project-runtime-token', () => ({
+  deriveProjectRuntimeToken: async () => 'fake-runtime-token',
+}))
+
+mock.module('../project-chat', () => ({
+  trackUsageFromStream: async (stream: ReadableStream<Uint8Array>) => {
+    const reader = stream.getReader()
+    while (true) {
+      const { done } = await reader.read()
+      if (done) break
+    }
+  },
+}))
+
+// The recorded SSE transcript the stub pod replays for /agent/chat.
+const POD_TRANSCRIPT = [
+  { type: 'text-delta', delta: 'Hello ' },
+  { type: 'text-delta', delta: 'from the agent' },
+  { type: 'data-turn-complete', data: { status: 'completed' } },
+]
+
+function sseStream(chunks: any[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder()
+  let i = 0
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i >= chunks.length) {
+        controller.close()
+        return
+      }
+      controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunks[i++])}\n\n`))
+    },
+  })
+}
+
+/** Overridable per-test so the concurrent-tasks test can hold the "pod"
+ * response open until it has confirmed the second request was rejected. */
+let podChatResponder: () => Promise<Response> = async () => new Response(sseStream(POD_TRANSCRIPT), { status: 200 })
+
+const originalFetch = globalThis.fetch
+globalThis.fetch = (async (input: any, init?: any) => {
+  const url = typeof input === 'string' ? input : (input?.url ?? String(input))
+  if (url.startsWith(FAKE_POD_URL)) {
+    if (url.endsWith('/agent/chat')) {
+      return podChatResponder()
+    }
+    throw new Error(`stub pod: unexpected request ${url}`)
+  }
+  return originalFetch(input, init)
+}) as any
+
+const { a2aProtocolRoutes } = await import('../a2a')
+const { mintA2aApiKey } = await import('../../lib/a2a/auth')
+const { Hono } = await import('hono')
+
+// ---------------------------------------------------------------------------
+// Test server + client setup
+// ---------------------------------------------------------------------------
+
+let server: ReturnType<typeof Bun.serve>
+let baseUrl: string
+let bearerToken: string
+
+function authedFetch(token: string): typeof fetch {
+  return (async (input: any, init: RequestInit = {}) => {
+    const headers = new Headers(init.headers)
+    headers.set('authorization', `Bearer ${token}`)
+    return fetch(input, { ...init, headers })
+  }) as typeof fetch
+}
+
+beforeAll(async () => {
+  const app = new Hono()
+  app.route('/a2a', a2aProtocolRoutes())
+  server = Bun.serve({ port: 0, fetch: app.fetch })
+  baseUrl = `http://localhost:${server.port}`
+  // buildAgentCard() (called per-request, see routes/a2a.ts) reads this at
+  // call time to compute the RPC URL it advertises in the card.
+  process.env.SHOGO_A2A_BASE_URL = baseUrl
+
+  const minted = await mintA2aApiKey({ projectId: PROJECT_ID, workspaceId: 'ws-1', createdBy: 'tester' })
+  bearerToken = minted.fullKey
+})
+
+afterAll(() => {
+  server.stop(true)
+  globalThis.fetch = originalFetch
+})
+
+async function makeClient() {
+  const fetchImpl = authedFetch(bearerToken)
+  const factory = new ClientFactory({
+    transports: [new JsonRpcTransportFactory({ fetchImpl })],
+    cardResolver: new DefaultAgentCardResolver({ fetchImpl }),
+  })
+  // `createFromUrl`'s default card path (AGENT_CARD_PATH) is site-root-
+  // relative (`/.well-known/agent-card.json`), which `new URL(path, base)`
+  // resolves against the origin only — it would silently drop our
+  // project-scoped prefix. Pass the full project-scoped card path instead.
+  return factory.createFromUrl(baseUrl, `/a2a/projects/${PROJECT_ID}/.well-known/agent-card.json`)
+}
+
+function sendRequest(text: string): SendMessageRequest {
+  return {
+    tenant: '',
+    message: {
+      messageId: crypto.randomUUID(),
+      contextId: '',
+      taskId: '',
+      role: 1, // ROLE_USER
+      parts: [{ content: { $case: 'text', value: text }, metadata: undefined, filename: '', mediaType: 'text/plain' }],
+      metadata: undefined,
+      extensions: [],
+      referenceTaskIds: [],
+    },
+    configuration: undefined,
+    metadata: undefined,
+  } as SendMessageRequest
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /a2a/projects/:projectId/.well-known/agent-card.json', () => {
+  it('requires a bearer token', async () => {
+    const res = await fetch(`${baseUrl}/a2a/projects/${PROJECT_ID}/.well-known/agent-card.json`)
+    expect(res.status).toBe(401)
+    expect(res.headers.get('www-authenticate')).toBe('Bearer')
+  })
+
+  it('rejects a key minted for a different project', async () => {
+    const other = await mintA2aApiKey({ projectId: 'some-other-project', workspaceId: 'ws-2', createdBy: 'tester' })
+    const res = await fetch(`${baseUrl}/a2a/projects/${PROJECT_ID}/.well-known/agent-card.json`, {
+      headers: { authorization: `Bearer ${other.fullKey}` },
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 for a project the store does not know about', async () => {
+    const missingKey = await mintA2aApiKey({ projectId: 'ghost-project', workspaceId: 'ws-3', createdBy: 'tester' })
+    const res = await fetch(`${baseUrl}/a2a/projects/ghost-project/.well-known/agent-card.json`, {
+      headers: { authorization: `Bearer ${missingKey.fullKey}` },
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns a v1.0 agent card advertising streaming and the project tenant', async () => {
+    const res = await fetch(`${baseUrl}/a2a/projects/${PROJECT_ID}/.well-known/agent-card.json`, {
+      headers: { authorization: `Bearer ${bearerToken}` },
+    })
+    expect(res.status).toBe(200)
+    const card = await res.json()
+    expect(card.name).toBe('Integration Project')
+    expect(card.capabilities.streaming).toBe(true)
+    expect(card.supportedInterfaces[0]).toMatchObject({
+      protocolBinding: 'JSONRPC',
+      protocolVersion: '1.0',
+      tenant: PROJECT_ID,
+      url: `${baseUrl}/a2a/projects/${PROJECT_ID}/rpc`,
+    })
+  })
+})
+
+describe('POST /a2a/projects/:projectId/rpc — message/send', () => {
+  it('rejects requests without a valid bearer token', async () => {
+    const res = await fetch(`${baseUrl}/a2a/projects/${PROJECT_ID}/rpc`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'message/send', params: sendRequest('hi') }),
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('drives a client.sendMessage() call end to end against the stub pod and returns a COMPLETED task', async () => {
+    const client = await makeClient()
+    const result = await client.sendMessage(sendRequest('Say hello'))
+    expect('status' in result).toBe(true)
+    if ('status' in result) {
+      expect(result.status?.state).toBe(TaskState.TASK_STATE_COMPLETED)
+      expect(result.artifacts?.[0]?.parts?.map((p: any) => p.content?.value).join('')).toBe('Hello from the agent')
+    }
+  })
+})
+
+describe('POST /a2a/projects/:projectId/rpc — message/stream', () => {
+  it('streams task -> artifactUpdate -> terminal COMPLETED statusUpdate events via SSE', async () => {
+    const client = await makeClient()
+    const received: StreamResponse['payload'][] = []
+    for await (const event of client.sendMessageStream(sendRequest('Say hello, streaming'))) {
+      received.push(event.payload)
+    }
+
+    expect(received[0]?.$case).toBe('task')
+    expect(received.some((p) => p?.$case === 'artifactUpdate')).toBe(true)
+
+    const last = received[received.length - 1]
+    expect(last?.$case).toBe('statusUpdate')
+    if (last?.$case === 'statusUpdate') {
+      expect(last.value.status?.state).toBe(TaskState.TASK_STATE_COMPLETED)
+    }
+
+    const text = received
+      .filter((p) => p?.$case === 'artifactUpdate')
+      .flatMap((p) => (p!.value as any).artifact.parts)
+      .map((part: any) => part.content?.value)
+      .join('')
+    expect(text).toBe('Hello from the agent')
+  })
+
+  it('rejects a second concurrent sendMessageStream on the same contextId', async () => {
+    // Hold the "pod" response open so the first turn stays in-flight long
+    // enough for the second request's ShogoAgentExecutor.execute() guard
+    // to observe it and reject — against the real stub this resolves
+    // near-instantly, which would let req2 land after req1 already settled.
+    let releasePod: ((res: Response) => void) | undefined
+    podChatResponder = () =>
+      new Promise<Response>((resolve) => {
+        releasePod = resolve
+      })
+
+    const client = await makeClient()
+    const contextId = `shared-${crypto.randomUUID()}`
+    const req1 = sendRequest('first')
+    req1.message!.contextId = contextId
+    const req2 = sendRequest('second')
+    req2.message!.contextId = contextId
+
+    const drain = async (req: SendMessageRequest) => {
+      const events: StreamResponse['payload'][] = []
+      for await (const e of client.sendMessageStream(req)) events.push(e.payload)
+      return events
+    }
+
+    const p1 = drain(req1)
+    // Wait until req1's chain has actually reached the pod fetch (i.e. is
+    // registered as in-flight) before firing req2.
+    while (!releasePod) {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+    const events2 = await drain(req2)
+
+    const last2 = events2[events2.length - 1]
+    expect(last2?.$case).toBe('statusUpdate')
+    if (last2?.$case === 'statusUpdate') {
+      expect(last2.value.status?.state).toBe(TaskState.TASK_STATE_FAILED)
+    }
+
+    // Now let req1 complete normally and restore the default responder.
+    releasePod!(new Response(sseStream(POD_TRANSCRIPT), { status: 200 }))
+    await p1
+    podChatResponder = async () => new Response(sseStream(POD_TRANSCRIPT), { status: 200 })
+  })
+})

--- a/apps/api/src/routes/a2a.ts
+++ b/apps/api/src/routes/a2a.ts
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * A2A (Agent2Agent) protocol routes — the shogo equivalent of Odin's
+ * `routes/a2a.py`.
+ *
+ * Two route groups, mounted separately (see `apps/api/src/server.ts`):
+ *
+ *   - `a2aProtocolRoutes()` → mounted at `/a2a` (deliberately OUTSIDE
+ *     `/api/*`, so the global `authMiddleware` doesn't apply — this
+ *     router self-authenticates with `shogo_a2a_*` bearer keys, same
+ *     posture as Odin's `require_a2a_key`):
+ *       - `GET  /a2a/projects/:projectId/.well-known/agent-card.json`
+ *       - `POST /a2a/projects/:projectId/rpc`
+ *
+ *   - `a2aKeyRoutes()` → mounted at `/api` (inherits session auth for
+ *     free, matching Odin's key-CRUD-under-normal-JWT posture):
+ *       - `POST   /api/projects/:projectId/a2a/keys`
+ *       - `GET    /api/projects/:projectId/a2a/keys`
+ *       - `DELETE /api/projects/:projectId/a2a/keys/:keyId`
+ *
+ * One `DefaultRequestHandler` (+ its `ShogoAgentExecutor` and
+ * `PrismaA2ATaskStore`) is cached per `projectId` in a bounded LRU —
+ * `DefaultExecutionEventBusManager` holds in-flight task event buses
+ * in-process, so a fresh handler per request would break `message/stream`
+ * and `tasks/resubscribe` (the resubscribing request would attach to a
+ * brand-new, empty bus manager). See `A2AHandlerCache` below for the
+ * eviction policy.
+ */
+
+import { Hono } from 'hono'
+import { AgentCard } from '@a2a-js/sdk'
+import { DefaultRequestHandler, type A2ARequestHandler } from '@a2a-js/sdk/server'
+import { authorizeProject } from '../middleware/auth'
+import { buildAgentCard, getA2aBaseUrl } from '../lib/a2a/card'
+import { PrismaA2ATaskStore } from '../lib/a2a/task-store'
+import { ShogoAgentExecutor } from '../lib/a2a/executor'
+import { buildA2AServerCallContext, handleA2AJsonRpc } from '../lib/a2a/hono-transport'
+import {
+  listA2aApiKeys,
+  mintA2aApiKey,
+  revokeA2aApiKey,
+  verifyA2aApiKey,
+  type VerifiedA2aKey,
+} from '../lib/a2a/auth'
+
+declare module 'hono' {
+  interface ContextVariableMap {
+    /** Set by the `/a2a/projects/:projectId/*` self-auth middleware. */
+    a2aKey?: VerifiedA2aKey
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Cached DefaultRequestHandler per project
+// -----------------------------------------------------------------------------
+
+interface CachedHandler {
+  handler: A2ARequestHandler
+  executor: ShogoAgentExecutor
+  lastAccess: number
+}
+
+const MAX_CACHED_HANDLERS = parseInt(process.env.A2A_HANDLER_CACHE_MAX || '200', 10)
+const HANDLER_IDLE_TTL_MS = parseInt(process.env.A2A_HANDLER_IDLE_TTL_MS || String(30 * 60 * 1000), 10)
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000
+
+/**
+ * Bounded LRU keyed by `projectId`. Unlike Odin's unbounded dict cache
+ * (`routes/a2a.py:46`, one entry per `(agent_id, project_id)`, never
+ * evicted), a per-project cache across a whole workspace fleet needs a
+ * ceiling. Entries with `executor.hasActiveWork` are never evicted —
+ * doing so would orphan a running turn and any live `message/stream`
+ * subscriber attached to its event bus.
+ */
+class A2AHandlerCache {
+  private readonly entries = new Map<string, CachedHandler>()
+
+  get(projectId: string): CachedHandler | undefined {
+    const entry = this.entries.get(projectId)
+    if (!entry) return undefined
+    entry.lastAccess = Date.now()
+    // Re-insert to move to the MRU end (Map iteration order == insertion order).
+    this.entries.delete(projectId)
+    this.entries.set(projectId, entry)
+    return entry
+  }
+
+  set(projectId: string, entry: CachedHandler): void {
+    this.entries.set(projectId, entry)
+    this.evictOverCapacity()
+  }
+
+  private evictOverCapacity(): void {
+    if (this.entries.size <= MAX_CACHED_HANDLERS) return
+    for (const [projectId, entry] of this.entries) {
+      if (this.entries.size <= MAX_CACHED_HANDLERS) break
+      if (entry.executor.hasActiveWork) continue
+      this.entries.delete(projectId)
+    }
+  }
+
+  sweepIdle(): void {
+    const now = Date.now()
+    for (const [projectId, entry] of this.entries) {
+      if (entry.executor.hasActiveWork) continue
+      if (now - entry.lastAccess > HANDLER_IDLE_TTL_MS) this.entries.delete(projectId)
+    }
+  }
+
+  get size(): number {
+    return this.entries.size
+  }
+}
+
+const handlerCache = new A2AHandlerCache()
+
+const sweepTimer = setInterval(() => handlerCache.sweepIdle(), SWEEP_INTERVAL_MS)
+if (sweepTimer && typeof sweepTimer === 'object' && 'unref' in sweepTimer) {
+  ;(sweepTimer as { unref: () => void }).unref()
+}
+
+class A2AProjectNotFoundError extends Error {
+  constructor(projectId: string) {
+    super(`Project ${projectId} not found`)
+  }
+}
+
+async function getOrCreateHandler(projectId: string, workspaceId: string): Promise<CachedHandler> {
+  const cached = handlerCache.get(projectId)
+  if (cached) return cached
+
+  // The card baked into the cached `DefaultRequestHandler` is used
+  // internally (protocol-version validation, `getAuthenticatedExtendedAgentCard`)
+  // — it is NOT what `.well-known/agent-card.json` serves. That route
+  // calls `buildAgentCard()` directly on every request so project edits
+  // (name, description, tools) show up immediately, matching Odin. The
+  // handler's copy going slightly stale between cache refreshes is fine:
+  // the fields it actually consumes (`supportedInterfaces`, `tenant`,
+  // `protocolVersion`) never change for a project's lifetime.
+  const card = await buildAgentCard({ projectId })
+  if (!card) throw new A2AProjectNotFoundError(projectId)
+
+  const taskStore = new PrismaA2ATaskStore()
+  const executor = new ShogoAgentExecutor({ projectId, workspaceId, taskStore })
+  const handler = new DefaultRequestHandler(card, taskStore, executor)
+
+  const entry: CachedHandler = { handler, executor, lastAccess: Date.now() }
+  handlerCache.set(projectId, entry)
+  return entry
+}
+
+// -----------------------------------------------------------------------------
+// Protocol routes — mounted at /a2a, self-authenticating
+// -----------------------------------------------------------------------------
+
+export function a2aProtocolRoutes() {
+  const router = new Hono()
+
+  // Self-auth: every request under /a2a/projects/:projectId/* must carry
+  // a valid `shogo_a2a_<keyId>.<secret>` bearer key scoped to that exact
+  // project. This deliberately covers the agent-card route too (matches
+  // Odin's `require_a2a_key` on the card endpoint) — clients must send
+  // the bearer token when *fetching the card*, not just when calling
+  // RPC. Every rejection reason collapses to the same 401 so a probing
+  // caller can't use response shape to enumerate valid projects/keys.
+  router.use('/projects/:projectId/*', async (c, next) => {
+    const projectId = c.req.param('projectId')
+    const authHeader = c.req.header('authorization') ?? ''
+    const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : ''
+    const result = token ? await verifyA2aApiKey(token, projectId) : { ok: false as const }
+    if (!result.ok) {
+      c.header('WWW-Authenticate', 'Bearer')
+      return c.json(
+        { error: { code: 'unauthorized', message: 'A valid shogo_a2a_<keyId>.<secret> bearer key for this project is required' } },
+        401,
+      )
+    }
+    c.set('a2aKey', result.key)
+    await next()
+  })
+
+  router.get('/projects/:projectId/.well-known/agent-card.json', async (c) => {
+    const projectId = c.req.param('projectId')
+    const card = await buildAgentCard({ projectId, baseUrl: getA2aBaseUrl() })
+    if (!card) {
+      return c.json({ error: { code: 'not_found', message: 'Project not found' } }, 404)
+    }
+    return c.json(AgentCard.toJSON(card))
+  })
+
+  router.post('/projects/:projectId/rpc', async (c) => {
+    const projectId = c.req.param('projectId')
+    const key = c.get('a2aKey')
+
+    let entry: CachedHandler
+    try {
+      entry = await getOrCreateHandler(projectId, key!.workspaceId)
+    } catch (err) {
+      if (err instanceof A2AProjectNotFoundError) {
+        return c.json({ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'Project not found' } }, 404)
+      }
+      throw err
+    }
+
+    const context = buildA2AServerCallContext({ projectId })
+    return handleA2AJsonRpc(c, entry.handler, context)
+  })
+
+  return router
+}
+
+/** Test/ops hook — number of cached handlers currently held in memory. */
+export function getA2AHandlerCacheSize(): number {
+  return handlerCache.size
+}
+
+// -----------------------------------------------------------------------------
+// Key management routes — mounted at /api, session-authed via authorizeProject
+// -----------------------------------------------------------------------------
+
+export function a2aKeyRoutes() {
+  const router = new Hono()
+
+  router.post('/projects/:projectId/a2a/keys', async (c) => {
+    const projectId = c.req.param('projectId')
+    const authResult = await authorizeProject(c, projectId)
+    if (!authResult.ok) {
+      return c.json({ error: { code: authResult.code, message: authResult.message } }, authResult.status)
+    }
+
+    const body = await c.req
+      .json<{ name?: string; expiresInDays?: number }>()
+      .catch((): { name?: string; expiresInDays?: number } => ({}))
+    const expiresAt = body.expiresInDays
+      ? new Date(Date.now() + body.expiresInDays * 24 * 60 * 60 * 1000)
+      : null
+
+    const authCtx = c.get('auth')
+    const minted = await mintA2aApiKey({
+      projectId: authResult.projectId,
+      workspaceId: authResult.workspaceId,
+      createdBy: authCtx?.userId ?? 'unknown',
+      name: body.name,
+      expiresAt,
+    })
+
+    return c.json(
+      {
+        id: minted.id,
+        keyId: minted.keyId,
+        name: minted.name,
+        // One-time reveal — never returned again after this response.
+        key: minted.fullKey,
+        projectId: minted.projectId,
+        createdAt: minted.createdAt,
+        expiresAt: minted.expiresAt,
+      },
+      201,
+    )
+  })
+
+  router.get('/projects/:projectId/a2a/keys', async (c) => {
+    const projectId = c.req.param('projectId')
+    const authResult = await authorizeProject(c, projectId)
+    if (!authResult.ok) {
+      return c.json({ error: { code: authResult.code, message: authResult.message } }, authResult.status)
+    }
+    const keys = await listA2aApiKeys(authResult.projectId)
+    return c.json({ keys })
+  })
+
+  router.delete('/projects/:projectId/a2a/keys/:keyId', async (c) => {
+    const projectId = c.req.param('projectId')
+    const authResult = await authorizeProject(c, projectId)
+    if (!authResult.ok) {
+      return c.json({ error: { code: authResult.code, message: authResult.message } }, authResult.status)
+    }
+    const keyId = c.req.param('keyId')
+    const revoked = await revokeA2aApiKey({ id: keyId, projectId: authResult.projectId })
+    if (!revoked) {
+      return c.json({ error: { code: 'not_found', message: 'Key not found' } }, 404)
+    }
+    return c.json({ ok: true })
+  })
+
+  return router
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -62,6 +62,7 @@ import { voiceRoutes } from './routes/voice'
 import { chatRoutes } from './routes/chat'
 import { createChatMessageEditRoutes } from './routes/chat-message-edits'
 import { toolsProxyRoutes } from './routes/tools-proxy'
+import { a2aProtocolRoutes, a2aKeyRoutes } from './routes/a2a'
 import {
   generateTitleCompletion,
   setTitleGenerationModelId,
@@ -7699,6 +7700,36 @@ app.route('/api', voiceRoutes())
 // (`shogo_sk_*`) or session cookie. Runtime-token callers are
 // rejected — see runtime-token.md §7 for the rationale.
 app.route('/api', chatRoutes())
+
+// =============================================================================
+// A2A (Agent2Agent) protocol — external callers reach a project's runtime
+// pod via JSON-RPC bearer keys. See apps/api/src/lib/a2a/* and
+// apps/api/src/routes/a2a.ts for the implementation.
+// =============================================================================
+
+// Key management (mint/list/revoke `shogo_a2a_*` keys) is session-authed —
+// mounted under /api so it inherits authMiddleware + the global /api/*
+// rate limiter above, same as every other project-scoped /api/projects/*
+// route.
+app.route('/api', a2aKeyRoutes())
+
+// Kill switch: unset or 'false' disables the protocol surface entirely
+// (key management above stays up either way, since minting a key that
+// can't be used yet is harmless and avoids a chicken-and-egg rollout).
+if (process.env.A2A_ENABLED === 'true') {
+  // The protocol router is mounted OUTSIDE /api/* — it self-authenticates
+  // with shogo_a2a_* bearer keys (see routes/a2a.ts), not session/runtime-
+  // token auth, so it must not go through authMiddleware or the /api/*
+  // rate limiter. It gets its own limiter here instead.
+  app.use(
+    '/a2a/*',
+    rateLimiter('a2a', {
+      max: Number(process.env.RATE_LIMIT_A2A_MAX) || 300,
+      windowMs: Number(process.env.RATE_LIMIT_A2A_WINDOW_MS) || 60_000,
+    }),
+  )
+  app.route('/a2a', a2aProtocolRoutes())
+}
 
 // =============================================================================
 // Domain API routes - For APIPersistence layer

--- a/apps/desktop/prisma/migrations/20260903000000_add_a2a_tables/migration.sql
+++ b/apps/desktop/prisma/migrations/20260903000000_add_a2a_tables/migration.sql
@@ -1,0 +1,57 @@
+-- Migration: add_a2a_tables
+-- Source:    prisma/schema.local.prisma
+--
+-- Hand-scoped, NOT the raw output of `bun run db:migrate:desktop`. That
+-- script's `prisma migrate diff` run also picked up ~8 tables' worth of
+-- pre-existing drift between this migration history and the current
+-- schema (agent_configs, agent_eval_sets, budget_alerts, eval_runs,
+-- model_experiments, subagent_model_overrides, usage_wallets,
+-- workspace_grants, plus a signup_attributions index) that predates this
+-- change and is already tracked as accepted tech debt in the allow-list
+-- in scripts/check-desktop-schema-drift.ts. Bundling an unrelated
+-- multi-table RedefineTables rewrite into this PR would be out of scope
+-- and harder to review, so this migration is trimmed to exactly the two
+-- new tables `A2aApiKey`/`A2aTask` add — verified to match the CREATE
+-- TABLE/CREATE INDEX statements Prisma itself emitted for them before
+-- trimming.
+
+-- CreateTable
+CREATE TABLE "a2a_api_keys" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "keyId" TEXT NOT NULL,
+    "hashedSecret" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "createdBy" TEXT NOT NULL,
+    "lastUsedAt" DATETIME,
+    "expiresAt" DATETIME,
+    "revokedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "a2a_api_keys_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "projects" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "a2a_tasks" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "contextId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "state" TEXT NOT NULL,
+    "taskJson" TEXT NOT NULL,
+    "chatSessionId" TEXT,
+    "lastSeq" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "a2a_api_keys_keyId_key" ON "a2a_api_keys"("keyId");
+
+-- CreateIndex
+CREATE INDEX "a2a_api_keys_projectId_idx" ON "a2a_api_keys"("projectId");
+
+-- CreateIndex
+CREATE INDEX "a2a_tasks_projectId_contextId_idx" ON "a2a_tasks"("projectId", "contextId");
+
+-- CreateIndex
+CREATE INDEX "a2a_tasks_projectId_updatedAt_idx" ON "a2a_tasks"("projectId", "updatedAt");

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
       "name": "@shogo/api",
       "version": "1.0.0",
       "dependencies": {
+        "@a2a-js/sdk": "1.1.0",
         "@ai-sdk/anthropic": "^3.0.37",
         "@ai-sdk/openai-compatible": "^2.0.41",
         "@aws-sdk/client-s3": "^3.975.0",
@@ -1133,6 +1134,8 @@
   },
   "packages": {
     "@0no-co/graphql.web": ["@0no-co/graphql.web@1.2.0", "", { "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0" }, "optionalPeers": ["graphql"] }, "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw=="],
+
+    "@a2a-js/sdk": ["@a2a-js/sdk@1.1.0", "", { "dependencies": { "jose": "^6.2.3" }, "peerDependencies": { "@bufbuild/protobuf": "^2.10.2", "@grpc/grpc-js": "^1.11.0", "express": "^4.21.2 || ^5.1.0" }, "optionalPeers": ["@bufbuild/protobuf", "@grpc/grpc-js", "express"] }, "sha512-/Mhzw9C6VW7pFbY2Rq0pnrjT0Fy9PV0c46A7Gx1ppRlYq2u/6OV/bNRIoVBKChb8UZ8bE0WzzCc0pIr2CdmG+w=="],
 
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
@@ -2796,7 +2799,7 @@
 
     "@types/better-sqlite3": ["@types/better-sqlite3@7.6.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
 
@@ -5638,6 +5641,8 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@a2a-js/sdk/jose": ["jose@6.2.10", "", {}, "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g=="],
+
     "@ai-sdk/anthropic/@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 
     "@ai-sdk/gateway/@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
@@ -6244,8 +6249,6 @@
 
     "@shogo/agent-runtime/@types/react": ["@types/react@19.1.17", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA=="],
 
-    "@shogo/agent-runtime/yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
-
     "@shogo/desktop-terminal/react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
     "@shogo/domain-stores/mobx-state-tree": ["mobx-state-tree@7.0.2", "", { "dependencies": { "ts-essentials": "^9.4.1" }, "peerDependencies": { "mobx": "^6.3.0" } }, "sha512-Qmqgo2Ho1/JRTquo0EWw0ZA/k4wTUNPMIBg98ALGN1V/0Gupic7dg4GDYUhNbiLsYHpp48VgpaCDpDIKV+jNkQ=="],
@@ -6295,6 +6298,8 @@
     "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "@ts-morph/common/minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
+
+    "@types/bun/bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "@types/graceful-fs/@types/node": ["@types/node@24.10.13", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg=="],
 

--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -1,0 +1,303 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2026 Shogo Technologies, Inc. -->
+
+# A2A (Agent2Agent) protocol
+
+Status: **implemented**, gated behind `A2A_ENABLED` — inert (routes not mounted)
+until that flag is set, so this ships dark by default.
+
+Exposes each project's coding agent over the [A2A protocol](https://a2a-community.github.io/A2A/)
+so external callers can discover it (agent card), send it queries
+(`message/send`), poll for results (`tasks/get`), and — the main way shogo's
+implementation goes beyond the reference — listen to the full turn as it
+happens (`message/stream` over SSE).
+
+Implementation: `apps/api/src/lib/a2a/*` and `apps/api/src/routes/a2a.ts`,
+mounted from `apps/api/src/server.ts`. Built against `@a2a-js/sdk@1.1.0`.
+
+This is shogo's version of the A2A server `alignment-project-server` already
+runs in odin-dev-stack (`services/a2a/*`, `routes/a2a.py`). The core pieces
+mirror that implementation 1:1 (bearer key shape, task store, card
+structure); the sections below call out where and why shogo's differs.
+
+## Why this looks different from Odin's
+
+In Odin, an agent is a DB row invoked in-process — `OdinAgentExecutor` calls
+`ToolUseAgent.ainvoke()` directly. In shogo, the agent is a **per-project pod**
+(`AgentGateway` in `packages/agent-runtime/src/gateway.ts`) that `apps/api`
+proxies to over HTTP. So `ShogoAgentExecutor` is a *stream consumer*, not an
+in-process invoker: it `POST`s to the pod's `/agent/chat` and maps its AI SDK
+`UIMessageChunk` SSE stream onto A2A events. That single fact drives most of
+the differences from Odin below — the resume-on-EOF logic, the
+one-turn-per-context guard, and `capabilities.streaming: true` (Odin's is
+`false`; it doesn't stream at all).
+
+```
+Client ──Bearer shogo_a2a_...──▶ /a2a/projects/:id/rpc (Hono)
+                                        │
+                                JsonRpcTransportHandler (@a2a-js/sdk/server)
+                                        │
+                                DefaultRequestHandler
+                                        │
+                                ShogoAgentExecutor
+                                        │
+                               POST {podUrl}/agent/chat  ──▶  AgentGateway (runtime pod)
+                                        │
+                        tee: mapPodChunkToA2AEvents ──▶ ExecutionEventBus ──▶ SSE
+                             trackUsageFromStream    ──▶ billing + ChatMessage/ToolCallLog
+```
+
+## Endpoints
+
+All protocol routes live under `/a2a`, deliberately **outside** `/api/*` —
+they self-authenticate with A2A bearer keys rather than the session/runtime
+tokens `authMiddleware` expects, and get their own rate limiter
+(`RATE_LIMIT_A2A_MAX` / `RATE_LIMIT_A2A_WINDOW_MS`, default 300 req/min) since
+the `/api/*` and `/v1/*` limiters don't cover them.
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| `GET` | `/a2a/projects/:projectId/.well-known/agent-card.json` | `shogo_a2a_*` bearer | Fetch the agent card |
+| `POST` | `/a2a/projects/:projectId/rpc` | `shogo_a2a_*` bearer | JSON-RPC 2.0 endpoint — `message/send`, `message/stream`, `tasks/get`, `tasks/cancel`, `tasks/list`, `tasks/resubscribe` |
+
+Key management is normal product surface, so it lives under `/api` and
+inherits session auth (`authorizeProject`) instead:
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| `POST` | `/api/projects/:projectId/a2a/keys` | Session | Mint a new key. Response includes the raw key **once** |
+| `GET` | `/api/projects/:projectId/a2a/keys` | Session | List keys (metadata only — never the secret) |
+| `DELETE` | `/api/projects/:projectId/a2a/keys/:keyId` | Session | Revoke a key |
+
+Key management stays up regardless of `A2A_ENABLED` — minting a key that
+can't be used yet is harmless, and it avoids a chicken-and-egg rollout where
+the protocol can't be tested until keys already exist.
+
+## Token format
+
+`shogo_a2a_<keyId>.<secret>` — mirrors Odin's `odin_a2a_<key_id>.<secret>`.
+
+- `keyId`: 12 random bytes, hex-encoded, stored **plaintext** in
+  `A2aApiKey.keyId` (unique-indexed). Not secret — it's a lookup key so
+  verification is a single `findUnique` instead of a table scan hashing
+  every row.
+- `secret`: 32 random bytes, hex-encoded. Hashed at rest with the repo's
+  existing SHA-256 `hashApiKey()` (`lib/api-keys-mint.ts`) — same primitive as
+  `shogo_sk_*` keys, not Odin's bcrypt. A fast hash is fine here: unlike a
+  user-chosen password, there's no offline-guessing risk to mitigate with a
+  slow KDF given 256 bits of random secret entropy.
+- Comparison is `crypto.timingSafeEqual` on the hashed value.
+- Every key is scoped to exactly one `projectId`; a key minted for project A
+  is rejected for project B.
+
+**Every verification failure is indistinguishable to the caller.** Malformed
+token, unknown `keyId`, revoked, expired, and wrong-project all collapse to
+the same `401` with `WWW-Authenticate: Bearer` — a probing client can't use
+response shape or timing to enumerate projects or valid `keyId`s.
+
+## The agent card requires auth
+
+Unlike most A2A servers, `GET /.well-known/agent-card.json` is **not**
+public here — it sits behind the same per-project bearer check as `/rpc`.
+This matches Odin's `require_a2a_key` on the card route and prevents project
+enumeration, but it means callers must send the bearer token when *fetching
+the card*, not just when calling RPC.
+
+**This is non-standard.** Many A2A clients (including `@a2a-js/sdk/client`'s
+`createFromUrl`) resolve the card unauthenticated first. Callers using such a
+client need the card fetch itself configured with the bearer header — see
+the integration test at `apps/api/src/routes/__tests__/a2a.test.ts` for a
+worked example (`A2AClientFetch` wrapping `fetch` to inject the header, or a
+`fetchImpl` option, depending on client version). Revisit this if it causes
+enough interop friction — the alternative is a public card with no
+project-identifying detail.
+
+Two more card notes:
+
+- Built fresh **on every request**, not cached — project name/description/
+  tools edits show up immediately.
+- `tenant` (the `projectId`) is set on every `AgentInterface`, and
+  `DefaultRequestHandler` threads it through `ServerCallContext.tenant` into
+  `PrismaA2ATaskStore` — this is the isolation Odin had to hand-roll by
+  passing `(agent_id, project_id)` into every constructor.
+
+## Making calls
+
+### `message/send` vs `message/stream`
+
+A coding-agent turn can run for minutes — long enough to blow past most HTTP
+client timeouts on a blocking call. Two ways to avoid that, no custom
+plumbing needed on either side (`SendMessageConfiguration.returnImmediately`
+is part of the spec and `DefaultRequestHandler` honors it):
+
+- **`message/stream`** — recommended. Opens an SSE connection and yields the
+  full lifecycle (`task` → `statusUpdate(WORKING)` → `artifactUpdate`* →
+  terminal `statusUpdate`) as it happens. This is the only way to get partial
+  text/tool-call events; use it if you want to "listen to events" rather than
+  just wait for a result.
+- **`message/send` with `returnImmediately: true`**, then poll
+  `tasks/get` — returns the task in `WORKING` as soon as it's created
+  instead of blocking until the turn finishes. Poll `tasks/get` until the
+  task reaches a terminal state (`COMPLETED` / `FAILED` / `CANCELED`) or
+  `INPUT_REQUIRED` / `AUTH_REQUIRED`.
+
+Plain `message/send` without `returnImmediately` blocks for the full turn
+duration and is not recommended for anything but quick, low-latency
+requests.
+
+### One in-flight turn per `contextId`
+
+Reuse the same `contextId` across `message/send`/`message/stream` calls to
+get continuous conversation memory on the pod (it's hashed into a stable
+`chatSessionId`). But concurrent `/agent/chat` calls on the same
+`chatSessionId` **queue silently** in the runtime pod rather than erroring,
+so a second task fired on a `contextId` that already has one in flight would
+otherwise hang with no explanation. The executor guards this explicitly: the
+second `execute()` call is rejected immediately with a JSON-RPC
+`TASK_NOT_CANCELABLE` (-32002) error — not a perfect semantic fit, but the
+closest existing A2A error class to "a turn is already running on this
+context" without inventing a custom code. Wait for the first task to reach a
+terminal or interactive (`INPUT_REQUIRED`/`AUTH_REQUIRED`) state before
+sending another message on the same `contextId`.
+
+### File input
+
+Only inline base64 file parts are accepted today (`defaultInputModes:
+['text/plain']` — no file capability advertised yet). The runtime pod only
+accepts `{ type: 'file', url: 'data:<mediaType>;base64,...' }` and explicitly
+does not fetch remote URLs server-side. An A2A `FilePart` carrying a `uri`
+(or a raw upload) is rejected with a clear terminal error rather than
+silently dropped. Fetching remote URLs server-side would need an SSRF guard
+— Odin's `agents/agentic_rag/tools/a2a/ssrf.py` — which is out of scope for
+v1.
+
+## Event mapping
+
+The runtime pod emits AI SDK `UIMessageChunk` SSE frames
+(`packages/agent-runtime/src/server.ts`'s `createUIMessageStream`).
+`apps/api/src/lib/a2a/event-mapper.ts` maps them onto A2A
+`AgentExecutionEvent`s:
+
+| Pod chunk | A2A event |
+|---|---|
+| `text-delta` | `artifactUpdate` on a single `response` artifact, `append: true` |
+| `text-end` | *(nothing — `lastChunk` comes from the terminal status instead)* |
+| `tool-input-available` | `statusUpdate(WORKING)` with a `DataPart` `{ toolCallId, toolName, input }` |
+| `tool-output-available` | `statusUpdate(WORKING)` with `{ toolCallId, output }` |
+| `tool-output-error` | `statusUpdate(WORKING)` with the error text |
+| `reasoning-start/delta/end` | Suppressed by default. Surfaced as `statusUpdate(WORKING)` with `metadata.kind: 'reasoning'` only if the caller requests the `https://shogo.ai/a2a/extensions/reasoning` extension |
+| `data-usage` | Accumulated, merged into the terminal status's `metadata.usage` (not its own event) |
+| `data-turn-seq` | No event — persisted to `A2aTask.lastSeq` for resume bookkeeping |
+| `error` | `statusUpdate(FAILED, final: true)` |
+| `data-turn-complete` | `statusUpdate(COMPLETED \| CANCELED \| FAILED, final: true)` based on `data.status` — **unless** overridden (see `ask_user` below) |
+
+Two interactive cases that need special handling, both mapping cleanly onto
+existing A2A states:
+
+- **`ask_user` tool call → `TASK_STATE_INPUT_REQUIRED`.** The agent can call
+  `ask_user`, which deliberately suppresses `tool-output-available` and ends
+  the turn until the user replies as the next message. Without special
+  handling, the task would report `COMPLETED` with no answer captured.
+  Whenever `data-turn-complete` arrives with an unanswered `ask_user` call
+  pending, the mapper overrides the terminal state to `INPUT_REQUIRED`
+  (using the question text as the status message) regardless of what
+  `data.status` said. This needs no extra plumbing on the resume side:
+  `DefaultRequestHandlerOptions.keepBusAliveStates` already defaults to
+  `INPUT_REQUIRED`/`AUTH_REQUIRED`, so the event bus stays alive and a
+  follow-up `message/send` on the same `taskId` resumes the conversation.
+- **`data-permission-request` → `TASK_STATE_AUTH_REQUIRED`.** Only emitted
+  when `SHOGO_LOCAL_MODE=true` with a non-default `strict`/`balanced`
+  security policy (cloud pods and the default `full_autonomy` policy never
+  hit this). The pod blocks tool execution — and the whole `/agent/chat`
+  response — for up to 30s before auto-denying. This is a **transient**
+  status update, not terminal: the executor surfaces it immediately (rather
+  than silently eating the 30s stall) and keeps consuming the same stream,
+  which resumes on its own once the pod's timeout or an operator's
+  out-of-band response fires. There is intentionally no v1 path for an A2A
+  client to answer this itself.
+
+## Resuming a dropped stream (not client-visible, but worth knowing)
+
+The Knative activator cuts pod-facing HTTP at ~5 minutes while the agent
+keeps running in the pod's own buffer — a normal occurrence for any turn
+that takes a while, not an edge case. If the executor's SSE read from
+`/agent/chat` ends without ever seeing `data-turn-complete`, it re-fetches
+`GET /agent/chat/:chatSessionId/stream?fromSeq=<lastSeq>` and keeps
+publishing from there (using the mapper's own `lastSeq`, not a full replay
+from 0 — since `append: true` artifact updates push new parts rather than
+replacing them, a full replay would duplicate every already-published text
+chunk). If that resume request comes back `204`, the pod's buffer has
+expired (stop, restart, or crash) and the task is failed with a terminal
+`FAILED` explaining that partial work may still be persisted. Bounded by
+`CHAT_UPSTREAM_FETCH_TIMEOUT_MS` (4h default; 90s on Metal) and
+`CHAT_STREAM_IDLE_TIMEOUT_MS` (1h idle-per-chunk), same env vars the regular
+chat proxy uses (`project-chat.ts`).
+
+## Billing and persistence
+
+Going straight to the pod would bypass the usual billing/persistence path,
+so the executor `tee()`s the pod's response body: one branch goes to
+`mapPodChunkToA2AEvents` (published on the A2A event bus), the other to
+`trackUsageFromStream` (the same function `POST /api/projects/:id/chat`
+uses) for billing and `ChatMessage`/`ToolCallLog` rows. A2A turns bill and
+persist exactly like UI turns — there's no separate accounting path to keep
+in sync.
+
+## Known limitations
+
+- **`tasks/resubscribe` is same-replica only.** It relies on the SDK's
+  in-process `DefaultExecutionEventBusManager`, so a resubscribe only
+  succeeds if it lands on the same `apps/api` replica that ran the original
+  `message/stream`. Behind a load balancer with multiple replicas, a
+  resubscribe routed elsewhere will not find the bus. A future phase could
+  back this with the pod's own durable replay
+  (`GET /agent/chat/:id/stream?fromSeq=N` + `StreamBufferStore` in
+  `packages/core/src/stream-buffer.ts`) via a custom event-bus manager, but
+  that buffer is in-memory with a 30-minute TTL and does not survive pod
+  migration either — it would narrow the gap, not close it.
+- **The agent card requires auth** — see above. Non-standard for A2A
+  clients that expect an unauthenticated card fetch.
+- **No named-`ProjectAgent` selection.** `POST /agent/chat` has no
+  `agentName` parameter, so there is nothing for A2A to route to beyond the
+  single pod agent. `ProjectAgent` rows are used only as card metadata
+  (name/description/tools) via a `chat`-skill fallback when no row exists.
+  If per-persona A2A endpoints are wanted later, they'd target
+  `/api/chat/turn` instead — a separate design.
+- **No outbound A2A client.** Shogo agents cannot themselves call other A2A
+  agents yet (Odin's `ExternalA2AClient` + `ssrf.py` equivalent).
+
+## Out of scope for v1
+
+Push notifications (`capabilities.pushNotifications: false` — the SDK's
+`DefaultPushNotificationSender` + a durable `PushNotificationStore` would
+make this straightforward later), gRPC/REST transports (JSON-RPC only),
+extended agent card (`capabilities.extendedAgentCard` /
+`getAuthenticatedExtendedAgentCard`), agent card JWS signing
+(`AgentCardSignatureGenerator`), remote/uploaded file input, named-
+`ProjectAgent` selection, an outbound A2A client, and any UI for key
+management (API only — mint/list/revoke via the `/api/projects/:id/a2a/keys`
+routes above).
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `A2A_ENABLED` | unset (disabled) | Kill switch — set to `'true'` to mount `/a2a/*`. Key management under `/api` is unaffected either way |
+| `SHOGO_A2A_BASE_URL` | falls back to `getFrontendUrl()`/`APP_URL` | Base URL A2A clients should use to reach this server — Odin's `BACKEND_ROOT_URL` equivalent. Used to build the card's `documentationUrl` and `supportedInterfaces[0].url` |
+| `RATE_LIMIT_A2A_MAX` | `300` | Requests per window for `/a2a/*` |
+| `RATE_LIMIT_A2A_WINDOW_MS` | `60000` | Rate-limit window, ms |
+| `A2A_HANDLER_CACHE_MAX` | `200` | Max cached `DefaultRequestHandler`s (one per project with recent A2A traffic) held in the bounded LRU |
+| `A2A_HANDLER_IDLE_TTL_MS` | `1800000` (30 min) | Idle eviction TTL for cached handlers with no active turn |
+| `A2A_METAL_WAIT_MS` | `90000` | How long the executor waits for a Metal pod to wake before failing the turn |
+| `CHAT_UPSTREAM_FETCH_TIMEOUT_MS` | `14400000` (4h) | Shared with the regular chat proxy — bounds the `/agent/chat` fetch |
+| `CHAT_STREAM_IDLE_TIMEOUT_MS` | `3600000` (1h) | Shared with the regular chat proxy — per-chunk idle timeout while reading the SSE stream |
+
+## Testing
+
+`apps/api/src/lib/a2a/__tests__/*` (unit: `auth`, `card`, `event-mapper`,
+`task-store`, `executor`) and
+`apps/api/src/routes/__tests__/a2a.test.ts` (integration: a real
+`@a2a-js/sdk/client` driving `/a2a/projects/:id/rpc` over `Bun.serve` against
+a stub pod replaying a recorded SSE transcript — validates the wire protocol
+without mocking it, mirroring Odin's `a2a_inbound_harness.py`). Run with
+`bun test src/lib/a2a src/routes/__tests__/a2a.test.ts` from `apps/api`.

--- a/packages/domain-stores/src/project.collection.ts
+++ b/packages/domain-stores/src/project.collection.ts
@@ -411,7 +411,7 @@ export const ProjectCollection = types
 // ============================================================================
 
 // Relation fields that expect IDs (safeReference)
-const relationFields = ["workspace","folder","members","inviteLinks","featureSessions","chatSessions","usageEvents","checkpoints","githubConnection","starredBy","agentConfig","meetings","marketplaceListing","agentCostMetrics","modelExperiments","subagentModelOverrides","agentEvalSets","voiceConfig","agents","projectFolders","preferredInstance","authConfig","authSignIns","attachedSessions","attachments","attachedTo","customDomains"]
+const relationFields = ["workspace","folder","members","inviteLinks","featureSessions","chatSessions","usageEvents","checkpoints","githubConnection","starredBy","agentConfig","meetings","marketplaceListing","agentCostMetrics","modelExperiments","subagentModelOverrides","agentEvalSets","voiceConfig","agents","projectFolders","preferredInstance","authConfig","authSignIns","attachedSessions","attachments","attachedTo","customDomains","a2aApiKeys"]
 
 /**
  * Transform API response for MST compatibility:

--- a/prisma/migrations/20260903000000_add_a2a_tables/migration.sql
+++ b/prisma/migrations/20260903000000_add_a2a_tables/migration.sql
@@ -1,0 +1,46 @@
+-- CreateTable
+CREATE TABLE "a2a_api_keys" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "keyId" TEXT NOT NULL,
+    "hashedSecret" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "createdBy" TEXT NOT NULL,
+    "lastUsedAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "a2a_api_keys_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "a2a_tasks" (
+    "id" TEXT NOT NULL,
+    "contextId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "state" TEXT NOT NULL,
+    "taskJson" TEXT NOT NULL,
+    "chatSessionId" TEXT,
+    "lastSeq" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "a2a_tasks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "a2a_api_keys_keyId_key" ON "a2a_api_keys"("keyId");
+
+-- CreateIndex
+CREATE INDEX "a2a_api_keys_projectId_idx" ON "a2a_api_keys"("projectId");
+
+-- CreateIndex
+CREATE INDEX "a2a_tasks_projectId_contextId_idx" ON "a2a_tasks"("projectId", "contextId");
+
+-- CreateIndex
+CREATE INDEX "a2a_tasks_projectId_updatedAt_idx" ON "a2a_tasks"("projectId", "updatedAt");
+
+-- AddForeignKey
+ALTER TABLE "a2a_api_keys" ADD CONSTRAINT "a2a_api_keys_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.local.prisma
+++ b/prisma/schema.local.prisma
@@ -246,6 +246,7 @@ model Project {
   attachments            ProjectAttachment[]     @relation("ProjectAttachmentAnchor")
   attachedTo             ProjectAttachment[]     @relation("ProjectAttachmentTarget")
   customDomains          CustomDomain[]
+  a2aApiKeys             A2aApiKey[]
 
   @@index([workspaceId])
   @@index([folderId])
@@ -1383,6 +1384,46 @@ model ApiKey {
   @@index([userId])
   @@index([workspaceId, deviceId])
   @@map("api_keys")
+}
+
+// =============================================================================
+// A2A PROTOCOL (Agent2Agent — see prisma/schema.prisma for the canonical
+// comment; mirrored here for local/desktop mode)
+// =============================================================================
+
+model A2aApiKey {
+  id           String    @id @default(cuid())
+  name         String
+  keyId        String    @unique
+  hashedSecret String
+  projectId    String
+  workspaceId  String
+  createdBy    String
+  lastUsedAt   DateTime?
+  expiresAt    DateTime?
+  revokedAt    DateTime?
+  createdAt    DateTime  @default(now())
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@index([projectId])
+  @@map("a2a_api_keys")
+}
+
+model A2aTask {
+  id            String   @id
+  contextId     String
+  projectId     String
+  state         String
+  taskJson      String
+  chatSessionId String?
+  lastSeq       Int      @default(0)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@index([projectId, contextId])
+  @@index([projectId, updatedAt])
+  @@map("a2a_tasks")
 }
 
 // =============================================================================

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -315,6 +315,7 @@ model Project {
   attachments            ProjectAttachment[]     @relation("ProjectAttachmentAnchor")
   attachedTo             ProjectAttachment[]     @relation("ProjectAttachmentTarget")
   customDomains          CustomDomain[]
+  a2aApiKeys             A2aApiKey[]
 
   @@index([workspaceId])
   @@index([folderId])
@@ -1927,6 +1928,57 @@ model ApiKey {
   @@index([userId])
   @@index([workspaceId, deviceId])
   @@map("api_keys")
+}
+
+// =============================================================================
+// A2A PROTOCOL (Agent2Agent — external callers reach a project's runtime
+// pod via JSON-RPC bearer keys; see apps/api/src/lib/a2a/*)
+// =============================================================================
+
+/// `shogo_a2a_<keyId>.<secret>` bearer keys, one per project. Verified in
+/// apps/api/src/lib/a2a/auth.ts by SHA-256-hashing the presented secret
+/// (mirroring `hashApiKey` from lib/api-keys-mint.ts) and comparing against
+/// `hashedSecret` with a timing-safe compare.
+model A2aApiKey {
+  id           String    @id @default(cuid())
+  name         String
+  keyId        String    @unique
+  hashedSecret String
+  projectId    String
+  workspaceId  String
+  createdBy    String
+  lastUsedAt   DateTime?
+  expiresAt    DateTime?
+  revokedAt    DateTime?
+  createdAt    DateTime  @default(now())
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@index([projectId])
+  @@map("a2a_api_keys")
+}
+
+/// One row per A2A `Task`, persisted by `PrismaA2ATaskStore`
+/// (apps/api/src/lib/a2a/task-store.ts). `taskJson` is the full serialized
+/// `@a2a-js/sdk` `Task` object — deliberately `String`, not `Json`, so this
+/// model never enters the `wrapForSqlite` translation layer (see
+/// apps/api/src/lib/prisma.ts) and both schemas stay byte-identical.
+/// `contextId` is scoped to `projectId`, not globally unique, since the
+/// same external caller could reuse a `contextId` shape across projects.
+model A2aTask {
+  id            String   @id
+  contextId     String
+  projectId     String
+  state         String
+  taskJson      String
+  chatSessionId String?
+  lastSeq       Int      @default(0)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@index([projectId, contextId])
+  @@index([projectId, updatedAt])
+  @@map("a2a_tasks")
 }
 
 // =============================================================================

--- a/scripts/check-multiregion-cron-locks.ts
+++ b/scripts/check-multiregion-cron-locks.ts
@@ -347,6 +347,12 @@ const ACCEPTED_UNIQUE_KEYS: UniqueKeyRule[] = [
     reason: 'Random key + hash; collision cryptographically impossible.',
   },
   {
+    key: 'A2aApiKey.keyId',
+    category: 'random_secret',
+    reason:
+      '12 random bytes hex-encoded (mintA2aApiKey in lib/a2a/auth.ts) — a plaintext lookup key, not the hashed secret; collision cryptographically impossible.',
+  },
+  {
     key: 'Instance.(hostname,userId,workspaceId)',
     category: 'single_tenant_upsert',
     reason:


### PR DESCRIPTION
## Summary

Exposes each project's coding agent over the [A2A (Agent2Agent) protocol](https://a2a-community.github.io/A2A/), so external callers can discover it (agent card), send it queries (`message/send`), poll for results (`tasks/get`), and listen to the full turn as it happens (`message/stream` over SSE). Mirrors the approach already running in odin-dev-stack's `alignment-project-server`, adapted for shogo's per-project runtime-pod architecture (the agent is a pod reached over HTTP, not an in-process invocation — see `docs/a2a.md` for the full writeup).

Built against `@a2a-js/sdk@1.1.0`. Ships dark behind an `A2A_ENABLED` kill switch — inert (routes not mounted) until that's set.

## Changes

- `apps/api/src/lib/a2a/auth.ts` — mint/verify/revoke `shogo_a2a_<keyId>.<secret>` bearer keys, SHA-256 hashed at rest, uniform 401 on any failure reason (can't be used to enumerate projects/keys).
- `apps/api/src/lib/a2a/task-store.ts` — `PrismaA2ATaskStore`, tenant-scoped by `projectId`.
- `apps/api/src/lib/a2a/card.ts` — per-request `AgentCard` builder (all v1.0-required fields, streaming capability, project-scoped tenant + RPC URL).
- `apps/api/src/lib/a2a/event-mapper.ts` — maps the runtime pod's `UIMessageChunk` SSE stream onto A2A `AgentExecutionEvent`s, including `ask_user` → `INPUT_REQUIRED` and `data-permission-request` → `AUTH_REQUIRED`.
- `apps/api/src/lib/a2a/executor.ts` — `ShogoAgentExecutor` bridges A2A into the pod's `/agent/chat`, tees into `trackUsageFromStream` for billing/persistence (A2A turns bill exactly like UI turns), resumes from the pod's buffer on a dropped stream (Knative activator cuts pod HTTP at ~5min), and guards one in-flight turn per `contextId`.
- `apps/api/src/lib/a2a/hono-transport.ts` — Hono adapter for `@a2a-js/sdk/server`'s `JsonRpcTransportHandler` (single JSON response or keep-alive SSE stream).
- `apps/api/src/routes/a2a.ts` — `GET .well-known/agent-card.json` + `POST rpc` under `/a2a` (self-authenticating, bounded LRU of cached `DefaultRequestHandler`s), plus key CRUD under `/api/projects/:id/a2a/keys` (session-authed). Mounted in `server.ts` behind `A2A_ENABLED`, with its own rate limiter since `/api/*`'s doesn't cover it.
- Prisma: `A2aApiKey` + `A2aTask` models on both the Postgres and SQLite (`schema.local.prisma`) schemas, with matching migrations. The desktop SQLite migration is hand-scoped — `db:migrate:desktop`'s diff also picked up ~8 tables' worth of pre-existing drift already tracked as accepted tech debt in `scripts/check-desktop-schema-drift.ts`; bundling that unrelated rewrite in would be out of scope, so the migration is trimmed to just the two new tables (verified against `check-desktop-schema-drift.ts`, which now shows zero *new* drift).
- `scripts/check-multiregion-cron-locks.ts` — classified `A2aApiKey.keyId` as `random_secret` (12 random bytes, hex-encoded; not the hashed secret).
- `apps/api/scripts/test-a2a-external-client.ts` — standalone smoke-test script that drives a real `@a2a-js/sdk/client` against a locally-running server, for manual end-to-end verification outside the automated test suite.
- `docs/a2a.md` — endpoints, token format, the (non-standard) authenticated-card-fetch requirement, `message/send` vs `message/stream` + `returnImmediately` guidance, the full event-mapping table, and known limitations (same-replica `tasks/resubscribe`, no outbound A2A client, etc).

## Testing

- [x] Added/updated tests — 95 unit + integration tests under `apps/api/src/lib/a2a/__tests__/*` (auth, card, event-mapper, task-store, executor) and `apps/api/src/routes/__tests__/a2a.test.ts`. The latter drives a real `@a2a-js/sdk/client` over HTTP against a stub pod replaying a recorded SSE transcript — validates the wire protocol without mocking it. Covers failure modes: missing `data-turn-complete` (buffer resume), `204` on resume (terminal `FAILED`), `ask_user` → `INPUT_REQUIRED`, and concurrent same-`contextId` tasks.
- [x] Tested locally — ran the full stack in local mode (SQLite, `A2A_ENABLED=true`) and drove it with `apps/api/scripts/test-a2a-external-client.ts` as a genuine external caller. All 17 checks passed against the live server: auth enforcement, authenticated card shape, JSON-RPC error envelopes, `message/send` + `tasks/get` polling, `message/stream` SSE lifecycle, and the one-turn-per-`contextId` guard (confirmed via the real rejection message from a live concurrent-request race, not a mock).
- [x] Verified no regressions — `bun run typecheck` shows no new errors attributable to this change (pre-existing failures in unrelated packages are unaffected); `bun scripts/check-desktop-schema-drift.ts` and `bun scripts/check-multiregion-cron-locks.ts` both pass clean.

## Related Issues

N/A — implements the plan in `.cursor/plans/shogo_a2a_server_f1364ce2.plan.md` (internal planning doc, not part of this diff).

## Notes for reviewers

- Schema/env changes: two new tables (`a2a_api_keys`, `a2a_tasks`) on both DB tracks; new env vars documented in `docs/a2a.md`'s Configuration section (`A2A_ENABLED`, `SHOGO_A2A_BASE_URL`, `RATE_LIMIT_A2A_*`, `A2A_HANDLER_CACHE_MAX`, `A2A_HANDLER_IDLE_TTL_MS`, `A2A_METAL_WAIT_MS`) — all optional with sane defaults, nothing required to deploy.
- Self-hosting / cloud-only: works identically on both tracks (local/desktop SQLite and cloud Postgres) — the executor talks to whatever pod `resolveProjectPodUrl` resolves, same as the existing chat proxy.
- SDK: no `@shogo-ai/sdk` surface changes; this is entirely additive within `apps/api`.

Made with [Cursor](https://cursor.com)