### PR TITLE
feat(ai-proxy): audio input support (Tier 1 pass-through + Tier 2 Whisper pipeline)

### DIFF
--- a/apps/api/src/__tests__/ai-proxy-audio-e2e.test.ts
+++ b/apps/api/src/__tests__/ai-proxy-audio-e2e.test.ts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+process.env.AI_PROXY_SECRET = process.env.AI_PROXY_SECRET || 'test-secret-ai-proxy-do-not-use-in-prod'
+process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET || 'test-better-auth-secret'
+/**
+ * Audio Input — End-to-End Integration Tests
+ *
+ * Exercises the full audio pipeline against the REAL OpenAI API (no fetch
+ * mocking) with a real spoken WAV clip:
+ *
+ *   1. Tier 1 — `POST /ai/v1/chat/completions` with `model: 'gpt-audio'` and
+ *      a real `input_audio` content block: proves the proxy's pure
+ *      pass-through actually gets OpenAI to understand spoken audio.
+ *   2. Tier 2 — `POST /ai/v1/audio/transcriptions`: proves the new Whisper
+ *      proxy route returns a real, accurate transcript.
+ *   3. Tier 2, full chain — starts a REAL HTTP server wrapping the proxy
+ *      routes and calls `transcribeAudioParts` (the exact function
+ *      `gateway.ts` calls for chat attachments) against it over a real
+ *      socket, proving the AI_PROXY_URL `/v1` stripping + auth header +
+ *      network round trip all work together, not just against mocks.
+ *
+ * Skipped entirely when OPENAI_API_KEY is not set (same convention as
+ * `ai-proxy-images-e2e.test.ts`).
+ *
+ * Run: OPENAI_API_KEY=sk-... bun test apps/api/src/__tests__/ai-proxy-audio-e2e.test.ts
+ */
+
+import { describe, test, expect, beforeAll, mock } from 'bun:test'
+import { Hono } from 'hono'
+import { readFileSync } from 'fs'
+import { generateProxyToken } from '../lib/ai-proxy-token'
+
+mock.module('../lib/prisma', () => ({
+  prisma: {
+    project: {
+      findFirst: async () => ({ id: 'audio-e2e-project', name: 'Audio E2E' }),
+      findUnique: async () => ({ id: 'audio-e2e-project', workspaceId: 'audio-e2e-workspace' }),
+    },
+    usageEvent: { create: async (args: any) => args.data },
+  },
+}))
+
+mock.module('../services/billing.service', () => ({
+  hasBalance: async () => true,
+  hasAdvancedModelAccess: async () => true,
+  checkUsageBalance: async () => ({ ok: true }),
+  consumeUsage: async () => ({ success: true, remainingIncludedUsd: 99 }),
+}))
+
+mock.module('../lib/proxy-billing-session', () => ({
+  accumulateUsage: () => {},
+  accumulateImageUsage: () => false,
+  hasSession: () => false,
+  hasActiveSession: () => false,
+}))
+
+mock.module('../lib/project-user-context', () => ({
+  getProjectUser: () => 'audio-e2e-user',
+}))
+
+import { aiProxyRoutes } from '../routes/ai-proxy'
+import { transcribeAudioParts } from '@shogo/agent-runtime/src/file-attachment-utils'
+
+const hasOpenAIKey = !!process.env.OPENAI_API_KEY
+
+// A short, real spoken clip: `say -o test-clip.wav --data-format=LEI16@16000
+// "The quick brown fox jumps over the lazy dog."` (macOS `say`, Samantha voice).
+const CLIP_PATH = '/tmp/audio-e2e/test-clip.wav'
+const CLIP_BASE64 = (() => {
+  try {
+    return readFileSync(CLIP_PATH).toString('base64')
+  } catch {
+    return null
+  }
+})()
+
+describe('Audio input — end-to-end (real OpenAI)', () => {
+  let app: Hono
+  let proxyToken: string
+
+  beforeAll(async () => {
+    app = new Hono()
+    app.route('/api', aiProxyRoutes())
+    proxyToken = await generateProxyToken('audio-e2e-project', 'audio-e2e-workspace', 'audio-e2e-user')
+  })
+
+  test(
+    'Tier 1: gpt-audio understands a real spoken clip via input_audio pass-through',
+    async () => {
+      if (!hasOpenAIKey || !CLIP_BASE64) {
+        console.log('[Audio E2E] Skipping — OPENAI_API_KEY not set or test clip missing')
+        return
+      }
+
+      const res = await app.fetch(
+        new Request('http://localhost/api/ai/v1/chat/completions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${proxyToken}` },
+          body: JSON.stringify({
+            model: 'gpt-audio',
+            modalities: ['text'],
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  { type: 'input_audio', input_audio: { data: CLIP_BASE64, format: 'wav' } },
+                  { type: 'text', text: 'Reply with exactly the words you heard, nothing else.' },
+                ],
+              },
+            ],
+          }),
+        })
+      )
+
+      console.log(`[Audio E2E] gpt-audio status: ${res.status}`)
+      expect(res.status).toBe(200)
+      const data = (await res.json()) as any
+      const content = data.choices?.[0]?.message?.content
+      console.log(`[Audio E2E] gpt-audio heard: "${content}"`)
+      expect(typeof content).toBe('string')
+      expect(content.toLowerCase()).toContain('fox')
+    },
+    60_000
+  )
+
+  test(
+    'Tier 2: POST /ai/v1/audio/transcriptions returns an accurate Whisper transcript',
+    async () => {
+      if (!hasOpenAIKey || !CLIP_BASE64) {
+        console.log('[Audio E2E] Skipping — OPENAI_API_KEY not set or test clip missing')
+        return
+      }
+
+      const form = new FormData()
+      const bytes = Buffer.from(CLIP_BASE64, 'base64')
+      form.append('file', new Blob([bytes], { type: 'audio/wav' }), 'test-clip.wav')
+
+      const res = await app.fetch(
+        new Request('http://localhost/api/ai/v1/audio/transcriptions', {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${proxyToken}` },
+          body: form,
+        })
+      )
+
+      console.log(`[Audio E2E] /audio/transcriptions status: ${res.status}`)
+      expect(res.status).toBe(200)
+      const data = (await res.json()) as any
+      console.log(`[Audio E2E] Whisper transcript: "${data.text}"`)
+      expect(data.text.toLowerCase()).toContain('fox')
+      expect(data.duration).toBeGreaterThan(0)
+    },
+    60_000
+  )
+
+  test(
+    'Tier 2, full chain: transcribeAudioParts -> real HTTP proxy server -> real Whisper',
+    async () => {
+      if (!hasOpenAIKey || !CLIP_BASE64) {
+        console.log('[Audio E2E] Skipping — OPENAI_API_KEY not set or test clip missing')
+        return
+      }
+
+      // Stand up a real listening HTTP server wrapping the exact same route
+      // registration used in production (server.ts mounts aiProxyRoutes()
+      // under /api), so this test exercises a real socket + real
+      // request/response cycle, not an in-process app.fetch() call.
+      const server = Bun.serve({ port: 0, fetch: app.fetch })
+      const proxyUrl = `http://localhost:${server.port}/api/ai/v1`
+
+      try {
+        const result = await transcribeAudioParts(
+          [
+            {
+              type: 'file',
+              mediaType: 'audio/wav',
+              url: `data:audio/wav;base64,${CLIP_BASE64}`,
+              name: 'test-clip.wav',
+            },
+          ],
+          { aiProxyUrl: proxyUrl, aiProxyToken: proxyToken }
+        )
+
+        console.log(`[Audio E2E] transcribeAudioParts result: "${result}"`)
+        expect(result).toContain('auto-transcribed')
+        expect(result.toLowerCase()).toContain('fox')
+      } finally {
+        server.stop(true)
+      }
+    },
+    60_000
+  )
+})

--- a/apps/api/src/__tests__/ai-proxy-audio-input.test.ts
+++ b/apps/api/src/__tests__/ai-proxy-audio-input.test.ts
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+process.env.AI_PROXY_SECRET = process.env.AI_PROXY_SECRET || 'test-secret-ai-proxy-do-not-use-in-prod'
+process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET || 'test-better-auth-secret'
+/**
+ * AI Proxy — `input_audio` content-block handling on
+ * `POST /ai/v1/chat/completions`.
+ *
+ * Covers:
+ *   - A model without `capabilities.supportsAudioInput` (e.g. gpt-5.5)
+ *     rejects `input_audio` blocks with a clear 400 up front, instead of
+ *     bouncing off OpenAI/Anthropic with a generic "text or image_url" error.
+ *   - `gpt-audio` (the one catalog entry with `supportsAudioInput: true`)
+ *     accepts `input_audio` blocks and forwards them upstream unmodified
+ *     (the OpenAI-compatible path is a pure pass-through — no local
+ *     transformation of content blocks).
+ *
+ * Run: bun test apps/api/src/__tests__/ai-proxy-audio-input.test.ts
+ */
+
+import { describe, test, expect, beforeAll, beforeEach, mock } from 'bun:test'
+import { withPrismaExports } from './helpers/prisma-mock-exports'
+
+process.env.SHOGO_LOCAL_MODE = 'true'
+delete process.env.SHOGO_API_KEY
+process.env.OPENAI_API_KEY = 'sk-openai-test'
+process.env.ANTHROPIC_API_KEY = 'sk-ant-test'
+
+mock.module('../lib/prisma', () => withPrismaExports({
+  prisma: {
+    project: {
+      findFirst: async () => ({ id: 'proj-audio', workspaceId: 'ws-audio', name: 'Audio Input Test' }),
+      findUnique: async () => ({ id: 'proj-audio', workspaceId: 'ws-audio' }),
+    },
+    usageEvent: { create: async () => ({}) },
+  },
+}))
+
+mock.module('../services/billing.service', () => ({
+  hasBalance: async () => true,
+  hasAdvancedModelAccess: async () => true,
+  checkUsageBalance: async () => ({ ok: true }),
+  consumeUsage: async () => ({ success: true, remainingIncludedUsd: 99 }),
+}))
+
+mock.module('../lib/proxy-billing-session', () => ({
+  openSession: () => null,
+  hasSession: () => false,
+  hasActiveSession: () => false,
+  accumulateUsage: () => false,
+  accumulateImageUsage: () => false,
+  setQualitySignals: () => false,
+  closeSession: async () => null,
+}))
+
+mock.module('../lib/project-user-context', () => ({
+  getProjectUser: () => 'user-audio',
+}))
+
+const originalFetch = globalThis.fetch
+let lastFetchUrl: string | null = null
+let lastFetchBody: any = null
+let nextResponse: Response | null = null
+
+beforeAll(() => {
+  globalThis.fetch = (async (input: any, init?: RequestInit) => {
+    lastFetchUrl = typeof input === 'string' ? input : input.url
+    lastFetchBody = init?.body ? JSON.parse(init.body as string) : null
+    return (
+      nextResponse ??
+      new Response(JSON.stringify({ choices: [{ message: { content: 'ok' } }], usage: {} }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+  }) as any
+})
+
+const { Hono } = await import('hono')
+const { aiProxyRoutes } = await import('../routes/ai-proxy')
+const { generateProxyToken } = await import('../lib/ai-proxy-token')
+
+function buildApp() {
+  const app = new Hono()
+  app.route('/api', aiProxyRoutes())
+  return app
+}
+
+let TOKEN: string
+
+beforeAll(async () => {
+  TOKEN = await generateProxyToken('proj-audio', 'ws-audio', 'user-audio')
+})
+
+beforeEach(() => {
+  lastFetchUrl = null
+  lastFetchBody = null
+  nextResponse = null
+})
+
+function postChatCompletions(body: any) {
+  const app = buildApp()
+  return app.fetch(
+    new Request('http://x/api/ai/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${TOKEN}` },
+      body: JSON.stringify(body),
+    })
+  )
+}
+
+describe('input_audio validation on non-audio models', () => {
+  test('rejects an input_audio block sent to a text-only model (gpt-5.5) with a clear 400', async () => {
+    const res = await postChatCompletions({
+      model: 'gpt-5.5',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'input_audio', input_audio: { data: 'ZmFrZS1hdWRpby1kYXRh', format: 'wav' } },
+            { type: 'text', text: 'What is said here?' },
+          ],
+        },
+      ],
+    })
+    expect(res.status).toBe(400)
+    const data = (await res.json()) as any
+    expect(data.error.code).toBe('audio_input_not_supported')
+    expect(data.error.message).toContain('gpt-audio')
+    // Rejected locally — never reaches the upstream provider.
+    expect(lastFetchUrl).toBeNull()
+  })
+
+  test('rejects input_audio sent to an Anthropic model too', async () => {
+    const res = await postChatCompletions({
+      model: 'claude-sonnet-5',
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'input_audio', input_audio: { data: 'ZmFrZQ==', format: 'wav' } }],
+        },
+      ],
+    })
+    expect(res.status).toBe(400)
+    const data = (await res.json()) as any
+    expect(data.error.code).toBe('audio_input_not_supported')
+  })
+
+  test('plain text-only messages to gpt-5.5 are unaffected (no false positive)', async () => {
+    const res = await postChatCompletions({
+      model: 'gpt-5.5',
+      messages: [{ role: 'user', content: 'hello' }],
+    })
+    expect(res.status).toBe(200)
+  })
+})
+
+describe('input_audio pass-through for gpt-audio', () => {
+  test('accepts an input_audio block and forwards it upstream unmodified', async () => {
+    const res = await postChatCompletions({
+      model: 'gpt-audio',
+      modalities: ['text', 'audio'],
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'input_audio', input_audio: { data: 'ZmFrZS1hdWRpby1kYXRh', format: 'wav' } },
+            { type: 'text', text: 'Transcribe this.' },
+          ],
+        },
+      ],
+    })
+    expect(res.status).toBe(200)
+    expect(lastFetchUrl).toBe('https://api.openai.com/v1/chat/completions')
+    expect(lastFetchBody.model).toBe('gpt-audio')
+    // Pass-through: the input_audio block reaches upstream byte-for-byte.
+    const forwardedBlock = lastFetchBody.messages[0].content[0]
+    expect(forwardedBlock.type).toBe('input_audio')
+    expect(forwardedBlock.input_audio.data).toBe('ZmFrZS1hdWRpby1kYXRh')
+    expect(forwardedBlock.input_audio.format).toBe('wav')
+  })
+})

--- a/apps/api/src/__tests__/ai-proxy-audio-transcriptions.test.ts
+++ b/apps/api/src/__tests__/ai-proxy-audio-transcriptions.test.ts
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+process.env.AI_PROXY_SECRET = process.env.AI_PROXY_SECRET || 'test-secret-ai-proxy-do-not-use-in-prod'
+process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET || 'test-better-auth-secret'
+/**
+ * AI Proxy Audio Transcription Tests
+ *
+ * Tests `POST /ai/v1/audio/transcriptions` — the internal Whisper proxy
+ * route that lets `transcribe_audio` (packages/agent-runtime/src/gateway-tools.ts)
+ * and `transcription.service.ts`'s cloud fallback go through the same
+ * auth/billing path as every other `/ai/v1/*` route instead of requiring a
+ * raw OpenAI key.
+ *
+ * Run: bun test apps/api/src/__tests__/ai-proxy-audio-transcriptions.test.ts
+ */
+
+import { describe, test, expect, beforeAll, beforeEach, mock } from 'bun:test'
+import { Hono } from 'hono'
+import { generateProxyToken } from '../lib/ai-proxy-token'
+
+let hasBalanceResult = true
+let consumeUsageCalls: any[] = []
+
+mock.module('../lib/prisma', () => ({
+  prisma: {
+    project: {
+      findFirst: async () => ({ id: 'audio-project', name: 'Audio Test' }),
+      findUnique: async () => ({ id: 'audio-project', workspaceId: 'audio-workspace' }),
+    },
+    usageEvent: {
+      create: async (args: any) => args.data,
+    },
+  },
+}))
+
+mock.module('../services/billing.service', () => ({
+  hasBalance: async () => hasBalanceResult,
+  checkUsageBalance: async () => ({ ok: hasBalanceResult }),
+  usageLimitErrorPayload: () => ({ message: 'Usage limit reached.', code: 'usage_limit_reached' }),
+  consumeUsage: async (args: any) => {
+    consumeUsageCalls.push(args)
+    return { success: true, remainingIncludedUsd: 99 }
+  },
+}))
+
+mock.module('../lib/proxy-billing-session', () => ({
+  accumulateUsage: () => {},
+  accumulateImageUsage: () => false,
+  hasSession: () => false,
+  hasActiveSession: () => false,
+}))
+
+mock.module('../lib/project-user-context', () => ({
+  getProjectUser: () => 'test-user',
+}))
+
+import { aiProxyRoutes } from '../routes/ai-proxy'
+
+describe('AI Proxy Audio Transcription Endpoint', () => {
+  let app: Hono
+  let proxyToken: string
+  const originalFetch = global.fetch
+  const originalOpenAIKey = process.env.OPENAI_API_KEY
+
+  beforeAll(async () => {
+    app = new Hono()
+    const router = aiProxyRoutes()
+    app.route('/api', router)
+
+    proxyToken = await generateProxyToken('audio-project', 'audio-workspace', 'audio-user')
+  })
+
+  beforeEach(() => {
+    hasBalanceResult = true
+    consumeUsageCalls = []
+    global.fetch = originalFetch
+    if (originalOpenAIKey) process.env.OPENAI_API_KEY = originalOpenAIKey
+  })
+
+  function audioForm(fileBytes: Uint8Array = new Uint8Array([1, 2, 3, 4]), name = 'clip.wav') {
+    const form = new FormData()
+    form.append('file', new Blob([fileBytes], { type: 'audio/wav' }), name)
+    return form
+  }
+
+  // ===========================================================================
+  // Auth
+  // ===========================================================================
+
+  test('returns 401 without auth', async () => {
+    const res = await app.fetch(
+      new Request('http://localhost/api/ai/v1/audio/transcriptions', {
+        method: 'POST',
+        body: audioForm(),
+      })
+    )
+    expect(res.status).toBe(401)
+    const data = (await res.json()) as any
+    expect(data.error.type).toBe('authentication_error')
+  })
+
+  // ===========================================================================
+  // Validation
+  // ===========================================================================
+
+  test('returns 400 without a file', async () => {
+    const form = new FormData()
+    form.append('model', 'whisper-1')
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/ai/v1/audio/transcriptions', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${proxyToken}` },
+        body: form,
+      })
+    )
+    expect(res.status).toBe(400)
+    const data = (await res.json()) as any
+    expect(data.error.code).toBe('missing_file')
+  })
+
+  test('returns 400 when the file exceeds the 25MB Whisper cap', async () => {
+    process.env.OPENAI_API_KEY = 'sk-test'
+    const oversized = Buffer.alloc(26 * 1024 * 1024)
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/ai/v1/audio/transcriptions', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${proxyToken}` },
+        body: audioForm(oversized),
+      })
+    )
+    expect(res.status).toBe(400)
+    const data = (await res.json()) as any
+    expect(data.error.code).toBe('file_too_large')
+  })
+
+  test('returns 503 when OpenAI is not configured', async () => {
+    delete process.env.OPENAI_API_KEY
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/ai/v1/audio/transcriptions', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${proxyToken}` },
+        body: audioForm(),
+      })
+    )
+    expect(res.status).toBe(503)
+    const data = (await res.json()) as any
+    expect(data.error.code).toBe('provider_not_configured')
+  })
+
+  // ===========================================================================
+  // Billing gate
+  // ===========================================================================
+
+  test('returns 402 when the workspace has no balance', async () => {
+    process.env.OPENAI_API_KEY = 'sk-test'
+    hasBalanceResult = false
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/ai/v1/audio/transcriptions', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${proxyToken}` },
+        body: audioForm(),
+      })
+    )
+    expect(res.status).toBe(402)
+    const data = (await res.json()) as any
+    expect(data.error.code).toBe('usage_limit_reached')
+  })
+
+  // ===========================================================================
+  // Happy path (mocked upstream)
+  // ===========================================================================
+
+  test('forwards to OpenAI Whisper, always requesting verbose_json, and bills by duration', async () => {
+    process.env.OPENAI_API_KEY = 'sk-test'
+    let capturedUrl = ''
+    let capturedAuth = ''
+    let capturedForm: FormData | null = null
+
+    global.fetch = (async (url: string, init: any) => {
+      capturedUrl = url
+      capturedAuth = init.headers.Authorization
+      capturedForm = init.body as FormData
+      return new Response(
+        JSON.stringify({ text: 'hello world', language: 'en', duration: 12.5, segments: [] }),
+        { status: 200 }
+      )
+    }) as any
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/ai/v1/audio/transcriptions', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${proxyToken}` },
+        body: audioForm(new Uint8Array([1, 2, 3]), 'note.wav'),
+      })
+    )
+
+    expect(res.status).toBe(200)
+    const data = (await res.json()) as any
+    expect(data.text).toBe('hello world')
+    expect(data.duration).toBe(12.5)
+
+    expect(capturedUrl).toBe('https://api.openai.com/v1/audio/transcriptions')
+    expect(capturedAuth).toBe('Bearer sk-test')
+    expect(capturedForm!.get('response_format')).toBe('verbose_json')
+
+    // Billed by duration (12.5s * $0.006/60s * 1.2 markup), not a flat fee.
+    expect(consumeUsageCalls.length).toBe(1)
+    expect(consumeUsageCalls[0].actionType).toBe('ai_audio_transcription')
+    expect(consumeUsageCalls[0].actionMetadata.durationSeconds).toBe(12.5)
+    expect(consumeUsageCalls[0].billedUsd).toBeGreaterThan(0)
+  })
+
+  test('forwards the language field when provided', async () => {
+    process.env.OPENAI_API_KEY = 'sk-test'
+    let capturedForm: FormData | null = null
+
+    global.fetch = (async (_url: string, init: any) => {
+      capturedForm = init.body as FormData
+      return new Response(JSON.stringify({ text: 'bonjour', language: 'fr', duration: 2 }), { status: 200 })
+    }) as any
+
+    const form = audioForm()
+    form.append('language', 'fr')
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/ai/v1/audio/transcriptions', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${proxyToken}` },
+        body: form,
+      })
+    )
+    expect(res.status).toBe(200)
+    expect(capturedForm!.get('language')).toBe('fr')
+  })
+
+  test('maps a non-2xx upstream response to a 500 with the error body surfaced', async () => {
+    process.env.OPENAI_API_KEY = 'sk-test'
+    global.fetch = (async () => new Response('bad request from openai', { status: 400 })) as any
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/ai/v1/audio/transcriptions', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${proxyToken}` },
+        body: audioForm(),
+      })
+    )
+    expect(res.status).toBe(500)
+    const data = (await res.json()) as any
+    expect(data.error.code).toBe('transcription_error')
+    expect(data.error.message).toContain('bad request from openai')
+  })
+})

--- a/apps/api/src/lib/usage-cost.ts
+++ b/apps/api/src/lib/usage-cost.ts
@@ -161,3 +161,22 @@ export function calculateImageUsageCost(
 
   return { rawUsd, billedUsd: rawUsd * MARKUP_MULTIPLIER }
 }
+
+// =============================================================================
+// Audio Transcription Usage Costs
+// =============================================================================
+
+/** OpenAI Whisper API list price: $0.006 per minute of audio, billed per second. */
+const WHISPER_USD_PER_SECOND = 0.006 / 60
+
+/**
+ * Calculate USD cost for a Whisper transcription call from the audio
+ * duration (seconds) reported by the API response. Falls back to a
+ * one-second minimum when duration is unavailable (e.g. non-JSON
+ * `response_format`) so a call is never billed at exactly $0.
+ */
+export function calculateTranscriptionUsageCost(durationSeconds: number | undefined): UsageCostResult {
+  const seconds = durationSeconds && durationSeconds > 0 ? durationSeconds : 1
+  const rawUsd = seconds * WHISPER_USD_PER_SECOND
+  return { rawUsd, billedUsd: rawUsd * MARKUP_MULTIPLIER }
+}

--- a/apps/api/src/routes/ai-proxy.ts
+++ b/apps/api/src/routes/ai-proxy.ts
@@ -54,6 +54,7 @@ import {
   OPENROUTER_MODEL_PREFIX,
   resolveAgentModeDefault,
   getMaxOutputTokens,
+  modelSupportsAudioInput,
   isOpenRouterModel,
   stripOpenRouterPrefix,
   type Provider,
@@ -84,6 +85,11 @@ interface ChatCompletionContentBlock {
   type: string
   text?: string
   image_url?: { url: string }
+  /** OpenAI Chat Completions audio-input shape. Only forwarded as-is to
+   *  upstream OpenAI; only models with `capabilities.supportsAudioInput`
+   *  (currently `gpt-audio`) accept it — see the `input_audio` validation
+   *  in the `/ai/v1/chat/completions` handler below. */
+  input_audio?: { data: string; format: string }
   /** Anthropic-native passthrough (used when client pre-translated). */
   cache_control?: AnthropicCacheControl
   /** Vercel AI SDK style; translated to wire `cache_control` in convertToAnthropicFormat. */
@@ -2134,7 +2140,7 @@ async function generateImageLocal(
   return await response.json() as ImageGenerationResponse
 }
 
-import { calculateImageUsageCost } from '../lib/usage-cost'
+import { calculateImageUsageCost, calculateTranscriptionUsageCost } from '../lib/usage-cost'
 
 async function recordImageUsage(
   tokenPayload: ProxyTokenPayload,
@@ -2178,6 +2184,45 @@ async function recordImageUsage(
     }
   } catch (err) {
     console.error('[AI Proxy] Failed to charge image usage:', err)
+  }
+}
+
+/**
+ * Record billing for a Whisper transcription call. Priced per-second of
+ * audio duration (see `calculateTranscriptionUsageCost`), independent of the
+ * chat-turn billing session — transcription is usually a standalone tool
+ * call (`transcribe_audio`) or attachment-processing step, not part of the
+ * per-message LLM cost accumulator used by `recordUsage`/`accumulateImageUsage`.
+ */
+async function recordTranscriptionUsage(
+  tokenPayload: ProxyTokenPayload,
+  model: string,
+  durationSeconds: number | undefined,
+) {
+  try {
+    const { rawUsd, billedUsd } = calculateTranscriptionUsageCost(durationSeconds)
+    if (billedUsd === 0) return
+
+    const billingProjectId = tokenPayload.projectId === 'api-key' ? null : (tokenPayload.projectId || null)
+    const billingUserId = getProjectUser(tokenPayload.projectId) || tokenPayload.userId || 'system'
+
+    const result = await billingService.consumeUsage({
+      workspaceId: tokenPayload.workspaceId,
+      projectId: billingProjectId,
+      memberId: billingUserId,
+      actionType: 'ai_audio_transcription',
+      rawUsd,
+      billedUsd,
+      actionMetadata: { model, durationSeconds, rawUsd },
+    })
+
+    if (result.success) {
+      console.log(`[AI Proxy] 🎙️ Charged $${billedUsd.toFixed(4)} (transcription, model: ${model}, ${durationSeconds?.toFixed(1) ?? '?'}s) — remaining included: $${result.remainingIncludedUsd?.toFixed(4)}`)
+    } else {
+      console.warn(`[AI Proxy] ⚠️ Could not charge transcription usage: ${result.error}`)
+    }
+  } catch (err) {
+    console.error('[AI Proxy] Failed to charge transcription usage:', err)
   }
 }
 
@@ -2569,6 +2614,31 @@ export function aiProxyRoutes() {
           },
           400
         )
+      }
+
+      // Reject `input_audio` content blocks up front with a clear, actionable
+      // error instead of letting them reach OpenAI/Anthropic and bounce back
+      // with a generic "content blocks are expected to be text or image_url"
+      // message. Only audio-native models (capabilities.supportsAudioInput,
+      // currently `gpt-audio`) accept input_audio blocks.
+      if (!modelSupportsAudioInput(request.model)) {
+        const hasAudioBlock = request.messages.some(
+          (msg) =>
+            Array.isArray(msg.content) &&
+            msg.content.some((block) => block.type === 'input_audio')
+        )
+        if (hasAudioBlock) {
+          return c.json(
+            {
+              error: {
+                message: `Model '${request.model}' does not accept audio input. Use an audio-native model (e.g. 'gpt-audio') for input_audio content blocks, or transcribe the audio to text first.`,
+                type: 'invalid_request_error',
+                code: 'audio_input_not_supported',
+              },
+            },
+            400
+          )
+        }
       }
 
       // Enforce workspace model visibility: a workspace admin may restrict the
@@ -3645,6 +3715,122 @@ export function aiProxyRoutes() {
       const statusCode = error.message?.includes('429') ? 429 : error.message?.includes('503') ? 503 : 500
       return c.json(
         { error: { message: error.message || 'Image edit failed', type: 'server_error', code: 'edit_error' } },
+        statusCode
+      )
+    }
+  })
+
+  /**
+   * POST /ai/v1/audio/transcriptions - Whisper transcription proxy
+   *
+   * Accepts multipart/form-data with an audio `file` (+ optional `model`,
+   * `language`, `prompt` fields) and forwards it to OpenAI's Whisper API
+   * using this server's own OPENAI_API_KEY, so transcription goes through
+   * the same auth/billing path as every other `/ai/v1/*` route instead of
+   * requiring callers to hold a raw OpenAI key.
+   *
+   * Internal callers (the `transcribe_audio` agent tool and the meetings
+   * transcription service) hit this route rather than OpenAI directly —
+   * see `packages/agent-runtime/src/gateway-tools.ts` and
+   * `apps/api/src/services/transcription.service.ts`.
+   *
+   * Always requests `verbose_json` from upstream (regardless of what the
+   * caller asked for) so the response includes `duration`, which is
+   * required to bill the call — both current callers already expect this
+   * shape.
+   */
+  const WHISPER_MAX_FILE_BYTES = 25 * 1024 * 1024 // OpenAI's documented Whisper upload cap
+
+  router.post('/ai/v1/audio/transcriptions', async (c) => {
+    const tokenPayload = await validateProxyAuth(c)
+    if (!tokenPayload) {
+      return c.json(
+        { error: { message: 'Invalid or missing proxy token.', type: 'authentication_error', code: 'invalid_api_key' } },
+        401
+      )
+    }
+
+    // An already-admitted chat turn still in flight is never re-gated
+    // mid-message — e.g. the transcribe_audio tool running inside a turn.
+    if (!isTurnInFlight(c, tokenPayload) && !await billingService.hasBalance(tokenPayload.workspaceId)) {
+      const usageLimit = await buildUsageLimitInfo(tokenPayload.workspaceId)
+      return c.json(
+        { error: { message: 'Usage limit reached. Enable usage-based pricing or upgrade your plan.', type: 'billing_error', code: 'usage_limit_reached', ...usageLimit } },
+        402
+      )
+    }
+
+    try {
+      const formData = await c.req.formData()
+      const file = formData.get('file') as File | null
+      const model = (formData.get('model') as string) || 'whisper-1'
+      const language = formData.get('language') as string | null
+      const prompt = formData.get('prompt') as string | null
+
+      if (!file) {
+        return c.json(
+          { error: { message: 'file is required', type: 'invalid_request_error', code: 'missing_file' } },
+          400
+        )
+      }
+
+      if (file.size > WHISPER_MAX_FILE_BYTES) {
+        return c.json(
+          {
+            error: {
+              message: `Audio file is ${(file.size / (1024 * 1024)).toFixed(1)}MB, which exceeds the ${WHISPER_MAX_FILE_BYTES / (1024 * 1024)}MB Whisper upload limit.`,
+              type: 'invalid_request_error',
+              code: 'file_too_large',
+            },
+          },
+          400
+        )
+      }
+
+      const openaiKey = process.env.OPENAI_API_KEY
+      if (!openaiKey) {
+        return c.json(
+          { error: { message: 'OpenAI is not configured on this server (required for audio transcription).', type: 'server_error', code: 'provider_not_configured' } },
+          503
+        )
+      }
+
+      console.log(`[AI Proxy] 🎙️ Transcription: ${tokenPayload.projectId} → openai/${model}`)
+
+      const forwardForm = new FormData()
+      forwardForm.append('file', file, file.name || 'audio')
+      forwardForm.append('model', model)
+      forwardForm.append('response_format', 'verbose_json')
+      if (language) forwardForm.append('language', language)
+      if (prompt) forwardForm.append('prompt', prompt)
+
+      const response = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${openaiKey}` },
+        body: forwardForm,
+        signal: c.req.raw.signal,
+      })
+
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(`OpenAI transcription error (${response.status}): ${errorText}`)
+      }
+
+      const result = await response.json() as {
+        text: string
+        language?: string
+        duration?: number
+        segments?: Array<{ start: number; end: number; text: string }>
+      }
+
+      recordTranscriptionUsage(tokenPayload, model, result.duration)
+
+      return c.json(result)
+    } catch (error: any) {
+      console.error('[AI Proxy] Transcription error:', error.message)
+      const statusCode = error.message?.includes('429') ? 429 : error.message?.includes('503') ? 503 : 500
+      return c.json(
+        { error: { message: error.message || 'Audio transcription failed', type: 'server_error', code: 'transcription_error' } },
         statusCode
       )
     }

--- a/apps/api/src/services/__tests__/transcription.service.test.ts
+++ b/apps/api/src/services/__tests__/transcription.service.test.ts
@@ -414,6 +414,22 @@ describe('transcribeCloud', () => {
     expect(receivedAuth).toBe('Bearer proxy-tok')
   })
 
+  it('strips a trailing /v1 from AI_PROXY_URL so the real proxy path (.../api/ai/v1/audio/transcriptions) is not doubled up', async () => {
+    // Production AI_PROXY_URL is always `${apiBase}/api/ai/v1` (see
+    // build-workspace-env.ts / build-project-env.ts / internal-proxy-config.ts).
+    // Appending `/v1/audio/transcriptions` naively would 404 against
+    // `.../api/ai/v1/v1/audio/transcriptions` instead of the real route.
+    process.env.AI_PROXY_URL = 'https://api.internal.example/api/ai/v1'
+    process.env.AI_PROXY_TOKEN = 'proxy-tok'
+    let receivedUrl = ''
+    fetchMock = async (url: string) => {
+      receivedUrl = url
+      return new Response(JSON.stringify({ text: 't', segments: [], language: 'en', duration: 0 }))
+    }
+    await svc.transcribeCloud(audioFile)
+    expect(receivedUrl).toBe('https://api.internal.example/api/ai/v1/audio/transcriptions')
+  })
+
   it('forwards the language hint as a form field', async () => {
     process.env.OPENAI_API_KEY = 'sk-test'
     let body: FormData | null = null

--- a/apps/api/src/services/transcription.service.ts
+++ b/apps/api/src/services/transcription.service.ts
@@ -192,7 +192,14 @@ export async function transcribeCloud(
   const proxyUrl = process.env.AI_PROXY_URL
   const proxyToken = process.env.AI_PROXY_TOKEN
 
-  const baseUrl = proxyUrl || 'https://api.openai.com'
+  // AI_PROXY_URL is set to `${apiBase}/api/ai/v1` (see build-workspace-env.ts /
+  // build-project-env.ts / internal-proxy-config.ts). Strip a trailing `/v1`
+  // before appending our own `/v1/audio/transcriptions` suffix below, so we
+  // don't double up on the version segment (`.../api/ai/v1/v1/audio/...`),
+  // which would 404 against the real `/ai/v1/audio/transcriptions` route.
+  // Mirrors the same stripping the `transcribe_audio` tool already does in
+  // packages/agent-runtime/src/gateway-tools.ts.
+  const baseUrl = proxyUrl ? proxyUrl.replace(/\/v1$/, '') : 'https://api.openai.com'
   const authHeader = proxyToken
     ? `Bearer ${proxyToken}`
     : apiKey

--- a/packages/agent-runtime/src/__tests__/file-attachment-utils.test.ts
+++ b/packages/agent-runtime/src/__tests__/file-attachment-utils.test.ts
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Shogo Technologies, Inc.
-import { afterEach, describe, test, expect } from 'bun:test'
+import { afterEach, beforeEach, describe, test, expect } from 'bun:test'
 import {
   _fileAttachmentSeamForTests,
   extractFilePartsAsText,
   parseFileAttachments,
+  transcribeAudioParts,
   type FilePart,
 } from '../file-attachment-utils'
 
@@ -111,6 +112,174 @@ describe('parseFileAttachments', () => {
     const { textContext, images } = parseFileAttachments(parts)
     expect(textContext).toBe('')
     expect(images).toEqual([])
+  })
+
+  test('routes audio/* parts to audioParts instead of inlining or images, and leaves textContext untouched', () => {
+    const parts: FilePart[] = [
+      {
+        type: 'file',
+        mediaType: 'audio/wav',
+        url: dataUrl('audio/wav', Buffer.from([1, 2, 3, 4])),
+        name: 'memo.wav',
+        savedPath: 'files/memo.wav',
+      },
+    ]
+    const { images, textContext, audioParts } = parseFileAttachments(parts)
+    expect(images).toEqual([])
+    // Audio is deferred for async transcription, not inlined synchronously —
+    // parseFileAttachments itself never mentions the audio attachment.
+    expect(textContext).toBe('')
+    expect(audioParts).toHaveLength(1)
+    expect(audioParts[0].name).toBe('memo.wav')
+    expect(audioParts[0].mediaType).toBe('audio/wav')
+  })
+
+  test('handles a mix of image, text, and audio parts in one call', () => {
+    const parts: FilePart[] = [
+      { type: 'file', mediaType: 'image/png', url: dataUrl('image/png', Buffer.from([0x89])), name: 'a.png' },
+      { type: 'file', mediaType: 'text/plain', url: dataUrl('text/plain', 'hi'), name: 'b.txt' },
+      { type: 'file', mediaType: 'audio/mpeg', url: dataUrl('audio/mpeg', Buffer.from([1])), name: 'c.mp3' },
+    ]
+    const { images, textContext, audioParts } = parseFileAttachments(parts)
+    expect(images).toHaveLength(1)
+    expect(audioParts).toHaveLength(1)
+    expect(audioParts[0].name).toBe('c.mp3')
+    expect(textContext).toContain('b.txt')
+    expect(textContext).not.toContain('c.mp3')
+  })
+})
+
+describe('transcribeAudioParts', () => {
+  const originalFetch = globalThis.fetch
+  const originalProxyUrl = process.env.AI_PROXY_URL
+  const originalProxyToken = process.env.AI_PROXY_TOKEN
+  const originalOpenAIKey = process.env.OPENAI_API_KEY
+
+  beforeEach(() => {
+    delete process.env.AI_PROXY_URL
+    delete process.env.AI_PROXY_TOKEN
+    delete process.env.OPENAI_API_KEY
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (originalProxyUrl === undefined) delete process.env.AI_PROXY_URL
+    else process.env.AI_PROXY_URL = originalProxyUrl
+    if (originalProxyToken === undefined) delete process.env.AI_PROXY_TOKEN
+    else process.env.AI_PROXY_TOKEN = originalProxyToken
+    if (originalOpenAIKey === undefined) delete process.env.OPENAI_API_KEY
+    else process.env.OPENAI_API_KEY = originalOpenAIKey
+  })
+
+  test('returns empty string for an empty batch (no network call)', async () => {
+    let called = false
+    globalThis.fetch = (async () => { called = true; return new Response('{}') }) as any
+    const result = await transcribeAudioParts([])
+    expect(result).toBe('')
+    expect(called).toBe(false)
+  })
+
+  test('emits a placeholder when no API key is configured', async () => {
+    const parts: FilePart[] = [
+      { type: 'file', mediaType: 'audio/wav', url: dataUrl('audio/wav', Buffer.from([1, 2])), name: 'x.wav' },
+    ]
+    const result = await transcribeAudioParts(parts)
+    expect(result).toContain('[Attached Audio (x.wav (audio/wav))]:')
+    expect(result).toContain('no OpenAI API key configured')
+  })
+
+  test('transcribes via the AI proxy URL, stripping a trailing /v1 before appending /v1/audio/transcriptions', async () => {
+    process.env.AI_PROXY_URL = 'https://api.internal.example/api/ai/v1'
+    process.env.AI_PROXY_TOKEN = 'proxy-tok'
+
+    let capturedUrl = ''
+    let capturedAuth = ''
+    globalThis.fetch = (async (url: string, init: any) => {
+      capturedUrl = url
+      capturedAuth = init.headers.Authorization
+      return new Response(JSON.stringify({ text: 'hello from whisper' }), { status: 200 })
+    }) as any
+
+    const parts: FilePart[] = [
+      { type: 'file', mediaType: 'audio/wav', url: dataUrl('audio/wav', Buffer.from([1, 2, 3])), name: 'memo.wav' },
+    ]
+    const result = await transcribeAudioParts(parts)
+
+    expect(capturedUrl).toBe('https://api.internal.example/api/ai/v1/audio/transcriptions')
+    expect(capturedAuth).toBe('Bearer proxy-tok')
+    expect(result).toBe('[Attached Audio (memo.wav (audio/wav)) — auto-transcribed]: hello from whisper')
+  })
+
+  test('falls back to OpenAI directly when no proxy is configured', async () => {
+    process.env.OPENAI_API_KEY = 'sk-direct'
+    let capturedUrl = ''
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url
+      return new Response(JSON.stringify({ text: 'direct transcript' }), { status: 200 })
+    }) as any
+
+    const parts: FilePart[] = [
+      { type: 'file', mediaType: 'audio/mpeg', url: dataUrl('audio/mpeg', Buffer.from([9])), name: 'clip.mp3' },
+    ]
+    const result = await transcribeAudioParts(parts)
+    expect(capturedUrl).toBe('https://api.openai.com/v1/audio/transcriptions')
+    expect(result).toContain('direct transcript')
+  })
+
+  test('emits a size-limit placeholder for audio over the 25MB Whisper cap, without calling fetch', async () => {
+    process.env.OPENAI_API_KEY = 'sk-direct'
+    let called = false
+    globalThis.fetch = (async () => { called = true; return new Response('{}') }) as any
+
+    // ~26MB of raw bytes, base64-encoded.
+    const bigBuffer = Buffer.alloc(26 * 1024 * 1024)
+    const parts: FilePart[] = [
+      { type: 'file', mediaType: 'audio/wav', url: dataUrl('audio/wav', bigBuffer), name: 'huge.wav' },
+    ]
+    const result = await transcribeAudioParts(parts)
+    expect(called).toBe(false)
+    expect(result).toContain('exceeds the 25MB Whisper upload limit')
+  })
+
+  test('emits a failure placeholder on a non-2xx upstream response', async () => {
+    process.env.OPENAI_API_KEY = 'sk-direct'
+    globalThis.fetch = (async () => new Response('rate limited', { status: 429 })) as any
+
+    const parts: FilePart[] = [
+      { type: 'file', mediaType: 'audio/wav', url: dataUrl('audio/wav', Buffer.from([1])), name: 'y.wav' },
+    ]
+    const result = await transcribeAudioParts(parts)
+    expect(result).toContain('Transcription failed (429)')
+    expect(result).toContain('rate limited')
+  })
+
+  test('emits a failure placeholder when fetch throws', async () => {
+    process.env.OPENAI_API_KEY = 'sk-direct'
+    globalThis.fetch = (async () => { throw new Error('network down') }) as any
+
+    const parts: FilePart[] = [
+      { type: 'file', mediaType: 'audio/wav', url: dataUrl('audio/wav', Buffer.from([1])), name: 'z.wav' },
+    ]
+    const result = await transcribeAudioParts(parts)
+    expect(result).toContain('Transcription failed: network down')
+  })
+
+  test('handles multiple audio parts, joining announcements with a blank line', async () => {
+    process.env.OPENAI_API_KEY = 'sk-direct'
+    let call = 0
+    globalThis.fetch = (async () => {
+      call++
+      return new Response(JSON.stringify({ text: `clip ${call}` }), { status: 200 })
+    }) as any
+
+    const parts: FilePart[] = [
+      { type: 'file', mediaType: 'audio/wav', url: dataUrl('audio/wav', Buffer.from([1])), name: 'a.wav' },
+      { type: 'file', mediaType: 'audio/wav', url: dataUrl('audio/wav', Buffer.from([2])), name: 'b.wav' },
+    ]
+    const result = await transcribeAudioParts(parts)
+    expect(result).toContain('clip 1')
+    expect(result).toContain('clip 2')
+    expect(result.split('\n\n')).toHaveLength(2)
   })
 })
 

--- a/packages/agent-runtime/src/file-attachment-utils.ts
+++ b/packages/agent-runtime/src/file-attachment-utils.ts
@@ -38,6 +38,15 @@ export interface FilePart {
 export interface ParsedAttachments {
   images: ImageContent[]
   textContext: string
+  /**
+   * Raw `audio/*` file parts, deferred for async transcription (see
+   * `transcribeAudioParts`). Not resolved here because `parseFileAttachments`
+   * is synchronous and transcription requires a network call — no model in
+   * the agent-runtime's pi-ai-backed chat loop accepts native audio content
+   * blocks (pi-ai's `Model.input` type only allows `"text" | "image"`), so
+   * every model gets audio via a text transcript, not a native audio block.
+   */
+  audioParts: FilePart[]
 }
 
 function formatSavedPathSuffix(savedPath?: string): string {
@@ -68,9 +77,10 @@ export const _fileAttachmentSeamForTests: {
 
 export function parseFileAttachments(parts: FilePart[]): ParsedAttachments {
   const fileParts = parts.filter((p) => p.type === 'file' && p.url)
-  if (fileParts.length === 0) return { images: [], textContext: '' }
+  if (fileParts.length === 0) return { images: [], textContext: '', audioParts: [] }
 
   const images: ImageContent[] = []
+  const audioParts: FilePart[] = []
   const sections: string[] = []
 
   for (const fp of fileParts) {
@@ -89,6 +99,14 @@ export function parseFileAttachments(parts: FilePart[]): ParsedAttachments {
       if (fp.savedPath) {
         sections.push(`[Attached Image (${label})]:${savedSuffix}`)
       }
+      continue
+    }
+
+    if (mediaType.startsWith('audio/')) {
+      // Deferred: no model in the agent-runtime chat loop accepts native
+      // audio content blocks, so every audio attachment is transcribed to
+      // text (see `transcribeAudioParts`) instead of being inlined here.
+      audioParts.push(fp)
       continue
     }
 
@@ -112,10 +130,133 @@ export function parseFileAttachments(parts: FilePart[]): ParsedAttachments {
     }
   }
 
-  return { images, textContext: sections.join('\n\n') }
+  return { images, textContext: sections.join('\n\n'), audioParts }
 }
 
 /** @deprecated Use parseFileAttachments instead */
 export function extractFilePartsAsText(parts: FilePart[]): string {
   return parseFileAttachments(parts).textContext
+}
+
+// ---------------------------------------------------------------------------
+// Audio transcription (Whisper, via the AI proxy)
+// ---------------------------------------------------------------------------
+
+/** OpenAI's documented Whisper upload cap (must match apps/api/src/routes/ai-proxy.ts). */
+const MAX_AUDIO_BYTES = 25 * 1024 * 1024
+
+/** Rough base64 -> decoded-byte-length estimate (base64 inflates by ~4/3). */
+function estimateDecodedBytes(base64Length: number): number {
+  return Math.floor((base64Length * 3) / 4)
+}
+
+const AUDIO_EXT_BY_MIME: Record<string, string> = {
+  'audio/mpeg': '.mp3',
+  'audio/mp3': '.mp3',
+  'audio/mp4': '.m4a',
+  'audio/x-m4a': '.m4a',
+  'audio/wav': '.wav',
+  'audio/x-wav': '.wav',
+  'audio/wave': '.wav',
+  'audio/webm': '.webm',
+  'audio/ogg': '.ogg',
+}
+
+export interface TranscribeAudioOptions {
+  /** Defaults to `process.env.AI_PROXY_URL`. */
+  aiProxyUrl?: string
+  /** Defaults to `process.env.AI_PROXY_TOKEN`. */
+  aiProxyToken?: string
+}
+
+/**
+ * Transcribe a batch of `audio/*` file parts via Whisper (through the AI
+ * proxy's `/ai/v1/audio/transcriptions` route when configured, else directly
+ * against OpenAI) and return a `textContext`-shaped announcement per clip,
+ * ready to append to `ParsedAttachments.textContext`.
+ *
+ * Mirrors the `transcribe_audio` agent tool's request shape
+ * (packages/agent-runtime/src/gateway-tools.ts) but operates on in-memory
+ * data-URL parts rather than a workspace file path, since chat attachments
+ * never touch disk before reaching the model.
+ */
+export async function transcribeAudioParts(
+  parts: FilePart[],
+  options: TranscribeAudioOptions = {},
+): Promise<string> {
+  if (parts.length === 0) return ''
+
+  const proxyUrl = options.aiProxyUrl ?? process.env.AI_PROXY_URL
+  const proxyToken = options.aiProxyToken ?? process.env.AI_PROXY_TOKEN
+  const directKey = process.env.OPENAI_API_KEY
+  // See the matching comment in gateway-tools.ts / transcription.service.ts:
+  // AI_PROXY_URL is `${apiBase}/api/ai/v1`; strip the trailing `/v1` before
+  // re-appending it so we land on `.../api/ai/v1/audio/transcriptions`.
+  const apiBase = proxyUrl ? proxyUrl.replace(/\/v1$/, '') : 'https://api.openai.com'
+  const apiKey = proxyToken || directKey
+
+  const sections: string[] = []
+
+  for (const fp of parts) {
+    const mediaType = fp.mediaType || 'audio/mpeg'
+    const url = fp.url || ''
+    const label = fp.name ? `${fp.name} (${mediaType})` : mediaType
+    const savedSuffix = formatSavedPathSuffix(fp.savedPath)
+
+    if (!apiKey) {
+      sections.push(`[Attached Audio (${label})]: Could not transcribe — no OpenAI API key configured.${savedSuffix}`)
+      continue
+    }
+
+    const base64Match = url.match(/^data:[^;]*;base64,(.+)$/)
+    if (!base64Match) {
+      sections.push(`[Attached Audio (${label})]: Could not decode audio data.${savedSuffix}`)
+      continue
+    }
+
+    const base64 = base64Match[1]
+    if (estimateDecodedBytes(base64.length) > MAX_AUDIO_BYTES) {
+      const sizeMb = (estimateDecodedBytes(base64.length) / (1024 * 1024)).toFixed(1)
+      sections.push(
+        `[Attached Audio (${label})]: Not transcribed — file is ~${sizeMb}MB, which exceeds the 25MB Whisper upload limit.${savedSuffix}`,
+      )
+      continue
+    }
+
+    try {
+      const buffer = Buffer.from(base64, 'base64')
+      const ext = AUDIO_EXT_BY_MIME[mediaType] || '.mp3'
+      const formData = new FormData()
+      formData.append('file', new Blob([buffer], { type: mediaType }), fp.name || `audio${ext}`)
+      formData.append('model', 'whisper-1')
+      formData.append('response_format', 'verbose_json')
+
+      const response = await fetch(`${apiBase}/v1/audio/transcriptions`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${apiKey}` },
+        body: formData,
+        signal: AbortSignal.timeout(120_000),
+      })
+
+      if (!response.ok) {
+        const errBody = await response.text().catch(() => '')
+        sections.push(
+          `[Attached Audio (${label})]: Transcription failed (${response.status}): ${errBody.slice(0, 300)}${savedSuffix}`,
+        )
+        continue
+      }
+
+      const result = (await response.json()) as { text?: string }
+      const text = result.text?.trim()
+      sections.push(
+        text
+          ? `[Attached Audio (${label}) — auto-transcribed]: ${text}${savedSuffix}`
+          : `[Attached Audio (${label})]: Transcription returned no text.${savedSuffix}`,
+      )
+    } catch (err: any) {
+      sections.push(`[Attached Audio (${label})]: Transcription failed: ${err.message}${savedSuffix}`)
+    }
+  }
+
+  return sections.join('\n\n')
 }

--- a/packages/agent-runtime/src/gateway-tools.ts
+++ b/packages/agent-runtime/src/gateway-tools.ts
@@ -6419,6 +6419,10 @@ function createTranscribeAudioTool(ctx: ToolContext): AgentTool {
       const proxyToken = ctx.aiProxyToken || process.env.AI_PROXY_TOKEN
       const directKey = process.env.OPENAI_API_KEY
 
+      // AI_PROXY_URL is `${apiBase}/api/ai/v1`; stripping the trailing `/v1`
+      // and re-appending it below lands on `.../api/ai/v1/audio/transcriptions`
+      // — the proxy's own transcription route (apps/api/src/routes/ai-proxy.ts)
+      // — rather than calling OpenAI directly with the proxy token.
       const apiBase = proxyUrl ? proxyUrl.replace(/\/v1$/, '') : 'https://api.openai.com'
       const apiKey = proxyToken || directKey
       if (!apiKey) {

--- a/packages/agent-runtime/src/gateway.ts
+++ b/packages/agent-runtime/src/gateway.ts
@@ -84,7 +84,7 @@ import { deriveApiUrl, getInternalHeaders, postCostMetric } from './internal-api
 import { getRuntimeTrust } from './runtime-trust'
 import { refreshTrust } from './trust-resolver'
 import type { FilePart } from './file-attachment-utils'
-import { parseFileAttachments } from './file-attachment-utils'
+import { parseFileAttachments, transcribeAudioParts } from './file-attachment-utils'
 import {
   SELF_EVOLUTION_GUIDE,
   BROWSER_TOOL_GUIDE,
@@ -1592,10 +1592,20 @@ export class AgentGateway {
         images = parsed.images
         this.emitLog(`Attached ${parsed.images.length} image(s) for vision`)
       }
-      if (parsed.textContext) {
+      let textContext = parsed.textContext
+      if (parsed.audioParts.length > 0) {
+        // No model reachable from this loop accepts native audio content
+        // blocks (pi-ai's `Model.input` type only allows `"text" | "image"`),
+        // so every audio attachment is auto-transcribed via Whisper and
+        // injected as text context, regardless of which model is selected.
+        this.emitLog(`Transcribing ${parsed.audioParts.length} audio attachment(s)...`)
+        const audioTranscripts = await transcribeAudioParts(parsed.audioParts)
+        textContext = [textContext, audioTranscripts].filter(Boolean).join('\n\n')
+      }
+      if (textContext) {
         effectiveText = text
-          ? `${text}\n\n${parsed.textContext}`
-          : parsed.textContext
+          ? `${text}\n\n${textContext}`
+          : textContext
       }
     }
 

--- a/packages/agent/src/model-catalog/helpers.ts
+++ b/packages/agent/src/model-catalog/helpers.ts
@@ -174,6 +174,17 @@ export function getMaxOutputTokens(id: string): number {
   return DEFAULT_MAX_OUTPUT_TOKENS
 }
 
+/**
+ * Whether a model accepts `input_audio` content blocks natively (see
+ * `ModelCapabilities.supportsAudioInput`). Unknown/unrated models (incl.
+ * DB-defined and OpenRouter models not in the static catalog) return
+ * `false` — they go through the Whisper-transcription fallback instead.
+ */
+export function modelSupportsAudioInput(id: string): boolean {
+  const entry = getModelEntry(id)
+  return entry?.capabilities?.supportsAudioInput === true
+}
+
 // ---------------------------------------------------------------------------
 // Family (for UI color coding)
 // ---------------------------------------------------------------------------

--- a/packages/agent/src/model-catalog/index.ts
+++ b/packages/agent/src/model-catalog/index.ts
@@ -56,6 +56,7 @@ export {
   getModelBillingModel,
   getModelFamily,
   getMaxOutputTokens,
+  modelSupportsAudioInput,
   getAvailableModels,
   getModelsByProvider,
   getProviderLabel,

--- a/packages/agent/src/model-catalog/models.ts
+++ b/packages/agent/src/model-catalog/models.ts
@@ -53,6 +53,14 @@ export interface ModelCapabilities {
    * specific failure mode.
    */
   subagentOrchestration?: CapabilityReliability
+  /**
+   * Whether this model accepts `input_audio` content blocks natively over
+   * the OpenAI-compatible chat/completions wire format (as opposed to
+   * requiring audio to be transcribed to text before it reaches the model).
+   * Absent/`undefined` means "no native audio input" — callers should fall
+   * back to Whisper transcription (see `transcribeAudioParts`).
+   */
+  supportsAudioInput?: boolean
 }
 
 /**
@@ -325,6 +333,31 @@ export const MODEL_CATALOG = {
     // workflows that fan out to children.
     capabilities: { subagentOrchestration: 'flaky' },
   },
+
+  // OpenAI — audio-native (accepts `input_audio` content blocks directly;
+  // see packages/agent-runtime/src/file-attachment-utils.ts for the
+  // Whisper-transcription fallback used by every other model).
+  'gpt-audio': {
+    id: 'gpt-audio',
+    provider: 'openai',
+    apiModel: 'gpt-audio',
+    displayName: 'GPT Audio',
+    shortDisplayName: 'GPT Audio',
+    tier: 'standard',
+    family: 'gpt',
+    generation: 'current',
+    // NOTE: OpenAI bills audio input/output tokens at a much higher
+    // per-token rate than text (no bucket in MODEL_DOLLAR_COSTS
+    // differentiates audio tokens from text tokens today). Using the
+    // most expensive existing bucket ('opus') as a conservative
+    // placeholder so audio usage isn't underbilled; replace with a
+    // dedicated audio billing bucket before shipping this broadly.
+    billingModel: 'opus',
+    maxOutputTokens: 4_096,
+    description: 'Accepts spoken audio directly as input (input_audio content blocks) and can respond in text or generated speech.',
+    capabilities: { supportsAudioInput: true },
+  },
+
   // OpenAI — legacy
   'gpt-4.1': {
     id: 'gpt-4.1',


### PR DESCRIPTION
## Summary

Adds audio input support to the LLM gateway, in two tiers:

### Tier 1 — native audio pass-through
- Adds `gpt-audio` to `MODEL_CATALOG` (`packages/agent/src/model-catalog/models.ts`) with a new `capabilities.supportsAudioInput` flag and a `modelSupportsAudioInput()` helper.
- `POST /ai/v1/chat/completions` now rejects `input_audio` content blocks up front with a clear `400 audio_input_not_supported` for any model that isn't audio-native, instead of letting the request bounce off the upstream provider with a generic "text or image_url" error.
- Note: `pi-ai`'s `Model.input` type only supports `"text" | "image"`, so no model reachable through the agent-runtime chat loop (mobile/desktop chat) can carry a native audio block — Tier 1 pass-through applies to direct API/SDK callers hitting `/ai/v1/chat/completions` raw. The chat product always goes through Tier 2 below.

### Tier 2 — transcribe-and-inject pipeline (works with every model, incl. Claude)
- New `POST /ai/v1/audio/transcriptions` proxy route: auth + balance gate + multipart forward to OpenAI Whisper + duration-based usage billing (`calculateTranscriptionUsageCost` in `usage-cost.ts`).
- `file-attachment-utils.ts`: `parseFileAttachments` now buckets `audio/*` parts into `audioParts` instead of inlining them; new `transcribeAudioParts()` transcribes them via the proxy (or direct OpenAI) into a `[Attached Audio ... — auto-transcribed]: ...` text block, with a 25MB Whisper-cap size guard.
- `gateway.ts` wires `transcribeAudioParts` into `processChatMessageStream` so any audio attachment becomes text context for whichever model is selected.
- **Bug fix**: `transcription.service.ts`'s `transcribeCloud` appended `/v1/audio/transcriptions` onto `AI_PROXY_URL` without stripping the URL's own trailing `/v1` (real `AI_PROXY_URL` is `${apiBase}/api/ai/v1`), producing a double `/v1/v1/` 404. `gateway-tools.ts`'s `transcribe_audio` tool already handled this correctly; `transcription.service.ts` now matches it, with a regression test.

## Testing

- New unit tests: proxy route (8), `input_audio` validation (4), `transcribeAudioParts`/attachment bucketing (10), plus the URL-fix regression test.
- Ran full `apps/api`, `packages/agent`, and `packages/agent-runtime` suites — remaining failures are pre-existing and reproduce identically on unmodified `main` (verified via side-by-side runs); none touch files changed in this PR.
- **Real end-to-end test** (`ai-proxy-audio-e2e.test.ts`, skipped without `OPENAI_API_KEY`): a real spoken WAV clip ("The quick brown fox jumps over the lazy dog.") run through:
  1. `gpt-audio` via `input_audio` pass-through — model correctly heard and repeated the phrase.
  2. The new `/ai/v1/audio/transcriptions` route — correct Whisper transcript + billing.
  3. `transcribeAudioParts` against a real running HTTP server wrapping the proxy — correct transcript, proving the full `gateway.ts` → proxy → Whisper chain over a real socket.

All three passed against live OpenAI.

## Out of scope

- No new record-and-attach audio UI in mobile/desktop — audio must arrive via an existing `file`-part upload path.
- No Gemini/OpenRouter audio model added — only `gpt-audio`.
- Full-duplex realtime voice (`gpt-realtime`, Gemini Live) is not part of this change.

Made with [Cursor](https://cursor.com)