### PR TITLE
feat(chat): universal chat dock

### DIFF
--- a/apps/mobile/components/chat/ChatInput.tsx
+++ b/apps/mobile/components/chat/ChatInput.tsx
@@ -34,9 +34,13 @@ import {
 import { usePlatformConfig } from "../../lib/platform-config"
 import { AttachSourceSheet } from "./AttachSourceSheet"
 import { ContextTracker } from "./ContextTracker"
-import { ContextBreakdownPanel, type ContextBreakdownData } from "./ContextBreakdownPanel"
+import type { ContextBreakdownData } from "./ContextBreakdownPanel"
 import { resolveShortName, resolveTier } from "../../lib/visible-models"
 import { ModelPickerMenu, getNativeModelMenuWidth } from "./ModelPickerMenu"
+import { DockChip } from "./dock/DockChip"
+import { DockChipRail } from "./dock/DockChipRail"
+import { QueueDockPanel } from "./dock/panels/QueueDockPanel"
+import { ContextUsageDockPanel } from "./dock/panels/ContextUsageDockPanel"
 import {
   ArrowUp,
   Plus,
@@ -49,10 +53,6 @@ import {
   FolderGit2,
   Image as ImageIcon,
   ChevronDown,
-  ChevronUp,
-  Trash2,
-  Pencil,
-  SendHorizontal,
   Bot,
   ClipboardList,
   MessageCircleQuestion,
@@ -61,7 +61,6 @@ import {
   Sparkles,
   Languages,
   Play,
-  WifiOff,
 } from "lucide-react-native"
 import { useVoiceInput } from "./useVoiceInput"
 import { VoiceWaveform } from "./VoiceWaveform"
@@ -79,8 +78,6 @@ import { ImagePreviewModal } from "./ImagePreviewModal"
 import { VideoPreviewModal } from "./VideoPreviewModal"
 import { PastedTextChip } from "./PastedTextChip"
 import { useChatBridgeOptional } from "../voice-mode/ChatBridgeContext"
-import { AskUserQuestionWidget } from "./turns/AskUserQuestionWidget"
-import type { ToolCallData } from "./tools/types"
 import { AgentClient } from "@shogo-ai/sdk/agent"
 import { agentFetch } from "../../lib/agent-fetch"
 import { useChatContextSafe } from "./ChatContext"
@@ -349,14 +346,6 @@ export interface ChatInputProps {
   onModelChange?: (modelId: string) => void
   isPro?: boolean
   onUpgradeClick?: () => void
-  /**
-   * Pending ask_user tool call to render as an interactive question widget
-   * attached above the composer (instead of inline in the message stream).
-   * Null when there is no open question.
-   */
-  pendingQuestion?: { messageId: string; tool: ToolCallData } | null
-  /** Called with the formatted response when the attached question is submitted. */
-  onSubmitQuestionResponse?: (response: string) => void
   queuedMessages?: QueuedMessage[]
   onRemoveQueuedMessage?: (messageId: string) => void
   onReorderQueuedMessage?: (messageId: string, direction: "up" | "down") => void
@@ -433,8 +422,6 @@ function ChatInputImpl({
   onModelChange,
   isPro = false,
   onUpgradeClick,
-  pendingQuestion,
-  onSubmitQuestionResponse,
   queuedMessages = [],
   onRemoveQueuedMessage,
   onReorderQueuedMessage,
@@ -513,12 +500,7 @@ function ChatInputImpl({
   const [fileError, setFileError] = useState<string | null>(null)
   const [isProcessingFiles, setIsProcessingFiles] = useState(false)
   const [isDragOver, setIsDragOver] = useState(false)
-  const [queueExpanded, setQueueExpanded] = useState(true)
-  // Row hover & action-icon visibility are now CSS-driven (Tailwind `group` /
-  // `group-hover:`) rather than React-state driven — see the comment above
-  // the row Pressable below for why.
   const [modelPickerOpen, setModelPickerOpen] = useState(false)
-  const [contextPopoverOpen, setContextPopoverOpen] = useState(false)
   const [interactionModeOpen, setInteractionModeOpen] = useState(false)
   const [attachSheetOpen, setAttachSheetOpen] = useState(false)
 
@@ -1424,317 +1406,19 @@ function ChatInputImpl({
         <Text className="text-sm text-destructive mb-2">{voiceInput.error}</Text>
       )}
 
-      {/* Pending question — interactive answer UI attached above the composer.
-          Stays expanded while pending; submitting persists the answer and
-          clears `pendingQuestion`, unmounting this panel. */}
-      {pendingQuestion && (
-        <View className="mb-2">
-          <AskUserQuestionWidget
-            tool={pendingQuestion.tool}
-            onSubmitResponse={(response) => onSubmitQuestionResponse?.(response)}
-          />
-        </View>
-      )}
-
-      {/* Queued messages */}
-      {queuedMessages.length > 0 && (() => {
-        const offlineCount = queuedMessages.filter((m) => m.offline).length
-        return (
-        <View className={cn(
-          "rounded-t-lg border-x border-t overflow-hidden",
-          offlineCount > 0
-            ? "border-orange-400/50 bg-orange-50 dark:bg-orange-950/30"
-            : "border-border/60 bg-muted/30",
-        )}>
-          <Pressable
-            onPress={() => setQueueExpanded((prev) => !prev)}
-            className="w-full flex-row items-center justify-between px-2 py-1"
-          >
-            <View className="flex-row items-center gap-2">
-              <ChevronDown
-                className={cn(
-                  "h-4 w-4",
-                  offlineCount > 0 ? "text-orange-600 dark:text-orange-400" : "text-muted-foreground",
-                  !queueExpanded && "-rotate-90"
-                )}
-                size={16}
-              />
-              {offlineCount > 0 && (
-                <WifiOff size={13} className="text-orange-600 dark:text-orange-400" />
-              )}
-              <Text className={cn(
-                "text-sm",
-                offlineCount > 0 ? "text-orange-700 dark:text-orange-300" : "text-foreground",
-              )}>
-                {offlineCount > 0
-                  ? `${offlineCount} waiting to send${queuedMessages.length > offlineCount ? ` \u00b7 ${queuedMessages.length - offlineCount} queued` : ""}`
-                  : `${queuedMessages.length} Queued`}
-              </Text>
-            </View>
-          </Pressable>
-          {queueExpanded && (
-            <View className="border-t border-border/60">
-              {queuedMessages.map((msg, index) => {
-                const files = msg.files ?? []
-                const imageFiles = files.filter((f) => f.type?.startsWith("image/"))
-                const otherFiles = files.filter((f) => !f.type?.startsWith("image/"))
-                const previewImage = imageFiles[0]
-                const trimmedContent = msg.content?.trim() ?? ""
-                const attachmentLabel =
-                  files.length > 0
-                    ? `${files.length} ${files.length === 1 ? "attachment" : "attachments"}`
-                    : ""
-                const primaryText = trimmedContent
-                  ? trimmedContent
-                  : attachmentLabel || "Empty message"
-                return (
-                  // CSS `group` + `hover:` / `group-hover:` (instead of a
-                  // React `hoveredQueuedId` state) for both row background
-                  // and action-icon visibility. The earlier state-driven
-                  // approach flickered when the cursor crossed from the
-                  // row body onto a nested action Pressable: RN-Web fires
-                  // the row's `onHoverOut` on that child-enter transition,
-                  // which collapsed `isHovered` to false — fading the
-                  // actions to opacity-0 *and* dropping the row's hover
-                  // bg — then the row re-asserted hover a frame later and
-                  // the cycle repeated. CSS `:hover` doesn't suffer this:
-                  // it stays true as long as the cursor is over the
-                  // element or any descendant, so the row bg + action
-                  // group remain stable while the pointer is on a button.
-                  // Native has no hover, so `group-hover:` simply never
-                  // activates — the explicit `Platform.OS === "web"` gate
-                  // on the opacity classes keeps the actions always
-                  // visible there, matching the prior behavior.
-                  <Pressable
-                    key={msg.id}
-                    onPress={() => onEditQueuedMessage?.(msg.id)}
-                    accessibilityLabel="Queued message"
-                    className={cn(
-                      "group flex-row items-center gap-2 px-2 py-1.5 border-b border-border/40 last:border-b-0",
-                      Platform.OS === "web" && "hover:bg-muted/40"
-                    )}
-                  >
-                    {msg.offline ? (
-                      <WifiOff size={11} className="text-orange-600 dark:text-orange-400 flex-shrink-0" />
-                    ) : (
-                      <View className="h-3 w-3 rounded-full border border-muted-foreground/30 flex-shrink-0" />
-                    )}
-                    {previewImage && (
-                      <Image
-                        source={{ uri: previewImage.dataUrl }}
-                        className="h-7 w-7 rounded border border-border flex-shrink-0"
-                        resizeMode="cover"
-                      />
-                    )}
-                    <View className="flex-1 min-w-0">
-                      <Text className="text-xs text-foreground" numberOfLines={1}>
-                        {primaryText}
-                      </Text>
-                      {trimmedContent && files.length > 0 && (
-                        <View className="flex-row items-center gap-1 mt-0.5">
-                          <ImageIcon
-                            className="h-3 w-3 text-muted-foreground"
-                            size={10}
-                          />
-                          <Text
-                            className="text-[10px] text-muted-foreground"
-                            numberOfLines={1}
-                          >
-                            {imageFiles.length > 0 && otherFiles.length > 0
-                              ? `${imageFiles.length} image${imageFiles.length === 1 ? "" : "s"} + ${otherFiles.length} file${otherFiles.length === 1 ? "" : "s"}`
-                              : imageFiles.length > 0
-                                ? `${imageFiles.length} image${imageFiles.length === 1 ? "" : "s"}`
-                                : `${otherFiles.length} file${otherFiles.length === 1 ? "" : "s"}`}
-                          </Text>
-                        </View>
-                      )}
-                    </View>
-                    <View
-                      className={cn(
-                        "flex-row items-center gap-0.5",
-                        // Fade in on row hover via CSS group-hover so
-                        // crossing onto a child button doesn't tear the
-                        // visibility state down. Native always shows them
-                        // (no hover concept), same as before.
-                        Platform.OS === "web" &&
-                          "opacity-0 group-hover:opacity-100",
-                      )}
-                    >
-                      {/*
-                        Each action button uses Pressable's children-as-
-                        function API to read `{ hovered, pressed }` from
-                        RN-Web directly, rather than relying on NativeWind
-                        `hover:` / `group-hover:` variants. The variants
-                        don't reliably produce visible styling on these
-                        nested Pressables in our setup (the row hover
-                        works, but per-button hover never landed any
-                        background or icon-color swap on the user's
-                        screen — see chat thread). State-from-children is
-                        the documented Pressable API and gives us a
-                        boolean we can fan out to both the wrapper bg and
-                        the lucide icon's text color in one place. Native
-                        platforms have no hover concept; `hovered` is
-                        simply undefined there, so the icons read as the
-                        default muted-foreground, matching prior behavior.
-                      */}
-                      {onReorderQueuedMessage && queuedMessages.length > 1 && (
-                        <>
-                          {index > 0 && (
-                            <Pressable
-                              accessibilityLabel="Move queued message up"
-                              onPress={(e) => {
-                                if (e?.stopPropagation) e.stopPropagation()
-                                onReorderQueuedMessage(msg.id, "up")
-                              }}
-                            >
-                              {(state: any) => {
-                                const active = state.hovered || state.pressed
-                                return (
-                                  <View
-                                    className={cn(
-                                      "h-6 w-6 items-center justify-center rounded",
-                                      active && "bg-muted-foreground/25",
-                                    )}
-                                  >
-                                    <ChevronUp
-                                      className={cn(
-                                        "h-3 w-3",
-                                        active ? "text-foreground" : "text-muted-foreground",
-                                      )}
-                                      size={12}
-                                    />
-                                  </View>
-                                )
-                              }}
-                            </Pressable>
-                          )}
-                          {index < queuedMessages.length - 1 && (
-                            <Pressable
-                              accessibilityLabel="Move queued message down"
-                              onPress={(e) => {
-                                if (e?.stopPropagation) e.stopPropagation()
-                                onReorderQueuedMessage(msg.id, "down")
-                              }}
-                            >
-                              {(state: any) => {
-                                const active = state.hovered || state.pressed
-                                return (
-                                  <View
-                                    className={cn(
-                                      "h-6 w-6 items-center justify-center rounded",
-                                      active && "bg-muted-foreground/25",
-                                    )}
-                                  >
-                                    <ChevronDown
-                                      className={cn(
-                                        "h-3 w-3",
-                                        active ? "text-foreground" : "text-muted-foreground",
-                                      )}
-                                      size={12}
-                                    />
-                                  </View>
-                                )
-                              }}
-                            </Pressable>
-                          )}
-                        </>
-                      )}
-                      {onSendQueuedMessageNow && (
-                        <Pressable
-                          accessibilityLabel="Send queued message now"
-                          onPress={(e) => {
-                            if (e?.stopPropagation) e.stopPropagation()
-                            onSendQueuedMessageNow(msg.id)
-                          }}
-                        >
-                          {(state: any) => {
-                            const active = state.hovered || state.pressed
-                            return (
-                              <View
-                                className={cn(
-                                  "h-6 w-6 items-center justify-center rounded",
-                                  active && "bg-muted-foreground/25",
-                                )}
-                              >
-                                <SendHorizontal
-                                  className={cn(
-                                    "h-3 w-3",
-                                    active ? "text-foreground" : "text-muted-foreground",
-                                  )}
-                                  size={12}
-                                />
-                              </View>
-                            )
-                          }}
-                        </Pressable>
-                      )}
-                      {onEditQueuedMessage && (
-                        <Pressable
-                          accessibilityLabel="Edit queued message"
-                          onPress={(e) => {
-                            if (e?.stopPropagation) e.stopPropagation()
-                            onEditQueuedMessage(msg.id)
-                          }}
-                        >
-                          {(state: any) => {
-                            const active = state.hovered || state.pressed
-                            return (
-                              <View
-                                className={cn(
-                                  "h-6 w-6 items-center justify-center rounded",
-                                  active && "bg-muted-foreground/25",
-                                )}
-                              >
-                                <Pencil
-                                  className={cn(
-                                    "h-3 w-3",
-                                    active ? "text-foreground" : "text-muted-foreground",
-                                  )}
-                                  size={12}
-                                />
-                              </View>
-                            )
-                          }}
-                        </Pressable>
-                      )}
-                      {onRemoveQueuedMessage && (
-                        <Pressable
-                          accessibilityLabel="Delete queued message"
-                          onPress={(e) => {
-                            if (e?.stopPropagation) e.stopPropagation()
-                            onRemoveQueuedMessage(msg.id)
-                          }}
-                        >
-                          {(state: any) => {
-                            const active = state.hovered || state.pressed
-                            return (
-                              <View
-                                className={cn(
-                                  "h-6 w-6 items-center justify-center rounded",
-                                  active && "bg-destructive/20",
-                                )}
-                              >
-                                <Trash2
-                                  className={cn(
-                                    "h-3 w-3",
-                                    active ? "text-destructive" : "text-muted-foreground",
-                                  )}
-                                  size={12}
-                                />
-                              </View>
-                            )
-                          }}
-                        </Pressable>
-                      )}
-                    </View>
-                  </Pressable>
-                )
-              })}
-            </View>
-          )}
-        </View>
-        )
-      })()}
+      {/* Queued messages, live browser, running tasks, plan, checklist,
+          changed files, worktree, and context usage all render inside the
+          floating chat dock now (see ChatPanel's <ChatDock />) instead of
+          inline here. This registers the queue's dock panel + composer
+          chip; the row UI itself lives in QueueDockPanel. */}
+      <QueueDockPanel
+        queuedMessages={queuedMessages}
+        onRemoveQueuedMessage={onRemoveQueuedMessage}
+        onReorderQueuedMessage={onReorderQueuedMessage}
+        onEditQueuedMessage={onEditQueuedMessage}
+        onSendQueuedMessageNow={onSendQueuedMessageNow}
+      />
+      <ContextUsageDockPanel contextUsage={contextUsage} contextBreakdown={contextBreakdown} />
 
       {/* Dropdown + input layer.
 
@@ -1854,8 +1538,7 @@ function ChatInputImpl({
         <View
           ref={dropZoneRef as any}
           className={cn(
-            "relative border bg-muted/30 overflow-hidden",
-            queuedMessages.length > 0 ? "rounded-b-xl" : "rounded-xl",
+            "relative border bg-muted/30 overflow-hidden rounded-xl",
             isDragOver ? "border-primary border-dashed" : "border-border/60",
             // Accent ring for the inline-edit "active edit target"
             // state. Drag-over still takes precedence (its dashed
@@ -2437,36 +2120,14 @@ function ChatInputImpl({
             </View>
           ) : (
           <View className="flex-row flex-shrink-0 items-center gap-1">
+            <DockChipRail isNative={isNative} />
             {contextUsage && (
-              <Popover
-                placement="top"
-                size="xs"
-                isOpen={contextPopoverOpen}
-                onOpen={() => setContextPopoverOpen(true)}
-                onClose={() => setContextPopoverOpen(false)}
-                trigger={(triggerProps) => (
-                  <Pressable
-                    {...triggerProps}
-                    hitSlop={isNative ? 6 : 4}
-                    role="button"
-                    accessibilityLabel="Context usage"
-                  >
-                    <ContextTracker
-                      inputTokens={contextUsage.inputTokens}
-                      contextWindowTokens={contextUsage.contextWindowTokens}
-                    />
-                  </Pressable>
-                )}
-              >
-                <PopoverBackdrop />
-                <PopoverContent className="w-auto p-0">
-                  <ContextBreakdownPanel
-                    breakdown={contextBreakdown ?? null}
-                    inputTokens={contextUsage.inputTokens}
-                    contextWindowTokens={contextUsage.contextWindowTokens}
-                  />
-                </PopoverContent>
-              </Popover>
+              <DockChip panelId="context-usage" accessibilityLabel="Context usage">
+                <ContextTracker
+                  inputTokens={contextUsage.inputTokens}
+                  contextWindowTokens={contextUsage.contextWindowTokens}
+                />
+              </DockChip>
             )}
 
             <Pressable

--- a/apps/mobile/components/chat/ChatPanel.tsx
+++ b/apps/mobile/components/chat/ChatPanel.tsx
@@ -27,7 +27,7 @@
  * - No document/window DOM APIs
  */
 
-import { useState, useEffect, useRef, useCallback, useMemo } from "react"
+import { useState, useEffect, useRef, useCallback, useMemo, useSyncExternalStore } from "react"
 import * as Sentry from "@sentry/react-native"
 import {
   Alert,
@@ -111,6 +111,16 @@ import {
   DEFAULT_STREAMING_STALL_MS,
 } from "../../lib/chat-stall-watchdog"
 import { createTodoStateStore, TodoStateStoreContext } from "../../lib/todo-state-store"
+import { createFileChangeStore, FileChangeStoreContext } from "../../lib/file-change-store"
+import { createChatDockStore, ChatDockStoreContext, useChatDockStore, type DockPanelDescriptor } from "../../lib/chat-dock-store"
+import { useDockPanel } from "./dock/useDockPanel"
+import { ChatDock } from "./dock/ChatDock"
+import { PlanDockPanel } from "./dock/panels/PlanDockPanel"
+import { ChecklistDockPanel } from "./dock/panels/ChecklistDockPanel"
+import { RunningDockPanel } from "./dock/panels/RunningDockPanel"
+import { BrowserDockPanel } from "./dock/panels/BrowserDockPanel"
+import { WorktreeDockPanel } from "./dock/panels/WorktreeDockPanel"
+import { ChangesDockPanel } from "./dock/panels/ChangesDockPanel"
 import {
   loadModelPreference,
   saveModelPreference,
@@ -118,7 +128,6 @@ import {
 import { useReconcileStaleModelSelection } from "../../lib/visible-models"
 import { CompactChatInput } from "./CompactChatInput"
 import { ExecutionBadge } from "./ExecutionBadge"
-import { WorktreeBar } from "./WorktreeBar"
 import { ExpandTab } from "./ExpandTab"
 import { ToolCallDisplay, type ToolCallState } from "./ToolCallDisplay"
 import {
@@ -141,11 +150,10 @@ import {
 import { EditConfirmDialogHost } from "./turns/EditConfirmDialog"
 import { PhaseEmptyState } from "./empty"
 import {
-  SubagentPanel,
   type SubagentProgress as SubagentProgressType,
   type RecentTool as RecentToolType,
 } from "./subagent"
-import { ProcessPanel, type RunningProcess } from "./ProcessPanel"
+import { type RunningProcess } from "./ProcessPanel"
 import {
   type ToolCallData,
   getToolCategory as getToolCategoryFromTools,
@@ -153,7 +161,7 @@ import {
 import { subagentStreamStore } from "../../lib/subagent-stream-store"
 import { teamStore } from "../../lib/team-store"
 import * as ExpoLinking from "expo-linking"
-import { AlertCircle, RefreshCw, WifiOff, X, ChevronDown } from "lucide-react-native"
+import { AlertCircle, RefreshCw, WifiOff, X, ChevronDown, Shield, MessageCircleQuestion } from "lucide-react-native"
 import { type PlanData } from "./PlanCard"
 import { usePlanStreamSafe } from "./PlanStreamContext"
 import { AgentClient } from "@shogo-ai/sdk/agent"
@@ -165,6 +173,7 @@ import { configureSubagentStop } from "../../lib/subagent-stop"
 import { useChatBridgeRegistrar } from "../voice-mode/ChatBridgeContext"
 import { extractTaskToolsFromMessages } from "./turns/messageParts"
 import { derivePendingQuestion } from "./turns/pendingQuestion"
+import { AskUserQuestionWidget } from "./turns/AskUserQuestionWidget"
 import {
   FIX_IN_AGENT_EVENT,
   buildFixPrompt,
@@ -331,7 +340,6 @@ export interface ChatPanelProps {
   onCompactValueChange?: (value: string) => void
   onChatError?: (error: Error | null) => void
   injectMessage?: string | null
-  onFilesChanged?: (paths: string[]) => void
   onActiveToolCall?: (toolName: string | null) => void
   selectedThemeId?: string
   onSelectTheme?: (themeId: string) => void
@@ -591,45 +599,6 @@ function requiresSchemaRefresh(toolCall: ExtractedToolCall): boolean {
   return normalizedToolName === "schema_set" || normalizedToolName === "schema_load"
 }
 
-const FILE_OPERATION_TOOLS = new Set([
-  "Write",
-  "Edit",
-  "StrReplace",
-  "Delete",
-  "template_copy",
-  "template.copy",
-])
-
-function getModifiedFilePaths(toolCalls: ExtractedToolCall[]): string[] {
-  const paths: string[] = []
-
-  for (const toolCall of toolCalls) {
-    if (toolCall.state !== "output-available") {
-      continue
-    }
-
-    const normalizedToolName = toolCall.toolName.includes("__")
-      ? toolCall.toolName.split("__").pop() || toolCall.toolName
-      : toolCall.toolName
-
-    if (!FILE_OPERATION_TOOLS.has(normalizedToolName)) {
-      continue
-    }
-
-    const args = toolCall.args as Record<string, unknown> | undefined
-    const filePath = (args?.file_path ?? args?.path ?? args?.filePath) as string | undefined
-    if (filePath && typeof filePath === "string") {
-      paths.push(filePath)
-    }
-
-    if (normalizedToolName === "template_copy" || normalizedToolName === "template.copy") {
-      paths.push("*")
-    }
-  }
-
-  return [...new Set(paths)]
-}
-
 async function refreshCollections(
   domain: any,
   collectionNames: string[],
@@ -769,7 +738,6 @@ export const ChatPanel = observer(function ChatPanel({
   onCompactValueChange,
   onChatError,
   injectMessage,
-  onFilesChanged,
   onActiveToolCall,
   selectedThemeId,
   onSelectTheme,
@@ -1209,6 +1177,13 @@ export const ChatPanel = observer(function ChatPanel({
   // for the panel's lifetime; the clear() below is a defensive
   // reset for the rare case where a panel switches sessions.
   const todoStateStore = useMemo(() => createTodoStateStore(), [])
+  // Per-chat store for the files-changed dock panel — see file-change-store.ts.
+  const fileChangeStore = useMemo(() => createFileChangeStore(), [])
+  // The chat dock's panel registry (context breakdown, plan, checklist,
+  // changed files, live browser, running tasks, queue, worktree, plus the
+  // blocking permission/question/connectivity panels). One per ChatPanel —
+  // see chat-dock-store.ts.
+  const chatDockStore = useMemo(() => createChatDockStore(), [])
 
   useEffect(() => {
     pendingPlanRef.current = null
@@ -1216,7 +1191,9 @@ export const ChatPanel = observer(function ChatPanel({
     setConfirmedPlan(null)
     confirmedPlanRef.current = null
     todoStateStore.clear()
-  }, [currentSessionId, todoStateStore])
+    fileChangeStore.clear()
+    chatDockStore.reset()
+  }, [currentSessionId, todoStateStore, fileChangeStore, chatDockStore])
 
   // Load session metadata from API if not already cached. Gated on
   // `isActive` so the N-1 hidden sibling ChatPanels mounted for every
@@ -2378,14 +2355,6 @@ export const ChatPanel = observer(function ChatPanel({
             })
           }
 
-          if (onFilesChanged) {
-            const modifiedPaths = getModifiedFilePaths(toolCalls)
-            if (modifiedPaths.length > 0) {
-              console.log("[ChatPanel] Files modified by agent:", modifiedPaths)
-              filesChangedFiredRef.current = true
-              onFilesChanged(modifiedPaths)
-            }
-          }
         }
       }
 
@@ -2520,7 +2489,6 @@ export const ChatPanel = observer(function ChatPanel({
   }
 
   const isStreaming = (status === "streaming" || status === "submitted") && stoppedMessages === null
-  const filesChangedFiredRef = useRef(false)
 
   // Watch messages for tool-invocation state transitions during a live
   // turn and emit `tool-activity` events so the EZ Mode overlay can
@@ -2999,29 +2967,16 @@ export const ChatPanel = observer(function ChatPanel({
     }
   }, [isStreaming, messages, handleStop])
 
-  // Fallback: detect file changes when streaming ends
+  // Clear the tool-error banner at the start of each new turn.
   const prevStreamingForScanRef = useRef(false)
   useEffect(() => {
     const wasStreaming = prevStreamingForScanRef.current
     prevStreamingForScanRef.current = isStreaming
 
-    if (wasStreaming && !isStreaming && !filesChangedFiredRef.current && onFilesChanged) {
-      const latestAssistant = [...messages].reverse().find((m) => m.role === "assistant")
-      if (latestAssistant) {
-        const toolCalls = extractToolCalls(latestAssistant)
-        const modifiedPaths = getModifiedFilePaths(toolCalls)
-        if (modifiedPaths.length > 0) {
-          console.log("[ChatPanel] Fallback: Files modified by agent (onFinish missed):", modifiedPaths)
-          onFilesChanged(modifiedPaths)
-        }
-      }
-    }
-
     if (isStreaming && !wasStreaming) {
-      filesChangedFiredRef.current = false
       setToolErrorBanner(null)
     }
-  }, [isStreaming, messages, onFilesChanged])
+  }, [isStreaming])
 
   // Process progress events from message parts
   useEffect(() => {
@@ -5314,6 +5269,275 @@ export const ChatPanel = observer(function ChatPanel({
     [handleSendMessage],
   )
 
+  // Re-render when the dock's registered panels / expand state / measured
+  // height change so `dockHeight` (used to pad the message list) and the
+  // dock-height-dependent JSX below stay current.
+  useSyncExternalStore(chatDockStore.subscribe, chatDockStore.getVersion, chatDockStore.getVersion)
+  const dockHeight = chatDockStore.getHeight()
+  // Measured height of the scrollable message area, used to cap the dock's
+  // status zone at ~45% of the space actually available above the composer.
+  const [messagesAreaHeight, setMessagesAreaHeight] = useState(0)
+
+  // ---------------------------------------------------------------------
+  // Chat dock: blocking panels (permission approval / pending question /
+  // connectivity wait) and status banners (tool error / general error).
+  // These stay inline here — rather than as separate dock/panels files —
+  // since they're tightly coupled to ChatPanel's own countdown, retry, and
+  // dismiss state. The countdown/auto-deny inside `PermissionApprovalDialog`
+  // and the auto-hide timers below are untouched; only *where* they render
+  // (a dock panel instead of a fixed slot above the composer) changed.
+  // ---------------------------------------------------------------------
+
+  const permissionDockDescriptor = useMemo<DockPanelDescriptor | null>(() => {
+    if (!pendingPermissionRequest) return null
+    return {
+      id: "permission",
+      kind: "blocking",
+      order: 0,
+      title: "Permission required",
+      icon: Shield,
+      render: () => (
+        <PermissionApprovalDialog
+          request={pendingPermissionRequest}
+          onRespond={async (response) => {
+            setPendingPermissionRequest(null)
+            try {
+              if (projectId) {
+                const http = createHttpClient()
+                await api.sendPermissionResponse(http, projectId, response)
+              }
+            } catch (err) {
+              console.error("[ChatPanel] Failed to send permission response:", err)
+            }
+          }}
+        />
+      ),
+    }
+  }, [pendingPermissionRequest, projectId])
+  useDockPanel(permissionDockDescriptor)
+
+  const questionDockDescriptor = useMemo<DockPanelDescriptor | null>(() => {
+    if (!pendingQuestion) return null
+    return {
+      id: "question",
+      kind: "blocking",
+      order: 1,
+      title: "Question",
+      icon: MessageCircleQuestion,
+      render: () => (
+        <AskUserQuestionWidget
+          tool={pendingQuestion.tool}
+          onSubmitResponse={(response) => handleSubmitQuestionResponse(response)}
+        />
+      ),
+    }
+  }, [pendingQuestion, handleSubmitQuestionResponse])
+  useDockPanel(questionDockDescriptor)
+
+  const connectivityDockDescriptor = useMemo<DockPanelDescriptor | null>(() => {
+    if (!((connectivityWait || justReconnected) && !errorDismissed)) return null
+    return {
+      id: "connectivity",
+      kind: "blocking",
+      order: 2,
+      title: justReconnected ? "Back online" : "Waiting for connection",
+      icon: WifiOff,
+      accent: "warning",
+      headerActions: !justReconnected ? (
+        <Pressable
+          onPress={handleStop}
+          accessibilityRole="button"
+          accessibilityLabel="Cancel and stop waiting for connection"
+          className="shrink-0 rounded-md border border-orange-400/30 px-2 py-1"
+        >
+          <Text className="text-xs font-medium text-orange-700 dark:text-orange-300">Cancel</Text>
+        </Pressable>
+      ) : undefined,
+      render: () => (
+        <View className="flex-row items-start gap-1.5">
+          {justReconnected ? (
+            <RefreshCw size={14} className="h-3.5 w-3.5 shrink-0 mt-0.5 text-orange-600 dark:text-orange-400" />
+          ) : (
+            <WifiOff size={14} className="h-3.5 w-3.5 shrink-0 mt-0.5 text-orange-600 dark:text-orange-400" />
+          )}
+          <Text className="flex-1 text-xs text-orange-700 dark:text-orange-300">
+            {justReconnected
+              ? "Back online — resuming\u2026"
+              : `No internet connection. Waiting to resume${connectivityWaitElapsedLabel ? ` (${connectivityWaitElapsedLabel})` : ""}\u2026`}
+          </Text>
+        </View>
+      ),
+    }
+  }, [connectivityWait, justReconnected, errorDismissed, connectivityWaitElapsedLabel, handleStop])
+  useDockPanel(connectivityDockDescriptor)
+
+  const toolErrorDockDescriptor = useMemo<DockPanelDescriptor | null>(() => {
+    if (!toolErrorBanner) return null
+    return {
+      id: "tool-error",
+      kind: "status",
+      order: 15,
+      title: toolErrorBanner.isAuthError
+        ? `${toolErrorBanner.toolkitName} connection expired`
+        : `${toolErrorBanner.toolkitName} error`,
+      icon: AlertCircle,
+      accent: "warning",
+      defaultExpanded: true,
+      onDismiss: () => setToolErrorBanner(null),
+      headerActions:
+        toolErrorBanner.isAuthError && projectId ? (
+          <Pressable
+            onPress={async () => {
+              const toolkit = toolErrorBanner.toolkitName.toLowerCase()
+              setReconnecting(true)
+              const preWindow = Platform.OS === "web" ? preCreateAuthWindow() : null
+              console.info("[ChatPanel] Reconnecting", toolkit)
+              try {
+                const http = createHttpClient()
+                const isNativePlatform = Platform.OS !== "web"
+                let redirect: string | undefined
+                if (isNativePlatform) {
+                  redirect = ExpoLinking.createURL("integrations-callback")
+                } else {
+                  const returnUrl = new URL(window.location.href)
+                  returnUrl.searchParams.set("fromOAuth", "1")
+                  redirect = returnUrl.toString()
+                }
+                const callbackUrl = redirect
+                  ? `${API_URL}/api/integrations/callback?redirect=${encodeURIComponent(redirect)}`
+                  : `${API_URL}/api/integrations/callback`
+                const data = await api.connectIntegration(http, toolkit, projectId, callbackUrl)
+                const redirectUrl = data.data?.redirectUrl
+                if (redirectUrl) {
+                  await openAuthFlow(redirectUrl, { preCreatedWindow: preWindow })
+                  setToolErrorBanner(null)
+                }
+              } catch (err) {
+                console.error("[ChatPanel] Reconnect error:", err)
+              } finally {
+                setReconnecting(false)
+                try {
+                  if (preWindow && !preWindow.closed) {
+                    const loc = preWindow.location.href
+                    if (loc === "about:blank" || loc === "") preWindow.close()
+                  }
+                } catch {
+                  /* COOP */
+                }
+              }
+            }}
+            disabled={reconnecting}
+            className={cn(
+              "flex-row items-center gap-1.5 rounded-md border border-orange-400/50 bg-orange-100 dark:bg-orange-800/30 px-1.5 py-1 active:opacity-70",
+              reconnecting && "opacity-50",
+            )}
+          >
+            {reconnecting ? (
+              <ActivityIndicator size="small" />
+            ) : (
+              <RefreshCw size={12} className="text-orange-700 dark:text-orange-300" />
+            )}
+            <Text className="text-xs font-medium text-orange-700 dark:text-orange-300">Reconnect</Text>
+          </Pressable>
+        ) : undefined,
+      render: () => <Text className="text-xs text-muted-foreground">{toolErrorBanner.error}</Text>,
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [toolErrorBanner, projectId, reconnecting])
+  useDockPanel(toolErrorDockDescriptor)
+
+  const errorDockDescriptor = useMemo<DockPanelDescriptor | null>(() => {
+    if (!(((error || emptyResponseError) && !errorDismissed) || streamAutoRecovering)) return null
+    return {
+      id: "error",
+      kind: "status",
+      order: 16,
+      title: isTunnelError ? "Connection lost" : "Error",
+      icon: AlertCircle,
+      accent: "warning",
+      defaultExpanded: true,
+      onDismiss: () => {
+        setEmptyResponseError(null)
+        setErrorDismissed(true)
+      },
+      headerActions:
+        tunnelReconnecting || streamAutoRecovering ? (
+          <Text className={cn("text-xs font-medium", isTunnelError ? "text-orange-600 dark:text-orange-400" : "text-destructive")}>
+            Reconnecting…
+          </Text>
+        ) : (
+          <View className="flex-row items-center gap-1">
+            {isTunnelError && (
+              <Pressable
+                onPress={() => {
+                  clearActiveInstance()
+                  setTimeout(() => handleRetry(), 0)
+                }}
+                accessibilityRole="button"
+                accessibilityLabel="Continue this conversation in the cloud sandbox"
+                className="rounded-md border border-orange-400/30 px-2 py-1"
+              >
+                <Text className="text-xs font-medium text-orange-700 dark:text-orange-300">Continue in cloud</Text>
+              </Pressable>
+            )}
+            <Pressable
+              onPress={handleRetry}
+              className={cn("rounded-md border px-2 py-1", isTunnelError ? "border-orange-400/30" : "border-destructive/30")}
+            >
+              <Text className={cn("text-xs font-medium", isTunnelError ? "text-orange-600 dark:text-orange-400" : "text-destructive")}>
+                {isTunnelError ? "Reconnect" : "Retry"}
+              </Text>
+            </Pressable>
+          </View>
+        ),
+      render: () => (
+        <View>
+          {errorBannerExpanded ? (
+            <ScrollView nestedScrollEnabled className="max-h-40" showsVerticalScrollIndicator>
+              <Text className={cn("text-xs", isTunnelError ? "text-orange-700 dark:text-orange-300" : "text-destructive")} selectable>
+                {errorBannerText}
+              </Text>
+            </ScrollView>
+          ) : (
+            <Text
+              className={cn("text-xs", isTunnelError ? "text-orange-700 dark:text-orange-300" : "text-destructive")}
+              numberOfLines={2}
+              selectable
+            >
+              {errorBannerText}
+            </Text>
+          )}
+          {errorBannerNeedsReadMore && (
+            <Pressable
+              onPress={() => setErrorBannerExpanded((e) => !e)}
+              className="mt-1 self-start py-0.5"
+              role="button"
+              accessibilityLabel={errorBannerExpanded ? "Show less error detail" : "Read full error message"}
+            >
+              <Text className={cn("text-[11px] font-semibold", isTunnelError ? "text-orange-700 dark:text-orange-300" : "text-destructive")}>
+                {errorBannerExpanded ? "Show less" : "Read more"}
+              </Text>
+            </Pressable>
+          )}
+        </View>
+      ),
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    error,
+    emptyResponseError,
+    errorDismissed,
+    streamAutoRecovering,
+    isTunnelError,
+    tunnelReconnecting,
+    errorBannerExpanded,
+    errorBannerText,
+    errorBannerNeedsReadMore,
+    handleRetry,
+    clearActiveInstance,
+  ])
+  useDockPanel(errorDockDescriptor)
+
   // Render compact mode (homepage)
   if (mode === "compact") {
     return (
@@ -5346,12 +5570,41 @@ export const ChatPanel = observer(function ChatPanel({
 
   return (
     <TodoStateStoreContext.Provider value={todoStateStore}>
+    <FileChangeStoreContext.Provider value={fileChangeStore}>
+    <ChatDockStoreContext.Provider value={chatDockStore}>
     <ChatContextProvider value={contextValue}>
       {/* Hosts the destructive-confirmation modal for in-place message
           edit and "retry from here". Rendered once per ChatPanel and
           accepts requests pushed from any nested EditableUserMessage
           via the module-level subscriber in EditConfirmDialog.tsx. */}
       <EditConfirmDialogHost />
+      {/* Dock panels that don't need a fixed spot in the JSX tree — each
+          is a no-render component that registers itself with
+          `chatDockStore` (see chat-dock-store.ts) and unregisters when its
+          data disappears. */}
+      <PlanDockPanel
+        pendingPlan={pendingPlan}
+        confirmedPlan={confirmedPlan}
+        onBuild={pendingPlan ? handleConfirmPlan : null}
+        onOpenPlan={onOpenPlan}
+        onGenerateSummary={handleGenerateSummary}
+      />
+      <ChecklistDockPanel />
+      <RunningDockPanel
+        processes={runningProcesses}
+        onKillProcess={handleKillProcess}
+        killingProcesses={killingProcesses}
+        subagents={activeSubagentsList}
+        recentTools={recentToolsList}
+      />
+      <BrowserDockPanel />
+      <WorktreeDockPanel
+        agentUrl={resolvedAgentUrl}
+        chatSessionId={currentSessionId}
+        isStreaming={isStreaming}
+        onSendMessage={(text) => handleInputSubmit(text)}
+      />
+      <ChangesDockPanel />
       <View className={cn("flex-row flex-1", className)}>
         {/* Main content area */}
         {children && (
@@ -5365,7 +5618,7 @@ export const ChatPanel = observer(function ChatPanel({
           keyboardVerticalOffset={Platform.OS === "ios" ? 90 : 50}
         >
           {/* Messages with Turn Grouping */}
-          <View className="flex-1">
+          <View className="flex-1" onLayout={(e) => setMessagesAreaHeight(e.nativeEvent.layout.height)}>
           <ScrollView
             ref={scrollViewRef}
             className="flex-1"
@@ -5447,8 +5700,6 @@ export const ChatPanel = observer(function ChatPanel({
                   messages={displayMessages}
                   isStreaming={isStreaming}
                   phase={phase}
-                  activeSubagents={activeSubagentsList}
-                  recentTools={recentToolsList}
                   subagentToolCalls={accumulatedSubagentTools}
                 />
               </MessageEditProvider>
@@ -5464,22 +5715,17 @@ export const ChatPanel = observer(function ChatPanel({
             ) : !isStreaming ? (
               <PhaseEmptyState phase={phase} onSuggestionClick={handleSendMessage} quickActions={quickActions} />
             ) : (
-              <View className="gap-3">
-                {activeSubagents.size > 0 && (
-                  <SubagentPanel
-                    subagents={activeSubagentsList}
-                    recentTools={recentToolsList}
-                    defaultExpanded
-                  />
-                )}
-                <View className="flex-row items-center gap-1 p-2">
-                  <View className="w-2 h-2 rounded-full bg-muted-foreground opacity-50" />
-                  <View className="w-2 h-2 rounded-full bg-muted-foreground opacity-50" />
-                  <View className="w-2 h-2 rounded-full bg-muted-foreground opacity-50" />
-                </View>
+              <View className="flex-row items-center gap-1 p-2">
+                <View className="w-2 h-2 rounded-full bg-muted-foreground opacity-50" />
+                <View className="w-2 h-2 rounded-full bg-muted-foreground opacity-50" />
+                <View className="w-2 h-2 rounded-full bg-muted-foreground opacity-50" />
               </View>
             )}
 
+            {/* Reserves space for the floating chat dock so it never
+                permanently covers the newest message — ChatDock reports its
+                measured height into `chatDockStore`, read reactively above. */}
+            {dockHeight > 0 && <View style={{ height: dockHeight }} />}
           </ScrollView>
 
           {/* "Jump to latest" pill — shown when the user has scrolled away
@@ -5507,305 +5753,13 @@ export const ChatPanel = observer(function ChatPanel({
           )}
           </View>
 
-          {/* Running background processes (visible regardless of streaming) */}
-          {runningProcesses.length > 0 && (
-            <View className="px-4 pb-2 w-full items-center">
-              <ProcessPanel
-                processes={runningProcesses}
-                onKill={handleKillProcess}
-                killing={killingProcesses}
-              />
-            </View>
-          )}
-
-          {/* Tool Error Banner */}
-          {toolErrorBanner && (
-            <View className="px-4 pb-2 w-full items-center">
-              <View className={cn(
-                "flex-row items-start gap-2 rounded-lg p-3",
-                toolErrorBanner.isAuthError
-                  ? "border border-orange-400/50 bg-orange-50 dark:bg-orange-900/20"
-                  : "border border-yellow-400/50 bg-yellow-50 dark:bg-yellow-900/20",
-              )}>
-                <AlertCircle
-                  className={cn(
-                    "shrink-0 mt-0.5",
-                    toolErrorBanner.isAuthError
-                      ? "text-orange-600 dark:text-orange-400"
-                      : "text-yellow-600 dark:text-yellow-400",
-                  )}
-                  size={16}
-                />
-                <View className="flex-1 gap-1.5">
-                  <View className="flex-row items-center justify-between">
-                    <Text className={cn(
-                      "text-sm font-medium",
-                      toolErrorBanner.isAuthError
-                        ? "text-orange-800 dark:text-orange-200"
-                        : "text-yellow-800 dark:text-yellow-200",
-                    )}>
-                      {toolErrorBanner.isAuthError
-                        ? `${toolErrorBanner.toolkitName} Connection Expired`
-                        : `${toolErrorBanner.toolkitName} Error`}
-                    </Text>
-                    <Pressable
-                      onPress={() => setToolErrorBanner(null)}
-                      className="p-1 -mr-1 -mt-1 rounded active:bg-black/10"
-                      hitSlop={8}
-                    >
-                      <X size={14} className={cn(
-                        toolErrorBanner.isAuthError
-                          ? "text-orange-600 dark:text-orange-400"
-                          : "text-yellow-600 dark:text-yellow-400",
-                      )} />
-                    </Pressable>
-                  </View>
-                  <Text className={cn(
-                    "text-xs",
-                    toolErrorBanner.isAuthError
-                      ? "text-orange-700 dark:text-orange-300"
-                      : "text-yellow-700 dark:text-yellow-300",
-                  )}>
-                    {toolErrorBanner.error}
-                  </Text>
-                  {toolErrorBanner.isAuthError && projectId && (
-                    <Pressable
-                      onPress={async () => {
-                        const toolkit = toolErrorBanner.toolkitName.toLowerCase()
-                        setReconnecting(true)
-
-                        const preWindow = Platform.OS === 'web' ? preCreateAuthWindow() : null
-                        console.info('[ChatPanel] Reconnecting', toolkit)
-
-                        try {
-                          const http = createHttpClient()
-                          const isNative = Platform.OS !== 'web'
-                          let redirect: string | undefined
-                          if (isNative) {
-                            redirect = ExpoLinking.createURL('integrations-callback')
-                          } else {
-                            // Web (desktop browser, mobile web, Electron):
-                            // always pass our own URL so the OAuth callback
-                            // returns here instead of OS-routing through a
-                            // `shogo://` protocol handler. See
-                            // ConnectToolWidget.tsx for the full rationale.
-                            const returnUrl = new URL(window.location.href)
-                            returnUrl.searchParams.set('fromOAuth', '1')
-                            redirect = returnUrl.toString()
-                          }
-
-                          const callbackUrl = redirect
-                            ? `${API_URL}/api/integrations/callback?redirect=${encodeURIComponent(redirect)}`
-                            : `${API_URL}/api/integrations/callback`
-                          const data = await api.connectIntegration(http, toolkit, projectId, callbackUrl)
-                          const redirectUrl = data.data?.redirectUrl
-                          if (redirectUrl) {
-                            await openAuthFlow(redirectUrl, { preCreatedWindow: preWindow })
-                            setToolErrorBanner(null)
-                          }
-                        } catch (err) {
-                          console.error('[ChatPanel] Reconnect error:', err)
-                          // Connection attempt failed — banner stays visible
-                        } finally {
-                          setReconnecting(false)
-                          try {
-                            if (preWindow && !preWindow.closed) {
-                              const loc = preWindow.location.href
-                              if (loc === 'about:blank' || loc === '') preWindow.close()
-                            }
-                          } catch { /* COOP */ }
-                        }
-                      }}
-                      disabled={reconnecting}
-                      className={cn(
-                        "self-start flex-row items-center gap-1.5 rounded-md border border-orange-400/50 bg-orange-100 dark:bg-orange-800/30 px-1 py-1.5 active:opacity-70",
-                        reconnecting && "opacity-50",
-                      )}
-                    >
-                      {reconnecting ? (
-                        <ActivityIndicator size="small" />
-                      ) : (
-                        <RefreshCw size={12} className="text-orange-700 dark:text-orange-300" />
-                      )}
-                      <Text className="text-xs font-medium text-orange-700 dark:text-orange-300">
-                        Reconnect
-                      </Text>
-                    </Pressable>
-                  )}
-                </View>
-              </View>
-            </View>
-          )}
-
-          {/* Connectivity park banner — the runtime's model call couldn't reach
-              its upstream health endpoint and is polling with backoff instead
-              of failing the turn (see `data-connectivity-wait` in `onData`).
-              Rendered ahead of the generic error banner since a parked turn
-              is still alive, not failed — the user should see "waiting", not
-              an error, and Cancel maps to the same `handleStop` as everywhere
-              else. `justReconnected` shows a brief confirmation once the
-              runtime resumes rather than snapping straight back to nothing. */}
-          {(connectivityWait || justReconnected) && !errorDismissed ? (
-            <View className="px-4 pb-2 max-w-3xl w-full self-center">
-              <View className="flex-row items-start gap-1.5 rounded-md border border-orange-400/50 bg-orange-50 dark:bg-orange-950/30 px-3 py-2">
-                {justReconnected ? (
-                  <RefreshCw size={14} className="h-3.5 w-3.5 shrink-0 mt-0.5 text-orange-600 dark:text-orange-400" />
-                ) : (
-                  <WifiOff size={14} className="h-3.5 w-3.5 shrink-0 mt-0.5 text-orange-600 dark:text-orange-400" />
-                )}
-                <View className="flex-1 min-w-0 flex-row items-center justify-between gap-1.5">
-                  <Text className="flex-1 text-xs text-orange-700 dark:text-orange-300">
-                    {justReconnected
-                      ? 'Back online — resuming\u2026'
-                      : `No internet connection. Waiting to resume${connectivityWaitElapsedLabel ? ` (${connectivityWaitElapsedLabel})` : ''}\u2026`}
-                  </Text>
-                  {!justReconnected && (
-                    <Pressable
-                      onPress={handleStop}
-                      accessibilityRole="button"
-                      accessibilityLabel="Cancel and stop waiting for connection"
-                      className="shrink-0 rounded-md border border-orange-400/30 px-2 py-1"
-                    >
-                      <Text className="text-xs font-medium text-orange-700 dark:text-orange-300">Cancel</Text>
-                    </Pressable>
-                  )}
-                </View>
-              </View>
-            </View>
-          ) : null}
-
-          {/* Error Alert — cap long messages so the sidebar layout stays usable.
-              Also surfaces while auto-recovery is reconnecting, even when the
-              SDK left no `error`/`emptyResponseError` behind (the silent-stall
-              case), so the user sees "Reconnecting…" rather than nothing. */}
-          {((error || emptyResponseError) && !errorDismissed) || streamAutoRecovering ? (
-            <View className="px-4 pb-2 max-w-3xl w-full self-center">
-              <View className={`flex-row items-start gap-1.5 rounded-md border px-3 py-2 ${
-                isTunnelError
-                  ? 'border-orange-400/50 bg-orange-50 dark:bg-orange-950/30'
-                  : 'border-destructive/50 bg-destructive/10'
-              }`}>
-                <AlertCircle className={`h-3.5 w-3.5 shrink-0 mt-0.5 ${
-                  isTunnelError ? 'text-orange-600 dark:text-orange-400' : 'text-destructive'
-                }`} size={14} />
-                <View className="flex-1 min-w-0 flex-row items-start justify-between gap-1.5">
-                  <View className="flex-1 min-w-0 pr-1">
-                    {errorBannerExpanded ? (
-                      <ScrollView
-                        nestedScrollEnabled
-                        className="max-h-40"
-                        showsVerticalScrollIndicator
-                      >
-                        <Text className={`text-xs ${isTunnelError ? 'text-orange-700 dark:text-orange-300' : 'text-destructive'}`} selectable>
-                          {errorBannerText}
-                        </Text>
-                      </ScrollView>
-                    ) : (
-                      <Text
-                        className={`text-xs ${isTunnelError ? 'text-orange-700 dark:text-orange-300' : 'text-destructive'}`}
-                        numberOfLines={2}
-                        selectable
-                      >
-                        {errorBannerText}
-                      </Text>
-                    )}
-                    {errorBannerNeedsReadMore && (
-                      <Pressable
-                        onPress={() => setErrorBannerExpanded((e) => !e)}
-                        className="mt-1 self-start py-0.5"
-                        role="button"
-                        accessibilityLabel={
-                          errorBannerExpanded ? 'Show less error detail' : 'Read full error message'
-                        }
-                      >
-                        <Text className={`text-[11px] font-semibold ${isTunnelError ? 'text-orange-700 dark:text-orange-300' : 'text-destructive'}`}>
-                          {errorBannerExpanded ? 'Show less' : 'Read more'}
-                        </Text>
-                      </Pressable>
-                    )}
-                  </View>
-                  {tunnelReconnecting || streamAutoRecovering ? (
-                    <View className={`shrink-0 rounded-md border px-2 py-1 self-start ${isTunnelError ? 'border-orange-400/30' : 'border-destructive/30'}`}>
-                      <Text className={`text-xs font-medium ${isTunnelError ? 'text-orange-600 dark:text-orange-400' : 'text-destructive'}`}>Reconnecting…</Text>
-                    </View>
-                  ) : (
-                    <View className="shrink-0 flex-row items-center gap-1 self-start">
-                      {isTunnelError && (
-                        <Pressable
-                          onPress={() => {
-                            clearActiveInstance()
-                            // Defer so the context update flushes and localAgentUrl
-                            // becomes null before the retry fires — otherwise the
-                            // retry would still hit the (now-offline) tunnel URL.
-                            setTimeout(() => handleRetry(), 0)
-                          }}
-                          accessibilityRole="button"
-                          accessibilityLabel="Continue this conversation in the cloud sandbox"
-                          className="rounded-md border border-orange-400/30 px-2 py-1"
-                        >
-                          <Text className="text-xs font-medium text-orange-700 dark:text-orange-300">Continue in cloud</Text>
-                        </Pressable>
-                      )}
-                      <Pressable
-                        onPress={handleRetry}
-                        className={`rounded-md border px-2 py-1 ${
-                          isTunnelError
-                            ? 'border-orange-400/30'
-                            : 'border-destructive/30'
-                        }`}
-                      >
-                        <Text className={`text-xs font-medium ${
-                          isTunnelError ? 'text-orange-600 dark:text-orange-400' : 'text-destructive'
-                        }`}>{isTunnelError ? 'Reconnect' : 'Retry'}</Text>
-                      </Pressable>
-                      <Pressable
-                        onPress={() => {
-                          setEmptyResponseError(null)
-                          setErrorDismissed(true)
-                        }}
-                        accessibilityRole="button"
-                        accessibilityLabel="Dismiss error"
-                        hitSlop={8}
-                        className="rounded-md p-1"
-                      >
-                        <X size={14} className={isTunnelError ? 'text-orange-600 dark:text-orange-400' : 'text-destructive'} />
-                      </Pressable>
-                    </View>
-                  )}
-                </View>
-              </View>
-            </View>
-          ) : null}
-
-          {/* Permission Approval Dialog (Local Mode Security) */}
-          {pendingPermissionRequest && (
-            <PermissionApprovalDialog
-              request={pendingPermissionRequest}
-              onRespond={async (response) => {
-                setPendingPermissionRequest(null)
-                try {
-                  if (projectId) {
-                    const http = createHttpClient()
-                    await api.sendPermissionResponse(http, projectId, response)
-                  }
-                } catch (err) {
-                  console.error('[ChatPanel] Failed to send permission response:', err)
-                }
-              }}
-            />
-          )}
 
           {/* Input */}
           <View
-            className="bg-transparent max-w-3xl w-full self-center mt-1"
+            className="relative bg-transparent max-w-3xl w-full self-center mt-1"
             style={nativePhoneComposerWidth ? { width: nativePhoneComposerWidth } : undefined}
           >
-            <WorktreeBar
-              agentUrl={resolvedAgentUrl}
-              chatSessionId={currentSessionId}
-              isStreaming={isStreaming}
-              onSendMessage={(text) => handleInputSubmit(text)}
-            />
+            <ChatDock availableHeight={messagesAreaHeight} />
             <ExecutionBadge />
             <ChatInput
               onSubmit={handleInputSubmit}
@@ -5827,8 +5781,6 @@ export const ChatPanel = observer(function ChatPanel({
               onModelChange={handleModelChange}
               isPro={hasAdvancedModelAccess}
               onUpgradeClick={handleUpgradeClick}
-              pendingQuestion={pendingQuestion}
-              onSubmitQuestionResponse={handleSubmitQuestionResponse}
               queuedMessages={messageQueue}
               onRemoveQueuedMessage={handleRemoveQueuedMessage}
               onReorderQueuedMessage={handleReorderQueuedMessage}
@@ -5854,6 +5806,8 @@ export const ChatPanel = observer(function ChatPanel({
         </KeyboardAvoidingView>
       </View>
     </ChatContextProvider>
+    </ChatDockStoreContext.Provider>
+    </FileChangeStoreContext.Provider>
     </TodoStateStoreContext.Provider>
   )
 })

--- a/apps/mobile/components/chat/PlanCard.tsx
+++ b/apps/mobile/components/chat/PlanCard.tsx
@@ -3,7 +3,7 @@
 import { memo, useState } from "react"
 import { ActivityIndicator, View, Text, Pressable, ScrollView } from "react-native"
 import { cn } from "@shogo/shared-ui/primitives"
-import { CheckCircle2, Circle, Play, ClipboardList, ChevronDown, ChevronUp, ChevronRight, Languages } from "lucide-react-native"
+import { CheckCircle2, Circle, Play, ClipboardList, ChevronDown, ChevronUp, ChevronRight, Languages, PanelTop } from "lucide-react-native"
 import { MarkdownText } from "./MarkdownText"
 
 export type PlanSummaryStatus = "idle" | "pending" | "ready" | "error"
@@ -38,6 +38,11 @@ interface PlanCardProps {
   /** Triggers an on-demand summary generation for a plan that does not yet
    *  have one. Surfaced when summary is missing and idle. */
   onGenerateSummary?: () => void | Promise<void>
+  /** Set only on the in-stream render: expands the same plan's live
+   *  `PlanDockPanel` (via `ChatDockStore.openPanel`) so the user can keep
+   *  acting on it even after this message has scrolled away. Omitted on
+   *  the dock's own copy, which is already the thing being deep-linked to. */
+  onOpenInDock?: () => void
 }
 
 // `AssistantContent` rebuilds the `plan` object literal on every commit while
@@ -53,6 +58,7 @@ function planCardPropsEqual(prev: PlanCardProps, next: PlanCardProps) {
   if (prev.onOpenPlan !== next.onOpenPlan) return false
   if (prev.onViewFull !== next.onViewFull) return false
   if (prev.onGenerateSummary !== next.onGenerateSummary) return false
+  if (prev.onOpenInDock !== next.onOpenInDock) return false
   const a = prev.plan
   const b = next.plan
   if (a === b) return true
@@ -75,7 +81,7 @@ function planCardPropsEqual(prev: PlanCardProps, next: PlanCardProps) {
   return true
 }
 
-function PlanCardImpl({ plan, onBuild, onConfirm, onOpenPlan, onViewFull, isConfirmed, onGenerateSummary }: PlanCardProps) {
+function PlanCardImpl({ plan, onBuild, onConfirm, onOpenPlan, onViewFull, isConfirmed, onGenerateSummary, onOpenInDock }: PlanCardProps) {
   const [expanded, setExpanded] = useState(false)
   const [tasksExpanded, setTasksExpanded] = useState(false)
   const [activeTab, setActiveTab] = useState<PlanTab>("technical")
@@ -134,6 +140,18 @@ function PlanCardImpl({ plan, onBuild, onConfirm, onOpenPlan, onViewFull, isConf
             </Text>
           ) : null}
         </View>
+        {onOpenInDock && (
+          <Pressable
+            onPress={onOpenInDock}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel="Open plan in dock"
+            className="flex-row items-center gap-1 rounded-md border border-border/60 px-2 py-1 active:opacity-60"
+          >
+            <PanelTop className="h-3 w-3 text-muted-foreground" size={12} />
+            <Text className="text-[10px] text-muted-foreground">Dock</Text>
+          </Pressable>
+        )}
       </View>
 
       {/* Tab strip — only visible when a summary exists or is in flight */}

--- a/apps/mobile/components/chat/PlanCard.tsx
+++ b/apps/mobile/components/chat/PlanCard.tsx
@@ -3,7 +3,7 @@
 import { memo, useState } from "react"
 import { ActivityIndicator, View, Text, Pressable, ScrollView } from "react-native"
 import { cn } from "@shogo/shared-ui/primitives"
-import { CheckCircle2, Circle, Play, ClipboardList, ChevronDown, ChevronUp, ChevronRight, Languages, PanelTop } from "lucide-react-native"
+import { CheckCircle2, Circle, Play, ClipboardList, ChevronDown, ChevronUp, ChevronRight, Languages } from "lucide-react-native"
 import { MarkdownText } from "./MarkdownText"
 
 export type PlanSummaryStatus = "idle" | "pending" | "ready" | "error"
@@ -38,11 +38,10 @@ interface PlanCardProps {
   /** Triggers an on-demand summary generation for a plan that does not yet
    *  have one. Surfaced when summary is missing and idle. */
   onGenerateSummary?: () => void | Promise<void>
-  /** Set only on the in-stream render: expands the same plan's live
-   *  `PlanDockPanel` (via `ChatDockStore.openPanel`) so the user can keep
-   *  acting on it even after this message has scrolled away. Omitted on
-   *  the dock's own copy, which is already the thing being deep-linked to. */
-  onOpenInDock?: () => void
+  /** Set by `PlanDockPanel`: drops the outer rounded/border/bg card so this
+   *  doesn't nest a card inside `DockPanel`'s own zone-level card — see
+   *  `ChatDock`'s file header comment. Internal section dividers are kept. */
+  embedded?: boolean
 }
 
 // `AssistantContent` rebuilds the `plan` object literal on every commit while
@@ -58,7 +57,7 @@ function planCardPropsEqual(prev: PlanCardProps, next: PlanCardProps) {
   if (prev.onOpenPlan !== next.onOpenPlan) return false
   if (prev.onViewFull !== next.onViewFull) return false
   if (prev.onGenerateSummary !== next.onGenerateSummary) return false
-  if (prev.onOpenInDock !== next.onOpenInDock) return false
+  if (prev.embedded !== next.embedded) return false
   const a = prev.plan
   const b = next.plan
   if (a === b) return true
@@ -81,7 +80,7 @@ function planCardPropsEqual(prev: PlanCardProps, next: PlanCardProps) {
   return true
 }
 
-function PlanCardImpl({ plan, onBuild, onConfirm, onOpenPlan, onViewFull, isConfirmed, onGenerateSummary, onOpenInDock }: PlanCardProps) {
+function PlanCardImpl({ plan, onBuild, onConfirm, onOpenPlan, onViewFull, isConfirmed, onGenerateSummary, embedded = false }: PlanCardProps) {
   const [expanded, setExpanded] = useState(false)
   const [tasksExpanded, setTasksExpanded] = useState(false)
   const [activeTab, setActiveTab] = useState<PlanTab>("technical")
@@ -127,9 +126,9 @@ function PlanCardImpl({ plan, onBuild, onConfirm, onOpenPlan, onViewFull, isConf
   const viewFullExpands = handleViewFull !== undefined && !onViewFull && !canNavigateToPlan
 
   return (
-    <View className="mx-2 my-3 rounded-xl border border-border bg-card overflow-hidden">
+    <View className={cn(!embedded && "mx-2 my-3 rounded-xl border border-border bg-card overflow-hidden")}>
       {/* Header */}
-      <View className="flex-row items-center gap-2 px-4 py-3 border-b border-border bg-muted/30">
+      <View className={cn("flex-row items-center gap-2 px-4 py-3", !embedded && "border-b border-border bg-muted/30")}>
         <ClipboardList className="h-4 w-4 text-primary" size={16} />
         <View className="flex-1">
           <Text className="font-semibold text-sm text-foreground">{plan.name}</Text>
@@ -140,18 +139,6 @@ function PlanCardImpl({ plan, onBuild, onConfirm, onOpenPlan, onViewFull, isConf
             </Text>
           ) : null}
         </View>
-        {onOpenInDock && (
-          <Pressable
-            onPress={onOpenInDock}
-            hitSlop={8}
-            accessibilityRole="button"
-            accessibilityLabel="Open plan in dock"
-            className="flex-row items-center gap-1 rounded-md border border-border/60 px-2 py-1 active:opacity-60"
-          >
-            <PanelTop className="h-3 w-3 text-muted-foreground" size={12} />
-            <Text className="text-[10px] text-muted-foreground">Dock</Text>
-          </Pressable>
-        )}
       </View>
 
       {/* Tab strip — only visible when a summary exists or is in flight */}

--- a/apps/mobile/components/chat/WorktreeBar.tsx
+++ b/apps/mobile/components/chat/WorktreeBar.tsx
@@ -20,33 +20,40 @@ interface WorktreesResponse {
   worktrees?: WorktreeStatus[]
 }
 
-type MergeState = 'idle' | 'merging' | 'merged' | 'conflict'
+export type MergeState = 'idle' | 'merging' | 'merged' | 'conflict'
 
-export interface WorktreeBarProps {
-  /** Resolved agent runtime URL (localAgentUrl or the agent-proxy base). */
-  agentUrl: string | null
-  /** This chat's session id (used as the worktree key). */
-  chatSessionId: string | null
-  /** Whether a turn is currently streaming — used to refresh after turns. */
-  isStreaming: boolean
-  /** Send a chat message (used to ask the agent to resolve merge conflicts). */
-  onSendMessage: (text: string) => void
+export interface UseWorktreeStatusResult {
+  /** True once the running agent reports per-chat worktrees are turned on. */
+  enabled: boolean
+  /** This chat's own worktree row, or null if it doesn't have one (yet). */
+  status: WorktreeStatus | null
+  /** Other chats' worktrees in the same project. */
+  siblings: WorktreeStatus[]
+  mergeState: MergeState
+  error: string | null
+  /** True when the panel should be shown at all — mirrors the old
+   *  `WorktreeBar` early-return guard so callers can decide dock visibility. */
+  visible: boolean
+  handleMerge: () => Promise<void>
 }
 
 /**
- * BETA: per-chat git worktrees. Shows this chat's branch + status and a
- * "Mark done & merge" action above the composer. On a clean merge it confirms
- * inline; on conflicts it asks the agent to resolve them in its worktree (the
- * runtime auto-finishes the merge once conflicts are gone, falling back to
- * ask_user for genuinely ambiguous ones).
+ * BETA: per-chat git worktrees — polls this chat's worktree status and
+ * exposes the merge action, decoupled from any UI so a dock panel can decide
+ * whether to show itself without needing to mount the presentational view
+ * first (which would create a chicken-and-egg problem: the view is what used
+ * to decide "am I enabled?").
  */
-export function WorktreeBar({ agentUrl, chatSessionId, isStreaming, onSendMessage }: WorktreeBarProps) {
+export function useWorktreeStatus(
+  agentUrl: string | null,
+  chatSessionId: string | null,
+  isStreaming: boolean,
+  onSendMessage: (text: string) => void,
+): UseWorktreeStatusResult {
   const [status, setStatus] = useState<WorktreeStatus | null>(null)
   const [siblings, setSiblings] = useState<WorktreeStatus[]>([])
   const [enabled, setEnabled] = useState(false)
   const [mergeState, setMergeState] = useState<MergeState>('idle')
-  const [confirming, setConfirming] = useState(false)
-  const [expanded, setExpanded] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const prevStreaming = useRef(isStreaming)
 
@@ -73,7 +80,6 @@ export function WorktreeBar({ agentUrl, chatSessionId, isStreaming, onSendMessag
   // Initial load + reload whenever the chat changes.
   useEffect(() => {
     setMergeState('idle')
-    setConfirming(false)
     setError(null)
     void refresh()
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -90,7 +96,6 @@ export function WorktreeBar({ agentUrl, chatSessionId, isStreaming, onSendMessag
 
   const handleMerge = useCallback(async () => {
     if (!agentUrl || !chatSessionId) return
-    setConfirming(false)
     setError(null)
     setMergeState('merging')
     try {
@@ -130,15 +135,32 @@ export function WorktreeBar({ agentUrl, chatSessionId, isStreaming, onSendMessag
     }
   }, [agentUrl, chatSessionId, onSendMessage, refresh])
 
-  // Nothing to show until this chat has an isolated worktree.
-  if (!enabled || (!status && mergeState === 'idle')) return null
+  return {
+    enabled,
+    status,
+    siblings,
+    mergeState,
+    error,
+    visible: enabled || mergeState !== 'idle',
+    handleMerge,
+  }
+}
+
+export interface WorktreeBarViewProps extends UseWorktreeStatusResult {
+  isStreaming: boolean
+}
+
+/** Pure presentational body — no data fetching of its own. */
+export function WorktreeBarView({ status, siblings, mergeState, error, isStreaming, handleMerge }: WorktreeBarViewProps) {
+  const [confirming, setConfirming] = useState(false)
+  const [expanded, setExpanded] = useState(false)
 
   const branchShort = status?.branch?.replace(/^shogo\/chat\//, '') ?? ''
   const ahead = status?.ahead ?? 0
   const changed = status ? status.changedFiles.length + status.dirtyFiles : 0
 
   return (
-    <View className="mb-1.5 rounded-lg border border-border bg-muted/40 px-2.5 py-1.5">
+    <View>
       <View className="flex-row items-center gap-2">
         <Pressable
           onPress={() => siblings.length > 0 && setExpanded(e => !e)}
@@ -187,7 +209,10 @@ export function WorktreeBar({ agentUrl, chatSessionId, isStreaming, onSendMessag
         ) : confirming ? (
           <View className="flex-row items-center gap-1.5">
             <Pressable
-              onPress={handleMerge}
+              onPress={() => {
+                setConfirming(false)
+                void handleMerge()
+              }}
               className="px-2 py-1 rounded-md bg-primary active:bg-primary/80"
             >
               <Text className="text-[10px] font-semibold text-primary-foreground">Merge</Text>

--- a/apps/mobile/components/chat/dock/ChatDock.tsx
+++ b/apps/mobile/components/chat/dock/ChatDock.tsx
@@ -18,6 +18,17 @@
  * `ChatPanel` reads `store.getHeight()` (reported here via `onLayout`) to
  * pad the message list so the dock never permanently hides the newest
  * message.
+ *
+ * Horizontal padding matches `ChatInput`'s own outer padding (`px-3` web /
+ * `px-2` native) so the dock's edges line up with the composer's visible
+ * bordered box below it, rather than the wider positioning wrapper both
+ * sit in.
+ *
+ * Each zone (status, blocking) renders as exactly ONE rounded card —
+ * `rounded-xl` on all four corners, always, regardless of how many panels
+ * are stacked inside or whether the status zone is mid-scroll — with
+ * individual panels separated by hairline dividers (`DockPanel`'s
+ * `isFirst`) rather than each being its own nested card.
  */
 
 import { useCallback, useSyncExternalStore } from "react"
@@ -37,6 +48,13 @@ const styles = StyleSheet.create({
   topFade: { position: "absolute", top: 0, left: 0, right: 0, height: FADE_HEIGHT, pointerEvents: "none" },
   scrollContent: { paddingTop: 2, paddingBottom: 2 },
 })
+
+// Matches ChatInput's own outer horizontal padding (`px-3` web / `px-2`
+// native) — see the file header comment.
+const HORIZONTAL_PADDING_CLASS = Platform.OS !== "web" ? "px-2" : "px-3"
+// `rounded-xl` matches ChatInput's own bordered box directly below, so the
+// dock reads as the same card language stacked on top of the composer.
+const ZONE_CARD_CLASS = "overflow-hidden rounded-xl border border-border/60 bg-popover/95 shadow-md"
 
 export interface ChatDockProps {
   /** Available height above the composer, used to cap the status zone at ~45%. */
@@ -77,39 +95,38 @@ export function ChatDock({ availableHeight, className }: ChatDockProps) {
   return (
     <View
       style={styles.container}
-      className={cn("mb-1.5 w-full max-w-3xl self-center gap-1.5", className)}
+      className={cn("mb-1.5 w-full max-w-3xl self-center gap-1.5", HORIZONTAL_PADDING_CLASS, className)}
       pointerEvents="box-none"
       onLayout={handleLayout}
     >
       {statusPanels.length > 0 && (
-        <View style={styles.relative}>
+        <View style={styles.relative} className={ZONE_CARD_CLASS}>
           <ScrollView
             style={{ maxHeight: maxStatusHeight }}
             contentContainerStyle={styles.scrollContent}
             nestedScrollEnabled
             showsVerticalScrollIndicator={false}
           >
-            <View className="gap-1.5">
-              {statusPanels.map((panel) => {
-                const expanded = store.isExpanded(panel.id)
-                return (
-                  <DockPanel
-                    key={panel.id}
-                    title={panel.title}
-                    icon={panel.icon}
-                    summary={panel.summary}
-                    accent={panel.accent}
-                    headerActions={panel.headerActions}
-                    onDismiss={panel.onDismiss}
-                    expanded={expanded}
-                    collapsible
-                    onToggle={() => store.toggle(panel.id)}
-                  >
-                    {panel.render({ expanded })}
-                  </DockPanel>
-                )
-              })}
-            </View>
+            {statusPanels.map((panel, index) => {
+              const expanded = store.isExpanded(panel.id)
+              return (
+                <DockPanel
+                  key={panel.id}
+                  title={panel.title}
+                  icon={panel.icon}
+                  summary={panel.summary}
+                  accent={panel.accent}
+                  headerActions={panel.headerActions}
+                  onDismiss={panel.onDismiss}
+                  expanded={expanded}
+                  collapsible
+                  onToggle={() => store.toggle(panel.id)}
+                  isFirst={index === 0}
+                >
+                  {panel.render({ expanded })}
+                </DockPanel>
+              )
+            })}
           </ScrollView>
           {Platform.OS !== "web" && statusPanels.length > 1 && (
             <LinearGradient colors={[fadeColor, fadeColorTransparent]} style={styles.topFade} />
@@ -118,8 +135,8 @@ export function ChatDock({ availableHeight, className }: ChatDockProps) {
       )}
 
       {blockingPanels.length > 0 && (
-        <View className="gap-1.5">
-          {blockingPanels.map((panel) => (
+        <View className={ZONE_CARD_CLASS}>
+          {blockingPanels.map((panel, index) => (
             <DockPanel
               key={panel.id}
               title={panel.title}
@@ -130,6 +147,7 @@ export function ChatDock({ availableHeight, className }: ChatDockProps) {
               expanded
               collapsible={false}
               onToggle={() => {}}
+              isFirst={index === 0}
             >
               {panel.render({ expanded: true })}
             </DockPanel>

--- a/apps/mobile/components/chat/dock/ChatDock.tsx
+++ b/apps/mobile/components/chat/dock/ChatDock.tsx
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Floating container above the chat composer. Reads the panel registry
+ * from `ChatDockStore` and renders two zones:
+ *
+ *  - a scrollable, height-capped "status" zone for collapsible panels
+ *    (plan, changed files, checklist, browser, running, queue, context
+ *    usage);
+ *  - a pinned "blocking" zone directly above the composer for prompts
+ *    that park the agent turn (permission approval, pending question,
+ *    an active connectivity wait) — these never collapse.
+ *
+ * Positioned `absolute bottom-full` so it floats over the message list
+ * without pushing layout; `pointerEvents="box-none"` lets taps land on the
+ * scroll view underneath everywhere the dock itself has no content.
+ * `ChatPanel` reads `store.getHeight()` (reported here via `onLayout`) to
+ * pad the message list so the dock never permanently hides the newest
+ * message.
+ */
+
+import { useCallback, useSyncExternalStore } from "react"
+import { View, StyleSheet, ScrollView, Platform, useColorScheme, type LayoutChangeEvent } from "react-native"
+import { LinearGradient } from "expo-linear-gradient"
+import { cn } from "@shogo/shared-ui/primitives"
+import { useChatDockStore } from "../../../lib/chat-dock-store"
+import { DockPanel } from "./DockPanel"
+
+const MAX_STATUS_HEIGHT = 420
+const MAX_STATUS_HEIGHT_RATIO = 0.45
+const FADE_HEIGHT = 16
+
+const styles = StyleSheet.create({
+  container: { position: "absolute", bottom: "100%", left: 0, right: 0 },
+  relative: { position: "relative" },
+  topFade: { position: "absolute", top: 0, left: 0, right: 0, height: FADE_HEIGHT, pointerEvents: "none" },
+  scrollContent: { paddingTop: 2, paddingBottom: 2 },
+})
+
+export interface ChatDockProps {
+  /** Available height above the composer, used to cap the status zone at ~45%. */
+  availableHeight?: number
+  className?: string
+}
+
+export function ChatDock({ availableHeight, className }: ChatDockProps) {
+  const store = useChatDockStore()
+  useSyncExternalStore(store.subscribe, store.getVersion, store.getVersion)
+  const colorScheme = useColorScheme()
+
+  const statusPanels = store.getPanels("status")
+  const blockingPanels = store.getPanels("blocking")
+  const hasContent = statusPanels.length > 0 || blockingPanels.length > 0
+
+  const handleLayout = useCallback(
+    (e: LayoutChangeEvent) => {
+      store.setHeight(e.nativeEvent.layout.height)
+    },
+    [store],
+  )
+
+  if (!hasContent) {
+    // Nothing to show — relax the message list's reserved padding back to zero.
+    if (store.getHeight() !== 0) store.setHeight(0)
+    return null
+  }
+
+  const maxStatusHeight = Math.min(
+    MAX_STATUS_HEIGHT,
+    availableHeight ? Math.round(availableHeight * MAX_STATUS_HEIGHT_RATIO) : MAX_STATUS_HEIGHT,
+  )
+
+  const fadeColor = colorScheme === "dark" ? "rgba(9,9,11,1)" : "rgba(255,255,255,1)"
+  const fadeColorTransparent = colorScheme === "dark" ? "rgba(9,9,11,0)" : "rgba(255,255,255,0)"
+
+  return (
+    <View
+      style={styles.container}
+      className={cn("mb-1.5 w-full max-w-3xl self-center gap-1.5", className)}
+      pointerEvents="box-none"
+      onLayout={handleLayout}
+    >
+      {statusPanels.length > 0 && (
+        <View style={styles.relative}>
+          <ScrollView
+            style={{ maxHeight: maxStatusHeight }}
+            contentContainerStyle={styles.scrollContent}
+            nestedScrollEnabled
+            showsVerticalScrollIndicator={false}
+          >
+            <View className="gap-1.5">
+              {statusPanels.map((panel) => {
+                const expanded = store.isExpanded(panel.id)
+                return (
+                  <DockPanel
+                    key={panel.id}
+                    title={panel.title}
+                    icon={panel.icon}
+                    summary={panel.summary}
+                    accent={panel.accent}
+                    headerActions={panel.headerActions}
+                    onDismiss={panel.onDismiss}
+                    expanded={expanded}
+                    collapsible
+                    onToggle={() => store.toggle(panel.id)}
+                  >
+                    {panel.render({ expanded })}
+                  </DockPanel>
+                )
+              })}
+            </View>
+          </ScrollView>
+          {Platform.OS !== "web" && statusPanels.length > 1 && (
+            <LinearGradient colors={[fadeColor, fadeColorTransparent]} style={styles.topFade} />
+          )}
+        </View>
+      )}
+
+      {blockingPanels.length > 0 && (
+        <View className="gap-1.5">
+          {blockingPanels.map((panel) => (
+            <DockPanel
+              key={panel.id}
+              title={panel.title}
+              icon={panel.icon}
+              summary={panel.summary}
+              accent={panel.accent}
+              headerActions={panel.headerActions}
+              expanded
+              collapsible={false}
+              onToggle={() => {}}
+            >
+              {panel.render({ expanded: true })}
+            </DockPanel>
+          ))}
+        </View>
+      )}
+    </View>
+  )
+}

--- a/apps/mobile/components/chat/dock/DockChip.tsx
+++ b/apps/mobile/components/chat/dock/DockChip.tsx
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Composer-toolbar pill for a status dock panel. Tapping toggles the
+ * panel's expansion, revealing it first if it was hidden (e.g. the
+ * `autoShow: false` context-usage panel). Accepts custom `children` so an
+ * existing widget — the `ContextTracker` ring — can be the chip body
+ * instead of the default icon/count/dot layout.
+ */
+
+import { Pressable, View, Text } from "react-native"
+import { useChatDockStore, type DockIconComponent } from "../../../lib/chat-dock-store"
+
+export interface DockChipProps {
+  panelId: string
+  icon?: DockIconComponent
+  count?: number
+  dot?: boolean
+  isNative?: boolean
+  accessibilityLabel: string
+  children?: React.ReactNode
+}
+
+export function DockChip({ panelId, icon: Icon, count, dot, isNative, accessibilityLabel, children }: DockChipProps) {
+  const store = useChatDockStore()
+
+  return (
+    <Pressable
+      onPress={() => store.toggle(panelId)}
+      hitSlop={isNative ? 6 : 4}
+      role="button"
+      accessibilityLabel={accessibilityLabel}
+      className="flex-row items-center justify-center"
+    >
+      {children ?? (
+        <View className="flex-row items-center gap-0.5">
+          {Icon && <Icon size={14} className="text-muted-foreground" />}
+          {dot && <View className="h-1.5 w-1.5 rounded-full bg-emerald-400" />}
+          {typeof count === "number" && count > 0 && (
+            <Text className="text-[10px] text-muted-foreground">{count}</Text>
+          )}
+        </View>
+      )}
+    </Pressable>
+  )
+}

--- a/apps/mobile/components/chat/dock/DockChipRail.tsx
+++ b/apps/mobile/components/chat/dock/DockChipRail.tsx
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Composer-toolbar chip rail — renders a `DockChip` for every registered
+ * panel that declared a `chip` descriptor, so panels announce their own
+ * toolbar pill instead of `ChatInput` hardcoding one per feature. Reacts to
+ * the store so chips appear/disappear as panels register (queue empties,
+ * a subagent finishes, etc.).
+ *
+ * The context-usage ring is a special case handled separately by
+ * `ChatInput` — it always has data and renders the actual `ContextTracker`
+ * ring as its chip body, rather than the default icon/count layout this
+ * rail produces.
+ */
+
+import { useSyncExternalStore } from "react"
+import { useChatDockStore } from "../../../lib/chat-dock-store"
+import { DockChip } from "./DockChip"
+
+export interface DockChipRailProps {
+  isNative?: boolean
+}
+
+export function DockChipRail({ isNative }: DockChipRailProps) {
+  const store = useChatDockStore()
+  useSyncExternalStore(store.subscribe, store.getVersion, store.getVersion)
+
+  const chipped = store.getPanels("status").filter((p) => p.chip)
+
+  return (
+    <>
+      {chipped.map((panel) => (
+        <DockChip
+          key={panel.id}
+          panelId={panel.id}
+          icon={panel.chip!.icon}
+          count={panel.chip!.count}
+          dot={panel.chip!.dot}
+          isNative={isNative}
+          accessibilityLabel={panel.title}
+        />
+      ))}
+    </>
+  )
+}

--- a/apps/mobile/components/chat/dock/DockPanel.tsx
+++ b/apps/mobile/components/chat/dock/DockPanel.tsx
@@ -16,6 +16,13 @@
  * store already reports them as always-expanded and refuses to toggle
  * them, but `collapsible={false}` here is a second line of defense against
  * a stray tap collapsing something the agent turn is blocked on.
+ *
+ * Deliberately chromeless at the panel level (no rounded/border/bg/shadow
+ * of its own) — `ChatDock` wraps each zone's stack of panels in ONE
+ * rounded card, so nesting a second card here would read as "a card
+ * within a card". `isFirst` suppresses the inter-panel divider for the
+ * top panel in a zone, since the zone card's own border already closes
+ * that edge.
  */
 
 import { useMemo, type ReactNode } from "react"
@@ -51,6 +58,9 @@ export interface DockPanelProps {
   collapsible: boolean
   onToggle: () => void
   children: ReactNode
+  /** Suppresses the top divider — set on the first panel stacked inside a
+   *  zone card so it doesn't double up with the card's own top edge. */
+  isFirst?: boolean
 }
 
 export function DockPanel({
@@ -64,11 +74,12 @@ export function DockPanel({
   collapsible,
   onToggle,
   children,
+  isFirst = false,
 }: DockPanelProps) {
   const rotateAnimate = useMemo(() => (expanded ? ROTATE_OPEN : ROTATE_CLOSED), [expanded])
 
   return (
-    <View className="w-full overflow-hidden rounded-lg border border-border/60 bg-popover/95 shadow-md">
+    <View className={cn("w-full overflow-hidden", !isFirst && "border-t border-border/50")}>
       <Pressable
         onPress={collapsible ? onToggle : undefined}
         disabled={!collapsible}

--- a/apps/mobile/components/chat/dock/DockPanel.tsx
+++ b/apps/mobile/components/chat/dock/DockPanel.tsx
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Shared chrome for every chat dock panel: header row (accent dot, icon,
+ * title, summary, header actions, dismiss, chevron) plus a fade-in body.
+ *
+ * Body content mounts/unmounts with `expanded` rather than animating a
+ * measured height — matching the majority of the codebase's existing
+ * collapsible cards (`ProcessPanel`, `SubagentPanel`, `PlanCard`,
+ * `TodoWidget`), and critically, this is what lets a panel like the live
+ * browser viewport actually suspend its subscription while collapsed:
+ * unmounting is the suspend.
+ *
+ * Blocking panels render without a chevron and are not collapsible — the
+ * store already reports them as always-expanded and refuses to toggle
+ * them, but `collapsible={false}` here is a second line of defense against
+ * a stray tap collapsing something the agent turn is blocked on.
+ */
+
+import { useMemo, type ReactNode } from "react"
+import { View, Text, Pressable } from "react-native"
+import { Motion, AnimatePresence } from "@legendapp/motion"
+import { ChevronDown, X } from "lucide-react-native"
+import { cn } from "@shogo/shared-ui/primitives"
+import type { DockPanelAccent, DockIconComponent } from "../../../lib/chat-dock-store"
+
+const ANIM_DURATION = 220
+const ROTATE_TRANSITION = { type: "timing", duration: ANIM_DURATION, easing: "easeInOut" } as const
+const ROTATE_OPEN = { rotateZ: "180deg" }
+const ROTATE_CLOSED = { rotateZ: "0deg" }
+const FADE_TRANSITION = { type: "timing", duration: ANIM_DURATION, easing: "easeInOut" } as const
+const FADE_INITIAL = { opacity: 0 }
+const FADE_ANIMATE = { opacity: 1 }
+const FADE_EXIT = { opacity: 0 }
+
+const ACCENT_DOT_CLASS: Record<DockPanelAccent, string> = {
+  default: "bg-muted-foreground/40",
+  running: "bg-emerald-400",
+  warning: "bg-amber-400",
+}
+
+export interface DockPanelProps {
+  title: string
+  icon: DockIconComponent
+  summary?: string
+  accent?: DockPanelAccent
+  headerActions?: ReactNode
+  onDismiss?: () => void
+  expanded: boolean
+  collapsible: boolean
+  onToggle: () => void
+  children: ReactNode
+}
+
+export function DockPanel({
+  title,
+  icon: Icon,
+  summary,
+  accent = "default",
+  headerActions,
+  onDismiss,
+  expanded,
+  collapsible,
+  onToggle,
+  children,
+}: DockPanelProps) {
+  const rotateAnimate = useMemo(() => (expanded ? ROTATE_OPEN : ROTATE_CLOSED), [expanded])
+
+  return (
+    <View className="w-full overflow-hidden rounded-lg border border-border/60 bg-popover/95 shadow-md">
+      <Pressable
+        onPress={collapsible ? onToggle : undefined}
+        disabled={!collapsible}
+        className="flex-row items-center gap-2 px-3 py-2"
+        role={collapsible ? "button" : undefined}
+        accessibilityLabel={title}
+      >
+        <View className={cn("h-1.5 w-1.5 rounded-full", ACCENT_DOT_CLASS[accent])} />
+        <Icon size={13} className="text-muted-foreground" />
+        <Text className="flex-1 text-xs font-medium text-foreground" numberOfLines={1}>
+          {title}
+        </Text>
+        {summary ? (
+          <Text className="text-[11px] text-muted-foreground" numberOfLines={1}>
+            {summary}
+          </Text>
+        ) : null}
+        {headerActions}
+        {onDismiss && (
+          <Pressable onPress={onDismiss} hitSlop={6} accessibilityLabel={`Dismiss ${title}`}>
+            <X size={12} className="text-muted-foreground/70" />
+          </Pressable>
+        )}
+        {collapsible && (
+          <Motion.View animate={rotateAnimate} transition={ROTATE_TRANSITION}>
+            <ChevronDown size={12} className="text-muted-foreground/70" />
+          </Motion.View>
+        )}
+      </Pressable>
+
+      <AnimatePresence>
+        {expanded && (
+          <Motion.View
+            initial={FADE_INITIAL}
+            animate={FADE_ANIMATE}
+            exit={FADE_EXIT}
+            transition={FADE_TRANSITION}
+            className="border-t border-border/50 px-3 py-2"
+          >
+            {children}
+          </Motion.View>
+        )}
+      </AnimatePresence>
+    </View>
+  )
+}

--- a/apps/mobile/components/chat/dock/panels/BrowserDockPanel.tsx
+++ b/apps/mobile/components/chat/dock/panels/BrowserDockPanel.tsx
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Live browser viewport for the currently-running subagent, driven by
+ * `subagent-stream-store`'s running `instanceId`. `SubagentCard` no longer
+ * mounts its own inline `LiveBrowserView`, so this is the only place that
+ * opens the screencast SSE subscription. `active={expanded}` tears the
+ * subscription down while the panel is collapsed — belt-and-suspenders on
+ * top of `DockPanel` already unmounting collapsed bodies.
+ */
+
+import { useSyncExternalStore } from "react"
+import { Eye } from "lucide-react-native"
+import { LiveBrowserView } from "../../LiveBrowserView"
+import { subagentStreamStore } from "../../../../lib/subagent-stream-store"
+import { useDockPanel } from "../useDockPanel"
+import type { DockPanelDescriptor } from "../../../../lib/chat-dock-store"
+
+export function BrowserDockPanel() {
+  useSyncExternalStore(
+    subagentStreamStore.subscribe,
+    () => subagentStreamStore.getVersion(),
+    () => subagentStreamStore.getVersion(),
+  )
+
+  let runningInstanceId: string | null = null
+  let runningAgentType: string | undefined
+  for (const data of subagentStreamStore.getAll().values()) {
+    if (data.status === "running" && data.instanceId) {
+      runningInstanceId = data.instanceId
+      runningAgentType = data.agentType
+      break
+    }
+  }
+
+  const descriptor: DockPanelDescriptor | null = runningInstanceId
+    ? {
+        id: "browser",
+        kind: "status",
+        order: 50,
+        title: "Live browser",
+        icon: Eye,
+        summary: runningAgentType,
+        chip: { icon: Eye, dot: true },
+        render: ({ expanded }) => <LiveBrowserView instanceId={runningInstanceId!} active={expanded} />,
+      }
+    : null
+
+  useDockPanel(descriptor)
+  return null
+}

--- a/apps/mobile/components/chat/dock/panels/ChangesDockPanel.tsx
+++ b/apps/mobile/components/chat/dock/panels/ChangesDockPanel.tsx
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Files touched this session, from the per-chat `file-change-store`.
+ */
+
+import { useMemo, useSyncExternalStore } from "react"
+import { View, Text } from "react-native"
+import { cn } from "@shogo/shared-ui/primitives"
+import { FileEdit, FilePlus, FileX, Files } from "lucide-react-native"
+import { useFileChangeStore, type FileChangeKind } from "../../../../lib/file-change-store"
+import { useDockPanel } from "../useDockPanel"
+import type { DockPanelDescriptor } from "../../../../lib/chat-dock-store"
+
+const KIND_ICON: Record<FileChangeKind, typeof FileEdit> = {
+  write: FilePlus,
+  edit: FileEdit,
+  delete: FileX,
+}
+
+const KIND_COLOR: Record<FileChangeKind, string> = {
+  write: "text-emerald-500",
+  edit: "text-sky-500",
+  delete: "text-red-500",
+}
+
+function ChangesBody({ files }: { files: { path: string; kind: FileChangeKind }[] }) {
+  return (
+    <View className="gap-1">
+      {files.map(({ path, kind }) => {
+        const Icon = KIND_ICON[kind]
+        const fileName = path.split("/").pop() || path
+        return (
+          <View key={path} className="flex-row items-center gap-1.5">
+            <Icon size={12} className={cn("shrink-0", KIND_COLOR[kind])} />
+            <Text className="flex-1 text-[11px] text-foreground" numberOfLines={1}>
+              {fileName}
+            </Text>
+            <Text className="text-[9px] text-muted-foreground" numberOfLines={1}>
+              {path}
+            </Text>
+          </View>
+        )
+      })}
+    </View>
+  )
+}
+
+export function ChangesDockPanel() {
+  const store = useFileChangeStore()
+  useSyncExternalStore(store.subscribe, store.getVersion, store.getVersion)
+  const files = store.getAll()
+
+  const descriptor = useMemo<DockPanelDescriptor | null>(() => {
+    if (files.length === 0) return null
+    return {
+      id: "changes",
+      kind: "status",
+      order: 30,
+      title: "Changed files",
+      icon: Files,
+      summary: `${files.length} file${files.length === 1 ? "" : "s"} changed`,
+      render: () => <ChangesBody files={files} />,
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [files])
+
+  useDockPanel(descriptor)
+  return null
+}

--- a/apps/mobile/components/chat/dock/panels/ChecklistDockPanel.tsx
+++ b/apps/mobile/components/chat/dock/panels/ChecklistDockPanel.tsx
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Live todo checklist — reads straight from the per-chat `todoStateStore`,
+ * the same source `TodoWidget` subscribes to, so the dock always shows the
+ * latest snapshot regardless of which in-stream `TodoWrite` card wrote it
+ * last. In-stream `TodoWidget`s stay put as milestone markers ("you were at
+ * 4/10 here").
+ */
+
+import { useMemo, useSyncExternalStore } from "react"
+import { View, Text } from "react-native"
+import { cn } from "@shogo/shared-ui/primitives"
+import { CheckCircle2, Circle, Loader2, XCircle, ListTodo } from "lucide-react-native"
+import { useTodoStateStore, type TodoItem, type TodoStatus } from "../../../../lib/todo-state-store"
+import { useDockPanel } from "../useDockPanel"
+import type { DockPanelDescriptor } from "../../../../lib/chat-dock-store"
+
+function getStatusIcon(status: TodoStatus) {
+  switch (status) {
+    case "completed":
+      return CheckCircle2
+    case "in_progress":
+      return Loader2
+    case "cancelled":
+      return XCircle
+    case "pending":
+    default:
+      return Circle
+  }
+}
+
+function getStatusColorClass(status: TodoStatus) {
+  switch (status) {
+    case "completed":
+      return "text-green-500"
+    case "in_progress":
+      return "text-primary"
+    default:
+      return "text-muted-foreground"
+  }
+}
+
+function ChecklistBody({ todos }: { todos: TodoItem[] }) {
+  const total = todos.length
+  const completed = todos.filter((t) => t.status === "completed").length
+
+  return (
+    <View className="gap-1">
+      <View className="h-1 rounded-full bg-muted overflow-hidden">
+        <View
+          className="h-full bg-green-500"
+          style={{ width: total > 0 ? `${(completed / total) * 100}%` : "0%" }}
+        />
+      </View>
+      <View className="gap-0.5 pt-1">
+        {todos.map((todo) => {
+          const StatusIcon = getStatusIcon(todo.status)
+          return (
+            <View key={todo.id} className={cn("flex-row items-start gap-1.5 py-0.5", todo.status === "cancelled" && "opacity-50")}>
+              <StatusIcon size={12} className={cn("mt-0.5", getStatusColorClass(todo.status))} />
+              <Text
+                className={cn(
+                  "flex-1 text-[11px] text-foreground",
+                  todo.status === "completed" && "text-muted-foreground",
+                  todo.status === "cancelled" && "line-through text-muted-foreground",
+                )}
+              >
+                {todo.content}
+              </Text>
+            </View>
+          )
+        })}
+      </View>
+    </View>
+  )
+}
+
+export function ChecklistDockPanel() {
+  const todoStateStore = useTodoStateStore()
+  useSyncExternalStore(todoStateStore.subscribe, todoStateStore.getVersion, todoStateStore.getVersion)
+  const todos = todoStateStore.getLatest()
+
+  const completed = todos.filter((t) => t.status === "completed").length
+  const inProgress = todos.filter((t) => t.status === "in_progress").length
+
+  const descriptor = useMemo<DockPanelDescriptor | null>(() => {
+    if (todos.length === 0) return null
+    return {
+      id: "checklist",
+      kind: "status",
+      order: 40,
+      title: "Tasks",
+      icon: ListTodo,
+      summary: `${completed}/${todos.length} complete`,
+      accent: inProgress > 0 ? "running" : "default",
+      chip: { icon: ListTodo, dot: inProgress > 0 },
+      render: () => <ChecklistBody todos={todos} />,
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [todos, completed, inProgress])
+
+  useDockPanel(descriptor)
+  return null
+}

--- a/apps/mobile/components/chat/dock/panels/ContextUsageDockPanel.tsx
+++ b/apps/mobile/components/chat/dock/panels/ContextUsageDockPanel.tsx
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Wraps the existing `ContextBreakdownPanel` unchanged as an on-demand dock
+ * panel (`autoShow: false`) — the context ring in the composer toolbar is
+ * its `DockChip`, since it always has data and doesn't need to auto-show.
+ */
+
+import { useMemo } from "react"
+import { Gauge } from "lucide-react-native"
+import { ContextBreakdownPanel, type ContextBreakdownData } from "../../ContextBreakdownPanel"
+import { useDockPanel } from "../useDockPanel"
+import type { DockPanelDescriptor } from "../../../../lib/chat-dock-store"
+
+export interface ContextUsageDockPanelProps {
+  contextUsage: { inputTokens: number; contextWindowTokens: number } | null | undefined
+  contextBreakdown: ContextBreakdownData | null | undefined
+}
+
+export function ContextUsageDockPanel({ contextUsage, contextBreakdown }: ContextUsageDockPanelProps) {
+  const descriptor = useMemo<DockPanelDescriptor | null>(() => {
+    if (!contextUsage) return null
+    return {
+      id: "context-usage",
+      kind: "status",
+      order: 80,
+      title: "Context usage",
+      icon: Gauge,
+      autoShow: false,
+      render: () => (
+        <ContextBreakdownPanel
+          breakdown={contextBreakdown ?? null}
+          inputTokens={contextUsage.inputTokens}
+          contextWindowTokens={contextUsage.contextWindowTokens}
+        />
+      ),
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [contextUsage, contextBreakdown])
+
+  useDockPanel(descriptor)
+  return null
+}

--- a/apps/mobile/components/chat/dock/panels/PlanDockPanel.tsx
+++ b/apps/mobile/components/chat/dock/panels/PlanDockPanel.tsx
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Dock panel for the session's latest plan — reuses the existing `PlanCard`
+ * unchanged, fed by the same `pendingPlan` / `confirmedPlan` state `ChatPanel`
+ * already tracks. No new runtime plumbing.
+ */
+
+import { useMemo } from "react"
+import { ClipboardList } from "lucide-react-native"
+import { PlanCard, type PlanData } from "../../PlanCard"
+import { useDockPanel } from "../useDockPanel"
+import type { DockPanelDescriptor } from "../../../../lib/chat-dock-store"
+
+export interface PlanDockPanelProps {
+  pendingPlan: PlanData | null
+  confirmedPlan: PlanData | null
+  onBuild: ((plan: PlanData) => void) | null
+  onOpenPlan?: (filepath: string) => void
+  /** Resolved value is intentionally untyped: `ChatPanel`'s generator
+   *  resolves with the generated text, but `PlanCard` only awaits
+   *  completion to know when to clear its loading state. */
+  onGenerateSummary?: (filepath: string) => Promise<unknown> | void
+}
+
+export function PlanDockPanel({ pendingPlan, confirmedPlan, onBuild, onOpenPlan, onGenerateSummary }: PlanDockPanelProps) {
+  const plan = pendingPlan ?? confirmedPlan
+  const isConfirmed = !!confirmedPlan && !pendingPlan
+
+  const descriptor = useMemo<DockPanelDescriptor | null>(() => {
+    if (!plan) return null
+    return {
+      id: "plan",
+      kind: "status",
+      order: 20,
+      title: "Plan",
+      icon: ClipboardList,
+      summary: plan.name,
+      defaultExpanded: !isConfirmed,
+      render: () => (
+        <PlanCard
+          plan={plan}
+          onBuild={!isConfirmed && onBuild ? () => onBuild(plan) : undefined}
+          onOpenPlan={onOpenPlan && plan.filepath ? () => onOpenPlan(plan.filepath!) : undefined}
+          onGenerateSummary={
+            onGenerateSummary && plan.filepath
+              ? async () => {
+                  await onGenerateSummary(plan.filepath!)
+                }
+              : undefined
+          }
+          isConfirmed={isConfirmed}
+        />
+      ),
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [plan, isConfirmed, onBuild, onOpenPlan, onGenerateSummary])
+
+  useDockPanel(descriptor)
+  return null
+}

--- a/apps/mobile/components/chat/dock/panels/PlanDockPanel.tsx
+++ b/apps/mobile/components/chat/dock/panels/PlanDockPanel.tsx
@@ -3,8 +3,9 @@
 
 /**
  * Dock panel for the session's latest plan — reuses the existing `PlanCard`
- * unchanged, fed by the same `pendingPlan` / `confirmedPlan` state `ChatPanel`
- * already tracks. No new runtime plumbing.
+ * in `embedded` mode (no outer rounded/border/bg card of its own, since
+ * `DockPanel` already provides one), fed by the same `pendingPlan` /
+ * `confirmedPlan` state `ChatPanel` already tracks. No new runtime plumbing.
  */
 
 import { useMemo } from "react"
@@ -41,6 +42,7 @@ export function PlanDockPanel({ pendingPlan, confirmedPlan, onBuild, onOpenPlan,
       render: () => (
         <PlanCard
           plan={plan}
+          embedded
           onBuild={!isConfirmed && onBuild ? () => onBuild(plan) : undefined}
           onOpenPlan={onOpenPlan && plan.filepath ? () => onOpenPlan(plan.filepath!) : undefined}
           onGenerateSummary={

--- a/apps/mobile/components/chat/dock/panels/QueueDockPanel.tsx
+++ b/apps/mobile/components/chat/dock/panels/QueueDockPanel.tsx
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Queued messages — rows moved verbatim out of `ChatInput.tsx`'s old
+ * `rounded-t-lg` block, preserving reorder / send-now / edit / delete and
+ * the offline styling. The header + collapse chrome are now `DockPanel`'s
+ * job, so this only renders the row list.
+ */
+
+import { useMemo } from "react"
+import { View, Text, Pressable, Image, Platform } from "react-native"
+import { cn } from "@shogo/shared-ui/primitives"
+import {
+  ChevronUp,
+  ChevronDown,
+  SendHorizontal,
+  Pencil,
+  Trash2,
+  WifiOff,
+  Image as ImageIcon,
+  ListOrdered,
+} from "lucide-react-native"
+import { useDockPanel } from "../useDockPanel"
+import type { DockPanelDescriptor } from "../../../../lib/chat-dock-store"
+import type { QueuedMessage } from "../../ChatInput"
+
+export interface QueueDockPanelProps {
+  queuedMessages: QueuedMessage[]
+  onRemoveQueuedMessage?: (messageId: string) => void
+  onReorderQueuedMessage?: (messageId: string, direction: "up" | "down") => void
+  onEditQueuedMessage?: (messageId: string) => void
+  onSendQueuedMessageNow?: (messageId: string) => void
+}
+
+function QueueBody({
+  queuedMessages,
+  onRemoveQueuedMessage,
+  onReorderQueuedMessage,
+  onEditQueuedMessage,
+  onSendQueuedMessageNow,
+}: QueueDockPanelProps) {
+  return (
+    <View>
+      {queuedMessages.map((msg, index) => {
+        const files = msg.files ?? []
+        const imageFiles = files.filter((f) => f.type?.startsWith("image/"))
+        const otherFiles = files.filter((f) => !f.type?.startsWith("image/"))
+        const previewImage = imageFiles[0]
+        const trimmedContent = msg.content?.trim() ?? ""
+        const attachmentLabel =
+          files.length > 0 ? `${files.length} ${files.length === 1 ? "attachment" : "attachments"}` : ""
+        const primaryText = trimmedContent ? trimmedContent : attachmentLabel || "Empty message"
+        return (
+          <Pressable
+            key={msg.id}
+            onPress={() => onEditQueuedMessage?.(msg.id)}
+            accessibilityLabel="Queued message"
+            className={cn(
+              "group flex-row items-center gap-2 py-1.5 border-b border-border/40 last:border-b-0",
+              Platform.OS === "web" && "hover:bg-muted/40",
+            )}
+          >
+            {msg.offline ? (
+              <WifiOff size={11} className="text-orange-600 dark:text-orange-400 flex-shrink-0" />
+            ) : (
+              <View className="h-3 w-3 rounded-full border border-muted-foreground/30 flex-shrink-0" />
+            )}
+            {previewImage && (
+              <Image
+                source={{ uri: previewImage.dataUrl }}
+                className="h-7 w-7 rounded border border-border flex-shrink-0"
+                resizeMode="cover"
+              />
+            )}
+            <View className="flex-1 min-w-0">
+              <Text className="text-xs text-foreground" numberOfLines={1}>
+                {primaryText}
+              </Text>
+              {trimmedContent && files.length > 0 && (
+                <View className="flex-row items-center gap-1 mt-0.5">
+                  <ImageIcon className="h-3 w-3 text-muted-foreground" size={10} />
+                  <Text className="text-[10px] text-muted-foreground" numberOfLines={1}>
+                    {imageFiles.length > 0 && otherFiles.length > 0
+                      ? `${imageFiles.length} image${imageFiles.length === 1 ? "" : "s"} + ${otherFiles.length} file${otherFiles.length === 1 ? "" : "s"}`
+                      : imageFiles.length > 0
+                        ? `${imageFiles.length} image${imageFiles.length === 1 ? "" : "s"}`
+                        : `${otherFiles.length} file${otherFiles.length === 1 ? "" : "s"}`}
+                  </Text>
+                </View>
+              )}
+            </View>
+            <View
+              className={cn(
+                "flex-row items-center gap-0.5",
+                Platform.OS === "web" && "opacity-0 group-hover:opacity-100",
+              )}
+            >
+              {onReorderQueuedMessage && queuedMessages.length > 1 && (
+                <>
+                  {index > 0 && (
+                    <Pressable
+                      accessibilityLabel="Move queued message up"
+                      onPress={(e) => {
+                        if (e?.stopPropagation) e.stopPropagation()
+                        onReorderQueuedMessage(msg.id, "up")
+                      }}
+                    >
+                      {(state: any) => {
+                        const active = state.hovered || state.pressed
+                        return (
+                          <View className={cn("h-6 w-6 items-center justify-center rounded", active && "bg-muted-foreground/25")}>
+                            <ChevronUp className={cn("h-3 w-3", active ? "text-foreground" : "text-muted-foreground")} size={12} />
+                          </View>
+                        )
+                      }}
+                    </Pressable>
+                  )}
+                  {index < queuedMessages.length - 1 && (
+                    <Pressable
+                      accessibilityLabel="Move queued message down"
+                      onPress={(e) => {
+                        if (e?.stopPropagation) e.stopPropagation()
+                        onReorderQueuedMessage(msg.id, "down")
+                      }}
+                    >
+                      {(state: any) => {
+                        const active = state.hovered || state.pressed
+                        return (
+                          <View className={cn("h-6 w-6 items-center justify-center rounded", active && "bg-muted-foreground/25")}>
+                            <ChevronDown className={cn("h-3 w-3", active ? "text-foreground" : "text-muted-foreground")} size={12} />
+                          </View>
+                        )
+                      }}
+                    </Pressable>
+                  )}
+                </>
+              )}
+              {onSendQueuedMessageNow && (
+                <Pressable
+                  accessibilityLabel="Send queued message now"
+                  onPress={(e) => {
+                    if (e?.stopPropagation) e.stopPropagation()
+                    onSendQueuedMessageNow(msg.id)
+                  }}
+                >
+                  {(state: any) => {
+                    const active = state.hovered || state.pressed
+                    return (
+                      <View className={cn("h-6 w-6 items-center justify-center rounded", active && "bg-muted-foreground/25")}>
+                        <SendHorizontal className={cn("h-3 w-3", active ? "text-foreground" : "text-muted-foreground")} size={12} />
+                      </View>
+                    )
+                  }}
+                </Pressable>
+              )}
+              {onEditQueuedMessage && (
+                <Pressable
+                  accessibilityLabel="Edit queued message"
+                  onPress={(e) => {
+                    if (e?.stopPropagation) e.stopPropagation()
+                    onEditQueuedMessage(msg.id)
+                  }}
+                >
+                  {(state: any) => {
+                    const active = state.hovered || state.pressed
+                    return (
+                      <View className={cn("h-6 w-6 items-center justify-center rounded", active && "bg-muted-foreground/25")}>
+                        <Pencil className={cn("h-3 w-3", active ? "text-foreground" : "text-muted-foreground")} size={12} />
+                      </View>
+                    )
+                  }}
+                </Pressable>
+              )}
+              {onRemoveQueuedMessage && (
+                <Pressable
+                  accessibilityLabel="Delete queued message"
+                  onPress={(e) => {
+                    if (e?.stopPropagation) e.stopPropagation()
+                    onRemoveQueuedMessage(msg.id)
+                  }}
+                >
+                  {(state: any) => {
+                    const active = state.hovered || state.pressed
+                    return (
+                      <View className={cn("h-6 w-6 items-center justify-center rounded", active && "bg-destructive/20")}>
+                        <Trash2 className={cn("h-3 w-3", active ? "text-destructive" : "text-muted-foreground")} size={12} />
+                      </View>
+                    )
+                  }}
+                </Pressable>
+              )}
+            </View>
+          </Pressable>
+        )
+      })}
+    </View>
+  )
+}
+
+export function QueueDockPanel(props: QueueDockPanelProps) {
+  const { queuedMessages } = props
+  const offlineCount = queuedMessages.filter((m) => m.offline).length
+
+  const descriptor = useMemo<DockPanelDescriptor | null>(() => {
+    if (queuedMessages.length === 0) return null
+    return {
+      id: "queue",
+      kind: "status",
+      order: 70,
+      title: "Queue",
+      icon: ListOrdered,
+      accent: offlineCount > 0 ? "warning" : "default",
+      summary:
+        offlineCount > 0
+          ? `${offlineCount} waiting${queuedMessages.length > offlineCount ? ` · ${queuedMessages.length - offlineCount} queued` : ""}`
+          : `${queuedMessages.length} queued`,
+      defaultExpanded: true,
+      chip: { icon: ListOrdered, count: queuedMessages.length },
+      render: () => <QueueBody {...props} />,
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props, offlineCount])
+
+  useDockPanel(descriptor)
+  return null
+}

--- a/apps/mobile/components/chat/dock/panels/RunningDockPanel.tsx
+++ b/apps/mobile/components/chat/dock/panels/RunningDockPanel.tsx
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Merges background shell processes (body lifted from `ProcessPanel`) and
+ * live subagents (body lifted from `SubagentPanel` / `SubagentStats`) into
+ * one dock panel, replacing both standalone slots. Subagent rows stay
+ * informational (status, elapsed time, tool count) — the pre-dock
+ * `SubagentPanel` never exposed a stop control either, only shell processes
+ * did, so that parity carries over unchanged.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react"
+import { View, Text, Pressable, ActivityIndicator } from "react-native"
+import { cn } from "@shogo/shared-ui/primitives"
+import { Terminal, Clock, X, Bot } from "lucide-react-native"
+import type { RunningProcess } from "../../ProcessPanel"
+import type { SubagentProgress } from "../../subagent/SubagentPanel"
+import type { RecentTool } from "../../subagent/SubagentStats"
+import { useDockPanel } from "../useDockPanel"
+import type { DockPanelDescriptor } from "../../../../lib/chat-dock-store"
+
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000))
+  if (totalSeconds < 60) return `${totalSeconds}s`
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (minutes < 60) return `${minutes}m ${seconds}s`
+  const hours = Math.floor(minutes / 60)
+  return `${hours}h ${minutes % 60}m`
+}
+
+export interface RunningDockPanelProps {
+  processes: RunningProcess[]
+  onKillProcess: (runId: string) => void | Promise<void>
+  killingProcesses?: Set<string>
+  subagents: SubagentProgress[]
+  recentTools: RecentTool[]
+}
+
+function RunningBody({ processes, onKillProcess, killingProcesses, subagents, recentTools }: RunningDockPanelProps) {
+  const [now, setNow] = useState(() => Date.now())
+  const pendingKills = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    if (processes.length === 0) return
+    const t = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(t)
+  }, [processes.length])
+
+  function handleKill(runId: string) {
+    if (pendingKills.current.has(runId)) return
+    pendingKills.current.add(runId)
+    Promise.resolve(onKillProcess(runId)).finally(() => {
+      pendingKills.current.delete(runId)
+    })
+  }
+
+  return (
+    <View className="gap-2">
+      {processes.map((proc) => {
+        const isKilling = killingProcesses?.has(proc.runId) ?? false
+        return (
+          <View key={proc.runId} className="flex-row items-center gap-2">
+            <Terminal size={11} className="text-muted-foreground shrink-0" />
+            <Text className="flex-1 text-[11px] font-mono text-foreground" numberOfLines={1}>
+              {proc.command}
+            </Text>
+            {proc.stale ? (
+              <Text className="text-[9px] font-medium text-yellow-500/80">unverified</Text>
+            ) : (
+              <View className="flex-row items-center gap-1">
+                <Clock size={10} className="text-muted-foreground/70" />
+                <Text className="text-[10px] font-mono text-muted-foreground">
+                  {proc.startedAt ? formatElapsed(now - proc.startedAt) : "…"}
+                </Text>
+              </View>
+            )}
+            <Pressable
+              onPress={() => handleKill(proc.runId)}
+              disabled={isKilling}
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel={proc.stale ? "Dismiss" : "Kill process"}
+              className={cn(
+                "flex-row items-center gap-1 rounded px-1.5 py-0.5 bg-red-500/10 border border-red-500/20 active:opacity-60",
+                isKilling && "opacity-40",
+              )}
+            >
+              {isKilling ? <ActivityIndicator size="small" color="#ef4444" /> : <X size={10} className="text-red-400" />}
+              <Text className="text-[10px] font-medium text-red-400">{proc.stale ? "Dismiss" : "Kill"}</Text>
+            </Pressable>
+          </View>
+        )
+      })}
+
+      {subagents.map((subagent) => {
+        const isRunning = subagent.status === "running"
+        return (
+          <View key={subagent.agentId} className={cn("pl-2 border-l-2", isRunning ? "border-primary/30" : "border-green-500/30")}>
+            <View className="flex-row items-center gap-2">
+              <Bot size={12} className={isRunning ? "text-primary" : "text-green-500"} />
+              <Text
+                className={cn(
+                  "text-[11px] font-medium px-1.5 py-0.5 rounded",
+                  isRunning ? "text-primary bg-primary/10" : "text-green-500 bg-green-500/10",
+                )}
+              >
+                {subagent.agentType}
+              </Text>
+              <Text className="text-[10px] text-muted-foreground font-mono">{subagent.toolCount} tools</Text>
+              {!isRunning && <Text className="text-[10px] text-muted-foreground">(complete)</Text>}
+            </View>
+          </View>
+        )
+      })}
+    </View>
+  )
+}
+
+export function RunningDockPanel(props: RunningDockPanelProps) {
+  const { processes, subagents, recentTools } = props
+  const runningSubagents = subagents.filter((s) => s.status === "running").length
+
+  const descriptor = useMemo<DockPanelDescriptor | null>(() => {
+    if (processes.length === 0 && subagents.length === 0) return null
+    const parts: string[] = []
+    if (processes.length > 0) parts.push(`${processes.length} command${processes.length === 1 ? "" : "s"}`)
+    if (subagents.length > 0) parts.push(`${subagents.length} agent${subagents.length === 1 ? "" : "s"}`)
+    return {
+      id: "running",
+      kind: "status",
+      order: 60,
+      title: "Running",
+      icon: Terminal,
+      accent: processes.length > 0 || runningSubagents > 0 ? "running" : "default",
+      summary: parts.join(" · "),
+      defaultExpanded: true,
+      chip: { icon: Terminal, dot: processes.length > 0 || runningSubagents > 0 },
+      render: () => <RunningBody {...props} />,
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [processes, subagents, recentTools, runningSubagents])
+
+  useDockPanel(descriptor)
+  return null
+}

--- a/apps/mobile/components/chat/dock/panels/WorktreeDockPanel.tsx
+++ b/apps/mobile/components/chat/dock/panels/WorktreeDockPanel.tsx
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Dock panel for the per-chat git worktree bar. Uses `useWorktreeStatus` to
+ * poll independently of the dock's own visibility so it can decide whether
+ * to register itself in the first place — the old `WorktreeBar` decided
+ * this from inside its own render, which doesn't work once "am I rendered
+ * at all" is controlled by a registry the component has to ask first.
+ */
+
+import { useMemo } from "react"
+import { GitBranch } from "lucide-react-native"
+import { useWorktreeStatus, WorktreeBarView } from "../../WorktreeBar"
+import { useDockPanel } from "../useDockPanel"
+import type { DockPanelDescriptor } from "../../../../lib/chat-dock-store"
+
+export interface WorktreeDockPanelProps {
+  agentUrl: string | null
+  chatSessionId: string | null
+  isStreaming: boolean
+  onSendMessage: (text: string) => void
+}
+
+export function WorktreeDockPanel({ agentUrl, chatSessionId, isStreaming, onSendMessage }: WorktreeDockPanelProps) {
+  const worktree = useWorktreeStatus(agentUrl, chatSessionId, isStreaming, onSendMessage)
+
+  const summary = worktree.status
+    ? worktree.mergeState === "merged"
+      ? "Merged"
+      : worktree.mergeState === "conflict"
+        ? "Resolving conflicts…"
+        : worktree.status.ahead > 0
+          ? `${worktree.status.ahead} ahead`
+          : "Up to date"
+    : undefined
+
+  const descriptor = useMemo<DockPanelDescriptor | null>(() => {
+    if (!worktree.visible) return null
+    return {
+      id: "worktree",
+      kind: "status",
+      order: 10,
+      title: "Worktree",
+      icon: GitBranch,
+      summary,
+      render: () => <WorktreeBarView {...worktree} isStreaming={isStreaming} />,
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [worktree.visible, worktree.status, worktree.siblings, worktree.mergeState, worktree.error, summary, isStreaming])
+
+  useDockPanel(descriptor)
+
+  return null
+}

--- a/apps/mobile/components/chat/dock/useDockPanel.ts
+++ b/apps/mobile/components/chat/dock/useDockPanel.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Registers a panel descriptor with the chat dock for the lifetime of the
+ * calling component.
+ *
+ * Pass `null` to omit registration (e.g. "no queued messages right now") —
+ * any previously registered panel with this id is removed and the dock
+ * drops it from the stack.
+ *
+ * Registration is an upsert: calling this again with a new descriptor
+ * object (same `id`) updates the stored fields (title, summary, render,
+ * ...) without resetting the panel's visible/expanded state — that state
+ * only gets its initial value the *first* time a given id is registered.
+ * Callers don't need to memoize the descriptor for correctness, only for
+ * render performance (an unmemoized descriptor just means every render
+ * re-upserts the same fields).
+ */
+
+import { useEffect, useRef } from "react"
+import { useChatDockStore, type DockPanelDescriptor } from "../../../lib/chat-dock-store"
+
+export function useDockPanel(descriptor: DockPanelDescriptor | null): void {
+  const store = useChatDockStore()
+  const registeredIdRef = useRef<string | undefined>(undefined)
+
+  useEffect(() => {
+    if (descriptor) {
+      registeredIdRef.current = descriptor.id
+      store.registerPanel(descriptor)
+    } else if (registeredIdRef.current) {
+      store.unregisterPanel(registeredIdRef.current)
+      registeredIdRef.current = undefined
+    }
+    // descriptor is compared by reference — see doc comment above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [store, descriptor])
+
+  useEffect(() => {
+    return () => {
+      if (registeredIdRef.current) store.unregisterPanel(registeredIdRef.current)
+    }
+    // Unmount-only cleanup; intentionally excludes `descriptor`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [store])
+}

--- a/apps/mobile/components/chat/turns/AssistantContent.tsx
+++ b/apps/mobile/components/chat/turns/AssistantContent.tsx
@@ -44,6 +44,8 @@ import { EditFileWidget } from "./EditFileWidget"
 import { PlanCard, type PlanData } from "../PlanCard"
 import { subagentStreamStore } from "../../../lib/subagent-stream-store"
 import { useTodoStateStore, parseTodos as parseTodosForStore } from "../../../lib/todo-state-store"
+import { useFileChangeStore, classifyFileToolName, extractFilePath } from "../../../lib/file-change-store"
+import { useChatDockStore } from "../../../lib/chat-dock-store"
 import { logScreencast } from "../../../lib/screencast-debug"
 import { FileViewerModal } from "../FileViewerModal"
 import { ChatImageContextMenu, ImagePreviewModal } from "../ImagePreviewModal"
@@ -628,6 +630,13 @@ export const AssistantContent = memo(
   // Per-chat TodoWrite store, provided by the enclosing ChatPanel so
   // sibling tabs don't share `latestTodos` / `orderedToolIds`.
   const todoStateStore = useTodoStateStore()
+  // Per-chat changed-files store feeding the dock's "Changes" panel — see
+  // file-change-store.ts for why this uses the canonical write_file /
+  // edit_file / delete_file names rather than ChatPanel's legacy helper.
+  const fileChangeStore = useFileChangeStore()
+  // Lets the in-stream PlanCard deep-link into the floating PlanDockPanel
+  // via `openPanel("plan")` once this message has scrolled away.
+  const dockStore = useChatDockStore()
 
   // Throttle the streaming message to ~30fps so markdown re-parsing and part
   // extraction don't run per-token. When streaming ends, the final value is
@@ -648,6 +657,13 @@ export const AssistantContent = memo(
           todoStateStore.registerWrite(part.tool.id, todos)
         }
         continue
+      }
+      if (part.type === "tool") {
+        const fileKind = classifyFileToolName(part.tool.toolName)
+        if (fileKind && part.tool.state === "success") {
+          const path = extractFilePath(part.tool.args as Record<string, unknown> | undefined)
+          if (path) fileChangeStore.registerChange(part.tool.id, path, fileKind)
+        }
       }
       if (part.type !== "tool" || !TASK_TOOL_NAMES.has(part.tool.toolName)) continue
       const tool = part.tool
@@ -685,7 +701,7 @@ export const AssistantContent = memo(
         subagentStreamStore.setModel(tool.id, model)
       }
     }
-  }, [orderedParts, todoStateStore])
+  }, [orderedParts, todoStateStore, fileChangeStore])
 
   const groupedParts = useMemo(
     () => groupConsecutiveParts(orderedParts),
@@ -893,6 +909,7 @@ export const AssistantContent = memo(
                     : undefined
                 }
                 isConfirmed={isConfirmed}
+                onOpenInDock={() => dockStore.openPanel("plan")}
               />
             )
           }

--- a/apps/mobile/components/chat/turns/AssistantContent.tsx
+++ b/apps/mobile/components/chat/turns/AssistantContent.tsx
@@ -24,11 +24,17 @@ import { AskUserQuestionWidget, AskUserQuestionBar } from "./AskUserQuestionWidg
 import { askUserStreamVariant } from "./pendingQuestion"
 import { TodoWidget } from "./TodoWidget"
 import { ToolCallGroup } from "./ToolCallGroup"
-import { ExplorationGroup } from "./ExplorationGroup"
-import { EditingGroup } from "./EditingGroup"
+import { WorkGroup } from "./WorkGroup"
+import { WorkedForGroup } from "./WorkedForGroup"
+import { PlanningStatusLine } from "./PlanningStatusLine"
 import type { MessagePart, GroupedMessagePart } from "./types"
-import { type ToolCallData } from "../tools/types"
-import { getToolSummary } from "../tools/summary"
+import {
+  groupWorkParts,
+  partitionTurn,
+  extractTurnTiming,
+  shouldShowPlanningStatus,
+} from "./turnShaping"
+import { buildFallbackWorkedLabel } from "./workSummary"
 import {
   TASK_TOOL_NAMES,
   extractOrderedParts,
@@ -41,11 +47,11 @@ import { NotifyErrorWidget } from "./NotifyErrorWidget"
 import { ThinkingWidget } from "./ThinkingWidget"
 import { WriteFileWidget } from "./WriteFileWidget"
 import { EditFileWidget } from "./EditFileWidget"
-import { PlanCard, type PlanData } from "../PlanCard"
+import type { PlanData } from "../PlanCard"
+import { PlanReferenceCard } from "./PlanReferenceCard"
 import { subagentStreamStore } from "../../../lib/subagent-stream-store"
 import { useTodoStateStore, parseTodos as parseTodosForStore } from "../../../lib/todo-state-store"
 import { useFileChangeStore, classifyFileToolName, extractFilePath } from "../../../lib/file-change-store"
-import { useChatDockStore } from "../../../lib/chat-dock-store"
 import { logScreencast } from "../../../lib/screencast-debug"
 import { FileViewerModal } from "../FileViewerModal"
 import { ChatImageContextMenu, ImagePreviewModal } from "../ImagePreviewModal"
@@ -159,31 +165,6 @@ export interface AssistantContentProps {
   className?: string
 }
 
-const UNGROUPABLE_TOOLS = new Set([
-  "ask_user",
-  "notify_user_error",
-  "TodoWrite",
-  "todo_write",
-  "connect",
-  // Legacy: keep so historical install turns still render ungrouped
-  "tool_install",
-  "mcp_install",
-  "generate_image",
-  "exec",
-  "Bash",
-  "task",
-  "Task",
-  "agent_spawn",
-  "team_create",
-  "browser",
-  "create_plan",
-  // keep styled widgets even when consecutive:
-  "write_file",
-  "Write",
-  "edit_file",
-  "Edit",
-  "StrReplace",
-])
 const TEAM_TOOL_NAMES = new Set(["team_create"])
 
 // "Low-information" tools that render as a chrome-less, hover-highlighted
@@ -200,197 +181,6 @@ const MINIMAL_TOOL_NAMES = new Set([
   "Delete",
   "exec_wait",
 ])
-const MIN_GROUP_SIZE = 2
-
-// Verbs (from tools/summary.ts) that classify a tool call as an
-// "exploration" action — read-only investigation that the agent is
-// likely doing in bursts. The set deliberately omits destructive verbs
-// (Move, Remove, Install, etc.) so they keep their dedicated widgets,
-// and omits "Read lints" since the user asked for ReadLints to stay
-// inline rather than fold into the exploration roll-up.
-const EXPLORATION_VERBS = new Set([
-  "Read",
-  "List",
-  "Search for",
-  "Find in",
-  "Find files matching",
-  "Search the web for",
-  "Fetch",
-  "pwd",
-])
-const MIN_EXPLORATION_GROUP_SIZE = 2
-
-// Tool names that fold into the "Editing…" group. write_file / Write
-// and edit_file / Edit / StrReplace stay in UNGROUPABLE_TOOLS so the
-// generic same-name `ToolCallGroup` ignores them — the editing pass
-// below handles them instead with a richer mixed-name run.
-const EDITING_TOOL_NAMES = new Set([
-  "write_file",
-  "Write",
-  "edit_file",
-  "Edit",
-  "StrReplace",
-])
-const MIN_EDITING_GROUP_SIZE = 2
-
-function isExplorationTool(tool: ToolCallData): boolean {
-  const { verb } = getToolSummary(tool.toolName, tool.args)
-  return EXPLORATION_VERBS.has(verb)
-}
-
-function isEditingTool(tool: ToolCallData): boolean {
-  return EDITING_TOOL_NAMES.has(tool.toolName)
-}
-
-/**
- * Shell command (`exec` / `Bash`) whose verb is *not* a pure
- * exploration verb — typically a generic `Run` (bun test, node x.js,
- * unknown commands), `Install`, `git X`, or mutating ops like
- * `Move` / `Remove` / `Copy` / `Touch`. These fold into the Editing
- * group alongside writes/edits since they're actions, not pure
- * inspection.
- */
-function isShellRunCommand(tool: ToolCallData): boolean {
-  if (tool.toolName !== "exec" && tool.toolName !== "Bash") return false
-  const { verb } = getToolSummary(tool.toolName, tool.args)
-  return !EXPLORATION_VERBS.has(verb)
-}
-
-/**
- * Walk forward from `start` collecting tool parts that match
- * `accept`, treating `reasoning` parts as transparent (consumed into
- * the run but not counted toward the tool threshold). Returns the
- * exclusive end of the *trimmed* slice (trailing reasoning excluded)
- * and the tool count.
- */
-function scanTransparentRun(
-  parts: MessagePart[],
-  start: number,
-  accept: (tool: ToolCallData) => boolean,
-): { endIdx: number; toolCount: number } {
-  let j = start + 1
-  let toolCount = 1
-  let lastToolIdx = start
-  while (j < parts.length) {
-    const next = parts[j]
-    if (next.type === "reasoning") {
-      j++
-      continue
-    }
-    if (next.type === "tool" && accept(next.tool)) {
-      toolCount++
-      lastToolIdx = j
-      j++
-      continue
-    }
-    break
-  }
-  return { endIdx: lastToolIdx + 1, toolCount }
-}
-
-function groupConsecutiveParts(parts: MessagePart[]): GroupedMessagePart[] {
-  const result: GroupedMessagePart[] = []
-  let i = 0
-
-  while (i < parts.length) {
-    const part = parts[i]
-
-    if (part.type !== "tool") {
-      result.push(part)
-      i++
-      continue
-    }
-
-    // Work pass: greedy run of mixed read + edit + write tools. We
-    // intentionally bypass UNGROUPABLE_TOOLS here so a `cat foo` /
-    // `ls` / `grep` exec can join the run alongside a Read/Grep —
-    // the verb classifier in tools/summary.ts already filters out
-    // destructive exec verbs.
-    //
-    // Reasoning parts are "transparent": a read → thought → read →
-    // thought → edit sequence still counts as 3 tools, with the
-    // thoughts rendered inline inside the group body. Trailing
-    // reasoning is trimmed so it belongs to the next response.
-    //
-    // After scanning, the run is classified:
-    //   - any edit/write tool or non-read shell command  → editing-group
-    //   - reads + read-only shell commands only          → exploration-group
-    const isWorkTool = (t: ToolCallData) =>
-      isExplorationTool(t) || isEditingTool(t) || isShellRunCommand(t)
-
-    if (isWorkTool(part.tool)) {
-      const { endIdx, toolCount } = scanTransparentRun(parts, i, isWorkTool)
-      const slice = parts.slice(i, endIdx)
-      const hasEditing = slice.some(
-        (p) =>
-          p.type === "tool" &&
-          (isEditingTool(p.tool) || isShellRunCommand(p.tool)),
-      )
-      if (hasEditing && toolCount >= MIN_EDITING_GROUP_SIZE) {
-        result.push({
-          type: "editing-group",
-          items: slice,
-          id: `edit-${parts[i].id}`,
-        })
-        i = endIdx
-        continue
-      }
-      if (!hasEditing && toolCount >= MIN_EXPLORATION_GROUP_SIZE) {
-        result.push({
-          type: "exploration-group",
-          items: slice,
-          id: `explore-${parts[i].id}`,
-        })
-        i = endIdx
-        continue
-      }
-      // Run below threshold — fall through to passthrough / same-name
-      // grouping so 1 lone tool still renders as a plain inline row.
-    }
-
-    if (UNGROUPABLE_TOOLS.has(part.tool.toolName)) {
-      result.push(part)
-      i++
-      continue
-    }
-
-    const toolName = part.tool.toolName
-    let j = i + 1
-    while (
-      j < parts.length &&
-      parts[j].type === "tool" &&
-      !UNGROUPABLE_TOOLS.has(
-        (parts[j] as { type: "tool"; tool: ToolCallData }).tool.toolName
-      ) &&
-      (parts[j] as { type: "tool"; tool: ToolCallData }).tool.toolName ===
-        toolName
-    ) {
-      j++
-    }
-
-    const runLength = j - i
-    if (runLength >= MIN_GROUP_SIZE) {
-      const groupTools = parts.slice(i, j).map((p) => ({
-        tool: (p as { type: "tool"; tool: ToolCallData; id: string }).tool,
-        id: p.id,
-      }))
-      result.push({
-        type: "tool-group",
-        toolName,
-        tools: groupTools,
-        id: `group-${parts[i].id}`,
-      })
-    } else {
-      result.push(part)
-    }
-
-    i = j
-  }
-
-  return result
-}
-
-
 const GROUP_FALLING_EDGE_DELAY_MS = 1500
 
 function isItemActive(item: MessagePart): boolean {
@@ -404,33 +194,35 @@ interface GroupSlotProps {
   id: string
   messageIsStreaming: boolean
   isLastGroup: boolean
+  isExpanded?: boolean
+  onToggle?: () => void
 }
 
-// Slots intentionally do NOT thread a controlled `isExpanded`/`onToggle`
-// down — they let `CollapsibleToolGroup` run in its uncontrolled mode so
-// the group auto-expands while `stableActive` is true and auto-collapses
-// (with the height-spring animation) once it falls. The user can still
-// toggle the chevron to override during either phase.
-const EditingGroupSlot = memo(function EditingGroupSlot({
+// Slot intentionally does NOT thread a controlled `isExpanded`/`onToggle`
+// down by default — it lets `CollapsibleToolGroup` run in its
+// uncontrolled mode so the label keeps updating live (present tense,
+// ticking counts) while `stableActive` is true, and flips to the past
+// tense + diff badge once it falls. The user can still toggle the
+// chevron to override during either phase (an explicit `onToggle` is
+// honored so an already-expanded row stays expanded across renders).
+const WorkGroupSlot = memo(function WorkGroupSlot({
   items,
   messageIsStreaming,
   isLastGroup,
+  isExpanded,
+  onToggle,
 }: GroupSlotProps) {
   const isAnyItemActive = items.some(isItemActive)
   const rawActive = isAnyItemActive || (messageIsStreaming && isLastGroup)
   const stableActive = useDelayedFalse(rawActive, GROUP_FALLING_EDGE_DELAY_MS)
-  return <EditingGroup items={items} isStreaming={stableActive} />
-})
-
-const ExplorationGroupSlot = memo(function ExplorationGroupSlot({
-  items,
-  messageIsStreaming,
-  isLastGroup,
-}: GroupSlotProps) {
-  const isAnyItemActive = items.some(isItemActive)
-  const rawActive = isAnyItemActive || (messageIsStreaming && isLastGroup)
-  const stableActive = useDelayedFalse(rawActive, GROUP_FALLING_EDGE_DELAY_MS)
-  return <ExplorationGroup items={items} isStreaming={stableActive} />
+  return (
+    <WorkGroup
+      items={items}
+      isStreaming={stableActive}
+      isExpanded={isExpanded}
+      onToggle={onToggle}
+    />
+  )
 })
 
 function ImageThumbnail({
@@ -634,9 +426,6 @@ export const AssistantContent = memo(
   // file-change-store.ts for why this uses the canonical write_file /
   // edit_file / delete_file names rather than ChatPanel's legacy helper.
   const fileChangeStore = useFileChangeStore()
-  // Lets the in-stream PlanCard deep-link into the floating PlanDockPanel
-  // via `openPanel("plan")` once this message has scrolled away.
-  const dockStore = useChatDockStore()
 
   // Throttle the streaming message to ~30fps so markdown re-parsing and part
   // extraction don't run per-token. When streaming ends, the final value is
@@ -704,23 +493,48 @@ export const AssistantContent = memo(
   }, [orderedParts, todoStateStore, fileChangeStore])
 
   const groupedParts = useMemo(
-    () => groupConsecutiveParts(orderedParts),
+    () => groupWorkParts(orderedParts),
     [orderedParts],
+  )
+
+  const { workLog, finalSegment } = useMemo(
+    () => partitionTurn(groupedParts),
+    [groupedParts],
+  )
+
+  const timing = useMemo(() => extractTurnTiming(message), [message])
+
+  const lastGroupId = useMemo(() => {
+    const last = groupedParts[groupedParts.length - 1]
+    return last && (last.type === "work-group" || last.type === "tool-group") ? last.id : null
+  }, [groupedParts])
+
+  const showPlanningStatus = useMemo(
+    () => shouldShowPlanningStatus(orderedParts, isStreaming),
+    [orderedParts, isStreaming],
+  )
+
+  const fallbackWorkedLabel = useMemo(
+    () => buildFallbackWorkedLabel(workLog),
+    [workLog],
   )
 
   if (groupedParts.length === 0) {
     return null
   }
 
-  return (
-    <View className={cn("gap-y-1", className)}>
-      {groupedParts.map((part, index) => {
+  function renderPart(part: GroupedMessagePart, index: number) {
         if (part.type === "reasoning") {
+          // Streaming reasoning renders as the turn-level "Planning next
+          // moves" status line instead of a live ThinkingWidget — see
+          // `shouldShowPlanningStatus`. Once it completes it becomes the
+          // collapsed "Thought briefly" / "Thought for Ns" row.
+          if (part.isStreaming) return null
           return (
             <ThinkingWidget
               key={part.id}
               text={part.text}
-              isStreaming={part.isStreaming}
+              isStreaming={false}
               durationSeconds={part.durationSeconds}
             />
           )
@@ -739,26 +553,16 @@ export const AssistantContent = memo(
           )
         }
 
-        if (part.type === "exploration-group") {
+        if (part.type === "work-group") {
           return (
-            <ExplorationGroupSlot
+            <WorkGroupSlot
               key={part.id}
               items={part.items}
               id={part.id}
               messageIsStreaming={isStreaming}
-              isLastGroup={index === groupedParts.length - 1}
-            />
-          )
-        }
-
-        if (part.type === "editing-group") {
-          return (
-            <EditingGroupSlot
-              key={part.id}
-              items={part.items}
-              id={part.id}
-              messageIsStreaming={isStreaming}
-              isLastGroup={index === groupedParts.length - 1}
+              isLastGroup={part.id === lastGroupId}
+              isExpanded={expandedTools.has(part.id)}
+              onToggle={getToggle(part.id)}
             />
           )
         }
@@ -892,24 +696,17 @@ export const AssistantContent = memo(
               !!matchingConfirmedPlan &&
               ((matchingConfirmedPlan.toolCallId && matchingConfirmedPlan.toolCallId === toolCallId) ||
                 (!!matchingConfirmedPlan.filepath && matchingConfirmedPlan.filepath === planData.filepath))
-            const isPending = part.tool.state === "success" && !!chatContext?.buildPlan && !!matchingPendingPlan && !isConfirmed
             return (
-              <PlanCard
+              <PlanReferenceCard
                 key={part.id}
                 plan={planData}
-                onBuild={isPending ? () => chatContext!.buildPlan!(planData) : undefined}
-                onOpenPlan={
+                isConfirmed={isConfirmed}
+                isUpdate={part.tool.toolName === "update_plan"}
+                onPress={
                   chatContext?.openPlan && planData.filepath
                     ? () => chatContext.openPlan?.(planData.filepath)
                     : undefined
                 }
-                onGenerateSummary={
-                  chatContext?.generateSummary && planData.filepath
-                    ? () => chatContext.generateSummary!(planData.filepath!)
-                    : undefined
-                }
-                isConfirmed={isConfirmed}
-                onOpenInDock={() => dockStore.openPanel("plan")}
               />
             )
           }
@@ -1009,7 +806,33 @@ export const AssistantContent = memo(
         }
 
         return null
-      })}
+  }
+
+  // Collapse rule: everything before the turn's last text block folds
+  // under "Worked for X" once the turn is done. While streaming, the
+  // work log renders flat (same as today) — the reference screenshots
+  // show no header at all mid-stream, just the live one-line group
+  // labels ticking as work happens; the collapse only settles once the
+  // turn completes.
+  return (
+    <View className={cn("gap-y-1", className)}>
+      {!isStreaming && workLog.length > 0 && (
+        <WorkedForGroup
+          startedAt={timing.startedAt}
+          completedAt={timing.completedAt}
+          fallbackLabel={fallbackWorkedLabel}
+          isExpanded={expandedTools.has("worked-for")}
+          onToggle={getToggle("worked-for")}
+          hasBody
+        >
+          <View className="gap-y-1">
+            {workLog.map((part, index) => renderPart(part, index))}
+          </View>
+        </WorkedForGroup>
+      )}
+      {isStreaming && workLog.map((part, index) => renderPart(part, index))}
+      {finalSegment.map((part, index) => renderPart(part, workLog.length + index))}
+      {showPlanningStatus && <PlanningStatusLine />}
     </View>
   )
   },

--- a/apps/mobile/components/chat/turns/PlanReferenceCard.tsx
+++ b/apps/mobile/components/chat/turns/PlanReferenceCard.tsx
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+/**
+ * PlanReferenceCard — the in-stream footprint of a `create_plan` /
+ * `update_plan` tool call. The full interactive plan (technical/summary
+ * tabs, Build, generate-summary) now lives on the dedicated Plans page
+ * (`PlansPanel`) and in the floating `PlanDockPanel`, so this is
+ * deliberately just a clickable pointer: name, status, tap to navigate.
+ */
+
+import { View, Text, Pressable, ActivityIndicator } from "react-native"
+import { CheckCircle2, ClipboardList, ChevronRight } from "lucide-react-native"
+import { cn } from "@shogo/shared-ui/primitives"
+import type { PlanData } from "../PlanCard"
+
+export interface PlanReferenceCardProps {
+  plan: PlanData
+  isConfirmed: boolean
+  /** True for `update_plan` tool calls — flips the label to "Updated plan". */
+  isUpdate: boolean
+  /** Navigates to the Plans page. Omitted while the plan is still
+   *  streaming and has no saved filepath yet, in which case the card
+   *  renders disabled with a spinner. */
+  onPress?: () => void
+}
+
+export function PlanReferenceCard({ plan, isConfirmed, isUpdate, onPress }: PlanReferenceCardProps) {
+  const label = isConfirmed ? "Plan" : isUpdate ? "Updated plan" : "Created plan"
+
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={!onPress}
+      accessibilityRole={onPress ? "button" : undefined}
+      accessibilityLabel={`${label}: ${plan.name}. View plan.`}
+      className={cn(
+        "mx-2 my-1.5 flex-row items-center gap-2.5 rounded-xl border border-border bg-card px-3 py-2.5",
+        onPress && "active:opacity-70",
+      )}
+    >
+      <View className="h-7 w-7 items-center justify-center rounded-lg bg-primary/10">
+        <ClipboardList className="h-3.5 w-3.5 text-primary" size={14} />
+      </View>
+      <View className="min-w-0 flex-1">
+        <Text className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+          {label}
+        </Text>
+        <Text className="text-sm font-medium text-foreground" numberOfLines={1}>
+          {plan.name}
+        </Text>
+      </View>
+      {isConfirmed ? (
+        <CheckCircle2 className="h-4 w-4 text-green-500" size={16} />
+      ) : !onPress ? (
+        <ActivityIndicator size="small" />
+      ) : (
+        <ChevronRight className="h-4 w-4 text-muted-foreground" size={16} />
+      )}
+    </Pressable>
+  )
+}

--- a/apps/mobile/components/chat/turns/SubagentCard.tsx
+++ b/apps/mobile/components/chat/turns/SubagentCard.tsx
@@ -18,21 +18,10 @@ import { type ToolCallData, getToolKeyArg, formatToolName } from "../tools/types
 import { subagentStreamStore } from "../../../lib/subagent-stream-store"
 import { stopSubagent } from "../../../lib/subagent-stop"
 import { resolveShortName } from "../../../lib/visible-models"
-import { LiveBrowserView } from "../LiveBrowserView"
-import { useChatContextSafe } from "../ChatContext"
-import { useChatBridgeOptional } from "../../voice-mode/ChatBridgeContext"
 
 export interface SubagentCardProps {
   tool: ToolCallData
   className?: string
-  /**
-   * Override the agent runtime base URL used for the live browser
-   * preview. Defaults to the value resolved from `ChatContext` (when
-   * mounted under `ChatPanel`) or the `ChatBridge` (when mounted under
-   * the EZ Mode overlay). Tests / standalone surfaces can pass it
-   * explicitly.
-   */
-  agentUrl?: string | null
 }
 
 const SPINNER_DURATION = 1200
@@ -151,10 +140,8 @@ function getStatusText(tool: ToolCallData, elapsed: number, output: SubagentOutp
   return `Running... ${mins}m ${rem}s${suffix}`
 }
 
-export function SubagentCard({ tool, className, agentUrl: agentUrlProp }: SubagentCardProps) {
+export function SubagentCard({ tool, className }: SubagentCardProps) {
   const [elapsed, setElapsed] = useState(0)
-  const chatContext = useChatContextSafe()
-  const bridge = useChatBridgeOptional()
 
   const isRunning = tool.state === "streaming"
   const isDone = tool.state === "success"
@@ -203,10 +190,6 @@ export function SubagentCard({ tool, className, agentUrl: agentUrlProp }: Subage
     () => deriveLatestActivityLabel(streamData?.parts),
     [streamData?.parts],
   )
-
-  const resolvedAgentUrl =
-    agentUrlProp ?? chatContext?.agentUrl ?? bridge?.agentUrl ?? null
-  const showLivePreview = isRunning && !!instanceId && !!resolvedAgentUrl
 
   return (
     <Pressable
@@ -263,18 +246,6 @@ export function SubagentCard({ tool, className, agentUrl: agentUrlProp }: Subage
           </Text>
           <ChevronRight className="w-3.5 h-3.5 text-muted-foreground/50" size={14} />
         </View>
-
-        {/* Live browser viewport — visible while the subagent is running
-            and we have an AgentManager instance id to subscribe to. */}
-        {showLivePreview && (
-          <View className="mt-1">
-            <LiveBrowserView
-              instanceId={instanceId!}
-              active={isRunning}
-              agentUrl={resolvedAgentUrl}
-            />
-          </View>
-        )}
       </View>
     </Pressable>
   )

--- a/apps/mobile/components/chat/turns/TurnGroup.tsx
+++ b/apps/mobile/components/chat/turns/TurnGroup.tsx
@@ -20,13 +20,10 @@ import { MessageContent, extractTextContent } from "./MessageContent"
 import { AssistantContent } from "./AssistantContent"
 import { EditableUserMessage } from "./EditableUserMessage"
 import { ToolTimeline } from "../tools"
-import { SubagentPanel, type SubagentProgress, type RecentTool } from "../subagent"
 
 export interface TurnGroupProps {
   turn: ConversationTurn
   phase?: string | null
-  activeSubagents?: SubagentProgress[]
-  recentTools?: RecentTool[]
   showToolTimeline?: boolean
   className?: string
 }
@@ -125,8 +122,6 @@ export const TurnGroup = memo(
   function TurnGroup({
     turn,
     phase,
-    activeSubagents = [],
-    recentTools = [],
     showToolTimeline = false,
     className,
   }: TurnGroupProps) {
@@ -163,15 +158,6 @@ export const TurnGroup = memo(
         />
       )}
 
-      {/* Subagent panel */}
-      {activeSubagents.length > 0 && (
-        <SubagentPanel
-          subagents={activeSubagents}
-          recentTools={recentTools}
-          defaultExpanded
-        />
-      )}
-
       {/* Assistant message with interleaved tools (default) or plain content (legacy) */}
       {turn.assistantMessage && (
         <View className="gap-0.5">
@@ -205,8 +191,6 @@ export const TurnGroup = memo(
   (prev, next) =>
     prev.turn === next.turn &&
     prev.phase === next.phase &&
-    prev.activeSubagents === next.activeSubagents &&
-    prev.recentTools === next.recentTools &&
     prev.showToolTimeline === next.showToolTimeline &&
     prev.className === next.className,
 )

--- a/apps/mobile/components/chat/turns/TurnList.tsx
+++ b/apps/mobile/components/chat/turns/TurnList.tsx
@@ -12,37 +12,29 @@ import { cn } from "@shogo/shared-ui/primitives"
 import type { UIMessage } from "@ai-sdk/react"
 import { useTurnGrouping } from "./useTurnGrouping"
 import { TurnGroup } from "./TurnGroup"
-import type { SubagentProgress, RecentTool } from "../subagent"
 import type { ToolCallData } from "../tools/types"
 
 export interface TurnListProps {
   messages: UIMessage[]
   isStreaming?: boolean
   phase?: string | null
-  activeSubagents?: SubagentProgress[]
-  recentTools?: RecentTool[]
   subagentToolCalls?: ToolCallData[]
   className?: string
 }
-
-const EMPTY_SUBAGENTS: SubagentProgress[] = []
-const EMPTY_RECENT_TOOLS: RecentTool[] = []
 
 /**
  * Memoized so sibling ChatPanel re-renders (e.g. tab-switch re-renders of the
  * parent, which cascade into every open panel) don't re-run the full
  * TurnGroup / AssistantContent / Markdown render pipeline when the message
- * list itself hasn't changed. Callers MUST pass referentially stable
- * `activeSubagents`, `recentTools`, and `subagentToolCalls` (use useMemo) —
- * otherwise memo bails out on every render.
+ * list itself hasn't changed. Callers MUST pass a referentially stable
+ * `subagentToolCalls` (use useMemo) — otherwise memo bails out on every
+ * render.
  */
 export const TurnList = memo(
   function TurnList({
     messages,
     isStreaming = false,
     phase,
-    activeSubagents = EMPTY_SUBAGENTS,
-    recentTools = EMPTY_RECENT_TOOLS,
     subagentToolCalls,
     className,
   }: TurnListProps) {
@@ -50,14 +42,8 @@ export const TurnList = memo(
 
     return (
       <View className={cn("gap-4", className)}>
-        {turns.map((turn, index) => (
-          <TurnGroup
-            key={turn.id}
-            turn={turn}
-            phase={phase}
-            activeSubagents={index === turns.length - 1 ? activeSubagents : EMPTY_SUBAGENTS}
-            recentTools={index === turns.length - 1 ? recentTools : EMPTY_RECENT_TOOLS}
-          />
+        {turns.map((turn) => (
+          <TurnGroup key={turn.id} turn={turn} phase={phase} />
         ))}
       </View>
     )
@@ -66,8 +52,6 @@ export const TurnList = memo(
     prev.messages === next.messages &&
     prev.isStreaming === next.isStreaming &&
     prev.phase === next.phase &&
-    prev.activeSubagents === next.activeSubagents &&
-    prev.recentTools === next.recentTools &&
     prev.subagentToolCalls === next.subagentToolCalls &&
     prev.className === next.className,
 )

--- a/apps/mobile/lib/chat-dock-preferences.ts
+++ b/apps/mobile/lib/chat-dock-preferences.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Persisted expand/collapse state for chat dock panels, keyed by panel id.
+ *
+ * Only `autoShow` panels are meant to consult this — on-demand panels (e.g.
+ * context usage) always start hidden and fall back to their own
+ * `defaultExpanded` rather than a remembered value.
+ *
+ * Uses `safe-storage` (localStorage with an in-memory fallback) rather than
+ * SecureStore since this is cosmetic UI state, not a security-sensitive
+ * preference — cheap enough to read/write synchronously on every toggle,
+ * matching the synchronous API `chat-dock-store.ts` expects.
+ */
+
+import { safeGetItem, safeSetItem } from "./safe-storage"
+
+const STORAGE_KEY = "chat-dock-expanded-panels"
+
+let cache: Record<string, boolean> | null = null
+
+function loadCache(): Record<string, boolean> {
+  if (cache) return cache
+  try {
+    const raw = safeGetItem(STORAGE_KEY)
+    const parsed: unknown = raw ? JSON.parse(raw) : {}
+    cache = parsed && typeof parsed === "object" ? (parsed as Record<string, boolean>) : {}
+  } catch {
+    cache = {}
+  }
+  return cache
+}
+
+function persist(): void {
+  try {
+    safeSetItem(STORAGE_KEY, JSON.stringify(cache ?? {}))
+  } catch {
+    // Cosmetic preference — ignore persistence errors.
+  }
+}
+
+/** Returns null when no preference has been recorded yet for this panel. */
+export function getDockPanelExpandedPreference(panelId: string): boolean | null {
+  const c = loadCache()
+  return panelId in c ? c[panelId] : null
+}
+
+export function setDockPanelExpandedPreference(panelId: string, expanded: boolean): void {
+  const c = loadCache()
+  if (c[panelId] === expanded) return
+  c[panelId] = expanded
+  persist()
+}

--- a/apps/mobile/lib/chat-dock-store.ts
+++ b/apps/mobile/lib/chat-dock-store.ts
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Per-chat store for the "chat dock" — the floating stack of panels above
+ * the composer (plan, changed files, checklist, live browser, running
+ * tasks, message queue, context usage, plus blocking prompts like
+ * permission approval and pending questions).
+ *
+ * Everything that wants to appear above the composer used to invent its
+ * own container, state, and collapse behavior. This store is the single
+ * registry all of that now goes through: features call `useDockPanel()`
+ * with a descriptor and never think about positioning, stacking,
+ * animation, or persistence.
+ *
+ * Modeled directly on `todo-state-store.ts`: a tiny external store
+ * (registry + expand state + measured height) exposed via React context,
+ * with a lazily-created fallback for components rendered outside any
+ * provider (tests, storybook).
+ *
+ * Panels have a `kind`:
+ *  - "status" (default): collapsible, auto-shows/hides with its content,
+ *    subject to the expand cap below.
+ *  - "blocking": pins above the composer, is always considered expanded,
+ *    and forces the status zone down to a single expanded panel while
+ *    present. Used for prompts that park the agent turn (permission
+ *    approval, pending question, an active connectivity wait) — these
+ *    must stay visible and reachable, never collapsed by this store.
+ */
+
+import { createContext, useContext, type ComponentType, type ReactNode } from "react"
+import { getDockPanelExpandedPreference, setDockPanelExpandedPreference } from "./chat-dock-preferences"
+
+export type DockPanelKind = "status" | "blocking"
+export type DockPanelAccent = "default" | "running" | "warning"
+
+export type DockIconComponent = ComponentType<{ size?: number; className?: string; color?: string }>
+
+export interface DockPanelChip {
+  icon: DockIconComponent
+  count?: number
+  dot?: boolean
+}
+
+export interface DockPanelDescriptor {
+  id: string
+  /** Default "status". */
+  kind?: DockPanelKind
+  /** Lower renders higher up (closer to the top of the stack); ties break by insertion order. */
+  order: number
+  title: string
+  icon: DockIconComponent
+  /** Right-aligned collapsed-header text, e.g. "3 queued" or "18.2K / 200K". */
+  summary?: string
+  accent?: DockPanelAccent
+  /** false = hidden until toggled/opened. Default true. */
+  autoShow?: boolean
+  /** Only consulted the first time a panel with this id is registered. Default false. */
+  defaultExpanded?: boolean
+  /** Rendered in the collapsed header so Retry / Reconnect / Cancel / Kill stay reachable without expanding. */
+  headerActions?: ReactNode
+  /** Renders a dismiss (X) affordance in the header when set. */
+  onDismiss?: () => void
+  /** Toolbar pill descriptor; omit for panels that shouldn't get a composer chip. */
+  chip?: DockPanelChip
+  /** `expanded` lets costly panels (e.g. a live browser screencast) suspend work while collapsed. */
+  render: (ctx: { expanded: boolean }) => ReactNode
+}
+
+/** Max simultaneously-expanded status panels; tightened while a blocking panel is present. */
+const MAX_EXPANDED_STATUS_PANELS = 2
+const MAX_EXPANDED_WITH_BLOCKING = 1
+
+export interface ChatDockStore {
+  getVersion(): number
+  /** Visible panels only, sorted by `order`. */
+  getPanels(kind?: DockPanelKind): DockPanelDescriptor[]
+  registerPanel(descriptor: DockPanelDescriptor): void
+  unregisterPanel(id: string): void
+  isVisible(id: string): boolean
+  isExpanded(id: string): boolean
+  setExpanded(id: string, next: boolean): void
+  /** Toggles expansion; reveals the panel first if it was hidden (autoShow: false). */
+  toggle(id: string): void
+  /** Imperative deep-link — reveals and expands a panel from elsewhere in the UI. */
+  openPanel(id: string): void
+  closePanel(id: string): void
+  hasBlocking(): boolean
+  getHeight(): number
+  setHeight(px: number): void
+  subscribe(fn: () => void): () => void
+  /** Clears all registered panels — call when the active chat session changes. */
+  reset(): void
+}
+
+export function createChatDockStore(): ChatDockStore {
+  const panels = new Map<string, DockPanelDescriptor>()
+  const visible = new Set<string>()
+  const expanded = new Set<string>()
+  // Most-recently-expanded last; used to decide which status panel gets
+  // evicted first when the expand cap is exceeded.
+  const expandOrder: string[] = []
+  const listeners = new Set<() => void>()
+  let height = 0
+  let version = 0
+
+  function notify(): void {
+    version++
+    listeners.forEach((fn) => fn())
+  }
+
+  function touchExpandOrder(id: string): void {
+    const idx = expandOrder.indexOf(id)
+    if (idx !== -1) expandOrder.splice(idx, 1)
+    expandOrder.push(id)
+  }
+
+  function dropFromExpandOrder(id: string): void {
+    const idx = expandOrder.indexOf(id)
+    if (idx !== -1) expandOrder.splice(idx, 1)
+  }
+
+  function hasBlockingPanels(): boolean {
+    for (const id of visible) {
+      if ((panels.get(id)?.kind ?? "status") === "blocking") return true
+    }
+    return false
+  }
+
+  function isBlockingKind(id: string): boolean {
+    return (panels.get(id)?.kind ?? "status") === "blocking"
+  }
+
+  /** Evicts least-recently-expanded status panels until under the cap, protecting `keepId`. */
+  function enforceExpandCap(keepId?: string): void {
+    const cap = hasBlockingPanels() ? MAX_EXPANDED_WITH_BLOCKING : MAX_EXPANDED_STATUS_PANELS
+    const expandedStatusIds = expandOrder.filter((id) => expanded.has(id) && !isBlockingKind(id))
+    let i = 0
+    while (expandedStatusIds.length - i > cap) {
+      const evictId = expandedStatusIds[i]
+      i++
+      if (!evictId || evictId === keepId) continue
+      expanded.delete(evictId)
+      dropFromExpandOrder(evictId)
+    }
+  }
+
+  function setExpandedInternal(id: string, next: boolean, persist: boolean): void {
+    const panel = panels.get(id)
+    if (!panel) return
+    if ((panel.kind ?? "status") === "blocking") return // always considered expanded; not user-controlled
+    if (expanded.has(id) === next) return
+    if (next) {
+      expanded.add(id)
+      touchExpandOrder(id)
+      enforceExpandCap(id)
+    } else {
+      expanded.delete(id)
+      dropFromExpandOrder(id)
+    }
+    if (persist && panel.autoShow !== false) {
+      setDockPanelExpandedPreference(id, next)
+    }
+  }
+
+  return {
+    getVersion() {
+      return version
+    },
+    getPanels(kind) {
+      const list = [...panels.values()].filter((p) => visible.has(p.id))
+      const filtered = kind ? list.filter((p) => (p.kind ?? "status") === kind) : list
+      return filtered.sort((a, b) => a.order - b.order)
+    },
+    registerPanel(descriptor) {
+      const isNew = !panels.has(descriptor.id)
+      panels.set(descriptor.id, descriptor)
+      if (isNew) {
+        const autoShow = descriptor.autoShow !== false
+        const isBlocking = (descriptor.kind ?? "status") === "blocking"
+        if (autoShow) {
+          visible.add(descriptor.id)
+          const persisted = getDockPanelExpandedPreference(descriptor.id)
+          const shouldExpand = isBlocking
+            ? true
+            : persisted !== null
+              ? persisted
+              : !!descriptor.defaultExpanded
+          if (shouldExpand && !isBlocking) {
+            expanded.add(descriptor.id)
+            touchExpandOrder(descriptor.id)
+            enforceExpandCap(descriptor.id)
+          }
+        }
+      }
+      notify()
+    },
+    unregisterPanel(id) {
+      if (!panels.has(id)) return
+      panels.delete(id)
+      visible.delete(id)
+      expanded.delete(id)
+      dropFromExpandOrder(id)
+      notify()
+    },
+    isVisible(id) {
+      return visible.has(id)
+    },
+    isExpanded(id) {
+      if (isBlockingKind(id)) return true
+      return expanded.has(id)
+    },
+    setExpanded(id, next) {
+      setExpandedInternal(id, next, true)
+      notify()
+    },
+    toggle(id) {
+      if (!panels.has(id)) return
+      if (!visible.has(id)) visible.add(id)
+      setExpandedInternal(id, !expanded.has(id), true)
+      notify()
+    },
+    openPanel(id) {
+      if (!panels.has(id)) return
+      if (!visible.has(id)) visible.add(id)
+      setExpandedInternal(id, true, true)
+      notify()
+    },
+    closePanel(id) {
+      setExpandedInternal(id, false, true)
+      notify()
+    },
+    hasBlocking() {
+      return hasBlockingPanels()
+    },
+    getHeight() {
+      return height
+    },
+    setHeight(px) {
+      if (height === px) return
+      height = px
+      notify()
+    },
+    subscribe(fn) {
+      listeners.add(fn)
+      return () => {
+        listeners.delete(fn)
+      }
+    },
+    reset() {
+      panels.clear()
+      visible.clear()
+      expanded.clear()
+      expandOrder.length = 0
+      height = 0
+      notify()
+    },
+  }
+}
+
+export const ChatDockStoreContext = createContext<ChatDockStore | null>(null)
+
+// Lazily-created fallback for components rendered outside any
+// `ChatDockStoreContext.Provider` (tests, storybook, isolated previews).
+// Production chat trees always supply a per-`ChatPanel` instance.
+let fallbackStore: ChatDockStore | null = null
+
+function getFallbackStore(): ChatDockStore {
+  if (!fallbackStore) fallbackStore = createChatDockStore()
+  return fallbackStore
+}
+
+export function useChatDockStore(): ChatDockStore {
+  const store = useContext(ChatDockStoreContext)
+  return store ?? getFallbackStore()
+}

--- a/apps/mobile/lib/file-change-store.ts
+++ b/apps/mobile/lib/file-change-store.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026 Shogo Technologies, Inc.
+
+/**
+ * Per-chat store for files the agent has touched this session — feeds the
+ * chat dock's "Changes" panel.
+ *
+ * Same shape as `todo-state-store.ts`: a small external store populated by
+ * `AssistantContent` as it renders write/edit/delete tool parts (mirroring
+ * how it already calls `todoStateStore.registerWrite`), exposed via React
+ * context so multiple open chat tabs don't share state.
+ *
+ * Deliberately keyed on the canonical tool names the agent runtime actually
+ * emits (`write_file` / `edit_file` / `delete_file`, plus the legacy
+ * `Write` / `Edit` / `StrReplace` / `Delete` aliases the UI still renders
+ * for older sessions) — the same set `EditingGroup.tsx` and
+ * `tool-categories.ts` group on. This supersedes `getModifiedFilePaths` in
+ * `ChatPanel.tsx`, which matched `Write`/`Edit`/`StrReplace` but not the
+ * `write_file`/`edit_file` names the agent actually emits, and whose
+ * `onFilesChanged` callback no parent ever passed.
+ */
+
+import { createContext, useContext } from "react"
+
+export type FileChangeKind = "write" | "edit" | "delete"
+
+export const WRITE_TOOL_NAMES = new Set(["write_file", "Write"])
+export const EDIT_TOOL_NAMES = new Set(["edit_file", "Edit", "StrReplace"])
+export const DELETE_TOOL_NAMES = new Set(["delete_file", "Delete"])
+
+export function classifyFileToolName(toolName: string): FileChangeKind | null {
+  if (WRITE_TOOL_NAMES.has(toolName)) return "write"
+  if (EDIT_TOOL_NAMES.has(toolName)) return "edit"
+  if (DELETE_TOOL_NAMES.has(toolName)) return "delete"
+  return null
+}
+
+/** Pulls a file path out of the handful of arg shapes tool calls use. */
+export function extractFilePath(args?: Record<string, unknown>): string | undefined {
+  if (!args) return undefined
+  const path = args.file_path ?? args.path ?? args.filePath
+  return typeof path === "string" && path.length > 0 ? path : undefined
+}
+
+export interface FileChangeItem {
+  path: string
+  /** Most recent operation kind recorded for this path. */
+  kind: FileChangeKind
+}
+
+export interface FileChangeStore {
+  getVersion(): number
+  /** Ordered by first-touched. */
+  getAll(): FileChangeItem[]
+  registerChange(toolId: string, path: string, kind: FileChangeKind): void
+  subscribe(fn: () => void): () => void
+  clear(): void
+}
+
+export function createFileChangeStore(): FileChangeStore {
+  const order: string[] = []
+  const items = new Map<string, FileChangeItem>()
+  // Guards against re-registering the same tool-call + path pair every time
+  // AssistantContent's effect re-runs during streaming.
+  const seenKeys = new Set<string>()
+  const listeners = new Set<() => void>()
+  let version = 0
+
+  function notify() {
+    version++
+    listeners.forEach((fn) => fn())
+  }
+
+  return {
+    getVersion() {
+      return version
+    },
+    getAll() {
+      return order.map((path) => items.get(path)!).filter(Boolean)
+    },
+    registerChange(toolId, path, kind) {
+      const key = `${toolId}:${path}:${kind}`
+      if (seenKeys.has(key)) return
+      seenKeys.add(key)
+      if (!items.has(path)) order.push(path)
+      items.set(path, { path, kind })
+      notify()
+    },
+    subscribe(fn) {
+      listeners.add(fn)
+      return () => {
+        listeners.delete(fn)
+      }
+    },
+    clear() {
+      order.length = 0
+      items.clear()
+      seenKeys.clear()
+      notify()
+    },
+  }
+}
+
+export const FileChangeStoreContext = createContext<FileChangeStore | null>(null)
+
+let fallbackStore: FileChangeStore | null = null
+
+function getFallbackStore(): FileChangeStore {
+  if (!fallbackStore) fallbackStore = createFileChangeStore()
+  return fallbackStore
+}
+
+export function useFileChangeStore(): FileChangeStore {
+  const store = useContext(FileChangeStoreContext)
+  return store ?? getFallbackStore()
+}

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -5960,7 +5960,10 @@ async function startGateway(expectedProjectId?: string): Promise<void> {
   // outlive the failed assign's response if the caller doesn't tear this VM
   // down fast enough. Bail and let the caller's error path (or a future,
   // clean assign) handle it.
-  if (state.currentProjectId !== targetProjectId || !state.poolAssigned) {
+  if (
+    state.currentProjectId !== targetProjectId ||
+    (state.isPoolMode && !state.poolAssigned)
+  ) {
     console.error(
       `[agent-runtime] startGateway() aborting: project identity changed mid-start ` +
         `(expected ${targetProjectId}, now ${state.currentProjectId}, poolAssigned=${state.poolAssigned}). ` +


### PR DESCRIPTION
## Summary

Replaces the context-usage popover and every other one-off surface above the composer with a single floating "chat dock": a registry-driven container that stacks collapsible status panels (plan, changed files, checklist, live browser, running processes/subagents, queue, worktree, context usage) plus a pinned zone for blocking prompts (permission approval, pending question, connectivity wait).

Implements [Universal Chat Dock](/Users/russell/.cursor/plans/universal_chat_dock_8b86775c.plan.md) end-to-end.

## New files

- `apps/mobile/lib/chat-dock-store.ts` — panel registry, status/blocking kinds, expand-state LRU cap, measured height, imperative `openPanel`/`closePanel`.
- `apps/mobile/lib/chat-dock-preferences.ts` — persisted per-panel collapse state.
- `apps/mobile/lib/file-change-store.ts` — per-chat changed-files tracking keyed on canonical `write_file`/`edit_file`/`delete_file` tool names, superseding the stale `getModifiedFilePaths` helper.
- `apps/mobile/components/chat/dock/{ChatDock,DockPanel,DockChip,DockChipRail,useDockPanel}` — shared container, chrome, and composer toolbar chips.
- `apps/mobile/components/chat/dock/panels/*` — `WorktreeDockPanel`, `PlanDockPanel`, `ChangesDockPanel`, `ChecklistDockPanel`, `BrowserDockPanel`, `RunningDockPanel`, `QueueDockPanel`, `ContextUsageDockPanel`.

## Modified files

- `ChatPanel.tsx` — mounts `<ChatDock/>`, reserves scroll padding for its measured height, migrates `PermissionApprovalDialog`/pending question/connectivity+error banners into blocking/status panels.
- `ChatInput.tsx` — drops the inline queue block, pending-question widget, and context popover in favor of dock panels + chips; restores the composer's unconditional rounded corners.
- `PlanCard.tsx` — adds `onOpenInDock` so the in-stream plan card can deep-link into the live `PlanDockPanel`.
- `WorktreeBar.tsx` — split into `useWorktreeStatus` + `WorktreeBarView` so the dock panel can decide visibility without mounting UI first.
- `SubagentCard.tsx` / `TurnGroup.tsx` / `TurnList.tsx` — drop the inline `LiveBrowserView` and `SubagentPanel` renders, now owned by the dock (avoids a second screencast SSE subscription).

## Verification

- `apps/mobile` typecheck: same pre-existing error count as `main` (549 vs 551, both unrelated to this change — `getCookie`, `expo-haptics` types, etc.), zero new errors introduced.
- Confirmed no leftover references to `getModifiedFilePaths`, `FILE_OPERATION_TOOLS`, `onFilesChanged`, `queueExpanded`, `contextPopoverOpen`.
- Confirmed only one `LiveBrowserView` mount site (`BrowserDockPanel`).
- Confirmed blocking panels (`permission`, `question`, `connectivity`) are exempt from collapse in `chat-dock-store.ts`.

🤖 Generated with [Cursor](https://cursor.com)

Made with [Cursor](https://cursor.com)