### PR TITLE
fix: add canvas-ready watchdog to prevent infinite loading on heavy projects

### DIFF
--- a/apps/mobile/app/(app)/projects/[id]/_layout.tsx
+++ b/apps/mobile/app/(app)/projects/[id]/_layout.tsx
@@ -536,6 +536,16 @@ export default observer(function ProjectLayout() {
     setCanvasThemeSupported(caps.supportsTheme)
   }, [])
 
+  const handleCanvasTimeout = useCallback((action: 'retry' | 'switch-to-chat' | 'disable-canvas') => {
+    if (action === 'switch-to-chat') {
+      setPreviewTab('chat-fullscreen')
+    } else if (action === 'disable-canvas') {
+      void updateProjectSettings({ activeMode: 'none', canvasEnabled: false })
+      setPreviewTab('chat-fullscreen')
+    }
+    // 'retry' is handled internally by CanvasWebView
+  }, [updateProjectSettings])
+
   // ── External preview (folder-linked / `workingMode === 'external'`) ─
   //
   // For Open-Folder projects we expose a desktop-only Electron
@@ -2846,6 +2856,7 @@ export default observer(function ProjectLayout() {
       iframeRefreshKey={iframeRefreshKey}
       onCanvasCapabilities={handleCanvasCapabilities}
       onCanvasError={handleCanvasError}
+      onCanvasTimeout={handleCanvasTimeout}
     />
   ) : null
 
@@ -4111,6 +4122,7 @@ function CanvasPanel({
   iframeRefreshKey = 0,
   onCanvasCapabilities,
   onCanvasError,
+  onCanvasTimeout,
 }: {
   agentUrl: string | null
   canvasBaseUrl?: string | null
@@ -4127,6 +4139,7 @@ function CanvasPanel({
       recentActions?: ReadonlyArray<{ ts: number; kind: string; target?: string; route?: string }>
     },
   ) => void
+  onCanvasTimeout?: (action: 'retry' | 'switch-to-chat' | 'disable-canvas') => void
 }) {
   // Phase-level visibility into what the runtime is doing while we wait
   // (installing deps, building, starting the API server, …).
@@ -4325,6 +4338,7 @@ function CanvasPanel({
         refreshKey={iframeRefreshKey}
         onCanvasCapabilities={onCanvasCapabilities}
         onCanvasError={onCanvasError}
+        onCanvasTimeout={onCanvasTimeout}
       />
     </View>
   )

--- a/apps/mobile/components/canvas/CanvasWebView.tsx
+++ b/apps/mobile/components/canvas/CanvasWebView.tsx
@@ -36,6 +36,9 @@ export interface CanvasErrorContext {
   recentActions?: CanvasErrorAction[]
 }
 
+/** How long to wait for `canvas-ready` before showing the timeout fallback. */
+const CANVAS_READY_TIMEOUT_MS = 15_000
+
 interface CanvasWebViewProps {
   agentUrl: string | null
   /** Direct runtime URL for the canvas iframe. When set, the iframe loads from
@@ -52,6 +55,9 @@ interface CanvasWebViewProps {
   onCanvasCapabilities?: (caps: CanvasCapabilities) => void
   /** Incremented externally to force the iframe to reload. */
   refreshKey?: number
+  /** Called when the canvas-ready watchdog fires. The `action` indicates
+   *  which fallback button the user clicked. */
+  onCanvasTimeout?: (action: 'retry' | 'switch-to-chat' | 'disable-canvas') => void
 }
 
 function postCanvasError(
@@ -74,7 +80,7 @@ function postCanvasError(
 // CanvasWebView — public component
 // ---------------------------------------------------------------------------
 
-export function CanvasWebView({ agentUrl, canvasBaseUrl, previewUrl, onCanvasError, onCanvasCapabilities, refreshKey }: CanvasWebViewProps) {
+export function CanvasWebView({ agentUrl, canvasBaseUrl, previewUrl, onCanvasError, onCanvasCapabilities, refreshKey, onCanvasTimeout }: CanvasWebViewProps) {
   const canvasUrl = canvasDocumentUrl({
     canvasBaseUrl,
     agentUrl,
@@ -104,7 +110,7 @@ export function CanvasWebView({ agentUrl, canvasBaseUrl, previewUrl, onCanvasErr
   }
 
   if (Platform.OS === 'web') {
-    return <CanvasIframe key={refreshKey} url={canvasUrl} agentUrl={agentUrl} themeMessage={themeMessage} onCanvasError={onCanvasError} onCanvasCapabilities={onCanvasCapabilities} />
+    return <CanvasIframe key={refreshKey} url={canvasUrl} agentUrl={agentUrl} themeMessage={themeMessage} onCanvasError={onCanvasError} onCanvasCapabilities={onCanvasCapabilities} onCanvasTimeout={onCanvasTimeout} />
   }
 
   return <CanvasNativeWebView key={refreshKey} url={canvasUrl} agentUrl={agentUrl} themeMessage={themeMessage} onCanvasError={onCanvasError} onCanvasCapabilities={onCanvasCapabilities} />
@@ -130,14 +136,17 @@ interface BridgeProps {
     context?: CanvasErrorContext,
   ) => void
   onCanvasCapabilities?: (caps: CanvasCapabilities) => void
+  onCanvasTimeout?: (action: 'retry' | 'switch-to-chat' | 'disable-canvas') => void
 }
 
-function CanvasIframe({ url, agentUrl, themeMessage, onCanvasError, onCanvasCapabilities }: BridgeProps) {
+function CanvasIframe({ url, agentUrl, themeMessage, onCanvasError, onCanvasCapabilities, onCanvasTimeout }: BridgeProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const readyRef = useRef(false)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<{ phase: string; message: string } | null>(null)
+  const [timedOut, setTimedOut] = useState(false)
   const [refreshCount, setRefreshCount] = useState(0)
+  const watchdogRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const sendToIframe = useCallback((msg: unknown) => {
     iframeRef.current?.contentWindow?.postMessage(msg, '*')
@@ -155,7 +164,24 @@ function CanvasIframe({ url, agentUrl, themeMessage, onCanvasError, onCanvasCapa
   useEffect(() => {
     setLoading(true)
     setError(null)
+    setTimedOut(false)
   }, [refreshCount])
+
+  // Canvas-ready watchdog: if the iframe doesn't post `canvas-ready` within
+  // CANVAS_READY_TIMEOUT_MS, show a timeout fallback so the user isn't stuck
+  // on an eternal "Loading preview…" spinner.
+  useEffect(() => {
+    if (readyRef.current || error || timedOut) return
+    watchdogRef.current = setTimeout(() => {
+      if (!readyRef.current) {
+        setTimedOut(true)
+        setLoading(false)
+      }
+    }, CANVAS_READY_TIMEOUT_MS)
+    return () => {
+      if (watchdogRef.current) clearTimeout(watchdogRef.current)
+    }
+  }, [refreshCount, error, timedOut])
 
   // Listen for messages from the iframe
   useEffect(() => {
@@ -165,6 +191,8 @@ function CanvasIframe({ url, agentUrl, themeMessage, onCanvasError, onCanvasCapa
 
       if (msg.type === 'canvas-ready') {
         readyRef.current = true
+        if (watchdogRef.current) clearTimeout(watchdogRef.current)
+        setTimedOut(false)
         setLoading(false)
         if (themeMessage) sendToIframe(themeMessage)
       } else if (msg.type === 'canvas-capabilities') {
@@ -196,8 +224,10 @@ function CanvasIframe({ url, agentUrl, themeMessage, onCanvasError, onCanvasCapa
 
   const handleRetry = useCallback(() => {
     setError(null)
+    setTimedOut(false)
     setLoading(true)
     readyRef.current = false
+    if (watchdogRef.current) clearTimeout(watchdogRef.current)
     setRefreshCount((c) => c + 1)
   }, [])
 
@@ -223,20 +253,58 @@ function CanvasIframe({ url, agentUrl, themeMessage, onCanvasError, onCanvasCapa
           </TouchableOpacity>
         </View>
       )}
-      <iframe
-        ref={iframeRef}
-        src={`${url}${url.includes('?') ? '&' : '?'}_v=${refreshCount}`}
-        data-testid="canvas-preview-iframe"
-        title="Project preview"
-        style={{
-          width: '100%',
-          height: '100%',
-          border: 'none',
-          backgroundColor: 'transparent',
-          opacity: loading || error ? 0 : 1,
-        } as any}
-        allow="clipboard-write; clipboard-read; microphone; camera; display-capture; autoplay; fullscreen; geolocation; midi; encrypted-media; accelerometer; gyroscope; magnetometer; xr-spatial-tracking"
-      />
+      {timedOut && (
+        <View style={styles.errorOverlay}>
+          <Text style={styles.errorIcon}>⏱️</Text>
+          <Text style={styles.errorTitle}>Canvas is not responding</Text>
+          <Text style={styles.errorMessage} numberOfLines={3}>
+            The preview did not load within {CANVAS_READY_TIMEOUT_MS / 1000} seconds.
+          </Text>
+          <View style={styles.timeoutActions}>
+            <TouchableOpacity
+              style={styles.retryButton}
+              onPress={() => {
+                onCanvasTimeout?.('retry')
+                handleRetry()
+              }}
+            >
+              <Text style={styles.retryButtonText}>Retry</Text>
+            </TouchableOpacity>
+            {onCanvasTimeout && (
+              <>
+                <TouchableOpacity
+                  style={styles.timeoutSecondaryButton}
+                  onPress={() => onCanvasTimeout('switch-to-chat')}
+                >
+                  <Text style={styles.timeoutSecondaryButtonText}>Switch to Chat</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={styles.timeoutSecondaryButton}
+                  onPress={() => onCanvasTimeout('disable-canvas')}
+                >
+                  <Text style={styles.timeoutSecondaryButtonText}>Disable Canvas</Text>
+                </TouchableOpacity>
+              </>
+            )}
+          </View>
+        </View>
+      )}
+      {!timedOut && (
+        <iframe
+          ref={iframeRef}
+          src={`${url}${url.includes('?') ? '&' : '?'}_v=${refreshCount}`}
+          data-testid="canvas-preview-iframe"
+          title="Project preview"
+          style={{
+            width: '100%',
+            height: '100%',
+            border: 'none',
+            backgroundColor: 'transparent',
+            opacity: loading || error ? 0 : 1,
+          } as any}
+          allow="clipboard-write; clipboard-read; microphone; camera; display-capture; autoplay; fullscreen; geolocation; midi; encrypted-media; accelerometer; gyroscope; magnetometer; xr-spatial-tracking"
+        />
+      )}
     </View>
   )
 }
@@ -475,5 +543,24 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '600',
     color: '#fff',
+  },
+  timeoutActions: {
+    flexDirection: 'row',
+    gap: 8,
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+  },
+  timeoutSecondaryButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 6,
+    backgroundColor: 'transparent',
+    borderWidth: 1,
+    borderColor: '#666',
+  },
+  timeoutSecondaryButtonText: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: '#888',
   },
 })


### PR DESCRIPTION
## Problem

The canvas iframe has no load watchdog. When a canvas app loads heavy content (e.g. the Shogo SEO project rendering a 773KB `/api/seo/opportunities` JSON table), it blocks Studio's main thread. The user sees **Page Unresponsive** with no way to recover — the "Loading preview..." spinner runs forever.
BEFORE FIX
<img width="1528" height="787" alt="image" src="https://github.com/user-attachments/assets/babbd178-67e5-4119-af4b-2ceaf63b58f0" />

## Root Cause

- The iframe runs same-origin with no timeout after mount
- `CONNECTION_TIMEOUT_MS` (60s) only fires when the agent URL is unavailable, not when a loaded iframe hangs
- The user has no escape: switching tabs is impossible because the main thread is blocked

## Fix

Add a **15-second canvas-ready watchdog** in `CanvasWebView.tsx`:

1. When the iframe mounts, start a 15s timer
2. The iframe's `canvas-bridge.js` already posts `canvas-ready` on successful init
3. If no `canvas-ready` arrives within 15s, **unmount the iframe** and show a fallback card:
   - **Retry** — remount the iframe
   - **Switch to Chat** — sets `previewTab` to `chat-fullscreen`
   - **Disable Canvas** — sets `canvasEnabled: false` for this project

Wire up `onCanvasTimeout` callback through `CanvasPanel` in `_layout.tsx` so the parent handles tab switching and canvas disable.

## Safety

This is **purely additive**:
- Healthy canvas apps (load in 2-5s) are unaffected — the timer clears on `canvas-ready`
- The fallback card only appears when canvas is already broken
- No existing behavior changes for working projects

## Files Changed

- `apps/mobile/components/canvas/CanvasWebView.tsx` — watchdog timer, timeout state, fallback UI
- `apps/mobile/app/(app)/projects/[id]/_layout.tsx` — `handleCanvasTimeout` callback, prop threading
